### PR TITLE
Feature: Inline env

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -14,6 +14,7 @@ data class YamlConfig(
     val name: String?,
     val appId: String,
     val initFlow: YamlInitFlowUnion?,
+    val env: Map<String, String> = emptyMap(),
 ) {
 
     private val ext = mutableMapOf<String, Any?>()

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1622,9 +1622,11 @@ class IntegrationTest {
         // Given
         val commands = readCommands("057_runFlow_env")
             .map {
-                it.injectEnv(mapOf(
-                    "OUTER_ENV" to "Outer Parameter"
-                ))
+                it.injectEnv(
+                    mapOf(
+                        "OUTER_ENV" to "Outer Parameter"
+                    )
+                )
             }
 
         val driver = driver {
@@ -1639,6 +1641,25 @@ class IntegrationTest {
         // No test failure
         driver.assertHasEvent(Event.InputText("Inner Parameter"))
         driver.assertHasEvent(Event.InputText("Outer Parameter"))
+        driver.assertHasEvent(Event.InputText("Overriden Parameter"))
+    }
+
+    @Test
+    fun `Case 058 - Inline env parameters`() {
+        // Given
+        val commands = readCommands("058_inline_env")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertHasEvent(Event.InputText("Inline Parameter"))
         driver.assertHasEvent(Event.InputText("Overriden Parameter"))
     }
 

--- a/maestro-test/src/test/resources/058_inline_env.yaml
+++ b/maestro-test/src/test/resources/058_inline_env.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+env:
+  INLINE_ENV: Inline Parameter
+---
+- inputText: ${INLINE_ENV}
+- runFlow: 058_subflow.yaml

--- a/maestro-test/src/test/resources/058_subflow.yaml
+++ b/maestro-test/src/test/resources/058_subflow.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+env:
+  INLINE_ENV: Overriden Parameter
+---
+- inputText: ${INLINE_ENV}


### PR DESCRIPTION
## Proposed Changes

Allowing to inline `env` parameters directly in file at the top level.

Why at the top level - since env variables are resolved statically at parsing time, we are not going to be able to handle cases where a user provides multiple `env` commands in a row. Hence limiting it to a top-level field for now.

## Testing
Integration test.