### PR TITLE
Add Maestro.ios(channel) initializer

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -24,6 +24,7 @@ import maestro.drivers.AndroidDriver
 import maestro.drivers.IOSDriver
 import maestro.utils.ViewUtils
 import dadb.Dadb
+import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import ios.idb.IdbIOSDevice
 import org.slf4j.LoggerFactory
@@ -282,6 +283,10 @@ class Maestro(private val driver: Driver) : AutoCloseable {
                 .usePlaintext()
                 .build()
 
+            return ios(channel)
+        }
+
+        fun ios(channel: ManagedChannel): Maestro {
             val driver = IOSDriver(IdbIOSDevice(channel))
             driver.open()
             return Maestro(driver)


### PR DESCRIPTION
Allow Maestro to be started on an existing, persistent GRPC channel