### PR TITLE
Fixing launching app when launcher activity throws `NullPointerException`

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -152,8 +152,8 @@ class AndroidDriver(
         try {
             val apkFile = AndroidAppFiles.getApkFile(dadb, appId)
             val manifest = apkFile.asManifest()
-            val launcherActivity = manifest.resolveLauncherActivity(appId)
             runCatching {
+                val launcherActivity = manifest.resolveLauncherActivity(appId)
                 val shellResponse = dadb.shell("am start-activity -n $appId/${launcherActivity}")
                 if (shellResponse.errorOutput.isNotEmpty()) shell("monkey --pct-syskeys 0 -p $appId 1")
             }.onFailure { shell("monkey --pct-syskeys 0 -p $appId 1") }


### PR DESCRIPTION
## Proposed Changes
Fix launching app when resolving launcher activity from manifest is throwing NullPointerException
 

