### PR TITLE
Fix: wrap Android text in quotes

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -209,7 +209,7 @@ class AndroidDriver(
     }
 
     override fun inputText(text: String) {
-        dadb.shell("input text $text")
+        dadb.shell("input text \"$text\"")
     }
 
     override fun openLink(link: String) {


### PR DESCRIPTION
Address part of issue #107 ([comment](https://github.com/mobile-dev-inc/maestro/issues/107#issuecomment-1235275341))