### PR TITLE
Fix: also compare regex as text when searching for view

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -60,7 +60,7 @@ object Filters {
     fun textMatches(regex: Regex): ElementLookupPredicate {
         return {
             it.attributes["text"]?.let { value ->
-                regex.matches(value)
+                regex.matches(value) || regex.pattern == value
             } ?: false
         }
     }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1534,6 +1534,28 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 055 - Tap on element - Compare regex`() {
+        // Given
+        val commands = readCommands("055_compare_regex")
+
+        val driver = driver {
+            element {
+                text = "(Secondary button)"
+                bounds = Bounds(0, 100, 100, 200)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertHasEvent(Event.Tap(Point(50, 150)))
+    }
+
     private fun orchestra(it: Maestro) = Orchestra(it, lookupTimeoutMs = 0L, optionalLookupTimeoutMs = 0L)
 
     private fun driver(builder: FakeLayoutElement.() -> Unit): FakeDriver {

--- a/maestro-test/src/test/resources/055_compare_regex.yaml
+++ b/maestro-test/src/test/resources/055_compare_regex.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- tapOn:
+    text: (Secondary button)


### PR DESCRIPTION
## Proposed Changes

When an element selector contains regex special characters we can easily miss the view, for example:

```
- tapOn: (Hello World)
```

Will not find a view with text `(Hello World)` as parentheses considered to be a part of the regex and are ignored. This fix changes that by also trying to match regex pattern itself against the text

## Testing
- Integration test

## Issues Fixed
Fixes #242 