### PR TITLE
feature: AndroidTV-Remote navigation

### DIFF
--- a/maestro-client/src/main/java/maestro/KeyCode.kt
+++ b/maestro-client/src/main/java/maestro/KeyCode.kt
@@ -11,6 +11,17 @@ enum class KeyCode(
     LOCK("Lock"),
     VOLUME_UP("Volume Up"),
     VOLUME_DOWN("Volume Down");
+    REMOTE_UP("Remote Dpad Up")
+    REMOTE_DOWN("Remote Dpad Down")
+    REMOTE_LEFT("Remote Dpad Left")
+    REMOTE_RIGHT("Remote Dpad Right")
+    REMOTE_CENTER("Remote Dpad Center")
+    REMOTE_PLAY_PAUSE("Remote Media Play Pause")
+    REMOTE_STOP("Remote Media Stop")
+    REMOTE_NEXT("Remote Media Next")
+    REMOTE_PREVIOUS("Remote Media Previous")
+    REMOTE_REWIND("Remote Media Rewind")
+    REMOTE_FAST_FORWARD("Remote Media Fast Forward")
 
     companion object {
         fun getByName(name: String): KeyCode? {

--- a/maestro-client/src/main/java/maestro/KeyCode.kt
+++ b/maestro-client/src/main/java/maestro/KeyCode.kt
@@ -10,18 +10,18 @@ enum class KeyCode(
     HOME("Home"),
     LOCK("Lock"),
     VOLUME_UP("Volume Up"),
-    VOLUME_DOWN("Volume Down");
-    REMOTE_UP("Remote Dpad Up")
-    REMOTE_DOWN("Remote Dpad Down")
-    REMOTE_LEFT("Remote Dpad Left")
-    REMOTE_RIGHT("Remote Dpad Right")
-    REMOTE_CENTER("Remote Dpad Center")
-    REMOTE_PLAY_PAUSE("Remote Media Play Pause")
-    REMOTE_STOP("Remote Media Stop")
-    REMOTE_NEXT("Remote Media Next")
-    REMOTE_PREVIOUS("Remote Media Previous")
-    REMOTE_REWIND("Remote Media Rewind")
-    REMOTE_FAST_FORWARD("Remote Media Fast Forward")
+    VOLUME_DOWN("Volume Down"),
+    REMOTE_UP("Remote Dpad Up"),
+    REMOTE_DOWN("Remote Dpad Down"),
+    REMOTE_LEFT("Remote Dpad Left"),
+    REMOTE_RIGHT("Remote Dpad Right"),
+    REMOTE_CENTER("Remote Dpad Center"),
+    REMOTE_PLAY_PAUSE("Remote Media Play Pause"),
+    REMOTE_STOP("Remote Media Stop"),
+    REMOTE_NEXT("Remote Media Next"),
+    REMOTE_PREVIOUS("Remote Media Previous"),
+    REMOTE_REWIND("Remote Media Rewind"),
+    REMOTE_FAST_FORWARD("Remote Media Fast Forward");
 
     companion object {
         fun getByName(name: String): KeyCode? {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -178,6 +178,17 @@ class AndroidDriver(
             KeyCode.VOLUME_DOWN -> 25
             KeyCode.HOME -> 3
             KeyCode.LOCK -> 276
+            KeyCode.REMOTE_UP -> 19
+            KeyCode.REMOTE_DOWN -> 20
+            KeyCode.REMOTE_LEFT -> 21
+            KeyCode.REMOTE_RIGHT -> 22
+            KeyCode.REMOTE_CENTER -> 23
+            KeyCode.REMOTE_PLAY_PAUSE -> 85
+            KeyCode.REMOTE_STOP -> 86
+            KeyCode.REMOTE_NEXT -> 87
+            KeyCode.REMOTE_PREVIOUS -> 88
+            KeyCode.REMOTE_REWIND -> 89
+            KeyCode.REMOTE_FAST_FORWARD -> 90
         }
 
         dadb.shell("input keyevent $intCode")

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -123,6 +123,17 @@ class IOSDriver(
             KeyCode.HOME -> pressButton(1)  // idb.HIDButtonType.HOME
             KeyCode.LOCK -> pressButton(2)  // idb.HIDButtonType.LOCK
             KeyCode.BACK -> Unit // Do nothing, back key is not available on iOS
+            KeyCode.REMOTE_UP -> pressKey(82)
+            KeyCode.REMOTE_DOWN -> pressKey(81)
+            KeyCode.REMOTE_LEFT -> pressKey(80)
+            KeyCode.REMOTE_RIGHT -> pressKey(79)
+            KeyCode.REMOTE_CENTER -> Unit
+            KeyCode.REMOTE_PLAY_PAUSE -> Unit
+            KeyCode.REMOTE_STOP -> Unit
+            KeyCode.REMOTE_NEXT -> Unit
+            KeyCode.REMOTE_PREVIOUS -> Unit
+            KeyCode.REMOTE_REWIND -> Unit
+            KeyCode.REMOTE_FAST_FORWARD -> Unit
         }
     }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -938,6 +938,17 @@ class IntegrationTest {
         driver.assertHasEvent(Event.PressKey(KeyCode.VOLUME_UP))
         driver.assertHasEvent(Event.PressKey(KeyCode.VOLUME_DOWN))
         driver.assertHasEvent(Event.PressKey(KeyCode.LOCK))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_UP))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_DOWN))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_LEFT))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_RIGHT))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_CENTER))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_PLAY_PAUSE))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_STOP))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_NEXT))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_PREVIOUS))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_REWIND))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_FAST_FORWARD))
     }
 
     @Test

