### PR TITLE
Feature: added env parameter to runFlow

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -166,6 +166,7 @@ data class YamlFluentCommand(
     private fun runFlow(flowPath: Path, command: YamlRunFlow): List<MaestroCommand> {
         val runFlowPath = getRunFlowPath(flowPath, command.file)
         return YamlCommandReader.readCommands(runFlowPath)
+            .map { it.injectEnv(command.env) }
     }
 
     private fun getRunFlowPath(flowPath: Path, runFlowPath: String): Path {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlRunFlow.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlRunFlow.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 data class YamlRunFlow(
     val file: String,
     val `when`: YamlCondition? = null,
+    val env: Map<String, String> = emptyMap(),
 ) {
 
     companion object {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1621,6 +1621,11 @@ class IntegrationTest {
     fun `Case 057 - Pass inner env variables to runFlow`() {
         // Given
         val commands = readCommands("057_runFlow_env")
+            .map {
+                it.injectEnv(mapOf(
+                    "OUTER_ENV" to "Outer Parameter"
+                ))
+            }
 
         val driver = driver {
         }
@@ -1633,6 +1638,8 @@ class IntegrationTest {
         // Then
         // No test failure
         driver.assertHasEvent(Event.InputText("Inner Parameter"))
+        driver.assertHasEvent(Event.InputText("Outer Parameter"))
+        driver.assertHasEvent(Event.InputText("Overriden Parameter"))
     }
 
     private fun orchestra(maestro: Maestro) = Orchestra(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1617,6 +1617,24 @@ class IntegrationTest {
         driver.assertHasEvent(Event.Tap(Point(50, 150)))
     }
 
+    @Test
+    fun `Case 057 - Pass inner env variables to runFlow`() {
+        // Given
+        val commands = readCommands("057_runFlow_env")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertHasEvent(Event.InputText("Inner Parameter"))
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/057_runFlow_env.yaml
+++ b/maestro-test/src/test/resources/057_runFlow_env.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+---
+- runFlow:
+    file: 057_subflow.yaml
+    env:
+      INNER_ENV: Inner Parameter

--- a/maestro-test/src/test/resources/057_subflow.yaml
+++ b/maestro-test/src/test/resources/057_subflow.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- inputText: ${INNER_ENV}

--- a/maestro-test/src/test/resources/057_subflow.yaml
+++ b/maestro-test/src/test/resources/057_subflow.yaml
@@ -1,3 +1,8 @@
 appId: com.example.app
 ---
 - inputText: ${INNER_ENV}
+- inputText: ${OUTER_ENV}
+- runFlow:
+    file: 057_subflow_override.yaml
+    env:
+      INNER_ENV: Overriden Parameter

--- a/maestro-test/src/test/resources/057_subflow_override.yaml
+++ b/maestro-test/src/test/resources/057_subflow_override.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- inputText: ${INNER_ENV}


### PR DESCRIPTION
## Proposed Changes

Passing variables down to `runFlow` command:

```
- runFlow:
     file: subFlow.yaml
     env:
         SUB_PARAMETER: Hello World
```

Sub flows within a `runFlow` can override parameters with their own values, just like you would expect in any programming language.

## Testing
Integration tests.