### PR TITLE
Fix the login command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -156,11 +156,9 @@ class ApiClient(
             .build()
         val response = client.newCall(request).execute()
 
-        response.use {
-            if (!response.isSuccessful) return Err(response)
-            val parsed = JSON.readValue(response.body?.bytes(), T::class.java)
-            return Ok(parsed)
-        }
+        if (!response.isSuccessful) return Err(response)
+        val parsed = JSON.readValue(response.body?.bytes(), T::class.java)
+        return Ok(parsed)
     }
 
     private fun RequestBody.observable(

--- a/maestro-cli/src/main/java/maestro/cli/command/LoginCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/LoginCommand.kt
@@ -22,7 +22,7 @@ class LoginCommand : Callable<Int> {
         val existingToken = auth.getCachedAuthToken()
 
         if (existingToken != null) {
-            message("Already logged in")
+            message("Already logged in. Run \"maestro logout\" to logout.")
             return 0
         }
 


### PR DESCRIPTION
Fixing the following error:
```
maestro login

No auth token found

Sign In or Sign Up using your company email address:
> leland@mobile.dev

We sent a login link to leland@mobile.dev. Click on the link there to finish logging in...
java.lang.IllegalStateException: closed
	at okio.RealBufferedSource.select(RealBufferedSource.kt:218)
	at okhttp3.internal.Util.readBomAsCharset(Util.kt:265)
	at okhttp3.ResponseBody.string(ResponseBody.kt:187)
	at maestro.cli.auth.Auth.triggerSignInFlow(Auth.kt:79)
	at maestro.cli.command.LoginCommand.call(LoginCommand.kt:29)
	at maestro.cli.command.LoginCommand.call(LoginCommand.kt:9)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
	at picocli.CommandLine.access$1200(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2159)
	at picocli.CommandLine.execute(CommandLine.java:2058)
	at maestro.cli.AppKt.main(App.kt:94)
```