### PR TITLE
Enable USB support for Android

### DIFF
--- a/maestro-cli/build.gradle
+++ b/maestro-cli/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     implementation project(':maestro-client')
     implementation project(':maestro-orchestra')
-    implementation "dev.mobile:dadb:1.1.0"
+    implementation "dev.mobile:dadb:1.2.0"
     implementation 'info.picocli:picocli:4.5.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2'

--- a/maestro-cli/src/main/java/maestro/cli/util/MaestroFactory.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/MaestroFactory.kt
@@ -22,6 +22,7 @@ package maestro.cli.util
 import maestro.Maestro
 import maestro.utils.SocketUtils.isPortOpen
 import dadb.Dadb
+import dadb.adbserver.AdbServerDadb
 
 object MaestroFactory {
     private const val defaultHost = "localhost"
@@ -48,10 +49,19 @@ object MaestroFactory {
             Dadb.create(host ?: defaultHost, port)
         } else {
             Dadb.discover(host ?: defaultHost)
+                ?: createAdbServerDadb()
                 ?: throw IllegalStateException("No android devices found.")
         }
 
         return Maestro.android(dadb)
+    }
+
+    private fun createAdbServerDadb(): Dadb? {
+        return try {
+            AdbServerDadb.create()
+        } catch (e: Exception) {
+            null
+        }
     }
 
     private fun createIos(host: String?, port: Int?): Maestro {

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     api 'io.grpc:grpc-okhttp:1.45.0'
     api 'com.google.protobuf:protobuf-kotlin:3.19.4'
     api 'com.michael-bull.kotlin-result:kotlin-result:1.1.14'
-    api "dev.mobile:dadb:1.1.0"
+    api "dev.mobile:dadb:1.2.0"
     api "org.slf4j:slf4j-simple:1.7.36"
     api 'com.squareup.okio:okio:3.2.0'
     api 'com.github.romankh3:image-comparison:4.4.0'


### PR DESCRIPTION
## Proposed Changes

Maestro now supports any Android device that is supported by a local adb server. This includes USB devices!

## Testing
Tested that Android Emulator and Physical device interaction works as expected.

## Issues Fixed

#80 