### PR TITLE
feat: add hideKeyboard event

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -59,4 +59,6 @@ interface Driver {
 
     fun openLink(link: String)
 
+    fun hideKeyboard()
+
 }

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -81,6 +81,13 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
+    fun hideKeyboard() {
+        LOGGER.info("Hiding Keyboard")
+
+        driver.hideKeyboard()
+        waitForAppToSettle()
+    }
+
     fun swipe(start: Point, end: Point) {
         LOGGER.info("Swiping from (${start.x},${start.y}) to (${end.x},${end.y})")
 

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -224,6 +224,10 @@ class AndroidDriver(
         dadb.shell("input keyevent 4")
     }
 
+    override fun hideKeyboard() {
+        dadb.shell("input keyevent 111")
+    }
+
     override fun inputText(text: String) {
         dadb.shell("input text \"$text\"")
     }

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -220,6 +220,8 @@ class IOSDriver(
 
     override fun backPress() {}
 
+    override fun hideKeyboard() {}
+
     override fun inputText(text: String) {
         iosDevice.input(text).expect {}
     }

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -220,7 +220,9 @@ class IOSDriver(
 
     override fun backPress() {}
 
-    override fun hideKeyboard() {}
+    override fun hideKeyboard() {
+        iosDevice.pressKey(41).expect {}
+    }
 
     override fun inputText(text: String) {
         iosDevice.input(text).expect {}

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -97,6 +97,31 @@ class BackPressCommand : Command {
     }
 }
 
+class HideKeyboardCommand : Command {
+
+    override fun equals(other: Any?): Boolean {
+        if (this == other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+
+    override fun toString(): String {
+        return "HideKeyboardCommand()"
+    }
+
+    override fun description(): String {
+        return "Hide Keyboard"
+    }
+
+    override fun injectEnv(env: Map<String, String>): HideKeyboardCommand {
+        return this
+    }
+}
+
 data class TapOnElementCommand(
     val selector: ElementSelector,
     val retryIfNoChange: Boolean? = null,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -121,6 +121,7 @@ class Orchestra(
             }
             is TapOnPointCommand -> tapOnPoint(command, command.retryIfNoChange ?: true)
             is BackPressCommand -> maestro.backPress()
+            is HideKeyboardCommand -> maestro.hideKeyboard()
             is ScrollCommand -> maestro.scrollVertical()
             is SwipeCommand -> swipeCommand(command)
             is AssertCommand -> assertCommand(command)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -24,6 +24,7 @@ import maestro.KeyCode
 import maestro.Point
 import maestro.orchestra.AssertCommand
 import maestro.orchestra.BackPressCommand
+import maestro.orchestra.HideKeyboardCommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.ElementTrait
 import maestro.orchestra.EraseTextCommand
@@ -67,6 +68,7 @@ data class YamlFluentCommand(
             eraseText != null -> MaestroCommand(EraseTextCommand(charactersToErase = eraseText.charactersToErase))
             action != null -> when (action) {
                 "back" -> MaestroCommand(BackPressCommand())
+                "hide keyboard" -> MaestroCommand(HideKeyboardCommand())
                 "scroll" -> MaestroCommand(ScrollCommand())
                 else -> error("Unknown navigation target: $action")
             }
@@ -236,6 +238,10 @@ data class YamlFluentCommand(
 
                 "back" -> YamlFluentCommand(
                     action = "back"
+                )
+
+                "hide keyboard" -> YamlFluentCommand(
+                    action = "hide keyboard"
                 )
 
                 "scroll" -> YamlFluentCommand(

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -162,6 +162,12 @@ class FakeDriver : Driver {
         events += Event.BackPress
     }
 
+    override fun hideKeyboard() {
+        ensureOpen()
+
+        events += Event.HideKeyboard
+    }
+
     override fun inputText(text: String) {
         ensureOpen()
 
@@ -232,6 +238,8 @@ class FakeDriver : Driver {
         object Scroll : Event(), UserInteraction
 
         object BackPress : Event(), UserInteraction
+
+        object HideKeyboard : Event(), UserInteraction
 
         data class InputText(
             val text: String

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1018,24 +1018,6 @@ class IntegrationTest {
         // Expect exception
     }
 
-    @Test
-    fun `Case 038 - Hide keyboard`() {
-        // Given
-        val commands = readCommands("038_hide_keyboard")
-
-        val driver = driver {
-        }
-
-        // When
-        Maestro(driver).use {
-            orchestra(it).runFlow(commands)
-        }
-
-        // Then
-        // No test failure
-        driver.assertHasEvent(Event.HideKeyboard)
-    }
-
     private fun orchestra(it: Maestro) = Orchestra(it, lookupTimeoutMs = 0L, optionalLookupTimeoutMs = 0L)
 
     private fun driver(builder: FakeLayoutElement.() -> Unit): FakeDriver {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1018,6 +1018,24 @@ class IntegrationTest {
         // Expect exception
     }
 
+    @Test
+    fun `Case 038 - Hide keyboard`() {
+        // Given
+        val commands = readCommands("038_hide_keyboard")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertHasEvent(Event.HideKeyboard)
+    }
+
     private fun orchestra(it: Maestro) = Orchestra(it, lookupTimeoutMs = 0L, optionalLookupTimeoutMs = 0L)
 
     private fun driver(builder: FakeLayoutElement.() -> Unit): FakeDriver {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1049,6 +1049,24 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 039 - Hide keyboard`() {
+        // Given
+        val commands = readCommands("039_hide_keyboard")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertHasEvent(Event.HideKeyboard)
+    }
+
     private fun orchestra(it: Maestro) = Orchestra(it, lookupTimeoutMs = 0L, optionalLookupTimeoutMs = 0L)
 
     private fun driver(builder: FakeLayoutElement.() -> Unit): FakeDriver {

--- a/maestro-test/src/test/resources/038_hide_keyboard.yaml
+++ b/maestro-test/src/test/resources/038_hide_keyboard.yaml
@@ -1,3 +1,0 @@
-appId: com.example.app
----
-- action: hideKeyboard

--- a/maestro-test/src/test/resources/038_hide_keyboard.yaml
+++ b/maestro-test/src/test/resources/038_hide_keyboard.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- action: hideKeyboard

--- a/maestro-test/src/test/resources/039_hide_keyboard.yaml
+++ b/maestro-test/src/test/resources/039_hide_keyboard.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- action: hideKeyboard

--- a/maestro-test/src/test/resources/039_hide_keyboard.yaml
+++ b/maestro-test/src/test/resources/039_hide_keyboard.yaml
@@ -1,3 +1,3 @@
 appId: com.example.app
 ---
-- action: hideKeyboard
+- action: hide keyboard


### PR DESCRIPTION
hi @dmitry-zaitsev 

## description

I have an issue when try to `tapOn` a button that blocked by device keyboard.

- the UI before keyboard is showing
![image](https://user-images.githubusercontent.com/6134774/189618544-c485a1b9-90af-4a8d-b974-1b5b391637eb.png)

- the UI after keyboard is showing
![image](https://user-images.githubusercontent.com/6134774/189619977-18cc2e02-2d47-4f6b-a900-2a3f239a3817.png)

## solution

I've tried to add `hideKeyboard()` event to avoid that failed case (before `tapOn()` desired button)
