### PR TITLE
Feature: enabled property + extra comparison properties

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -19,6 +19,7 @@
 
 package maestro.cli.command
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import maestro.cli.App
 import maestro.cli.util.MaestroFactory
@@ -35,6 +36,7 @@ class PrintHierarchyCommand : Runnable {
     override fun run() {
         MaestroFactory.createMaestro(parent?.platform, parent?.host, parent?.port).use {
             val hierarchy = jacksonObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .writerWithDefaultPrettyPrinter()
                 .writeValueAsString(it.viewHierarchy().root)
 

--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -198,4 +198,10 @@ object Filters {
         }
     }
 
+    fun enabled(expected: Boolean): ElementFilter {
+        return { nodes ->
+            nodes.filter { it.enabled == expected }
+        }
+    }
+
 }

--- a/maestro-client/src/main/java/maestro/TreeNode.kt
+++ b/maestro-client/src/main/java/maestro/TreeNode.kt
@@ -23,6 +23,10 @@ data class TreeNode(
     val attributes: Map<String, String> = emptyMap(),
     val children: List<TreeNode> = emptyList(),
     val clickable: Boolean? = null,
+    val enabled: Boolean? = null,
+    val focused: Boolean? = null,
+    val checked: Boolean? = null,
+    val selected: Boolean? = null,
 ) {
 
     fun aggregate(): List<TreeNode> {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -337,6 +337,22 @@ class AndroidDriver(
                 attributesBuilder["bounds"] = node.getAttribute("bounds")
             }
 
+            if (node.hasAttribute("enabled")) {
+                attributesBuilder["enabled"] = node.getAttribute("enabled")
+            }
+
+            if (node.hasAttribute("focused")) {
+                attributesBuilder["focused"] = node.getAttribute("focused")
+            }
+
+            if (node.hasAttribute("checked")) {
+                attributesBuilder["checked"] = node.getAttribute("checked")
+            }
+
+            if (node.hasAttribute("selected")) {
+                attributesBuilder["selected"] = node.getAttribute("selected")
+            }
+
             attributesBuilder
         } else {
             emptyMap()
@@ -351,11 +367,18 @@ class AndroidDriver(
         return TreeNode(
             attributes = attributes,
             children = children,
-            clickable = (node as? Element)
-                ?.getAttribute("clickable")
-                ?.let { it == "true" }
-                ?: false
+            clickable = node.getBoolean("clickable"),
+            enabled = node.getBoolean("enabled"),
+            focused = node.getBoolean("focused"),
+            checked = node.getBoolean("checked"),
+            selected = node.getBoolean("selected"),
         )
+    }
+
+    private fun Node.getBoolean(name: String): Boolean? {
+        return (this as? Element)
+            ?.getAttribute(name)
+            ?.let { it == "true" }
     }
 
     private fun installMaestroApks() {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -201,7 +201,8 @@ class IOSDriver(
                 }
 
                 TreeNode(
-                    attributes = attributes
+                    attributes = attributes,
+                    enabled = node.enabled,
                 )
             }
         )

--- a/maestro-ios/src/main/java/ios/device/AccessibilityNode.kt
+++ b/maestro-ios/src/main/java/ios/device/AccessibilityNode.kt
@@ -28,6 +28,7 @@ data class AccessibilityNode(
     @SerializedName("AXUniqueId") val axUniqueId: String?,
     @SerializedName("AXLabel") val axLabel: String?,
     @SerializedName("AXValue") val axValue: String?,
+    val enabled: Boolean?,
 ) {
 
     data class Frame(

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -33,6 +33,7 @@ data class ElementSelector(
     val optional: Boolean = false,
     val traits: List<ElementTrait>? = null,
     val index: Int? = null,
+    val enabled: Boolean? = null,
 ) {
 
     data class SizeSelector(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -468,6 +468,16 @@ class Orchestra(
                 filters += filter
             }
 
+        selector.enabled
+            ?.let {
+                descriptions += if (it) {
+                    "Enabled"
+                } else {
+                    "Disabled"
+                }
+                filters += Filters.enabled(it)
+            }
+
         var resultFilter = Filters.intersect(filters)
         resultFilter = selector.index
             ?.let {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -41,4 +41,5 @@ data class YamlElementSelector(
     val containsChild: YamlElementSelectorUnion? = null,
     val traits: String? = null,
     val index: Int? = null,
+    val enabled: Boolean? = null,
 ) : YamlElementSelectorUnion

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -343,6 +343,7 @@ data class YamlFluentCommand(
                 ?.split(" ")
                 ?.map { ElementTrait.valueOf(it.replace('-', '_').uppercase()) },
             index = selector.index,
+            enabled = selector.enabled,
             optional = selector.optional ?: false,
         )
     }

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeLayoutElement.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeLayoutElement.kt
@@ -28,6 +28,7 @@ data class FakeLayoutElement(
     var text: String? = null,
     var bounds: Bounds? = null,
     var clickable: Boolean = false,
+    var enabled: Boolean = true,
     var color: Color = Color.BLACK,
     var onClick: (FakeLayoutElement) -> Unit = {},
     val children: MutableList<FakeLayoutElement> = mutableListOf(),
@@ -51,6 +52,7 @@ data class FakeLayoutElement(
         return TreeNode(
             attributes = attributes,
             clickable = clickable,
+            enabled = enabled,
             children = children.map { it.toTreeNode() }
         )
     }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1535,6 +1535,36 @@ class IntegrationTest {
     }
 
     @Test
+    fun `Case 054 - Enabled state`() {
+        // Given
+        val commands = readCommands("054_enabled")
+
+        val driver = driver {
+
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+                onClick = {
+                    enabled = false
+                }
+            }
+
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEventCount(
+            Event.Tap(Point(50, 50)),
+            1
+        )
+    }
+
+    @Test
     fun `Case 055 - Tap on element - Compare regex`() {
         // Given
         val commands = readCommands("055_compare_regex")

--- a/maestro-test/src/test/resources/054_enabled.yaml
+++ b/maestro-test/src/test/resources/054_enabled.yaml
@@ -1,0 +1,12 @@
+appId: com.other.app
+---
+- assertVisible:
+    text: Button
+    enabled: true
+- tapOn: Button
+- assertNotVisible:
+    text: Button
+    enabled: true
+- assertVisible:
+    text: Button
+    enabled: false


### PR DESCRIPTION
## Proposed Changes

- Introduce `enabled` property into `ElementSelector`
- Introduce `focused`, `selected`, `checked` property in `TreeNode` for better layout change detection (but without introducing them in `ElementSelector` as they are Android-only)

## Testing
- Tested locally on Android and iOS
- Integration tests

## Issues Fixed

Fixes #249