### PR TITLE
Fix: populate iOS accessibility value

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -141,9 +141,12 @@ class IOSDriver(
             children = accessibilityNodes.map { node ->
                 val attributes = mutableMapOf<String, String>()
 
-                (node.title ?: node.axLabel)?.let {
-                    attributes["text"] = it
-                }
+                (node.title
+                    ?: node.axLabel
+                    ?: node.axValue
+                    )?.let {
+                        attributes["text"] = it
+                    }
 
                 (node.axUniqueId)?.let {
                     attributes["resource-id"] = it

--- a/maestro-ios/src/main/java/ios/device/AccessibilityNode.kt
+++ b/maestro-ios/src/main/java/ios/device/AccessibilityNode.kt
@@ -26,7 +26,8 @@ data class AccessibilityNode(
     val title: String?,
     val type: String?,
     @SerializedName("AXUniqueId") val axUniqueId: String?,
-    @SerializedName("AXLabel") val axLabel: String?
+    @SerializedName("AXLabel") val axLabel: String?,
+    @SerializedName("AXValue") val axValue: String?,
 ) {
 
     data class Frame(


### PR DESCRIPTION
Text fields have their value (and Hint) reported as `AXValue` field that we were not taking into account.