### PR TITLE
Tweak: increase iOS input latency

### DIFF
--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -192,7 +192,7 @@ class IdbIOSDevice(
             TextInputUtil.textToListOfEvents(text)
                 .forEach {
                     stream.onNext(it)
-                    Thread.sleep(25)
+                    Thread.sleep(75)
                 }
             stream.onCompleted()
         }


### PR DESCRIPTION
It appears that there are still some race conditions: #167 

Introducing 25ms did help greatly last time, tripling the latency just to be on a safe side