### PR TITLE
fix: hideKeyboard didn't work

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -225,7 +225,7 @@ class AndroidDriver(
     }
 
     override fun hideKeyboard() {
-        dadb.shell("input keyevent 111")
+        dadb.shell("input keyevent 66")
     }
 
     override fun inputText(text: String) {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -224,7 +224,7 @@ class IOSDriver(
     override fun backPress() {}
 
     override fun hideKeyboard() {
-        iosDevice.pressKey(41).expect {}
+        iosDevice.pressKey(40).expect {}
     }
 
     override fun inputText(text: String) {


### PR DESCRIPTION
hi @dmitry-zaitsev 

just realized that `escape` key didn't work on latest android API.
I've updated the `keyevent` both on `android` and `ios`.

please let me know if I miss anything 🙇🏻 