### PR TITLE
Opt-out from jdk8 dependency when installing with brew

### DIFF
--- a/maestro-cli/build.gradle
+++ b/maestro-cli/build.gradle
@@ -91,6 +91,7 @@ jreleaser {
                 path = 'build/distributions/maestro.zip'
             }
             brew {
+                extraProperties.put('skipJava', 'true')
                 active = 'RELEASE'
                 formulaName = 'Maestro'
 


### PR DESCRIPTION
## Proposed Changes

Configures jreleaser Gradle plugin in a way that `openjdk@8` will not be added as a dependency in the [generated brew formula ](https://github.com/mobile-dev-inc/homebrew-tap/blob/8ab370773f5b2a2dbf1eb57a0533e0dc317c31fb/Formula/maestro.rb#L10)

## Testing

- Pull these changes locally
- Generate the target formula

```bash
$> ./gradlew clean maestro-cli:jreleaserPackage
```

- Check no `openjdk` dependency in the generated formula

```bash
$> grep -L openjdk maestro-cli/build/jreleaser/package/maestro/brew/Formula/maestro.rb
```

## Issues Fixed

Fixes #402 

## Additional comments

An update in public docs warning users that a proper JDK available at `$PATH` is required in order to run **maestro** is probably useful as well.  🙂
