### PR TITLE
Fix: Await channel termination when closing a gRPC ManagedChannel

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -42,6 +42,7 @@ import org.w3c.dom.Element
 import org.w3c.dom.Node
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import javax.xml.parsers.DocumentBuilderFactory
 
@@ -110,6 +111,10 @@ class AndroidDriver(
         instrumentationSession?.close()
         instrumentationSession = null
         channel.shutdown()
+
+        if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+            throw TimeoutException("Couldn't close Maestro Android driver due to gRPC timeout")
+        }
     }
 
     override fun deviceInfo(): DeviceInfo {

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -51,6 +51,8 @@ import ios.device.DeviceInfo
 import ios.grpc.BlockingStreamObserver
 import java.io.File
 import java.io.InputStream
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 class IdbIOSDevice(
     private val channel: ManagedChannel,
@@ -362,6 +364,10 @@ class IdbIOSDevice(
 
     override fun close() {
         channel.shutdown()
+
+        if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+            throw TimeoutException("Couldn't close Maestro iOS driver due to gRPC timeout")
+        }
     }
 
     companion object {


### PR DESCRIPTION
Fixed #114 