### PR TITLE
Fix: hide keyboard on Android

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -261,6 +261,7 @@ class AndroidDriver(
 
     override fun hideKeyboard() {
         dadb.shell("input keyevent 66")
+        dadb.shell("input keyevent 111")
     }
 
     override fun takeScreenshot(out: Sink) {


### PR DESCRIPTION
## Testing
Tested on an emulator

## Issues Fixed

`hideKeyboard` was not always working

Fixes #229 