### PR TITLE
Tweaks: speeding up Maestro flows

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -131,7 +131,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun tap(
         element: UiElement,
         retryIfNoChange: Boolean = true,
-        waitUntilVisible: Boolean = true,
+        waitUntilVisible: Boolean = false,
         longPress: Boolean = false,
     ) {
         LOGGER.info("Tapping on element: $element")
@@ -219,11 +219,6 @@ class Maestro(private val driver: Driver) : AutoCloseable {
 
             LOGGER.info("Nothing changed in the UI.")
         }
-
-        if (retryIfNoChange) {
-            LOGGER.info("Attempting to tap again since there was no change in the UI")
-            tap(x, y, false, longPress)
-        }
     }
 
     private fun tryTakingScreenshot() = try {
@@ -249,11 +244,14 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return if (retryIfNoChange) 2 else 1
     }
 
-    fun pressKey(code: KeyCode) {
+    fun pressKey(code: KeyCode, waitForAppToSettle: Boolean = true) {
         LOGGER.info("Pressing key $code")
 
         driver.pressKey(code)
-        waitForAppToSettle()
+
+        if (waitForAppToSettle) {
+            waitForAppToSettle()
+        }
     }
 
     fun findElementByText(text: String, timeoutMs: Long): UiElement {
@@ -312,7 +310,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return filter(viewHierarchy().aggregate())
     }
 
-    private fun waitForAppToSettle(): ViewHierarchy {
+    fun waitForAppToSettle(): ViewHierarchy {
         // Time buffer for any visual effects and transitions that might occur between actions.
         MaestroTimer.sleep(MaestroTimer.Reason.BUFFER, 300)
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -31,9 +31,9 @@ import maestro.orchestra.ElementSelector
 import maestro.orchestra.ElementTrait
 import maestro.orchestra.EraseTextCommand
 import maestro.orchestra.HideKeyboardCommand
-import maestro.orchestra.InputTextCommand
 import maestro.orchestra.InputRandomCommand
 import maestro.orchestra.InputRandomType
+import maestro.orchestra.InputTextCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.OpenLinkCommand
@@ -217,7 +217,7 @@ data class YamlFluentCommand(
         longPress: Boolean = false,
     ): MaestroCommand {
         val retryIfNoChange = (tapOn as? YamlElementSelector)?.retryTapIfNoChange ?: true
-        val waitUntilVisible = (tapOn as? YamlElementSelector)?.waitUntilVisible ?: true
+        val waitUntilVisible = (tapOn as? YamlElementSelector)?.waitUntilVisible ?: false
         val point = (tapOn as? YamlElementSelector)?.point
 
         return if (point != null) {
@@ -242,36 +242,6 @@ data class YamlFluentCommand(
                     retryIfNoChange = retryIfNoChange,
                     waitUntilVisible = waitUntilVisible,
                     longPress = longPress,
-                )
-            )
-        }
-    }
-
-    private fun longPressCommand(tapOn: YamlElementSelectorUnion): MaestroCommand {
-        val retryIfNoChange = (tapOn as? YamlElementSelector)?.retryTapIfNoChange ?: true
-        val waitUntilVisible = (tapOn as? YamlElementSelector)?.waitUntilVisible ?: true
-        val point = (tapOn as? YamlElementSelector)?.point
-
-        return if (point != null) {
-            val points = point.split(",")
-                .map {
-                    it.trim().toInt()
-                }
-
-            MaestroCommand(
-                TapOnPointCommand(
-                    x = points[0],
-                    y = points[1],
-                    retryIfNoChange = retryIfNoChange,
-                    waitUntilVisible = waitUntilVisible,
-                )
-            )
-        } else {
-            MaestroCommand(
-                command = TapOnElementCommand(
-                    selector = toElementSelector(tapOn),
-                    retryIfNoChange = retryIfNoChange,
-                    waitUntilVisible = waitUntilVisible,
                 )
             )
         }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -209,7 +209,7 @@ class IntegrationTest {
 
         // Then
         // No test failure
-        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 3)
+        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 2)
     }
 
     @Test


### PR DESCRIPTION
## Proposed Changes

Several different improvements that should help speed up Maestro flows:

- In case if there is no change after a tap on element we retry only once instead of twice
- `waitUntilVisible` now default to `false` as this is a rather exotic use case that is unlikely to be needed by majority of apps
- Starting timeout countdown from the latest iteraction/mutation of view hierarchy instead of current time. This makes consequent Optional steps as well as Assertions _much_ faster as they can just assume that hierarchy did not change and are going to fail fast
- `eraseText` no longer waits for app to settle on _each_ key press
- Caching `deviceInfo` value, allowing it to be reused across commands (saves a network call on each command)