### PR TITLE
fix: only save state of its own package name

### DIFF
--- a/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
@@ -39,9 +39,10 @@ object AndroidAppFiles {
 
     fun push(dadb: Dadb, packageName: String, appFilesZip: File) {
         val remoteZip = "/data/local/tmp/app.zip"
+        val appDataDir = "/data/data/"
         dadb.push(appFilesZip, remoteZip)
         try {
-            shell(dadb, "run-as $packageName unzip -o -d / $remoteZip")
+            shell(dadb, "run-as $packageName unzip -o -d $appDataDir $remoteZip")
         } finally {
             shell(dadb, "rm $remoteZip")
         }
@@ -55,10 +56,9 @@ object AndroidAppFiles {
 
     private fun listRemoteFiles(dadb: Dadb, packageName: String, options: String): List<String> {
         val result = shell(dadb, "run-as $packageName find $options")
-        val appDataDir = "/data/data/$packageName"
         return result.lines()
             .filter { it.isNotBlank() }
-            .map { "$appDataDir/${it.removePrefix("./")}" }
+            .map { "$packageName/${it.removePrefix("./")}" }
     }
 
     private fun shell(dadb: Dadb, command: String): String {


### PR DESCRIPTION
Currently, the `pull` function for the Android driver zips all files that the adb user has access to. Afterward it zips in a `/data/data/package.name` folder structure, this could cause issues since this user should only have access to the folder `package.name` within the `/data/data`.

This PR inverts this logic to zip as a simple  `package.name/` folder structure
