### PR TITLE
Fix: Added delay between key inputs on iOS

### DIFF
--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -190,6 +190,7 @@ class IdbIOSDevice(
             TextInputUtil.textToListOfEvents(text)
                 .forEach {
                     stream.onNext(it)
+                    Thread.sleep(25)
                 }
             stream.onCompleted()
         }


### PR DESCRIPTION
We were sending key events to iOS without any delay between inputs, possibly causing race conditions and resulting in some events being discarded.