### PR TITLE
Tweak: Comparing screenshots after tapping on a view

### DIFF
--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -50,11 +50,11 @@ dependencies {
     api "dev.mobile:dadb:1.1.0"
     api "org.slf4j:slf4j-simple:1.7.36"
     api 'com.squareup.okio:okio:3.2.0'
+    api 'com.github.romankh3:image-comparison:4.4.0'
 
     implementation project(':maestro-ios')
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'de.upb.cs.swt:axml:2.1.2'
-    implementation 'com.github.romankh3:image-comparison:4.4.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation project(':maestro-ios')
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'de.upb.cs.swt:axml:2.1.2'
+    implementation 'com.github.romankh3:image-comparison:4.4.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -197,7 +197,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
                     screenshotAfterTap
                 ).compareImages().differencePercent
 
-                if (imageDiff > 0.005) {
+                if (imageDiff > SCREENSHOT_DIFF_THRESHOLD) {
                     LOGGER.info("Something have changed in the UI judging by screenshot (d=$imageDiff). Proceed.")
                     return
                 } else {
@@ -360,6 +360,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     companion object {
 
         private val LOGGER = LoggerFactory.getLogger(Maestro::class.java)
+        private const val SCREENSHOT_DIFF_THRESHOLD = 0.005 // 0.5%
 
         fun ios(host: String, port: Int): Maestro {
             val channel = ManagedChannelBuilder.forAddress(host, port)

--- a/maestro-test/build.gradle
+++ b/maestro-test/build.gradle
@@ -6,10 +6,10 @@ dependencies {
     implementation project(":maestro-orchestra")
     implementation project(':maestro-client')
     implementation 'com.google.truth:truth:1.1.3'
+    implementation 'com.squareup.okio:okio:3.2.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-    testImplementation 'com.squareup.okio:okio:3.0.0'
 }
 
 test {

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeLayoutElement.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeLayoutElement.kt
@@ -20,12 +20,16 @@
 package maestro.test.drivers
 
 import maestro.TreeNode
+import java.awt.Color
+import java.awt.Graphics
 
 data class FakeLayoutElement(
     var id: String? = null,
     var text: String? = null,
     var bounds: Bounds? = null,
     var clickable: Boolean = false,
+    var color: Color = Color.BLACK,
+    var onClick: (FakeLayoutElement) -> Unit = {},
     val children: MutableList<FakeLayoutElement> = mutableListOf(),
 ) {
 
@@ -58,11 +62,54 @@ data class FakeLayoutElement(
         return child
     }
 
+    fun draw(graphics: Graphics) {
+        bounds?.let { b ->
+            val previousColor = graphics.color
+
+            graphics.color = color
+            graphics.drawRect(
+                b.left,
+                b.top,
+                b.right - b.left,
+                b.bottom - b.top
+            )
+
+            text?.let {
+                graphics.drawString(it, b.left, b.top)
+            }
+
+            graphics.color = previousColor
+        }
+
+        children.forEach { it.draw(graphics) }
+    }
+
+    fun dispatchClick(x: Int, y: Int): Boolean {
+        children.forEach {
+            if (it.dispatchClick(x, y)) {
+                return true
+            }
+        }
+
+        return if (bounds?.contains(x, y) == true) {
+            onClick(this)
+            true
+        } else {
+            false
+        }
+    }
+
     data class Bounds(
         val left: Int,
         val top: Int,
         val right: Int,
         val bottom: Int,
-    )
+    ) {
+
+        fun contains(x: Int, y: Int): Boolean {
+            return x in left..right && y in top..bottom
+        }
+
+    }
 
 }


### PR DESCRIPTION
One of the common sources of confusion when using Maestro is - why sometimes we tap on a view multiple times?

This PR helps to mitigate that by _also_ comparing screenshots before and after user interaction to verify that indeed something have visibly changed in the hierarchy.

To facilitate the testing, `FakeDriver` was updated to actually draw a screen onto an image, just like a real device would.