### PR TITLE
Tweak: prioritise cliackable elements

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -36,6 +36,8 @@ object Filters {
             ?.toList() ?: emptyList()
     }
 
+    fun compose(first: ElementFilter, second: ElementFilter): ElementFilter = compose(listOf(first, second))
+
     fun compose(filters: List<ElementFilter>): ElementFilter = { nodes ->
         filters
             .fold(nodes) { acc, filter ->
@@ -187,6 +189,12 @@ object Filters {
                     .sortedBy { it.toUiElementOrNull()?.bounds?.y ?: Int.MAX_VALUE }
                     .getOrNull(idx)
             )
+        }
+    }
+
+    fun clickableFirst(): ElementFilter {
+        return { nodes ->
+            nodes.sortedByDescending { it.clickable }
         }
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -353,19 +353,21 @@ class Orchestra(
                 filters += filter
             }
 
-        val finalFilter = selector.index
+        var resultFilter = Filters.intersect(filters)
+        resultFilter = selector.index
             ?.let {
                 Filters.compose(
-                    listOf(
-                        Filters.intersect(filters),
-                        Filters.index(it),
-                    )
+                    resultFilter,
+                    Filters.index(it)
                 )
-            } ?: Filters.intersect(filters)
+            } ?: Filters.compose(
+            resultFilter,
+            Filters.clickableFirst()
+        )
 
         return FilterWithDescription(
             descriptions.joinToString(", "),
-            finalFilter,
+            resultFilter,
         )
     }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1343,6 +1343,41 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 048 - tapOn prioritises clickable elements`() {
+        // Given
+        val commands = readCommands("048_tapOn_clickable")
+
+        val driver = driver {
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 200, 200)
+                clickable = true
+
+                onClick = {
+                    text = "Clicked"
+                }
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.Tap(Point(100, 100)),
+            )
+        )
+    }
+
     private fun orchestra(it: Maestro) = Orchestra(it, lookupTimeoutMs = 0L, optionalLookupTimeoutMs = 0L)
 
     private fun driver(builder: FakeLayoutElement.() -> Unit): FakeDriver {

--- a/maestro-test/src/test/resources/048_tapOn_clickable.yaml
+++ b/maestro-test/src/test/resources/048_tapOn_clickable.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- tapOn: Button


### PR DESCRIPTION
## Proposed Changes

When selecting an element among multiple matching candidates, prioritise ones that have `clickable=true`. Note that we keep the default behaviour in cases where `index` is specified explicitly

## Testing
Added integration test

## Issues Fixed

Fixes #228 