### PR TITLE
Tweak: allowing to skip package name when matching by id

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
@@ -59,7 +59,7 @@ class QueryCommand : Runnable {
             }
 
             id?.let {
-                filters += Filters.idMatches(it.toRegex(Orchestra.REGEX_OPTIONS)).asFilter()
+                filters += Filters.idMatches(it.toRegex(Orchestra.REGEX_OPTIONS))
             }
 
             if (filters.isEmpty()) {

--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -63,11 +63,27 @@ object Filters {
         }
     }
 
-    fun idMatches(regex: Regex): ElementLookupPredicate {
-        return {
-            it.attributes["resource-id"]?.let { value ->
-                regex.matches(value)
-            } ?: false
+    fun idMatches(regex: Regex): ElementFilter {
+        return { nodes ->
+            val exactMatches = nodes
+                .filter {
+                    it.attributes["resource-id"]?.let { value ->
+                        regex.matches(value)
+                    } ?: false
+                }
+                .toSet()
+
+            val idWithoutPrefixMatches = nodes
+                .filter {
+                    it.attributes["resource-id"]?.let { value ->
+                        regex.matches(value.substringAfterLast('/'))
+                    } ?: false
+                }
+                .toSet()
+
+            exactMatches
+                .union(idWithoutPrefixMatches)
+                .toList()
         }
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -224,7 +224,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun findElementByIdRegex(regex: Regex, timeoutMs: Long): UiElement {
         LOGGER.info("Looking for element by id regex: ${regex.pattern} (timeout $timeoutMs)")
 
-        return findElementWithTimeout(timeoutMs, Filters.idMatches(regex).asFilter())
+        return findElementWithTimeout(timeoutMs, Filters.idMatches(regex))
             ?: throw MaestroException.ElementNotFound(
                 "No element has id that matches regex $regex",
                 viewHierarchy().root

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -282,7 +282,7 @@ class Orchestra(
         selector.idRegex
             ?.let {
                 descriptions += "Id matching regex: $it"
-                filters += Filters.idMatches(it.toRegex(REGEX_OPTIONS)).asFilter()
+                filters += Filters.idMatches(it.toRegex(REGEX_OPTIONS))
             }
 
         selector.size

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1002,7 +1002,7 @@ class IntegrationTest {
     }
 
     @Test(expected = UnicodeNotSupportedError::class)
-    fun `Case 037 - throw exception when trying to input text with unicode characters`() {
+    fun `Case 037 - Throw exception when trying to input text with unicode characters`() {
         // Given
         val commands = readCommands("037_unicode_input")
 
@@ -1016,6 +1016,37 @@ class IntegrationTest {
 
         // Then
         // Expect exception
+    }
+
+    @Test
+    fun `Case 038 - Partial id matching`() {
+        // Given
+        val commands = readCommands("038_partial_id")
+
+        val driver = driver {
+            element {
+                id = "com.google.android.inputmethod.latin:id/another_keyboard_area"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+
+            element {
+                id = "com.google.android.inputmethod.latin:id/keyboard_area"
+                bounds = Bounds(0, 100, 100, 200)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        driver.assertEvents(
+            listOf(
+                Event.Tap(Point(50, 150)),
+                Event.Tap(Point(50, 50)),
+            )
+        )
     }
 
     private fun orchestra(it: Maestro) = Orchestra(it, lookupTimeoutMs = 0L, optionalLookupTimeoutMs = 0L)

--- a/maestro-test/src/test/resources/038_partial_id.yaml
+++ b/maestro-test/src/test/resources/038_partial_id.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+---
+- tapOn:
+    id: "keyboard_area"
+    retryTapIfNoChange: false
+- tapOn:
+    id: ".*keyboard_area"
+    retryTapIfNoChange: false


### PR DESCRIPTION
There seem to be some confusion about how to match views by ID on Android: #163 

Tweaking the logic to match by ID following this order:
- First, try to find any view with id that matches a regex
- If there is none, find a view where id without package name matches a regex