### PR TITLE
Feature: test reports

### DIFF
--- a/maestro-cli/build.gradle
+++ b/maestro-cli/build.gradle
@@ -29,15 +29,20 @@ dependencies {
     implementation project(':maestro-ios')
     implementation "dev.mobile:dadb:1.2.6"
     implementation 'info.picocli:picocli:4.5.2'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1'
-    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4'
+    implementation 'com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.13.4'
     implementation 'org.fusesource.jansi:jansi:2.4.0'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'io.ktor:ktor-client-core:2.1.2'
     implementation 'io.ktor:ktor-client-cio:2.1.2'
     implementation 'org.rauschig:jarchivelib:1.2.0'
     implementation 'net.harawata:appdirs:1.2.1'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testImplementation "com.google.truth:truth:1.1.3"
 }
 
 java {
@@ -103,4 +108,8 @@ jreleaser {
             }
         }
     }
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -84,6 +84,7 @@ private fun printVersion() {
 fun main(args: Array<String>) {
     val commandLine = CommandLine(App())
         .setUsageHelpWidth(160)
+        .setCaseInsensitiveEnumValuesAllowed(true)
         .setExecutionExceptionHandler { ex, cmd, parseResult ->
             val message = if (ex is CliError) {
                 ex.message

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -24,6 +24,8 @@ import maestro.cli.CliError
 import maestro.cli.runner.TestRunner
 import maestro.cli.runner.TestSuiteInteractor
 import maestro.cli.util.MaestroFactory
+import okio.buffer
+import okio.sink
 import picocli.CommandLine
 import picocli.CommandLine.Option
 import java.io.File
@@ -45,6 +47,9 @@ class TestCommand : Callable<Int> {
 
     @Option(names = ["-e", "--env"])
     private var env: Map<String, String> = emptyMap()
+
+    @Option(names = ["--report"])
+    private var report: File? = null
 
     @CommandLine.Spec
     lateinit var commandSpec: CommandLine.Model.CommandSpec
@@ -71,11 +76,10 @@ class TestCommand : Callable<Int> {
                 )
             }
 
-            val suiteResult = TestSuiteInteractor.runTestSuite(
-                maestro,
-                device,
-                flowFile,
-                env
+            val suiteResult = TestSuiteInteractor(maestro, device).runTestSuite(
+                input = flowFile,
+                env = env,
+                reportOut = report?.sink()?.buffer()
             )
 
             if (suiteResult.passed) {

--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -1,0 +1,25 @@
+package maestro.cli.model
+
+data class TestExecutionSummary(
+    val passed: Boolean,
+    val suites: List<SuiteResult>,
+    val deviceName: String? = null,
+) {
+
+    data class SuiteResult(
+        val passed: Boolean,
+        val flows: List<FlowResult>,
+    )
+
+    data class FlowResult(
+        val name: String,
+        val fileName: String,
+        val status: FlowStatus,
+        val failure: Failure? = null,
+    )
+
+    data class Failure(
+        val message: String,
+    )
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -1,0 +1,97 @@
+package maestro.cli.report
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlText
+import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import maestro.cli.model.FlowStatus
+import maestro.cli.model.TestExecutionSummary
+import okio.Sink
+import okio.buffer
+
+class JUnitTestSuiteReporter(
+    private val mapper: ObjectMapper
+) : TestSuiteReporter {
+
+    override fun report(
+        summary: TestExecutionSummary,
+        out: Sink
+    ) {
+        mapper
+            .writerWithDefaultPrettyPrinter()
+            .writeValue(
+                out.buffer().outputStream(),
+                TestSuites(
+                    suites = summary
+                        .suites
+                        .map { suite ->
+                            TestSuite(
+                                name = "Test Suite",
+                                device = summary.deviceName,
+                                failures = suite.flows.count { it.status == FlowStatus.ERROR },
+                                tests = suite.flows.size,
+                                testCases = suite.flows
+                                    .map { flow ->
+                                        TestCase(
+                                            id = flow.fileName,
+                                            name = flow.name,
+                                            failure = flow.failure?.let { failure ->
+                                                Failure(
+                                                    message = failure.message,
+                                                )
+                                            }
+                                        )
+                                    }
+                            )
+                        }
+                )
+            )
+    }
+
+    @JacksonXmlRootElement(localName = "testsuites")
+    private data class TestSuites(
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JsonProperty("testsuite")
+        val suites: List<TestSuite>,
+    )
+
+    @JacksonXmlRootElement(localName = "testsuite")
+    private data class TestSuite(
+        @JacksonXmlProperty(isAttribute = true) val name: String,
+        @JacksonXmlProperty(isAttribute = true) val device: String?,
+        @JacksonXmlProperty(isAttribute = true) val tests: Int,
+        @JacksonXmlProperty(isAttribute = true) val failures: Int,
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JsonProperty("testcase")
+        val testCases: List<TestCase>,
+    )
+
+    private data class TestCase(
+        @JacksonXmlProperty(isAttribute = true) val id: String,
+        @JacksonXmlProperty(isAttribute = true) val name: String,
+        val failure: Failure? = null,
+    )
+
+    private data class Failure(
+        @JacksonXmlText val message: String,
+    )
+
+    companion object {
+
+        fun xml() = JUnitTestSuiteReporter(
+            XmlMapper().apply {
+                registerModule(KotlinModule.Builder().build())
+                setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
+            }
+        )
+
+    }
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
@@ -1,0 +1,10 @@
+package maestro.cli.report
+
+enum class ReportFormat(
+    val fileExtension: String?
+) {
+
+    JUNIT(".xml"),
+    NOOP(null),
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
@@ -1,0 +1,12 @@
+package maestro.cli.report
+
+object ReporterFactory {
+
+    fun buildReporter(format: ReportFormat): TestSuiteReporter {
+        return when (format) {
+            ReportFormat.JUNIT -> JUnitTestSuiteReporter.xml()
+            ReportFormat.NOOP -> TestSuiteReporter.NOOP
+        }
+    }
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
@@ -1,0 +1,13 @@
+package maestro.cli.report
+
+import maestro.cli.model.TestExecutionSummary
+import okio.Sink
+
+interface TestSuiteReporter {
+
+    fun report(
+        summary: TestExecutionSummary,
+        out: Sink,
+    )
+
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
@@ -10,4 +10,12 @@ interface TestSuiteReporter {
         out: Sink,
     )
 
+    companion object {
+        val NOOP: TestSuiteReporter = object : TestSuiteReporter {
+            override fun report(summary: TestExecutionSummary, out: Sink) {
+                // no-op
+            }
+        }
+    }
+
 }

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -4,7 +4,6 @@ import maestro.Maestro
 import maestro.cli.device.Device
 import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
-import maestro.cli.report.JUnitTestSuiteReporter
 import maestro.cli.report.TestSuiteReporter
 import maestro.cli.util.PrintUtils
 import maestro.cli.view.ErrorViewUtils
@@ -18,7 +17,7 @@ import java.io.File
 class TestSuiteInteractor(
     private val maestro: Maestro,
     private val device: Device? = null,
-    private val reporter: TestSuiteReporter = JUnitTestSuiteReporter.xml(),
+    private val reporter: TestSuiteReporter,
 ) {
 
     fun runTestSuite(

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -3,24 +3,34 @@ package maestro.cli.runner
 import maestro.Maestro
 import maestro.cli.device.Device
 import maestro.cli.model.FlowStatus
+import maestro.cli.model.TestExecutionSummary
+import maestro.cli.report.JUnitTestSuiteReporter
+import maestro.cli.report.TestSuiteReporter
 import maestro.cli.util.PrintUtils
+import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
 import maestro.orchestra.Orchestra
 import maestro.orchestra.yaml.YamlCommandReader
+import okio.Sink
 import java.io.File
 
-object TestSuiteInteractor {
+class TestSuiteInteractor(
+    private val maestro: Maestro,
+    private val device: Device? = null,
+    private val reporter: TestSuiteReporter = JUnitTestSuiteReporter.xml(),
+) {
 
     fun runTestSuite(
-        maestro: Maestro,
-        device: Device?,
         input: File,
+        reportOut: Sink?,
         env: Map<String, String>,
-    ): SuiteResult {
+    ): TestExecutionSummary {
         return if (input.isFile) {
             runTestSuite(
-                maestro, device, listOf(input), env
+                listOf(input),
+                reportOut,
+                env,
             )
         } else {
             val flowFiles = input
@@ -33,18 +43,19 @@ object TestSuiteInteractor {
                 .toList()
 
             runTestSuite(
-                maestro, device, flowFiles, env
+                flowFiles,
+                reportOut,
+                env,
             )
         }
     }
 
     fun runTestSuite(
-        maestro: Maestro,
-        device: Device?,
         flows: List<File>,
+        reportOut: Sink?,
         env: Map<String, String>,
-    ): SuiteResult {
-        val flowResults = mutableListOf<SuiteResult.FlowResult>()
+    ): TestExecutionSummary {
+        val flowResults = mutableListOf<TestExecutionSummary.FlowResult>()
 
         PrintUtils.message("Waiting for flows to complete...")
         println()
@@ -59,7 +70,6 @@ object TestSuiteInteractor {
 
             // TODO accumulate extra information
             // - Command statuses
-            // - Errors
             // - View hierarchies
             flowResults.add(result)
         }
@@ -77,20 +87,35 @@ object TestSuiteInteractor {
             )
         )
 
-        return SuiteResult(
+        val summary = TestExecutionSummary(
             passed = passed,
-            flows = flowResults,
-            device = device,
+            deviceName = device?.description,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = passed,
+                    flows = flowResults
+                )
+            )
         )
+
+        if (reportOut != null) {
+            reporter.report(
+                summary,
+                reportOut
+            )
+        }
+
+        return summary
     }
 
     private fun runFlow(
         flowFile: File,
         env: Map<String, String>,
         maestro: Maestro,
-    ): SuiteResult.FlowResult {
+    ): TestExecutionSummary.FlowResult {
         var flowName: String = flowFile.nameWithoutExtension
         var flowStatus: FlowStatus
+        var errorMessage: String? = null
 
         try {
             val commands = YamlCommandReader.readCommands(flowFile.toPath())
@@ -111,7 +136,7 @@ object TestSuiteInteractor {
         } catch (e: Exception) {
             flowStatus = FlowStatus.ERROR
 
-            // TODO preserve error for report
+            errorMessage = ErrorViewUtils.exceptionToMessage(e)
         }
 
         TestSuiteStatusView.showFlowCompletion(
@@ -121,23 +146,16 @@ object TestSuiteInteractor {
             )
         )
 
-        return SuiteResult.FlowResult(
+        return TestExecutionSummary.FlowResult(
             name = flowName,
+            fileName = flowFile.nameWithoutExtension,
             status = flowStatus,
+            failure = if (flowStatus == FlowStatus.ERROR) {
+                TestExecutionSummary.Failure(
+                    message = errorMessage ?: "Unknown error",
+                )
+            } else null,
         )
-    }
-
-    data class SuiteResult(
-        val passed: Boolean,
-        val flows: List<FlowResult>,
-        val device: Device? = null,
-    ) {
-
-        data class FlowResult(
-            val name: String,
-            val status: FlowStatus,  // TODO do not depend on view model
-        )
-
     }
 
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -1,0 +1,113 @@
+package maestro.cli.report
+
+import com.google.common.truth.Truth.assertThat
+import maestro.cli.model.FlowStatus
+import maestro.cli.model.TestExecutionSummary
+import okio.Buffer
+import org.junit.jupiter.api.Test
+
+class JUnitTestSuiteReporterTest {
+
+    @Test
+    fun `XML - Test passed`() {
+        // Given
+        val testee = JUnitTestSuiteReporter.xml()
+
+        val summary = TestExecutionSummary(
+            passed = true,
+            deviceName = "iPhone 14",
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = true,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow A",
+                            fileName = "flow_a",
+                            status = FlowStatus.SUCCESS,
+                        ),
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow B",
+                            fileName = "flow_b",
+                            status = FlowStatus.WARNING,
+                        ),
+                    )
+                )
+            )
+        )
+        val sink = Buffer()
+
+        // When
+        testee.report(
+            summary = summary,
+            out = sink
+        )
+        val resultStr = sink.readUtf8()
+
+        // Then
+        assertThat(resultStr).isEqualTo(
+            """
+                <?xml version='1.0' encoding='UTF-8'?>
+                <testsuites>
+                  <testsuite name="Test Suite" device="iPhone 14" tests="2" failures="0">
+                    <testcase id="flow_a" name="Flow A"/>
+                    <testcase id="flow_b" name="Flow B"/>
+                  </testsuite>
+                </testsuites>
+                
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `XML - Test failed`() {
+        // Given
+        val testee = JUnitTestSuiteReporter.xml()
+
+        val summary = TestExecutionSummary(
+            passed = false,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = false,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow A",
+                            fileName = "flow_a",
+                            status = FlowStatus.SUCCESS,
+                        ),
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow B",
+                            fileName = "flow_b",
+                            status = FlowStatus.ERROR,
+                            failure = TestExecutionSummary.Failure("Error message")
+                        ),
+                    )
+                )
+            )
+        )
+        val sink = Buffer()
+
+        // When
+        testee.report(
+            summary = summary,
+            out = sink
+        )
+        val resultStr = sink.readUtf8()
+
+        // Then
+        assertThat(resultStr).isEqualTo(
+            """
+                <?xml version='1.0' encoding='UTF-8'?>
+                <testsuites>
+                  <testsuite name="Test Suite" tests="2" failures="1">
+                    <testcase id="flow_a" name="Flow A"/>
+                    <testcase id="flow_b" name="Flow B">
+                      <failure>Error message</failure>
+                    </testcase>
+                  </testsuite>
+                </testsuites>
+                
+            """.trimIndent()
+        )
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes

Adding `--report` option to a `test` command that generates a JUnit-compatible test report in XML format. Sample output:

```
<?xml version='1.0' encoding='UTF-8'?>
<testsuites>
  <testsuite name="Test Suite" device="Pixel_3_API_30_Google_Play_" tests="6" failures="2">
    <testcase id="misconfigured" name="misconfigured">
      <failure>Could not parse Flow file:

Flow files must contain a config section and a commands section. Found 1 section: ../DevToolTester/android/.mobiledev/misconfigured.yaml</failure>
    </testcase>
    <testcase id="failing" name="Failing test">
      <failure>Element not found: Text matching regex: Something incorrect</failure>
    </testcase>
    <testcase id="appCrash" name="App Crash"/>
    <testcase id="memoryLeak" name="Memory Leak"/>
    <testcase id="loggedOutContent" name="Logged Out Content"/>
    <testcase id="loggedInContent" name="Logged In Content"/>
  </testsuite>
</testsuites>
```