### PR TITLE
Better check ios simulator status when starting tests

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -1,7 +1,6 @@
 package maestro.cli.device
 
 import com.github.michaelbull.result.get
-import com.github.michaelbull.result.runCatching
 import dadb.Dadb
 import io.grpc.ManagedChannelBuilder
 import ios.idb.IdbIOSDevice

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -96,7 +96,6 @@ object DeviceService {
 
             // The first time a simulator boots up, it can
             // take 10's of seconds to complete.
-
             MaestroTimer.retryUntilTrue(timeoutMs = 60000) {
                 val process = ProcessBuilder("xcrun", "simctl", "bootstatus", device.instanceId)
                     .start()
@@ -107,10 +106,11 @@ object DeviceService {
 
             // Test if idb can get accessibility info elements with non-zero frame with
             MaestroTimer.retryUntilTrue(timeoutMs = 20000) {
-                iosDevice
+                val nodes = iosDevice
                     .contentDescriptor()
                     .get()
-                    ?.takeIf { nodes -> nodes.any { it.frame?.width != 0F } } != null
+
+                nodes?.any { it.frame?.width != 0F } == true
             } || error("idb_companion is not able to fetch accessibility info")
 
             Unit // Ignore result when completed

--- a/maestro-client/src/main/java/maestro/MaestroTimer.kt
+++ b/maestro-client/src/main/java/maestro/MaestroTimer.kt
@@ -23,6 +23,20 @@ object MaestroTimer {
         return null
     }
 
+    fun <T> retryWhileThrowing(timeoutMs: Long, block: () -> T): T {
+        val endTime = System.currentTimeMillis() + timeoutMs
+        var lastException: Exception
+        do {
+            try {
+                return block()
+            } catch (e: Exception) {
+                lastException = e
+            }
+        } while (System.currentTimeMillis() < endTime)
+
+        throw lastException
+    }
+
     enum class Reason {
         WAIT_UNTIL_VISIBLE,
         WAIT_TO_SETTLE,

--- a/maestro-client/src/main/java/maestro/MaestroTimer.kt
+++ b/maestro-client/src/main/java/maestro/MaestroTimer.kt
@@ -23,18 +23,19 @@ object MaestroTimer {
         return null
     }
 
-    fun <T> retryWhileThrowing(timeoutMs: Long, block: () -> T): T {
+    fun retryUntilTrue(timeoutMs: Long, block: () -> Boolean): Boolean {
         val endTime = System.currentTimeMillis() + timeoutMs
-        var lastException: Exception
         do {
             try {
-                return block()
-            } catch (e: Exception) {
-                lastException = e
+                if (block()) {
+                    return true
+                }
+            } catch (ignored: Exception) {
+                // Try again
             }
         } while (System.currentTimeMillis() < endTime)
 
-        throw lastException
+        return false
     }
 
     enum class Reason {


### PR DESCRIPTION
## Proposed Changes

Check if
* idb port is open
* sim boot status is booted
* accessibility info returns frames with non-zero width

## Testing

Manual testing

## Issues Fixed

When running `maestro test` on an iOS Simulator, the error `java.lang.IllegalStateException: idb_companion did not start in time` can mean several things:
* idb did not start correctly
* iOS Simulator boot time too long
* Issue with Accessibility frameworks SDK / Simulator runtime

This change checks for these causes and reports with a different error message for each of them.
