### PR TITLE
Wait longer for idb and simulator, print wait status to cli

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -90,13 +90,15 @@ object DeviceService {
             .build()
 
         IdbIOSDevice(channel).use { iosDevice ->
-            MaestroTimer.retryUntilTrue(timeoutMs = 2000) {
+            println("Waiting for idb service to start..")
+            MaestroTimer.retryUntilTrue(timeoutMs = 60000) {
                 Socket(idbHost, idbPort).use { true }
             } || error("idb_companion did not start in time")
 
             // The first time a simulator boots up, it can
             // take 10's of seconds to complete.
-            MaestroTimer.retryUntilTrue(timeoutMs = 60000) {
+            println("Waiting for Simulator to boot..")
+            MaestroTimer.retryUntilTrue(timeoutMs = 120000) {
                 val process = ProcessBuilder("xcrun", "simctl", "bootstatus", device.instanceId)
                     .start()
                 process
@@ -105,6 +107,7 @@ object DeviceService {
             } || error("Simulator failed to boot")
 
             // Test if idb can get accessibility info elements with non-zero frame with
+            println("Waiting for Accessibility info to become available..")
             MaestroTimer.retryUntilTrue(timeoutMs = 20000) {
                 val nodes = iosDevice
                     .contentDescriptor()
@@ -113,7 +116,7 @@ object DeviceService {
                 nodes?.any { it.frame?.width != 0F } == true
             } || error("idb_companion is not able to fetch accessibility info")
 
-            Unit // Ignore result when completed
+            println("Simulator ${device.description} ready")
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

* Timeout idb_companion starting if socket is not open within one minute
* Timeout Simulator booting if bootstatus is not positive within two minutes
* Print the to the cli what is being waited on

<img width="639" alt="Screenshot 2022-11-07 at 19 53 48" src="https://user-images.githubusercontent.com/915211/200391501-c76164f2-60dd-449e-a2f5-25d182fab46c.png">


## Testing

Tested locally

## Issues Fixed

Launching idb_companion can take up to a minute, Below a minute makes maestro runs unstable (sometimes idb is fast enough, sometimes it isn't).
Booting the simulator on an older, less capable Mac for the first time will take over a minute to complete.
Users waiting for maestro to start idb and the simulator are informed via cli messages.