### PR TITLE
Fix: removed internal modifier

### DIFF
--- a/maestro-ios/src/main/java/ios/idb/TextInputUtil.kt
+++ b/maestro-ios/src/main/java/ios/idb/TextInputUtil.kt
@@ -24,7 +24,7 @@ import idb.Idb.HIDEvent
 import idb.Idb.HIDEvent.HIDPress
 import idb.hIDEvent
 
-internal object TextInputUtil {
+object TextInputUtil {
 
     /*
      * Implementation is borrowed from Python idb client


### PR DESCRIPTION
## Issues Fixed

On mobile.dev side, we are getting the following exception:

```
Failed to execute maestro commands
com.github.michaelbull.result.UnwrapException: kotlin.Unit java.lang.IllegalAccessError: class ios.idb.IdbIOSDevice tried to access private method 'java.util.List ios.idb.TextInputUtil.keyPressToEvents(long)' (ios.idb.IdbIOSDevice and ios.idb.TextInputUtil are in unnamed module of loader 'app')
    at maestro.drivers.IOSDriver.pressKey(IOSDriver.kt:130)
    at maestro.drivers.IOSDriver.pressKey(IOSDriver.kt:120)
    at maestro.Maestro.pressKey(Maestro.kt:197)
    at maestro.orchestra.Orchestra.eraseTextCommand(Orchestra.kt:155)
    at maestro.orchestra.Orchestra.executeCommand(Orchestra.kt:149)
    at maestro.orchestra.Orchestra.executeCommands(Orchestra.kt:107)
    at maestro.orchestra.Orchestra.runFlow(Orchestra.kt:69)
    at maestro.orchestra.Orchestra.runFlow$default(Orchestra.kt:54)
    at api.benchmark.runner.flow.IOSFlowRunner$runUnsafe$1.invoke(IOSFlowRunner.kt:138)
    at api.benchmark.runner.flow.IOSFlowRunner$runUnsafe$1.invoke(IOSFlowRunner.kt:76)
    at api.benchmark.runner.flow.IOSFlowRunner.withAppArchive(IOSFlowRunner.kt:195)
    at api.benchmark.runner.flow.IOSFlowRunner.runUnsafe(IOSFlowRunner.kt:76)
    at api.benchmark.runner.flow.IOSFlowRunner.run(IOSFlowRunner.kt:63)
    at dev.mobile.worker.services.ProdBenchmarkProcessorService.processBenchmark$lambda-0(ProdBenchmarkProcessorService.kt:83)
    at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
    at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:829)
```

Though hypothetically there should be no issues with `internal` access modifier, in practice it is causing more problems than it solves.