### PR TITLE
Stop the app before clearing the filesystem on iOS clearAppState()

### DIFF
--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -328,6 +328,14 @@ class IdbIOSDevice(
 
     override fun clearAppState(id: String): Result<Idb.RmResponse, Throwable> {
 
+        // Stop the app before clearing the file system
+        // This prevents the app from saving its state after it has been cleared
+        stop(id)
+        
+        // Wait for the app to be stopped, unfortunately idb's stop()
+        // does not wait for the process to finish
+        Thread.sleep(500)
+
         // deletes app data, including container folder
         val result = runCatching {
             blockingStub.rm(rmRequest {


### PR DESCRIPTION
## Proposed Changes

Stop the app if it is running when clearing the app state.

## Testing

Tested locally

## Issues Fixed

MOB-1561