--- a/maestro-test/src/test/resources/034_press_key.yaml
+++ b/maestro-test/src/test/resources/034_press_key.yaml
@@ -7,3 +7,14 @@ appId: com.example.app
 - pressKey: Volume Up
 - pressKey: volume Down
 - pressKey: lOcK
+- pressKey: remote dpad up
+- pressKey: Remote dpad Down
+- pressKey: Remote Dpad Left
+- pressKey: Remote Dpad Right
+- pressKey: remote dpad Center
+- pressKey: rEmote Media plAy Pause
+- pressKey: RemOte MediA StoP
+- pressKey: remote Media NeXt
+- pressKey: Remote Media Previous
+- pressKey: REMOTE MEDIA REWIND
+- pressKey: Remote Media Fast Forward

--- a/maestro-test/src/test/resources/034_press_key.yaml
+++ b/maestro-test/src/test/resources/034_press_key.yaml
@@ -3,7 +3,7 @@ appId: com.example.app
 - pressKey: Enter
 - pressKey: Backspace
 - pressKey: Home
-- pressKey: back
+- pressKey: Back
 - pressKey: Volume Up
-- pressKey: volume Down
-- pressKey: lOcK
+- pressKey: Volume Down
+- pressKey: Lock

--- a/maestro-test/src/test/resources/034_press_key.yaml
+++ b/maestro-test/src/test/resources/034_press_key.yaml
@@ -3,7 +3,7 @@ appId: com.example.app
 - pressKey: Enter
 - pressKey: Backspace
 - pressKey: Home
-- pressKey: Back
+- pressKey: back
 - pressKey: Volume Up
-- pressKey: Volume Down
-- pressKey: Lock
+- pressKey: volume Down
+- pressKey: lOcK


### PR DESCRIPTION
hi all,

I've added AndroidTV Remote navigation to `pressKey()`
- `Remote Dpad Up`
- `Remote Dpad Down`
- `Remote Dpad Left`
- `Remote Dpad Right`
- `Remote Dpad Center`
- `Remote Media Play Pause`
- `Remote Media Stop`
- `Remote Media Next`
- `Remote Media Previous`
- `Remote Media Rewind`
- `Remote Media Fast Forward`

please let me know if I miss anything 🙇🏻 