### PR TITLE
Prepare maestro to make it easier to add new commands

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -21,6 +21,7 @@ package maestro.cli.runner
 
 import maestro.Maestro
 import maestro.MaestroException
+import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
 import maestro.orchestra.OrchestraAppState
@@ -43,7 +44,7 @@ object MaestroCommandRunner {
                 ResultView.UiState.Running(
                     initCommands = (initFlow?.commands ?: emptyList())
                         // Don't render configuration commands
-                        .filter { it.applyConfigurationCommand == null }
+                        .filter { it.command !is ApplyConfigurationCommand }
                         .mapIndexed { _, command ->
                             CommandState(
                                 command = command,
@@ -52,7 +53,7 @@ object MaestroCommandRunner {
                         },
                     commands = commands
                         // Don't render configuration commands
-                        .filter { it.applyConfigurationCommand == null }
+                        .filter { it.command !is ApplyConfigurationCommand }
                         .mapIndexed { _, command ->
                             CommandState(
                                 command = command,

--- a/maestro-orchestra-models/build.gradle
+++ b/maestro-orchestra-models/build.gradle
@@ -12,4 +12,10 @@ plugins.withId("com.vanniktech.maven.publish") {
 
 dependencies {
     implementation project(path: ':maestro-client')
+
+    api 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1'
+    api 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2'
+
+    testImplementation "junit:junit:4.13.2"
+    testImplementation "com.google.truth:truth:1.1.3"
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -23,7 +23,7 @@ import maestro.KeyCode
 import maestro.Point
 import maestro.orchestra.util.Env.injectEnv
 
-interface Command {
+sealed interface Command {
 
     fun description(): String
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -19,88 +19,44 @@
 
 package maestro.orchestra
 
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+
+@JsonSerialize(using = MaestroCommandSerializer::class)
 data class MaestroCommand(
-    val tapOnElement: TapOnElementCommand? = null,
-    val tapOnPoint: TapOnPointCommand? = null,
-    val scrollCommand: ScrollCommand? = null,
-    val swipeCommand: SwipeCommand? = null,
-    val backPressCommand: BackPressCommand? = null,
-    val assertCommand: AssertCommand? = null,
-    val inputTextCommand: InputTextCommand? = null,
-    val launchAppCommand: LaunchAppCommand? = null,
-    val applyConfigurationCommand: ApplyConfigurationCommand? = null,
-    val openLinkCommand: OpenLinkCommand? = null,
-    val pressKeyCommand: PressKeyCommand? = null,
-    val eraseTextCommand: EraseTextCommand? = null,
+    val command: Command?,
 ) {
 
     fun injectEnv(envParameters: Map<String, String>): MaestroCommand {
-        return copy(
-            tapOnElement = tapOnElement?.injectEnv(envParameters),
-            tapOnPoint = tapOnPoint?.injectEnv(envParameters),
-            scrollCommand = scrollCommand?.injectEnv(envParameters),
-            swipeCommand = swipeCommand?.injectEnv(envParameters),
-            backPressCommand = backPressCommand?.injectEnv(envParameters),
-            assertCommand = assertCommand?.injectEnv(envParameters),
-            inputTextCommand = inputTextCommand?.injectEnv(envParameters),
-            launchAppCommand = launchAppCommand?.injectEnv(envParameters),
-            applyConfigurationCommand = applyConfigurationCommand?.injectEnv(envParameters),
-            openLinkCommand = openLinkCommand?.injectEnv(envParameters),
-            pressKeyCommand = pressKeyCommand?.injectEnv(envParameters),
-            eraseTextCommand = eraseTextCommand?.injectEnv(envParameters),
-        )
+        return copy(command = command?.injectEnv(envParameters))
     }
 
     fun description(): String {
-        tapOnElement?.let {
-            return it.description()
-        }
-
-        tapOnPoint?.let {
-            return it.description()
-        }
-
-        scrollCommand?.let {
-            return it.description()
-        }
-
-        swipeCommand?.let {
-            return it.description()
-        }
-
-        backPressCommand?.let {
-            return it.description()
-        }
-
-        assertCommand?.let {
-            return it.description()
-        }
-
-        inputTextCommand?.let {
-            return it.description()
-        }
-
-        launchAppCommand?.let {
-            return it.description()
-        }
-
-        applyConfigurationCommand?.let {
-            return it.description()
-        }
-
-        openLinkCommand?.let {
-            return it.description()
-        }
-
-        pressKeyCommand?.let {
-            return it.description()
-        }
-
-        eraseTextCommand?.let {
-            return it.description()
-        }
-
-        return "No op"
+        return command?.description() ?: "No op"
     }
+}
 
+class MaestroCommandSerializer : JsonSerializer<MaestroCommand>() {
+    override fun serialize(
+        value: MaestroCommand,
+        gen: JsonGenerator,
+        serializers: SerializerProvider
+    ) {
+        val commandNameKey = value.command!!::class.java.simpleName
+            .replaceFirstChar(Char::lowercaseChar)
+
+        val commandNameKeyForServer = when (commandNameKey) {
+            "tapOnElementCommand" -> "tapOnElement"
+            "tapOnPointCommand" -> "tapOnPoint"
+            else -> commandNameKey
+        }
+
+        with(gen) {
+            writeStartObject()
+            writeObjectField(commandNameKeyForServer, value.command)
+            writeEndObject()
+        }
+    }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -24,6 +24,12 @@ import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
 
+/**
+ * The Mobile.dev platform uses this class in the backend and hence the custom
+ * serialization logic. The earlier implementation of this class had a nullable field for
+ * each command. Sometime in the future we may move this serialization logic to the backend
+ * itself, where it would be more relevant.
+ */
 @JsonSerialize(using = MaestroCommandSerializer::class)
 data class MaestroCommand(
     val command: Command?,

--- a/maestro-orchestra-models/src/test/kotlin/LitmusTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/LitmusTest.kt
@@ -1,0 +1,10 @@
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class LitmusTest {
+    @Test
+    fun `junit and truth are setup`() {
+        assertThat(true)
+            .isTrue()
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -104,7 +104,7 @@ class Orchestra(
             .forEachIndexed { index, command ->
                 onCommandStart(index, command)
                 try {
-                    executeCommand(command)
+                    executeCommand(command.command)
                     onCommandComplete(index, command)
                 } catch (e: Throwable) {
                     onCommandFailed(index, command, e)
@@ -114,39 +114,21 @@ class Orchestra(
         return true
     }
 
-    private fun executeCommand(command: MaestroCommand) {
-        when {
-            command.tapOnElement != null -> command.tapOnElement
-                ?.let {
-                    tapOnElement(
-                        it,
-                        it.retryIfNoChange ?: true,
-                        it.waitUntilVisible ?: true,
-                    )
-                }
-            command.tapOnPoint != null -> command.tapOnPoint
-                ?.let {
-                    tapOnPoint(
-                        it,
-                        it.retryIfNoChange ?: true,
-                    )
-                }
-            command.backPressCommand != null -> maestro.backPress()
-            command.scrollCommand != null -> maestro.scrollVertical()
-            command.swipeCommand != null -> command.swipeCommand
-                ?.let { swipeCommand(it) }
-            command.assertCommand != null -> command.assertCommand
-                ?.let { assertCommand(it) }
-            command.inputTextCommand != null -> command.inputTextCommand
-                ?.let { inputTextCommand(it) }
-            command.launchAppCommand != null -> command.launchAppCommand
-                ?.let { launchAppCommand(it) }
-            command.openLinkCommand != null -> command.openLinkCommand
-                ?.let { openLinkCommand(it) }
-            command.pressKeyCommand != null -> command.pressKeyCommand
-                ?.let { pressKeyCommand(it) }
-            command.eraseTextCommand != null -> command.eraseTextCommand
-                ?.let { eraseTextCommand(it) }
+    private fun executeCommand(command: Command?) {
+        when (command) {
+            is TapOnElementCommand -> {
+                tapOnElement(command, command.retryIfNoChange ?: true, command.waitUntilVisible ?: true)
+            }
+            is TapOnPointCommand -> tapOnPoint(command, command.retryIfNoChange ?: true)
+            is BackPressCommand -> maestro.backPress()
+            is ScrollCommand -> maestro.scrollVertical()
+            is SwipeCommand -> swipeCommand(command)
+            is AssertCommand -> assertCommand(command)
+            is InputTextCommand -> inputTextCommand(command)
+            is LaunchAppCommand -> launchAppCommand(command)
+            is OpenLinkCommand -> openLinkCommand(command)
+            is PressKeyCommand -> pressKeyCommand(command)
+            is EraseTextCommand -> eraseTextCommand(command)
         }
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -115,7 +115,7 @@ class Orchestra(
     }
 
     private fun executeCommand(command: Command?) {
-        when (command) {
+        return when (command) {
             is TapOnElementCommand -> {
                 tapOnElement(command, command.retryIfNoChange ?: true, command.waitUntilVisible ?: true)
             }
@@ -129,6 +129,7 @@ class Orchestra(
             is OpenLinkCommand -> openLinkCommand(command)
             is PressKeyCommand -> pressKeyCommand(command)
             is EraseTextCommand -> eraseTextCommand(command)
+            is ApplyConfigurationCommand, null -> { /* no-op */ }
         }
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.error.NoInputException
@@ -60,7 +61,12 @@ object YamlCommandReader {
     }
 
     fun getConfig(commands: List<MaestroCommand>): MaestroConfig? {
-        return commands.firstNotNullOfOrNull { it.applyConfigurationCommand }?.config
+        val configurationCommand = commands
+            .map(MaestroCommand::command)
+            .filterIsInstance<ApplyConfigurationCommand>()
+            .firstOrNull()
+
+        return configurationCommand?.config
     }
 
     private fun readConfigAndCommands(flowPath: Path): Pair<YamlConfig, List<YamlFluentCommand>> {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -30,7 +30,7 @@ data class YamlConfig(
             initFlow = initFlow(flowPath),
             ext = ext.toMap()
         )
-        return MaestroCommand(applyConfigurationCommand = ApplyConfigurationCommand(config))
+        return MaestroCommand(ApplyConfigurationCommand(config))
     }
 
     fun getInitFlowPath(flowPath: Path): Path? {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -58,36 +58,16 @@ data class YamlFluentCommand(
             launchApp != null -> launchApp(launchApp, appId)
             tapOn != null -> tapCommand(tapOn)
             longPressOn != null -> tapCommand(longPressOn, longPress = true)
-            assertVisible != null -> MaestroCommand(
-                assertCommand = AssertCommand(
-                    visible = toElementSelector(assertVisible),
-                )
-            )
-            assertNotVisible != null -> MaestroCommand(
-                assertCommand = AssertCommand(
-                    notVisible = toElementSelector(assertNotVisible),
-                )
-            )
-            inputText != null -> MaestroCommand(
-                inputTextCommand = InputTextCommand(inputText)
-            )
+            assertVisible != null -> MaestroCommand(AssertCommand(visible = toElementSelector(assertVisible)))
+            assertNotVisible != null -> MaestroCommand(AssertCommand(notVisible = toElementSelector(assertNotVisible),))
+            inputText != null -> MaestroCommand(InputTextCommand(inputText))
             swipe != null -> swipeCommand(swipe)
-            openLink != null -> MaestroCommand(
-                openLinkCommand = OpenLinkCommand(openLink)
-            )
-            pressKey != null -> MaestroCommand(
-                pressKeyCommand = PressKeyCommand(
-                    code = KeyCode.getByName(pressKey) ?: throw SyntaxError("Unknown key name: $pressKey")
-                )
-            )
-            eraseText != null -> MaestroCommand(
-                eraseTextCommand = EraseTextCommand(
-                    charactersToErase = eraseText.charactersToErase
-                )
-            )
+            openLink != null -> MaestroCommand(OpenLinkCommand(openLink))
+            pressKey != null -> MaestroCommand(PressKeyCommand(code = KeyCode.getByName(pressKey) ?: throw SyntaxError("Unknown key name: $pressKey")))
+            eraseText != null -> MaestroCommand(EraseTextCommand(charactersToErase = eraseText.charactersToErase))
             action != null -> when (action) {
-                "back" -> MaestroCommand(backPressCommand = BackPressCommand())
-                "scroll" -> MaestroCommand(scrollCommand = ScrollCommand())
+                "back" -> MaestroCommand(BackPressCommand())
+                "scroll" -> MaestroCommand(ScrollCommand())
                 else -> error("Unknown navigation target: $action")
             }
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
@@ -96,7 +76,7 @@ data class YamlFluentCommand(
 
     private fun launchApp(command: YamlLaunchApp, appId: String): MaestroCommand {
         return MaestroCommand(
-            launchAppCommand = LaunchAppCommand(
+            LaunchAppCommand(
                 appId = command.appId ?: appId,
                 clearState = command.clearState,
             )
@@ -118,7 +98,7 @@ data class YamlFluentCommand(
                 }
 
             MaestroCommand(
-                tapOnPoint = TapOnPointCommand(
+                TapOnPointCommand(
                     x = points[0],
                     y = points[1],
                     retryIfNoChange = retryIfNoChange,
@@ -128,7 +108,7 @@ data class YamlFluentCommand(
             )
         } else {
             MaestroCommand(
-                tapOnElement = TapOnElementCommand(
+                TapOnElementCommand(
                     selector = toElementSelector(tapOn),
                     retryIfNoChange = retryIfNoChange,
                     waitUntilVisible = waitUntilVisible,
@@ -150,7 +130,7 @@ data class YamlFluentCommand(
                 }
 
             MaestroCommand(
-                tapOnPoint = TapOnPointCommand(
+                TapOnPointCommand(
                     x = points[0],
                     y = points[1],
                     retryIfNoChange = retryIfNoChange,
@@ -159,7 +139,7 @@ data class YamlFluentCommand(
             )
         } else {
             MaestroCommand(
-                tapOnElement = TapOnElementCommand(
+                TapOnElementCommand(
                     selector = toElementSelector(tapOn),
                     retryIfNoChange = retryIfNoChange,
                     waitUntilVisible = waitUntilVisible,
@@ -196,9 +176,7 @@ data class YamlFluentCommand(
             throw IllegalStateException("No end point configured for swipe action")
         }
 
-        return MaestroCommand(
-            swipeCommand = SwipeCommand(startPoint, endPoint)
-        )
+        return MaestroCommand(SwipeCommand(startPoint, endPoint))
     }
 
     private fun toElementSelector(selectorUnion: YamlElementSelectorUnion): ElementSelector {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -231,6 +231,38 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize ApplyConfigurationCommand`() {
+        // given
+        val command = MaestroCommand(
+            applyConfigurationCommand = ApplyConfigurationCommand(
+                MaestroConfig(
+                    appId = "com.twitter.android",
+                    name = "Twitter",
+                )
+            )
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "applyConfigurationCommand" : {
+                "config" : {
+                  "appId" : "com.twitter.android",
+                  "name" : "Twitter",
+                  "ext" : { }
+                }
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -43,6 +43,39 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize TapOnPointCommand`() {
+        // given
+        val command = MaestroCommand(
+            tapOnPoint = TapOnPointCommand(
+                x = 100,
+                y = 100,
+                retryIfNoChange = false,
+                waitUntilVisible = true,
+                longPress = false,
+            )
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // the
+        @Language("json")
+        val expectedJson = """
+            {
+              "tapOnPoint" : {
+                "x" : 100,
+                "y" : 100,
+                "retryIfNoChange" : false,
+                "waitUntilVisible" : true,
+                "longPress" : false
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.google.common.truth.Truth.assertThat
+import maestro.KeyCode
 import maestro.Point
 import org.intellij.lang.annotations.Language
 import org.junit.Test
@@ -279,6 +280,29 @@ internal class MaestroCommandSerializationTest {
             {
               "openLinkCommand" : {
                 "link" : "https://mobile.dev"
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
+    @Test
+    fun `serialize PressKeyCommand`() {
+        // given
+        val command = MaestroCommand(
+            pressKeyCommand = PressKeyCommand(KeyCode.ENTER)
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "pressKeyCommand" : {
+                "code" : "ENTER"
               }
             }
           """.trimIndent()

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -1,0 +1,55 @@
+package maestro.orchestra
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.ObjectWriter
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.google.common.truth.Truth.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+internal class MaestroCommandSerializationTest {
+    @Test
+    fun `serialize TapOnElementCommand`() {
+        // given
+        val command = MaestroCommand(
+            tapOnElement = TapOnElementCommand(
+                selector = ElementSelector(textRegex = "[A-f0-9]"),
+                retryIfNoChange = false,
+                waitUntilVisible = true,
+                longPress = false,
+            )
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // the
+        @Language("json")
+        val expectedJson = """
+            {
+              "tapOnElement" : {
+                "selector" : {
+                  "textRegex" : "[A-f0-9]",
+                  "optional" : false
+                },
+                "retryIfNoChange" : false,
+                "waitUntilVisible" : true,
+                "longPress" : false
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
+    private fun MaestroCommand.toJson(): String =
+        objectWriter().writeValueAsString(this)
+
+    private fun objectWriter(): ObjectWriter {
+        return ObjectMapper()
+            .setSerializationInclusion(Include.NON_NULL)
+            .registerModule(KotlinModule.Builder().build())
+            .writerWithDefaultPrettyPrinter()
+    }
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -25,7 +25,7 @@ internal class MaestroCommandSerializationTest {
         // when
         val serializedCommandJson = command.toJson()
 
-        // the
+        // then
         @Language("json")
         val expectedJson = """
             {
@@ -60,7 +60,7 @@ internal class MaestroCommandSerializationTest {
         // when
         val serializedCommandJson = command.toJson()
 
-        // the
+        // then
         @Language("json")
         val expectedJson = """
             {
@@ -87,7 +87,7 @@ internal class MaestroCommandSerializationTest {
         // when
         val serializedCommandJson = command.toJson()
 
-        // the
+        // then
         @Language("json")
         val expectedJson = """
             {
@@ -111,7 +111,7 @@ internal class MaestroCommandSerializationTest {
         // when
         val serializedCommandJson = command.toJson()
 
-        // the
+        // then
         @Language("json")
         val expectedJson = """
             {
@@ -141,7 +141,7 @@ internal class MaestroCommandSerializationTest {
         // when
         val serializedCommandJson = command.toJson()
 
-        // the
+        // then
         @Language("json")
         val expectedJson = """
             {
@@ -165,7 +165,7 @@ internal class MaestroCommandSerializationTest {
         // when
         val serializedCommandJson = command.toJson()
 
-        // the
+        // then
         @Language("json")
         val expectedJson = """
             {
@@ -195,7 +195,7 @@ internal class MaestroCommandSerializationTest {
         // when
         val serializedCommandJson = command.toJson()
 
-        // the
+        // then
         @Language("json")
         val expectedJson = """
             {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -310,6 +310,29 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize EraseTextCommand`() {
+        // given
+        val command = MaestroCommand(
+            eraseTextCommand = EraseTextCommand(128)
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "eraseTextCommand" : {
+                "charactersToErase" : 128
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -152,6 +152,39 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize AssertCommand`() {
+        // given
+        val command = MaestroCommand(
+            assertCommand = AssertCommand(
+                ElementSelector(textRegex = "[A-f0-9]"),
+                ElementSelector(textRegex = "\\s")
+            )
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // the
+        @Language("json")
+        val expectedJson = """
+            {
+              "assertCommand" : {
+                "visible" : {
+                  "textRegex" : "[A-f0-9]",
+                  "optional" : false
+                },
+                "notVisible" : {
+                  "textRegex" : "\\s",
+                  "optional" : false
+                }
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.google.common.truth.Truth.assertThat
+import maestro.Point
 import org.intellij.lang.annotations.Language
 import org.junit.Test
 
@@ -91,6 +92,39 @@ internal class MaestroCommandSerializationTest {
         val expectedJson = """
             {
               "scrollCommand" : { }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
+    @Test
+    fun `serialize SwipeCommand`() {
+        // given
+        val command = MaestroCommand(
+            swipeCommand = SwipeCommand(
+                Point(10, 10),
+                Point(100, 100),
+            )
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // the
+        @Language("json")
+        val expectedJson = """
+            {
+              "swipeCommand" : {
+                "startPoint" : {
+                  "x" : 10,
+                  "y" : 10
+                },
+                "endPoint" : {
+                  "x" : 100,
+                  "y" : 100
+                }
+              }
             }
           """.trimIndent()
         assertThat(serializedCommandJson)

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -185,6 +185,29 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize InputTextCommand`() {
+        // given
+        val command = MaestroCommand(
+            inputTextCommand = InputTextCommand("Hello, world!")
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // the
+        @Language("json")
+        val expectedJson = """
+            {
+              "inputTextCommand" : {
+                "text" : "Hello, world!"
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -263,6 +263,29 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize OpenLinkCommand`() {
+        // given
+        val command = MaestroCommand(
+            openLinkCommand = OpenLinkCommand("https://mobile.dev")
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "openLinkCommand" : {
+                "link" : "https://mobile.dev"
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -131,6 +131,27 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize BackPressCommand`() {
+        // given
+        val command = MaestroCommand(
+            backPressCommand = BackPressCommand()
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // the
+        @Language("json")
+        val expectedJson = """
+            {
+              "backPressCommand" : { }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -208,6 +208,29 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize LaunchAppCommand`() {
+        // given
+        val command = MaestroCommand(
+            launchAppCommand = LaunchAppCommand("com.twitter.android")
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "launchAppCommand" : {
+                "appId" : "com.twitter.android"
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -15,7 +15,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize TapOnElementCommand`() {
         // given
         val command = MaestroCommand(
-            tapOnElement = TapOnElementCommand(
+            TapOnElementCommand(
                 selector = ElementSelector(textRegex = "[A-f0-9]"),
                 retryIfNoChange = false,
                 waitUntilVisible = true,
@@ -49,7 +49,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize TapOnPointCommand`() {
         // given
         val command = MaestroCommand(
-            tapOnPoint = TapOnPointCommand(
+            TapOnPointCommand(
                 x = 100,
                 y = 100,
                 retryIfNoChange = false,
@@ -82,7 +82,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize ScrollCommand`() {
         // given
         val command = MaestroCommand(
-            scrollCommand = ScrollCommand()
+            ScrollCommand()
         )
 
         // when
@@ -103,7 +103,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize SwipeCommand`() {
         // given
         val command = MaestroCommand(
-            swipeCommand = SwipeCommand(
+            SwipeCommand(
                 Point(10, 10),
                 Point(100, 100),
             )
@@ -136,7 +136,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize BackPressCommand`() {
         // given
         val command = MaestroCommand(
-            backPressCommand = BackPressCommand()
+            BackPressCommand()
         )
 
         // when
@@ -157,7 +157,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize AssertCommand`() {
         // given
         val command = MaestroCommand(
-            assertCommand = AssertCommand(
+            AssertCommand(
                 ElementSelector(textRegex = "[A-f0-9]"),
                 ElementSelector(textRegex = "\\s")
             )
@@ -190,7 +190,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize InputTextCommand`() {
         // given
         val command = MaestroCommand(
-            inputTextCommand = InputTextCommand("Hello, world!")
+            InputTextCommand("Hello, world!")
         )
 
         // when
@@ -213,7 +213,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize LaunchAppCommand`() {
         // given
         val command = MaestroCommand(
-            launchAppCommand = LaunchAppCommand("com.twitter.android")
+            LaunchAppCommand("com.twitter.android")
         )
 
         // when
@@ -236,7 +236,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize ApplyConfigurationCommand`() {
         // given
         val command = MaestroCommand(
-            applyConfigurationCommand = ApplyConfigurationCommand(
+            ApplyConfigurationCommand(
                 MaestroConfig(
                     appId = "com.twitter.android",
                     name = "Twitter",
@@ -268,7 +268,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize OpenLinkCommand`() {
         // given
         val command = MaestroCommand(
-            openLinkCommand = OpenLinkCommand("https://mobile.dev")
+            OpenLinkCommand("https://mobile.dev")
         )
 
         // when
@@ -291,7 +291,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize PressKeyCommand`() {
         // given
         val command = MaestroCommand(
-            pressKeyCommand = PressKeyCommand(KeyCode.ENTER)
+            PressKeyCommand(KeyCode.ENTER)
         )
 
         // when
@@ -314,7 +314,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize EraseTextCommand`() {
         // given
         val command = MaestroCommand(
-            eraseTextCommand = EraseTextCommand(128)
+            EraseTextCommand(128)
         )
 
         // when

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -76,6 +76,27 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(expectedJson)
     }
 
+    @Test
+    fun `serialize ScrollCommand`() {
+        // given
+        val command = MaestroCommand(
+            scrollCommand = ScrollCommand()
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // the
+        @Language("json")
+        val expectedJson = """
+            {
+              "scrollCommand" : { }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectWriter().writeValueAsString(this)
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
@@ -1,0 +1,32 @@
+package maestro.orchestra
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class MaestroCommandTest {
+    @Test
+    fun `description (no commands)`() {
+        // given
+        val maestroCommand = MaestroCommand()
+
+        // when
+        val description = maestroCommand.description()
+
+        // then
+        assertThat(description)
+            .isEqualTo("No op")
+    }
+
+    @Test
+    fun `description (at least one command)`() {
+        // given
+        val maestroCommand = MaestroCommand(backPressCommand = BackPressCommand())
+
+        // when
+        val description = maestroCommand.description()
+
+        // then
+        assertThat(description)
+            .isEqualTo("Press back")
+    }
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
@@ -7,7 +7,7 @@ internal class MaestroCommandTest {
     @Test
     fun `description (no commands)`() {
         // given
-        val maestroCommand = MaestroCommand()
+        val maestroCommand = MaestroCommand(null)
 
         // when
         val description = maestroCommand.description()
@@ -20,7 +20,7 @@ internal class MaestroCommandTest {
     @Test
     fun `description (at least one command)`() {
         // given
-        val maestroCommand = MaestroCommand(backPressCommand = BackPressCommand())
+        val maestroCommand = MaestroCommand(BackPressCommand())
 
         // when
         val description = maestroCommand.description()

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -252,21 +252,7 @@ internal class YamlCommandReaderTest {
     }
 
     private fun commands(vararg commands: Command): List<MaestroCommand> {
-        return commands.map(this::toMaestroCommand).toList()
-    }
-
-    private fun toMaestroCommand(command: Command): MaestroCommand {
-        val constructor = MaestroCommand::class.java.constructors[1]
-        val parameterIndex = constructor.parameterTypes.indexOf(command::class.java)
-        if (parameterIndex == -1) throw IllegalArgumentException("Unsupported command type: ${command::class.java}")
-        val args = constructor.parameters.map { parameter ->
-            when (parameter.type) {
-                command::class.java -> command
-                Int::class.java -> 0
-                else -> null
-            }
-        }
-        return constructor.newInstance(*args.toTypedArray()) as MaestroCommand
+        return commands.map(::MaestroCommand).toList()
     }
 
     private fun parseCommands(): List<MaestroCommand> {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -485,14 +485,14 @@ class IntegrationTest {
         assertThat(commands).isEqualTo(
             listOf(
                 MaestroCommand(
-                    applyConfigurationCommand = ApplyConfigurationCommand(
+                    ApplyConfigurationCommand(
                         config = MaestroConfig(
                             appId = "com.example.app",
                             initFlow = MaestroInitFlow(
                                 appId = "com.example.app",
                                 commands = listOf(
                                     MaestroCommand(
-                                        launchAppCommand = LaunchAppCommand(
+                                        LaunchAppCommand(
                                             appId = "com.example.app"
                                         )
                                     )
@@ -502,7 +502,7 @@ class IntegrationTest {
                     ),
                 ),
                 MaestroCommand(
-                    launchAppCommand = LaunchAppCommand(
+                    LaunchAppCommand(
                         appId = "com.example.app"
                     )
                 )


### PR DESCRIPTION
This is the same set of changes from https://github.com/mobile-dev-inc/maestro/pull/150 but with added tests for `MaestroCommand` serialisation for the backend.

**Things to note**
1. The `MaestroCommandSerializer` has two exceptions with property names `tapOnPoint` and `tapOnPoint`. The rest of the commands have a `Command` suffix (e.g. `swipeCommand`). We preserve this behavior so that the contract with the backend remains the same after the refactor.
2. The `MaestroCommandSerializationTest` has duplication. I found IntelliJ's syntax highlighting from language injection (`@Language("json")`) useful in the IDE. We could go with a JUnit parameterised test or a combination approval test if you find it too verbose.
3. I have added a comment to `MaestroCommand` on why we need the custom serializer.

If this PR gets accepted, the next steps are the same as discussed in #150 (starting with `Orchestra.executeCommand`).