### PR TITLE
Fix idb service start hanging issue

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -91,14 +91,14 @@ object DeviceService {
 
         IdbIOSDevice(channel).use { iosDevice ->
             println("Waiting for idb service to start..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 60000) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 60000, delayMs = 1000) {
                 Socket(idbHost, idbPort).use { true }
             } || error("idb_companion did not start in time")
 
             // The first time a simulator boots up, it can
             // take 10's of seconds to complete.
             println("Waiting for Simulator to boot..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 120000) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 120000, delayMs = 1000) {
                 val process = ProcessBuilder("xcrun", "simctl", "bootstatus", device.instanceId)
                     .start()
                 process
@@ -108,7 +108,7 @@ object DeviceService {
 
             // Test if idb can get accessibility info elements with non-zero frame with
             println("Waiting for Accessibility info to become available..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 20000) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 20000, delayMs = 1000) {
                 val nodes = iosDevice
                     .contentDescriptor()
                     .get()

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -91,14 +91,14 @@ object DeviceService {
 
         IdbIOSDevice(channel).use { iosDevice ->
             println("Waiting for idb service to start..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 60000, delayMs = 1000) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 60000, delayMs = 500) {
                 Socket(idbHost, idbPort).use { true }
             } || error("idb_companion did not start in time")
 
             // The first time a simulator boots up, it can
             // take 10's of seconds to complete.
             println("Waiting for Simulator to boot..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 120000, delayMs = 1000) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 120000, delayMs = 500) {
                 val process = ProcessBuilder("xcrun", "simctl", "bootstatus", device.instanceId)
                     .start()
                 process
@@ -108,7 +108,7 @@ object DeviceService {
 
             // Test if idb can get accessibility info elements with non-zero frame with
             println("Waiting for Accessibility info to become available..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 20000, delayMs = 1000) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 20000, delayMs = 500) {
                 val nodes = iosDevice
                     .contentDescriptor()
                     .get()

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -91,14 +91,14 @@ object DeviceService {
 
         IdbIOSDevice(channel).use { iosDevice ->
             println("Waiting for idb service to start..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 60000, delayMs = 500) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 60000, delayMs = 100) {
                 Socket(idbHost, idbPort).use { true }
             } || error("idb_companion did not start in time")
 
             // The first time a simulator boots up, it can
             // take 10's of seconds to complete.
             println("Waiting for Simulator to boot..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 120000, delayMs = 500) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 120000, delayMs = 100) {
                 val process = ProcessBuilder("xcrun", "simctl", "bootstatus", device.instanceId)
                     .start()
                 process
@@ -108,7 +108,7 @@ object DeviceService {
 
             // Test if idb can get accessibility info elements with non-zero frame with
             println("Waiting for Accessibility info to become available..")
-            MaestroTimer.retryUntilTrue(timeoutMs = 20000, delayMs = 500) {
+            MaestroTimer.retryUntilTrue(timeoutMs = 20000, delayMs = 100) {
                 val nodes = iosDevice
                     .contentDescriptor()
                     .get()

--- a/maestro-client/src/main/java/maestro/MaestroTimer.kt
+++ b/maestro-client/src/main/java/maestro/MaestroTimer.kt
@@ -23,10 +23,13 @@ object MaestroTimer {
         return null
     }
 
-    fun retryUntilTrue(timeoutMs: Long, block: () -> Boolean): Boolean {
+    fun retryUntilTrue(timeoutMs: Long, delayMs: Long? = null, block: () -> Boolean): Boolean {
         val endTime = System.currentTimeMillis() + timeoutMs
         do {
             try {
+                delayMs?.let {
+                    sleep(Reason.BUFFER, delayMs)
+                }
                 if (block()) {
                     return true
                 }


### PR DESCRIPTION
## Proposed Changes
Currently idb_companion start often hangs infinitely with the message `Waiting for idb service to start...`, this PR fixes that.

## Testing
Tested locally