### PR TITLE
Use describe instead of accessibilityInfo when  idb_companion is started

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -90,9 +90,9 @@ object DeviceService {
                 try {
                     // The idea is that view hierarchy is empty while device is still booting
                     iosDevice
-                        .contentDescriptor()
+                        .deviceInfo()
                         .get()
-                        ?.takeIf { nodes -> nodes.any { it.frame?.width != 0F } }
+                        ?.takeIf { it.widthPixels > 0 }
                 } catch (ignored: Exception) {
                     // Ignore
                     null


### PR DESCRIPTION
## Proposed Changes

## Testing
* brew upgrade
* maestro test samples/ios-flow.yaml

## Issues Fixed
Maestro fails to run iOS flow tests after `brew upgrade`