### PR TITLE
Tweak: more robust device-selection logic. Embedding idb_companion

### DIFF
--- a/maestro-cli/build.gradle
+++ b/maestro-cli/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     implementation project(':maestro-client')
     implementation project(':maestro-orchestra')
-    implementation "dev.mobile:dadb:1.2.1"
+    implementation "dev.mobile:dadb:1.2.2"
     implementation 'info.picocli:picocli:4.5.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2'

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -54,7 +54,7 @@ class App {
     var platform: String? = null
 
     @Option(names = ["--host"])
-    var host: String = "localhost"
+    var host: String? = null
 
     @Option(names = ["--port"])
     var port: Int? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -34,7 +34,7 @@ class PrintHierarchyCommand : Runnable {
     private val parent: App? = null
 
     override fun run() {
-        MaestroFactory.createMaestro(parent?.platform, parent?.host, parent?.port).use {
+        MaestroFactory.createMaestro(parent?.host, parent?.port).use {
             val hierarchy = jacksonObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .writerWithDefaultPrettyPrinter()

--- a/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
@@ -51,7 +51,7 @@ class QueryCommand : Runnable {
 
     override fun run() {
 
-        MaestroFactory.createMaestro(parent?.platform, parent?.host, parent?.port).use { maestro ->
+        MaestroFactory.createMaestro(parent?.host, parent?.port).use { maestro ->
             val filters = mutableListOf<ElementFilter>()
 
             text?.let {

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -20,6 +20,7 @@
 package maestro.cli.command
 
 import maestro.cli.App
+import maestro.cli.CliError
 import maestro.cli.runner.TestRunner
 import maestro.cli.util.MaestroFactory
 import picocli.CommandLine
@@ -55,7 +56,11 @@ class TestCommand : Callable<Int> {
             )
         }
 
-        val maestro = MaestroFactory.createMaestro(parent?.platform, parent?.host, parent?.port)
+        if (parent?.platform != null) {
+            throw CliError("--platform option was deprecated. You can remove it to run your test.")
+        }
+
+        val maestro = MaestroFactory.createMaestro(parent?.host, parent?.port)
 
         if (!continuous) return TestRunner.runSingle(maestro, flowFile, env)
 

--- a/maestro-cli/src/main/java/maestro/cli/device/Device.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/Device.kt
@@ -1,0 +1,15 @@
+package maestro.cli.device
+
+data class Device(
+    val id: String,
+    val description: String,
+    val platform: Platform,
+    val connected: Boolean,
+) {
+
+    enum class Platform(val description: String) {
+        ANDROID("Android"),
+        IOS("iOS"),
+    }
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -1,0 +1,160 @@
+package maestro.cli.device
+
+import com.github.michaelbull.result.expect
+import dadb.Dadb
+import io.grpc.ManagedChannelBuilder
+import ios.idb.IdbIOSDevice
+import maestro.MaestroTimer
+import maestro.cli.CliError
+import maestro.cli.device.ios.Simctl
+import maestro.cli.util.EnvUtils
+import java.io.File
+
+object DeviceService {
+
+    fun startDevice(device: Device): Device {
+        when (device.platform) {
+            Device.Platform.IOS -> {
+                Simctl.launchSimulator(device.id)
+                Simctl.awaitLaunch(device.id)
+                return device
+            }
+            Device.Platform.ANDROID -> {
+                val androidHome = EnvUtils.androidHome()
+                    ?: throw CliError("ANDROID_HOME environment variable is not set. Unable to find 'ANDROID_HOME/tools/emulator' executable.")
+
+                ProcessBuilder(
+                    File(androidHome, "tools/emulator").absolutePath,
+                    "@${device.id}",
+                ).start()
+
+                val dadb = MaestroTimer.withTimeout(30000) {
+                    try {
+                        Dadb.discover()
+                    } catch (ignored: Exception) {
+                        Thread.sleep(100)
+                        null
+                    }
+                } ?: throw CliError("Unable to start device: ${device.id}")
+
+                return device.copy(id = dadb.toString())
+            }
+        }
+    }
+
+    fun prepareDevice(device: Device) {
+        if (device.platform == Device.Platform.IOS) {
+            killIdbCompanion()
+            startIdbCompanion(device)
+        }
+    }
+
+    private fun startIdbCompanion(device: Device) {
+        ProcessBuilder("idb_companion", "--udid", device.id)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
+        val iosDevice = IdbIOSDevice(
+            ManagedChannelBuilder.forAddress("localhost", 10882)
+                .usePlaintext()
+                .build()
+        )
+        try {
+            // Try to connect to the device repeatedly
+            MaestroTimer.withTimeout(10000) {
+                try {
+                    iosDevice.deviceInfo().expect {}
+                } catch (ignored: Exception) {
+                    // Ignore
+                    null
+                }
+            } ?: error("idb_companion did not start in time")
+        } finally {
+            iosDevice.close()
+        }
+    }
+
+    private fun killIdbCompanion() {
+        ProcessBuilder("killall", "idb_companion")
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+            .waitFor()
+    }
+
+    fun listConnectedDevices(): List<Device> {
+        return listAvailableDevices()
+            .filter { it.connected }
+    }
+
+    fun listAvailableDevices(): List<Device> {
+        return listAndroidDevices() + listIOSDevices()
+    }
+
+    private fun listAndroidDevices(): List<Device> {
+        val connectedDevices = Dadb.list()
+            .map {
+                Device(
+                    id = it.toString(),
+                    description = it.toString(),
+                    platform = Device.Platform.ANDROID,
+                    connected = true
+                )
+            }
+
+        // Note that there is a possibility that AVD is actually already connected and is present in
+        // connectedDevices.
+        val avds = try {
+            ProcessBuilder("emulator", "-list-avds")
+                .start()
+                .inputStream
+                .bufferedReader()
+                .useLines { lines ->
+                    lines
+                        .map {
+                            Device(
+                                id = it,
+                                description = it,
+                                platform = Device.Platform.ANDROID,
+                                connected = false
+                            )
+                        }
+                        .toList()
+                }
+        } catch (ignored: Exception) {
+            emptyList()
+        }
+
+        return connectedDevices + avds
+    }
+
+    private fun listIOSDevices(): List<Device> {
+        val simctlList = Simctl.list()
+
+        val runtimes = simctlList
+            .runtimes
+
+        return runtimes
+            .flatMap { runtime ->
+                runtime.supportedDeviceTypes
+                    .flatMap { supportedDeviceType ->
+                        simctlList.devices
+                            .values
+                            .flatten()
+                            .filter {
+                                it.isAvailable &&
+                                    it.deviceTypeIdentifier == supportedDeviceType.identifier
+                            }
+                    }
+                    .map { device ->
+                        Device(
+                            id = device.udid,
+                            description = "${device.name} - ${runtime.name} - ${device.udid}",
+                            platform = Device.Platform.IOS,
+                            connected = device.state == "Booted"
+                        )
+                    }
+            }
+    }
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceInteractor.kt
@@ -1,0 +1,57 @@
+package maestro.cli.device
+
+object PickDeviceInteractor {
+
+    fun pickDevice(): Device {
+        return pickDeviceInternal()
+            .let { pickedDevice ->
+                var result = pickedDevice
+
+                if (!result.connected) {
+                    result = DeviceService.startDevice(pickedDevice)
+                }
+
+                DeviceService.prepareDevice(result)
+
+                result
+            }
+    }
+
+    private fun pickDeviceInternal(): Device {
+        val connectedDevices = DeviceService.listConnectedDevices()
+
+        if (connectedDevices.size == 1) {
+            val device = connectedDevices[0]
+
+            PickDeviceView.showRunOnDevice(device)
+
+            return device
+        }
+
+        if (connectedDevices.isEmpty()) {
+            return startDevice()
+        }
+
+        return pickRunningDevice(connectedDevices)
+    }
+
+    private fun startDevice(): Device {
+        val availableDevices = DeviceService.listAvailableDevices()
+
+        return PickDeviceView.pickDeviceToStart(availableDevices)
+    }
+
+    private fun pickRunningDevice(devices: List<Device>): Device {
+        return PickDeviceView.pickRunningDevice(devices)
+    }
+
+}
+
+fun main() {
+    println(PickDeviceInteractor.pickDevice())
+
+    println("Ready")
+    while (!Thread.interrupted()) {
+        Thread.sleep(1000)
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
@@ -1,0 +1,61 @@
+package maestro.cli.device
+
+object PickDeviceView {
+
+    fun showRunOnDevice(device: Device) {
+        println("Running on ${device.description}")
+    }
+
+    fun pickDeviceToStart(devices: List<Device>): Device {
+        printIndexedDevices(devices)
+
+        println("No running devices detected. Choose a device to boot and run on.")
+        println()
+        println("Enter a number from the list above:")
+
+        return pickIndex(devices)
+    }
+
+    fun pickRunningDevice(devices: List<Device>): Device {
+        printIndexedDevices(devices)
+
+        println("Multiple running devices detected. Choose a device to run on.")
+        println()
+        println("Enter a number from the list above:")
+
+        return pickIndex(devices)
+    }
+
+    private fun <T> pickIndex(data: List<T>): T {
+        while (!Thread.interrupted()) {
+            val index = readLine()?.toIntOrNull() ?: 0
+
+            if (index < 1 || index > data.size) {
+                println("Invalid index")
+                continue
+            }
+
+            return data[index - 1]
+        }
+
+        error("Interrupted")
+    }
+
+    private fun printIndexedDevices(devices: List<Device>) {
+        val devicesByPlatform = devices.groupBy {
+            it.platform
+        }
+
+        var index = 0
+
+        devicesByPlatform.forEach { (platform, devices) ->
+            println(platform.description)
+            println()
+            devices.forEach { device ->
+                println("    [${++index}] ${device.description}")
+            }
+            println()
+        }
+    }
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/device/ios/Simctl.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/ios/Simctl.kt
@@ -1,0 +1,50 @@
+package maestro.cli.device.ios
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import maestro.MaestroTimer
+import maestro.cli.CliError
+import maestro.cli.util.CommandLineUtils.runCommand
+
+object Simctl {
+    fun list(): SimctlList {
+        val command = listOf("xcrun", "simctl", "list", "-j")
+
+        val process = ProcessBuilder(command).start()
+        val json = String(process.inputStream.readAllBytes())
+
+        return jacksonObjectMapper().readValue(json)
+    }
+
+    fun awaitLaunch(deviceId: String) {
+        MaestroTimer.withTimeout(30000) {
+            if (list()
+                    .devices
+                    .values
+                    .flatMap { it }
+                    .find { it.udid == deviceId }
+                    ?.state == "Booted"
+            ) true else null
+        } ?: throw CliError("Device $deviceId did not boot in time")
+    }
+
+    fun launchSimulator(deviceId: String) {
+        runCommand("xcrun simctl boot $deviceId")
+
+        var exceptionToThrow: Exception? = null
+
+        // Up to 10 iterations => max wait time of 1 second
+        repeat(10) {
+            try {
+                runCommand("open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID $deviceId")
+                return
+            } catch (e: Exception) {
+                exceptionToThrow = e
+                Thread.sleep(100)
+            }
+        }
+
+        exceptionToThrow?.let { throw it }
+    }
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/device/ios/SimctlList.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/ios/SimctlList.kt
@@ -1,0 +1,57 @@
+package maestro.cli.device.ios
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SimctlList(
+    val devicetypes: List<DeviceType>,
+    val runtimes: List<Runtime>,
+    val devices: Map<String, List<Device>>,
+    val pairs: Map<String, Pair>,
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class DeviceType(
+        val identifier: String,
+        val name: String,
+        val bundlePath: String,
+        val productFamily: String,
+        val maxRuntimeVersion: Long?,
+        val maxRuntimeVersionString: String?,
+        val minRuntimeVersion: Long?,
+        val minRuntimeVersionString: String?,
+        val modelIdentifier: String?,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class Runtime(
+        val bundlePath: String,
+        val buildversion: String,
+        val platform: String?,
+        val runtimeRoot: String,
+        val identifier: String,
+        val version: String,
+        val isInternal: Boolean,
+        val isAvailable: Boolean,
+        val name: String,
+        val supportedDeviceTypes: List<DeviceType>,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class Device(
+        val name: String,
+        val dataPath: String?,
+        val logPath: String?,
+        val udid: String,
+        val isAvailable: Boolean,
+        val deviceTypeIdentifier: String?,
+        val state: String,
+        val availabilityError: String?,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class Pair(
+        val watch: Device,
+        val phone: Device,
+        val state: String,
+    )
+}

--- a/maestro-cli/src/main/java/maestro/cli/util/CommandLineUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/CommandLineUtils.kt
@@ -1,0 +1,59 @@
+package maestro.cli.util
+
+import okio.buffer
+import okio.source
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+object CommandLineUtils {
+
+    fun runCommand(command: String, waitForCompletion: Boolean = true, outputFile: File? = null): Process {
+        LOGGER.info("Running command line operation: $command")
+
+        val parts = command.split("\\s".toRegex())
+            .map { it.trim() }
+
+        return runCommand(parts, waitForCompletion, outputFile)
+    }
+
+    @Suppress("SpreadOperator")
+    fun runCommand(parts: List<String>, waitForCompletion: Boolean = true, outputFile: File? = null): Process {
+        LOGGER.info("Running command line operation: $parts")
+
+        val process = if (outputFile != null) {
+            ProcessBuilder(*parts.toTypedArray())
+                .redirectOutput(outputFile)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
+                .start()
+        } else {
+            ProcessBuilder(*parts.toTypedArray())
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
+                .start()
+        }
+
+        if (waitForCompletion) {
+            if (!process.waitFor(5, TimeUnit.MINUTES)) {
+                throw TimeoutException()
+            }
+
+            if (process.exitValue() != 0) {
+                val processOutput = process.errorStream
+                    .source()
+                    .buffer()
+                    .readUtf8()
+
+                LOGGER.error("Process failed with exit code ${process.exitValue()}")
+                LOGGER.error(processOutput)
+
+                throw IllegalStateException(processOutput)
+            }
+        }
+
+        return process
+    }
+
+    private val LOGGER = LoggerFactory.getLogger(CommandLineUtils::class.java)
+}

--- a/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
@@ -1,0 +1,13 @@
+package maestro.cli.util
+
+object EnvUtils {
+
+    fun androidHome(): String? {
+        return System.getenv("ANDROID_HOME")
+            ?: System.getenv("ANDROID_SDK_ROOT")
+            ?: System.getenv("ANDROID_SDK_HOME")
+            ?: System.getenv("ANDROID_SDK")
+            ?: System.getenv("ANDROID")
+    }
+
+}

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     api 'io.grpc:grpc-okhttp:1.45.0'
     api 'com.google.protobuf:protobuf-kotlin:3.19.4'
     api 'com.michael-bull.kotlin-result:kotlin-result:1.1.14'
-    api "dev.mobile:dadb:1.2.1"
+    api "dev.mobile:dadb:1.2.2"
     api "org.slf4j:slf4j-simple:1.7.36"
     api 'com.squareup.okio:okio:3.2.0'
     api 'com.github.romankh3:image-comparison:4.4.0'


### PR DESCRIPTION
## Proposed Changes

There are 4 major changes:

- We no longer assume that `idb_companion` is running and launching it ourselves. If it is already running, we are restarting it (has shown to improve stability).
- If there are multiple devices running, we ask the user to pick one explicitly.
- For that reason, `--platform` option is deprecated.
- If no devices are running, user can pick one to start up.

## Testing
Tested manually.