### PR TITLE
Tweak: scanning contents of iOS group views to try and find more children

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -127,9 +127,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     ) {
         LOGGER.info("Tapping on element: $element")
 
-        waitForAppToSettle()
-
-        val hierarchyBeforeTap = viewHierarchy()
+        val hierarchyBeforeTap = waitForAppToSettle()
 
         val center = (
             hierarchyBeforeTap
@@ -139,7 +137,12 @@ class Maestro(private val driver: Driver) : AutoCloseable {
                 ?: element
             ).bounds
             .center()
-        tap(center.x, center.y, retryIfNoChange, longPress)
+        tap(
+            center.x,
+            center.y,
+            retryIfNoChange,
+            longPress
+        )
 
         val hierarchyAfterTap = viewHierarchy()
 
@@ -177,9 +180,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
             } else {
                 driver.tap(Point(x, y))
             }
-            waitForAppToSettle()
-
-            val hierarchyAfterTap = viewHierarchy()
+            val hierarchyAfterTap = waitForAppToSettle()
 
             if (hierarchyBeforeTap != hierarchyAfterTap) {
                 LOGGER.info("Something have changed in the UI judging by view hierarchy. Proceed.")
@@ -229,7 +230,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     }
 
     private fun getNumberOfRetries(retryIfNoChange: Boolean): Int {
-        return if (retryIfNoChange) 3 else 1
+        return if (retryIfNoChange) 2 else 1
     }
 
     fun pressKey(code: KeyCode) {
@@ -295,18 +296,23 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return filter(viewHierarchy().aggregate())
     }
 
-    private fun waitForAppToSettle() {
+    private fun waitForAppToSettle(): ViewHierarchy {
         // Time buffer for any visual effects and transitions that might occur between actions.
         MaestroTimer.sleep(MaestroTimer.Reason.BUFFER, 300)
 
         val hierarchyBefore = viewHierarchy()
+        var latestHierarchy: ViewHierarchy? = null
         repeat(10) {
             val hierarchyAfter = viewHierarchy()
             if (hierarchyBefore == hierarchyAfter) {
-                return
+                return hierarchyAfter
             }
+
+            latestHierarchy = hierarchyAfter
             MaestroTimer.sleep(MaestroTimer.Reason.WAIT_TO_SETTLE, 200)
         }
+
+        return latestHierarchy ?: hierarchyBefore
     }
 
     fun inputText(text: String) {

--- a/maestro-ios/src/main/java/ios/IOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/IOSDevice.kt
@@ -33,6 +33,8 @@ interface IOSDevice : AutoCloseable {
 
     fun contentDescriptor(): Result<List<AccessibilityNode>, Throwable>
 
+    fun describePoint(x: Int, y: Int): Result<List<AccessibilityNode>, Throwable>
+
     fun tap(x: Int, y: Int): Result<Unit, Throwable>
 
     fun longPress(x: Int, y: Int): Result<Unit, Throwable>

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -86,6 +86,22 @@ class IdbIOSDevice(
         }
     }
 
+    override fun describePoint(x: Int, y: Int): Result<List<AccessibilityNode>, Throwable> {
+        return runCatching {
+            val response = blockingStub.accessibilityInfo(accessibilityInfoRequest {
+                point = point {
+                    this.x = x.toDouble()
+                    this.y = y.toDouble()
+                }
+                format = Idb.AccessibilityInfoRequest.Format.NESTED
+            })
+
+            listOf(
+                GSON.fromJson(response.json, AccessibilityNode::class.java)
+            )
+        }
+    }
+
     override fun tap(x: Int, y: Int): Result<Unit, Throwable> {
         return press(x, y, holdDelay = 50)
     }
@@ -330,7 +346,7 @@ class IdbIOSDevice(
 
     override fun clearKeychain(): Result<Unit, Throwable> {
         return runCatching {
-            blockingStub.clearKeychain(clearKeychainRequest {  })
+            blockingStub.clearKeychain(clearKeychainRequest { })
         }
     }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -208,7 +208,7 @@ class IntegrationTest {
 
         // Then
         // No test failure
-        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 4)
+        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 3)
     }
 
     @Test


### PR DESCRIPTION
- Using `idb.describePoint` to find children of a tab bar view
- Improving efficiency of Maestro by removing redundant `viewHierarchy()` calls and reducing number of tap probes from 3 to 2