### PR TITLE
Adds directional swipe, makes swipe speed configurable through duration and fix iOS scroll

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -56,6 +56,8 @@ interface Driver {
 
     fun swipe(start: Point, end: Point)
 
+    fun swipe(swipeDirection: SwipeDirection)
+
     fun backPress()
 
     fun inputText(text: String)

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -54,9 +54,9 @@ interface Driver {
 
     fun scrollVertical()
 
-    fun swipe(start: Point, end: Point)
+    fun swipe(start: Point, end: Point, durationMs: Long)
 
-    fun swipe(swipeDirection: SwipeDirection)
+    fun swipe(swipeDirection: SwipeDirection, durationMs: Long)
 
     fun backPress()
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -108,10 +108,10 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-    fun swipe(swipeDirection: SwipeDirection? = null, start: Point? = null, end: Point? = null) {
+    fun swipe(swipeDirection: SwipeDirection? = null, start: Point? = null, end: Point? = null, duration: Long) {
         when {
-            swipeDirection != null -> driver.swipe(swipeDirection)
-            start != null && end != null -> driver.swipe(start, end)
+            swipeDirection != null -> driver.swipe(swipeDirection, duration)
+            start != null && end != null -> driver.swipe(start, end, duration)
         }
 
         waitForAppToSettle()

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -108,10 +108,12 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-    fun swipe(start: Point, end: Point) {
-        LOGGER.info("Swiping from (${start.x},${start.y}) to (${end.x},${end.y})")
+    fun swipe(swipeDirection: SwipeDirection? = null, start: Point? = null, end: Point? = null) {
+        when {
+            swipeDirection != null -> driver.swipe(swipeDirection)
+            start != null && end != null -> driver.swipe(start, end)
+        }
 
-        driver.swipe(start, end)
         waitForAppToSettle()
     }
 

--- a/maestro-client/src/main/java/maestro/SwipeDirection.kt
+++ b/maestro-client/src/main/java/maestro/SwipeDirection.kt
@@ -1,0 +1,8 @@
+package maestro
+
+enum class SwipeDirection {
+    UP,
+    DOWN,
+    RIGHT,
+    LEFT
+}

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -31,6 +31,7 @@ import maestro.Maestro
 import maestro.MaestroException.UnableToTakeScreenshot
 import maestro.MaestroTimer
 import maestro.Point
+import maestro.SwipeDirection
 import maestro.TreeNode
 import maestro.android.AndroidAppFiles
 import maestro.android.asManifest
@@ -271,6 +272,10 @@ class AndroidDriver(
 
     override fun swipe(start: Point, end: Point) {
         dadb.shell("input swipe ${start.x} ${start.y} ${end.x} ${end.y} 2000")
+    }
+
+    override fun swipe(swipeDirection: SwipeDirection) {
+        TODO("Not yet implemented")
     }
 
     override fun backPress() {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -270,36 +270,36 @@ class AndroidDriver(
         dadb.shell("input swipe 500 1000 700 -900 2000")
     }
 
-    override fun swipe(start: Point, end: Point) {
-        dadb.shell("input swipe ${start.x} ${start.y} ${end.x} ${end.y} 2000")
+    override fun swipe(start: Point, end: Point, durationMs: Long) {
+        dadb.shell("input swipe ${start.x} ${start.y} ${end.x} ${end.y} $durationMs")
     }
 
-    override fun swipe(swipeDirection: SwipeDirection) {
+    override fun swipe(swipeDirection: SwipeDirection, durationMs: Long) {
         val deviceInfo = deviceInfo()
         when (swipeDirection) {
             SwipeDirection.UP -> {
                 val startX = deviceInfo.widthPixels / 2
                 val startY = deviceInfo.heightPixels
                 val endY = deviceInfo.heightPixels / 2
-                dadb.shell("input swipe $startX $startY $startX $endY 2000")
+                dadb.shell("input swipe $startX $startY $startX $endY $durationMs")
             }
             SwipeDirection.DOWN -> {
                 val startX = deviceInfo.widthPixels / 2
                 val startY = 0
                 val endY = deviceInfo.heightPixels / 2
-                dadb.shell("input swipe $startX $startY $startX $endY 2000")
+                dadb.shell("input swipe $startX $startY $startX $endY $durationMs")
             }
             SwipeDirection.RIGHT -> {
                 val startX = deviceInfo.widthPixels / 2
                 val startY = deviceInfo.heightPixels / 2
                 val endX = deviceInfo.widthPixels
-                dadb.shell("input swipe $startX $startY $endX $startY 2000")
+                dadb.shell("input swipe $startX $startY $endX $startY $durationMs")
             }
             SwipeDirection.LEFT -> {
                 val startX = deviceInfo.widthPixels / 2
                 val startY = deviceInfo.heightPixels / 2
                 val endX = 0
-                dadb.shell("input swipe $startX $startY $endX $startY 2000")
+                dadb.shell("input swipe $startX $startY $endX $startY $durationMs")
             }
         }
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -275,7 +275,33 @@ class AndroidDriver(
     }
 
     override fun swipe(swipeDirection: SwipeDirection) {
-        TODO("Not yet implemented")
+        val deviceInfo = deviceInfo()
+        when (swipeDirection) {
+            SwipeDirection.UP -> {
+                val startX = deviceInfo.widthPixels / 2
+                val startY = deviceInfo.heightPixels
+                val endY = deviceInfo.heightPixels / 2
+                dadb.shell("input swipe $startX $startY $startX $endY 2000")
+            }
+            SwipeDirection.DOWN -> {
+                val startX = deviceInfo.widthPixels / 2
+                val startY = 0
+                val endY = deviceInfo.heightPixels / 2
+                dadb.shell("input swipe $startX $startY $startX $endY 2000")
+            }
+            SwipeDirection.RIGHT -> {
+                val startX = deviceInfo.widthPixels / 2
+                val startY = deviceInfo.heightPixels / 2
+                val endX = deviceInfo.widthPixels
+                dadb.shell("input swipe $startX $startY $endX $startY 2000")
+            }
+            SwipeDirection.LEFT -> {
+                val startX = deviceInfo.widthPixels / 2
+                val startY = deviceInfo.heightPixels / 2
+                val endX = 0
+                dadb.shell("input swipe $startX $startY $endX $startY 2000")
+            }
+        }
     }
 
     override fun backPress() {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -252,7 +252,43 @@ class IOSDriver(
     }
 
     override fun swipe(swipeDirection: SwipeDirection) {
-        TODO("Not yet implemented")
+        val width = widthPixels ?: throw IllegalStateException("Device width not available")
+        val height = heightPixels ?: throw IllegalStateException("Device height not available")
+
+        when(swipeDirection) {
+            SwipeDirection.UP -> {
+                iosDevice.scroll(
+                    xStart = width / 4,
+                    yStart = height,
+                    xEnd = width / 4 ,
+                    yEnd = height / 4
+                ).expect {}
+            }
+            SwipeDirection.DOWN -> {
+                iosDevice.scroll(
+                    xStart = width / 4,
+                    yStart = 0,
+                    xEnd = width,
+                    yEnd = height / 4
+                ).expect {}
+            }
+            SwipeDirection.RIGHT -> {
+                iosDevice.scroll(
+                    xStart =  0,
+                    yStart = height / 4,
+                    xEnd =  width / 4 ,
+                    yEnd = height / 4
+                ).expect {}
+            }
+            SwipeDirection.LEFT -> {
+                iosDevice.scroll(
+                    xStart = width / 4 ,
+                    yStart = height / 4,
+                    xEnd =  0,
+                    yEnd = height / 4
+                ).expect {}
+            }
+        }
     }
 
     override fun backPress() {}

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -215,7 +215,7 @@ class IOSDriver(
 
         iosDevice.scroll(
             xStart = screenWidth / 2,
-            yStart = screenHeight / 4,
+            yStart = screenHeight / 2,
             xEnd = screenWidth / 2,
             yEnd = 0
         ).expect {}

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -23,6 +23,7 @@ import com.github.michaelbull.result.expect
 import com.github.michaelbull.result.getOr
 import com.github.michaelbull.result.getOrThrow
 import ios.IOSDevice
+import ios.idb.IdbIOSDevice
 import maestro.DeviceInfo
 import maestro.Driver
 import maestro.KeyCode
@@ -217,7 +218,8 @@ class IOSDriver(
             xStart = screenWidth / 2,
             yStart = screenHeight / 2,
             xEnd = screenWidth / 2,
-            yEnd = 0
+            yEnd = 0,
+            durationMs = IdbIOSDevice.DEFAULT_SWIPE_DURATION_MILLIS
         ).expect {}
     }
 
@@ -240,18 +242,19 @@ class IOSDriver(
         }
     }
 
-    override fun swipe(start: Point, end: Point) {
+    override fun swipe(start: Point, end: Point, durationMs: Long) {
         validate(start, end)
 
         iosDevice.scroll(
             xStart = start.x,
             yStart = start.y,
             xEnd = end.x,
-            yEnd = end.y
+            yEnd = end.y,
+            durationMs = durationMs
         ).expect {}
     }
 
-    override fun swipe(swipeDirection: SwipeDirection) {
+    override fun swipe(swipeDirection: SwipeDirection, durationMs: Long) {
         val width = widthPixels ?: throw IllegalStateException("Device width not available")
         val height = heightPixels ?: throw IllegalStateException("Device height not available")
 
@@ -261,7 +264,8 @@ class IOSDriver(
                     xStart = width / 4,
                     yStart = height,
                     xEnd = width / 4 ,
-                    yEnd = height / 4
+                    yEnd = height / 4,
+                    durationMs = durationMs
                 ).expect {}
             }
             SwipeDirection.DOWN -> {
@@ -269,7 +273,8 @@ class IOSDriver(
                     xStart = width / 4,
                     yStart = 0,
                     xEnd = width,
-                    yEnd = height / 4
+                    yEnd = height / 4,
+                    durationMs = durationMs
                 ).expect {}
             }
             SwipeDirection.RIGHT -> {
@@ -277,7 +282,8 @@ class IOSDriver(
                     xStart =  0,
                     yStart = height / 4,
                     xEnd =  width / 4 ,
-                    yEnd = height / 4
+                    yEnd = height / 4,
+                    durationMs = durationMs
                 ).expect {}
             }
             SwipeDirection.LEFT -> {
@@ -285,7 +291,8 @@ class IOSDriver(
                     xStart = width / 4 ,
                     yStart = height / 4,
                     xEnd =  0,
-                    yEnd = height / 4
+                    yEnd = height / 4,
+                    durationMs = durationMs
                 ).expect {}
             }
         }

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -28,6 +28,7 @@ import maestro.Driver
 import maestro.KeyCode
 import maestro.MaestroException
 import maestro.Point
+import maestro.SwipeDirection
 import maestro.TreeNode
 import maestro.utils.FileUtils
 import okio.Sink
@@ -248,6 +249,10 @@ class IOSDriver(
             xEnd = end.x,
             yEnd = end.y
         ).expect {}
+    }
+
+    override fun swipe(swipeDirection: SwipeDirection) {
+        TODO("Not yet implemented")
     }
 
     override fun backPress() {}

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -215,11 +215,12 @@ class IOSDriver(
         val screenHeight = heightPixels ?: throw IllegalStateException("Screen height not available")
 
         iosDevice.scroll(
-            xStart = screenWidth / 2,
-            yStart = screenHeight / 2,
-            xEnd = screenWidth / 2,
+            xStart = screenWidth / 4,
+            yStart = screenHeight / 4,
+            xEnd = screenWidth / 4,
             yEnd = 0,
-            durationMs = IdbIOSDevice.DEFAULT_SWIPE_DURATION_MILLIS
+            durationMs = IdbIOSDevice.DEFAULT_SWIPE_DURATION_MILLIS,
+            scrollType = IdbIOSDevice.ScrollType.SCROLL
         ).expect {}
     }
 
@@ -250,7 +251,8 @@ class IOSDriver(
             yStart = start.y,
             xEnd = end.x,
             yEnd = end.y,
-            durationMs = durationMs
+            durationMs = durationMs,
+            scrollType = IdbIOSDevice.ScrollType.SWIPE
         ).expect {}
     }
 
@@ -265,7 +267,8 @@ class IOSDriver(
                     yStart = height,
                     xEnd = width / 4 ,
                     yEnd = height / 4,
-                    durationMs = durationMs
+                    durationMs = durationMs,
+                    IdbIOSDevice.ScrollType.SWIPE
                 ).expect {}
             }
             SwipeDirection.DOWN -> {
@@ -274,7 +277,8 @@ class IOSDriver(
                     yStart = 0,
                     xEnd = width,
                     yEnd = height / 4,
-                    durationMs = durationMs
+                    durationMs = durationMs,
+                    IdbIOSDevice.ScrollType.SWIPE
                 ).expect {}
             }
             SwipeDirection.RIGHT -> {
@@ -283,7 +287,8 @@ class IOSDriver(
                     yStart = height / 4,
                     xEnd =  width / 4 ,
                     yEnd = height / 4,
-                    durationMs = durationMs
+                    durationMs = durationMs,
+                    IdbIOSDevice.ScrollType.SWIPE
                 ).expect {}
             }
             SwipeDirection.LEFT -> {
@@ -292,7 +297,8 @@ class IOSDriver(
                     yStart = height / 4,
                     xEnd =  0,
                     yEnd = height / 4,
-                    durationMs = durationMs
+                    durationMs = durationMs,
+                    IdbIOSDevice.ScrollType.SWIPE
                 ).expect {}
             }
         }

--- a/maestro-ios/src/main/java/ios/IOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/IOSDevice.kt
@@ -43,7 +43,7 @@ interface IOSDevice : AutoCloseable {
 
     fun pressButton(code: Int): Result<Unit, Throwable>
 
-    fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int): Result<Unit, Throwable>
+    fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int, durationMs: Long): Result<Unit, Throwable>
 
     /**
      * Inputs text into the currently focused element.

--- a/maestro-ios/src/main/java/ios/IOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/IOSDevice.kt
@@ -23,6 +23,7 @@ import com.github.michaelbull.result.Result
 import idb.Idb
 import ios.device.AccessibilityNode
 import ios.device.DeviceInfo
+import ios.idb.IdbIOSDevice
 import okio.Sink
 import java.io.File
 import java.io.InputStream
@@ -43,7 +44,7 @@ interface IOSDevice : AutoCloseable {
 
     fun pressButton(code: Int): Result<Unit, Throwable>
 
-    fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int, durationMs: Long): Result<Unit, Throwable>
+    fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int, durationMs: Long, scrollType: IdbIOSDevice.ScrollType): Result<Unit, Throwable>
 
     /**
      * Inputs text into the currently focused element.

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -20,6 +20,8 @@
 package ios.idb
 
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.get
+import com.github.michaelbull.result.getOrThrow
 import com.github.michaelbull.result.runCatching
 import com.google.gson.Gson
 import com.google.protobuf.ByteString
@@ -181,11 +183,13 @@ class IdbIOSDevice(
         }
     }
 
-    override fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int, durationMs: Long): Result<Unit, Throwable> {
+    override fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int, durationMs: Long, scrollType: ScrollType): Result<Unit, Throwable> {
+        val deviceInfo = deviceInfo().getOrThrow { throw IllegalStateException("Device info not available") }
         return runCatching {
             val responseObserver = BlockingStreamObserver<Idb.HIDResponse>()
             val stream = asyncStub.hid(responseObserver)
 
+            val durationS = (durationMs.toDouble() / 1000)
             val swipeAction = HIDEventKt.hIDSwipe {
                 this.start = point {
                     this.x = xStart.toDouble()
@@ -195,8 +199,8 @@ class IdbIOSDevice(
                     this.x = xEnd.toDouble()
                     this.y = yEnd.toDouble()
                 }
-                this.duration = (durationMs / 1000).toDouble()
-                this.delta = DEFAULT_SWIPE_DELTA
+                this.duration = if (durationS >= 1.0) DEFAULT_SWIPE_DURATION_MILLIS.toDouble() / 1000 else durationS
+                this.delta = if (scrollType == ScrollType.SWIPE) SCROLL_FACTOR * deviceInfo.widthPixels else SCROLL_FACTOR * deviceInfo.heightPixels
             }
 
             stream.onNext(
@@ -425,7 +429,12 @@ class IdbIOSDevice(
         // 4Mb, the default max read for gRPC
         private const val CHUNK_SIZE = 1024 * 1024 * 3
         private val GSON = Gson()
-        const val DEFAULT_SWIPE_DURATION_MILLIS = 2000L
-        private const val DEFAULT_SWIPE_DELTA = 100.0
+        private const val SCROLL_FACTOR = 0.07
+        const val DEFAULT_SWIPE_DURATION_MILLIS = 1000L
+    }
+
+    enum class ScrollType {
+        SCROLL,
+        SWIPE
     }
 }

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -190,11 +190,13 @@ class IdbIOSDevice(
                 this.start = point {
                     this.x = xStart.toDouble()
                     this.y = yStart.toDouble()
-                }
+                }.toBuilder().build()
                 this.end = point {
                     this.x = xEnd.toDouble()
                     this.y = yEnd.toDouble()
                 }
+                this.duration = DEFAULT_SWIPE_DURATION_SECONDS
+                this.delta = DEFAULT_SWIPE_DELTA
             }
 
             stream.onNext(
@@ -423,5 +425,7 @@ class IdbIOSDevice(
         // 4Mb, the default max read for gRPC
         private const val CHUNK_SIZE = 1024 * 1024 * 3
         private val GSON = Gson()
+        private const val DEFAULT_SWIPE_DURATION_SECONDS = 1.0
+        private const val DEFAULT_SWIPE_DELTA = 100.0
     }
 }

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -181,7 +181,7 @@ class IdbIOSDevice(
         }
     }
 
-    override fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int): Result<Unit, Throwable> {
+    override fun scroll(xStart: Int, yStart: Int, xEnd: Int, yEnd: Int, durationMs: Long): Result<Unit, Throwable> {
         return runCatching {
             val responseObserver = BlockingStreamObserver<Idb.HIDResponse>()
             val stream = asyncStub.hid(responseObserver)
@@ -195,7 +195,7 @@ class IdbIOSDevice(
                     this.x = xEnd.toDouble()
                     this.y = yEnd.toDouble()
                 }
-                this.duration = DEFAULT_SWIPE_DURATION_SECONDS
+                this.duration = (durationMs / 1000).toDouble()
                 this.delta = DEFAULT_SWIPE_DELTA
             }
 
@@ -425,7 +425,7 @@ class IdbIOSDevice(
         // 4Mb, the default max read for gRPC
         private const val CHUNK_SIZE = 1024 * 1024 * 3
         private val GSON = Gson()
-        private const val DEFAULT_SWIPE_DURATION_SECONDS = 1.0
+        const val DEFAULT_SWIPE_DURATION_MILLIS = 2000L
         private const val DEFAULT_SWIPE_DELTA = 100.0
     }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -21,6 +21,7 @@ package maestro.orchestra
 
 import maestro.KeyCode
 import maestro.Point
+import maestro.SwipeDirection
 import maestro.orchestra.util.Env.injectEnv
 import maestro.orchestra.util.InputRandomTextHelper
 
@@ -39,12 +40,21 @@ sealed interface CompositeCommand : Command {
 }
 
 data class SwipeCommand(
-    val startPoint: Point,
-    val endPoint: Point,
+    val direction: SwipeDirection? = null,
+    val startPoint: Point? = null,
+    val endPoint: Point? = null,
 ) : Command {
 
     override fun description(): String {
-        return "Swipe from (${startPoint.x},${startPoint.y}) to (${endPoint.x},${endPoint.y})"
+        return when {
+            direction != null -> {
+                "Swiping in $direction direction"
+            }
+            startPoint != null && endPoint != null -> {
+                "Swipe from (${startPoint.x},${startPoint.y}) to (${endPoint.x},${endPoint.y})"
+            }
+            else -> "Invalid input to swipe command"
+        }
     }
 
     override fun injectEnv(env: Map<String, String>): SwipeCommand {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -43,15 +43,16 @@ data class SwipeCommand(
     val direction: SwipeDirection? = null,
     val startPoint: Point? = null,
     val endPoint: Point? = null,
+    val duration: Long = DEFAULT_DURATION_IN_MILLIS
 ) : Command {
 
     override fun description(): String {
         return when {
             direction != null -> {
-                "Swiping in $direction direction"
+                "Swiping in $direction direction in $duration ms"
             }
             startPoint != null && endPoint != null -> {
-                "Swipe from (${startPoint.x},${startPoint.y}) to (${endPoint.x},${endPoint.y})"
+                "Swipe from (${startPoint.x},${startPoint.y}) to (${endPoint.x},${endPoint.y}) in $duration ms"
             }
             else -> "Invalid input to swipe command"
         }
@@ -61,6 +62,9 @@ data class SwipeCommand(
         return this
     }
 
+    companion object {
+        const val DEFAULT_DURATION_IN_MILLIS = 2000L
+    }
 }
 
 class ScrollCommand : Command {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -505,7 +505,7 @@ class Orchestra(
     }
 
     private fun swipeCommand(command: SwipeCommand) {
-        maestro.swipe(command.startPoint, command.endPoint)
+        maestro.swipe(command.direction, command.startPoint, command.endPoint)
     }
 
     private object CommandSkipped : Exception()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -505,7 +505,7 @@ class Orchestra(
     }
 
     private fun swipeCommand(command: SwipeCommand) {
-        maestro.swipe(command.direction, command.startPoint, command.endPoint)
+        maestro.swipe(command.direction, command.startPoint, command.endPoint, command.duration)
     }
 
     private object CommandSkipped : Exception()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -278,9 +278,9 @@ data class YamlFluentCommand(
     }
 
     private fun swipeCommand(swipe: YamlSwipe): MaestroCommand {
-        when {
-            swipe.direction != null -> return MaestroCommand(SwipeCommand(direction = swipe.direction, duration = swipe.duration))
-            swipe.start != null && swipe.end != null -> {
+        when (swipe) {
+            is YamlSwipeDirection -> return MaestroCommand(SwipeCommand(direction = swipe.direction, duration = swipe.duration))
+            is YamlCoordinateSwipe -> {
                 val start = swipe.start
                 val end = swipe.end
                 val startPoint: Point?

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -65,7 +65,7 @@ data class YamlFluentCommand(
     val inputRandomEmail: YamlInputRandomEmail? = null,
     val inputRandomPersonName: YamlInputRandomPersonName? = null,
     val launchApp: YamlLaunchApp? = null,
-    val swipe: YamlElementSelectorUnion? = null,
+    val swipe: YamlSwipe? = null,
     val openLink: String? = null,
     val pressKey: String? = null,
     val eraseText: YamlEraseText? = null,
@@ -277,35 +277,38 @@ data class YamlFluentCommand(
         }
     }
 
-    private fun swipeCommand(tapOn: YamlElementSelectorUnion): MaestroCommand {
-        val start = (tapOn as? YamlElementSelector)?.start
-        val end = (tapOn as? YamlElementSelector)?.end
-        val startPoint: Point?
-        val endPoint: Point?
+    private fun swipeCommand(swipe: YamlSwipe): MaestroCommand {
+        when {
+            swipe.direction != null -> {
+                return MaestroCommand(SwipeCommand(direction = swipe.direction))
+            }
+            swipe.start != null && swipe.end != null -> {
+                val start = swipe.start
+                val end = swipe.end
+                val startPoint: Point?
+                val endPoint: Point?
 
-        if (start != null) {
-            val points = start.split(",")
-                .map {
-                    it.trim().toInt()
-                }
+                val startPoints = start.split(",")
+                    .map {
+                        it.trim().toInt()
+                    }
+                startPoint = Point(startPoints[0], startPoints[1])
 
-            startPoint = Point(points[0], points[1])
-        } else {
-            throw IllegalStateException("No start point configured for swipe action")
+                val endPoints = end.split(",")
+                    .map {
+                        it.trim().toInt()
+                    }
+                endPoint = Point(endPoints[0], endPoints[1])
+
+                return MaestroCommand(SwipeCommand(startPoint = startPoint, endPoint = endPoint))
+            }
+            else -> {
+                throw IllegalStateException(
+                    "Provide swipe direction UP, DOWN, RIGHT OR LEFT or by giving explicit " +
+                        "start and end coordinates."
+                )
+            }
         }
-
-        if (end != null) {
-            val points = end.split(",")
-                .map {
-                    it.trim().toInt()
-                }
-
-            endPoint = Point(points[0], points[1])
-        } else {
-            throw IllegalStateException("No end point configured for swipe action")
-        }
-
-        return MaestroCommand(SwipeCommand(startPoint, endPoint))
     }
 
     private fun toElementSelector(selectorUnion: YamlElementSelectorUnion): ElementSelector {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -279,9 +279,7 @@ data class YamlFluentCommand(
 
     private fun swipeCommand(swipe: YamlSwipe): MaestroCommand {
         when {
-            swipe.direction != null -> {
-                return MaestroCommand(SwipeCommand(direction = swipe.direction))
-            }
+            swipe.direction != null -> return MaestroCommand(SwipeCommand(direction = swipe.direction, duration = swipe.duration))
             swipe.start != null && swipe.end != null -> {
                 val start = swipe.start
                 val end = swipe.end
@@ -300,7 +298,7 @@ data class YamlFluentCommand(
                     }
                 endPoint = Point(endPoints[0], endPoints[1])
 
-                return MaestroCommand(SwipeCommand(startPoint = startPoint, endPoint = endPoint))
+                return MaestroCommand(SwipeCommand(startPoint = startPoint, endPoint = endPoint, duration = swipe.duration))
             }
             else -> {
                 throw IllegalStateException(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
@@ -1,14 +1,56 @@
 package maestro.orchestra.yaml
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.TreeNode
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import maestro.SwipeDirection
 
-data class YamlSwipe(
-    val direction: SwipeDirection? = null,
-    val start: String? = null,
-    val end: String? = null,
-    val duration: Long = DEFAULT_DURATION_IN_MILLIS
-) {
-    companion object {
-        private const val DEFAULT_DURATION_IN_MILLIS = 2000L
+@JsonDeserialize(using = YamlSwipeDeserializer::class)
+interface YamlSwipe {
+    val duration: Long
+}
+
+data class YamlSwipeDirection(val direction: SwipeDirection, override val duration: Long = DEFAULT_DURATION_IN_MILLIS) : YamlSwipe
+data class YamlCoordinateSwipe(val start: String, val end: String, override val duration: Long = DEFAULT_DURATION_IN_MILLIS) : YamlSwipe
+
+private const val DEFAULT_DURATION_IN_MILLIS = 2000L
+
+class YamlSwipeDeserializer: JsonDeserializer<YamlSwipe>() {
+
+    override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): YamlSwipe {
+        val mapper = parser.codec as ObjectMapper
+        val root: TreeNode = mapper.readTree(parser)
+        val isDirectionalSwipe = root.fieldNames().asSequence().toList() == listOf("direction", "duration") || root.fieldNames().asSequence().toList() == listOf("direction")
+        val isCoordinateSwipe = root.fieldNames().asSequence().toList() == listOf("start", "end", "duration") || root.fieldNames().asSequence().toList() == listOf("start", "end")
+        return when {
+            isDirectionalSwipe ->  {
+                val duration = getDuration(root)
+                val direction = SwipeDirection.valueOf(root.get("direction").toString().replace("\"", ""))
+                YamlSwipeDirection(direction, duration)
+            }
+            isCoordinateSwipe -> {
+                YamlCoordinateSwipe(
+                    root.path("start").toString().replace("\"", ""),
+                    root.path("end").toString().replace("\"", ""),
+                    getDuration(root)
+                )
+            }
+            else -> throw IllegalStateException(
+                "Provide swipe direction UP, DOWN, RIGHT OR LEFT or by giving explicit " +
+                    "start and end coordinates."
+            )
+        }
+     }
+
+    private fun getDuration(root: TreeNode): Long {
+        return if (root.path("duration").toString().isEmpty()) {
+            DEFAULT_DURATION_IN_MILLIS
+        } else {
+            root.path("duration").toString().replace("\"", "").toLong()
+        }
     }
+
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
@@ -1,0 +1,9 @@
+package maestro.orchestra.yaml
+
+import maestro.SwipeDirection
+
+data class YamlSwipe(
+    val direction: SwipeDirection? = null,
+    val start: String? = null,
+    val end: String? = null
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
@@ -5,5 +5,10 @@ import maestro.SwipeDirection
 data class YamlSwipe(
     val direction: SwipeDirection? = null,
     val start: String? = null,
-    val end: String? = null
-)
+    val end: String? = null,
+    val duration: Long = DEFAULT_DURATION_IN_MILLIS
+) {
+    companion object {
+        private const val DEFAULT_DURATION_IN_MILLIS = 2000L
+    }
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -113,8 +113,8 @@ internal class MaestroCommandSerializationTest {
         // given
         val command = MaestroCommand(
             SwipeCommand(
-                Point(10, 10),
-                Point(100, 100),
+                startPoint = Point(10, 10),
+                endPoint = Point(100, 100),
             )
         )
 
@@ -134,7 +134,8 @@ internal class MaestroCommandSerializationTest {
                 "endPoint" : {
                   "x" : 100,
                   "y" : 100
-                }
+                },
+                "duration" : 2000
               }
             }
           """.trimIndent()

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -26,6 +26,7 @@ import maestro.Driver
 import maestro.KeyCode
 import maestro.MaestroException
 import maestro.Point
+import maestro.SwipeDirection
 import maestro.TreeNode
 import okio.Sink
 import okio.buffer
@@ -166,6 +167,12 @@ class FakeDriver : Driver {
         ensureOpen()
 
         events += Event.Swipe(start, end)
+    }
+
+    override fun swipe(swipeDirection: SwipeDirection) {
+        ensureOpen()
+
+        events += Event.SwipeWithDirection(swipeDirection)
     }
 
     override fun backPress() {
@@ -311,6 +318,8 @@ class FakeDriver : Driver {
             val start: Point,
             val End: Point
         ) : Event(), UserInteraction
+
+        data class SwipeWithDirection(val swipeDirection: SwipeDirection): Event(), UserInteraction
 
         data class LaunchApp(
             val appId: String

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -163,16 +163,16 @@ class FakeDriver : Driver {
         events += Event.Scroll
     }
 
-    override fun swipe(start: Point, end: Point) {
+    override fun swipe(start: Point, end: Point, durationMs: Long) {
         ensureOpen()
 
-        events += Event.Swipe(start, end)
+        events += Event.Swipe(start, end, durationMs)
     }
 
-    override fun swipe(swipeDirection: SwipeDirection) {
+    override fun swipe(swipeDirection: SwipeDirection, durationMs: Long) {
         ensureOpen()
 
-        events += Event.SwipeWithDirection(swipeDirection)
+        events += Event.SwipeWithDirection(swipeDirection, durationMs)
     }
 
     override fun backPress() {
@@ -316,10 +316,11 @@ class FakeDriver : Driver {
 
         data class Swipe(
             val start: Point,
-            val End: Point
+            val End: Point,
+            val durationMs: Long
         ) : Event(), UserInteraction
 
-        data class SwipeWithDirection(val swipeDirection: SwipeDirection): Event(), UserInteraction
+        data class SwipeWithDirection(val swipeDirection: SwipeDirection, val durationMs: Long): Event(), UserInteraction
 
         data class LaunchApp(
             val appId: String

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -6,6 +6,7 @@ import maestro.Maestro
 import maestro.MaestroException
 import maestro.MaestroTimer
 import maestro.Point
+import maestro.SwipeDirection
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
@@ -479,7 +480,7 @@ class IntegrationTest {
 
         // Then
         // No test failure
-        driver.assertHasEvent(Event.Swipe(Point(100, 500), Point(100, 200)))
+        driver.assertHasEvent(Event.Swipe(start = Point(100, 500), End = Point(100, 200)))
     }
 
     @Test
@@ -1668,6 +1669,21 @@ class IntegrationTest {
         // No test failure
         driver.assertHasEvent(Event.InputText("Inline Parameter"))
         driver.assertHasEvent(Event.InputText("Overriden Parameter"))
+    }
+
+    @Test
+    fun `Case 059 - Do a directional swipe command`() {
+        // given
+        val commands = readCommands("059_directional_swipe_command")
+        val driver = driver { }
+
+        // when
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // then
+        driver.assertHasEvent(Event.SwipeWithDirection(SwipeDirection.RIGHT))
     }
 
     private fun orchestra(maestro: Maestro) = Orchestra(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1683,7 +1683,7 @@ class IntegrationTest {
         }
 
         // then
-        driver.assertHasEvent(Event.SwipeWithDirection(SwipeDirection.RIGHT, 2000))
+        driver.assertHasEvent(Event.SwipeWithDirection(SwipeDirection.RIGHT, 500))
     }
 
     private fun orchestra(maestro: Maestro) = Orchestra(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -480,7 +480,7 @@ class IntegrationTest {
 
         // Then
         // No test failure
-        driver.assertHasEvent(Event.Swipe(start = Point(100, 500), End = Point(100, 200)))
+        driver.assertHasEvent(Event.Swipe(start = Point(100, 500), End = Point(100, 200), durationMs = 3000))
     }
 
     @Test
@@ -1683,7 +1683,7 @@ class IntegrationTest {
         }
 
         // then
-        driver.assertHasEvent(Event.SwipeWithDirection(SwipeDirection.RIGHT))
+        driver.assertHasEvent(Event.SwipeWithDirection(SwipeDirection.RIGHT, 2000))
     }
 
     private fun orchestra(maestro: Maestro) = Orchestra(

--- a/maestro-test/src/test/resources/017_swipe.yaml
+++ b/maestro-test/src/test/resources/017_swipe.yaml
@@ -3,3 +3,4 @@ appId: com.example.app
 - swipe:
     start: 100,500
     end: 100,200
+    duration: 3000

--- a/maestro-test/src/test/resources/059_directional_swipe_command.yaml
+++ b/maestro-test/src/test/resources/059_directional_swipe_command.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- swipe:
+    direction: RIGHT

--- a/maestro-test/src/test/resources/059_directional_swipe_command.yaml
+++ b/maestro-test/src/test/resources/059_directional_swipe_command.yaml
@@ -2,3 +2,4 @@ appId: com.example.app
 ---
 - swipe:
     direction: RIGHT
+    duration: 2000

--- a/maestro-test/src/test/resources/059_directional_swipe_command.yaml
+++ b/maestro-test/src/test/resources/059_directional_swipe_command.yaml
@@ -2,4 +2,4 @@ appId: com.example.app
 ---
 - swipe:
     direction: RIGHT
-    duration: 2000
+    duration: 500


### PR DESCRIPTION
## Proposed Changes
### Adding directional swipe

Adds directional swipe: RIGHT, LEFT, DOWN, UP. This will help in use cases like swiping pagers in onboarding irrespective of device width height. API:
```
- swipe:
      direction: LEFT | RIGHT | UP | DOWN
```
PS: start and end coordinates still remain but are optional now.

### Controlling swipe speed
Swipe speed can be controlled by supplying duration. More the duration slower the swipe speed. The lesser the duration the more swipe speed. API:

```
- swipe:
     direction: LEFT
     duration: 300
```

### Fix iOS scrolling
Accounting scroll delta and duration which fixes iOS vertical scrolling as well

## Testing

https://user-images.githubusercontent.com/12881364/200290424-32c19707-3bbf-4eef-8658-7dfd175e947a.mp4

https://user-images.githubusercontent.com/12881364/200289793-119f3a61-56f5-4d06-b8d5-ab98b445bbb9.mp4

https://user-images.githubusercontent.com/12881364/200299337-6fe688dc-38a7-4feb-85a9-2243ab42ea20.mp4

## Issues Fixed
https://github.com/mobile-dev-inc/maestro/issues/251
