### PR TITLE
Silence compiler warnings about opt-in kotlin flag for grpc generated code

### DIFF
--- a/maestro-android/build.gradle
+++ b/maestro-android/build.gradle
@@ -26,6 +26,11 @@ protobuf {
     }
 }
 
+kotlin.sourceSets.all {
+    // Prevent build warnings for grpc's generated opt-in code
+    languageSettings.optIn("kotlin.RequiresOptIn")
+}
+
 android {
     compileSdk 31
 

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -31,6 +31,11 @@ compileKotlin {
     dependsOn generateProto
 }
 
+kotlin.sourceSets.all {
+    // Prevent build warnings for grpc's generated opt-in code
+    languageSettings.optIn("kotlin.RequiresOptIn")
+}
+
 sourceSets {
     main {
         java {

--- a/maestro-ios/build.gradle
+++ b/maestro-ios/build.gradle
@@ -31,6 +31,11 @@ compileKotlin {
     dependsOn generateProto
 }
 
+kotlin.sourceSets.all {
+    // Prevent build warnings for grpc's generated opt-in code
+    languageSettings.optIn("kotlin.RequiresOptIn")
+}
+
 sourceSets {
     main {
         java {


### PR DESCRIPTION
## Proposed Changes

Change build.gradle options to pass RequiresOptIn to the kotlin compile to silence compiler warnings on grpc generated code.

## Testing
CI build
