### PR TITLE
breaking change: change upload name to be an option instead of positional argument

### DIFF
--- a/maestro
+++ b/maestro
@@ -3,4 +3,4 @@
 set -e
 
 ./gradlew :maestro-cli:installDist -q
-./maestro-cli/build/install/maestro/bin/maestro $*
+./maestro-cli/build/install/maestro/bin/maestro "$@"

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -82,7 +82,7 @@ class ApiClient(
         authToken: String,
         appFile: Path,
         workspaceZip: Path,
-        uploadName: String,
+        uploadName: String?,
         mappingFile: Path?,
         repoOwner: String?,
         repoName: String?,
@@ -94,7 +94,9 @@ class ApiClient(
         if (!workspaceZip.exists()) throw CliError("Workspace zip does not exist: ${workspaceZip.absolutePathString()}")
 
         val requestPart = mutableMapOf<String, String>()
-        requestPart["benchmarkName"] = uploadName
+        if (uploadName != null) {
+            requestPart["benchmarkName"] = uploadName
+        }
         repoOwner?.let { requestPart["repoOwner"] = it }
         repoName?.let { requestPart["repoName"] = it }
         branch?.let { requestPart["branch"] = it }

--- a/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
@@ -49,9 +49,6 @@ import kotlin.system.exitProcess
 )
 class UploadCommand : Callable<Int> {
 
-    @CommandLine.Parameters(description = ["The name of this upload"])
-    private lateinit var uploadName: String
-
     @CommandLine.Parameters(description = ["App binary to run your Flows against"])
     private lateinit var appFile: File
 
@@ -81,6 +78,9 @@ class UploadCommand : Callable<Int> {
 
     @Option(order = 7, names = ["-e", "--env"], description = ["Environment variables to inject into your Flows"])
     private var env: Map<String, String> = emptyMap()
+
+    @Option(order = 8, names = ["--name"], description = ["Name of the upload"])
+    private var uploadName: String? = null
 
     private lateinit var client: ApiClient
 


### PR DESCRIPTION
As the mobile.dev backend has been updated to not require an upload name, this change aligns maestro-cli with this change and makes the upload name an optional parameter instead of a positional argument.

**Usage**
Before
`maestro upload TestUpload <appFile> <flowFile>`

After
`maestro upload --name TestUpload <appFile> <flowFile>`