### PR TITLE
Also text match axUniqueId and axValue in iOS Driver

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -181,15 +181,21 @@ class IOSDriver(
                 val attributes = mutableMapOf<String, String>()
 
                 (node.title
+                    ?: node.axUniqueId
                     ?: node.axLabel
                     ?: node.axValue
                     )?.let {
                         attributes["text"] = it
                     }
 
+                node.title?.let { attributes["title"] = it }
+
                 (node.axUniqueId)?.let {
                     attributes["resource-id"] = it
                 }
+
+                node.axLabel?.let { attributes["label"] = it }
+                node.axValue?.let { attributes["value"] = it }
 
                 node.frame?.let {
                     val left = it.x.toInt()


### PR DESCRIPTION
## Proposed Changes
iOS elements can have only a axValue and no title or axLabel.
This change enables text matching on both axUniqueId (which can be set by the engineer) and axValue (which is automatically set by UIKit).


## Testing
Manually tested
