### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Install [Facebook IDB](https://fbidb.io/) tool
 
 ```
 brew tap facebook/fb
-brew install idb-companion
+brew install facebook/fb/idb-companion
 ```
 
 And launch it:


### PR DESCRIPTION
### Before this PR
Following the installation process in the documentation gives an error:
<img width="750" alt="image" src="https://user-images.githubusercontent.com/26744253/191195506-1972d210-10c0-4603-ab85-3b81d741525d.png">

### Problem
There are 2 taps with the same name which causes an installation conflict: 
- `mobile-dev-inc/tap/idb-companion`
- `facebook/fb/idb-companion`

I have imagined that the one from `facebook` is for now the correct one, and I have opened a pull request in order that the installation process doesn't throw an error anymore. Let me know if the one from `mobile-dev-inc` is the correct one and I can change my PR.

Have a good day and thanks for this library 🙌