### PR TITLE
Fix: inject env parameters into conditions

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -440,6 +440,7 @@ data class RunFlowCommand(
     override fun injectEnv(env: Map<String, String>): Command {
         return copy(
             commands = commands.map { it.injectEnv(env) },
+            condition = condition?.injectEnv(env),
         )
     }
 
@@ -488,6 +489,7 @@ data class RepeatCommand(
         return copy(
             times = times?.injectEnv(env),
             commands = commands.map { it.injectEnv(env) },
+            condition = condition?.injectEnv(env),
         )
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
@@ -5,6 +5,13 @@ data class Condition(
     val notVisible: ElementSelector? = null,
 ) {
 
+    fun injectEnv(env: Map<String, String>): Condition {
+        return copy(
+            visible = visible?.injectEnv(env),
+            notVisible = notVisible?.injectEnv(env),
+        )
+    }
+
     fun description(): String {
         val descriptions = mutableListOf<String>()
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1382,6 +1382,13 @@ class IntegrationTest {
     fun `Case 049 - Run flow conditionally`() {
         // Given
         val commands = readCommands("049_run_flow_conditionally")
+            .map {
+                it.injectEnv(
+                    mapOf(
+                        "NOT_CLICKED" to "Not Clicked"
+                    )
+                )
+            }
 
         val driver = driver {
             val indicator = element {

--- a/maestro-test/src/test/resources/049_run_flow_conditionally.yaml
+++ b/maestro-test/src/test/resources/049_run_flow_conditionally.yaml
@@ -7,5 +7,5 @@ appId: com.other.app
 - assertVisible: Clicked
 - runFlow:
     when:
-      visible: Not Clicked
+      visible: ${NOT_CLICKED}
     file: 008_tap_on_element.yaml


### PR DESCRIPTION
We were not taking `env` parameters into account in conditions

Fixes #328 