### PR TITLE
Opens only app based launcher activity in case of 3rd party launcher

### DIFF
--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -51,6 +51,8 @@ dependencies {
     api "org.slf4j:slf4j-simple:1.7.36"
     api 'com.squareup.okio:okio:3.2.0'
     api 'com.github.romankh3:image-comparison:4.4.0'
+    api "com.android.tools:sdk-common:30.3.0"
+    api "com.android.tools.apkparser:apkanalyzer:30.3.0"
 
     implementation project(':maestro-ios')
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
@@ -37,6 +37,15 @@ object AndroidAppFiles {
         }
     }
 
+    fun getApkFile(dadb: Dadb, appId: String): File {
+        val apkPath = dadb.shell("pm list packages -f | grep $appId")
+            .output.substringAfterLast("package:").substringBefore("=$appId")
+        apkPath.substringBefore("=$appId")
+        val dst = File.createTempFile("tmp", ".apk")
+        dadb.pull(dst, apkPath)
+        return dst
+    }
+
     fun push(dadb: Dadb, packageName: String, appFilesZip: File) {
         val remoteZip = "/data/local/tmp/app.zip"
         dadb.push(appFilesZip, remoteZip)

--- a/maestro-client/src/main/java/maestro/android/AndroidExt.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidExt.kt
@@ -1,0 +1,32 @@
+package maestro.android
+
+import com.android.ide.common.xml.AndroidManifestParser
+import com.android.ide.common.xml.ManifestData
+import com.android.tools.apk.analyzer.Archive
+import com.android.tools.apk.analyzer.Archives
+import com.android.tools.apk.analyzer.BinaryXmlParser
+import org.xml.sax.SAXException
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.io.IOException
+import java.nio.file.Files
+import javax.xml.parsers.ParserConfigurationException
+
+fun File.asManifest(): ManifestData {
+    return Archives.open(toPath()).use { context -> getManifestData(context.archive) }
+}
+
+@Throws(IOException::class)
+private fun getManifestData(archive: Archive): ManifestData {
+    val manifestPath = archive.contentRoot.resolve("AndroidManifest.xml")
+    val manifestBytes = BinaryXmlParser.decodeXml(
+        "AndroidManifest.xml", Files.readAllBytes(manifestPath)
+    )
+    return try {
+        AndroidManifestParser.parse(ByteArrayInputStream(manifestBytes))
+    } catch (e: ParserConfigurationException) {
+        throw IOException(e)
+    } catch (e: SAXException) {
+        throw IOException(e)
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/mobile-dev-inc/maestro/issues/172

## Reproducing the issue

1. Implementing leakcanary
2. Write down the following test:
```
val dadb =  Dadb.create("localhost", 5555)
val maestro = Maestro.android(dadb)
repeat(10) {
    maestro.launchApp("com.example.name")
    Thread.sleep(3000)
}
```
Was able to observe that out of 10 majority times leak canary launcher opens

## Fix
Check for launcher activities and opens the one which starts with the app id passed. Since all the third-party ones will start with different package id.
