### PR TITLE
Store idb_companion logs for later inspection

### DIFF
--- a/maestro-cli/build.gradle
+++ b/maestro-cli/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'io.ktor:ktor-client-core:2.1.2'
     implementation 'io.ktor:ktor-client-cio:2.1.2'
     implementation 'org.rauschig:jarchivelib:1.2.0'
+    implementation 'net.harawata:appdirs:1.2.1'
 }
 
 java {

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -27,6 +27,7 @@ import maestro.cli.command.PrintHierarchyCommand
 import maestro.cli.command.QueryCommand
 import maestro.cli.command.TestCommand
 import maestro.cli.command.UploadCommand
+import maestro.cli.debuglog.DebugLogStore
 import org.fusesource.jansi.AnsiConsole
 import picocli.CommandLine
 import picocli.CommandLine.Command
@@ -99,6 +100,8 @@ fun main(args: Array<String>) {
 
     val exitCode = commandLine
         .execute(*args)
+
+    DebugLogStore.finalizeRun()
 
     if (commandLine.isVersionHelpRequested) {
         printVersion()

--- a/maestro-cli/src/main/java/maestro/cli/debuglog/DebugLogStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/debuglog/DebugLogStore.kt
@@ -1,0 +1,59 @@
+package maestro.cli.debuglog
+
+import maestro.cli.App
+import net.harawata.appdirs.AppDirsFactory
+import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Properties
+
+object DebugLogStore {
+
+    private val logDirectory = createLogDirectory()
+
+    fun logOutputOf(processBuilder: ProcessBuilder) {
+        val command = processBuilder.command().first() ?: "unknown"
+        val logFile = logFile(command)
+        val redirect = ProcessBuilder.Redirect.to(logFile)
+        processBuilder
+            .redirectOutput(redirect)
+            .redirectError(redirect)
+    }
+
+    private fun logFile(named: String): File {
+        return File(logDirectory, "$named.log")
+    }
+
+    private fun createLogDirectory(): File {
+        val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd_HHmmss")
+        val date = dateFormatter.format(LocalDateTime.now())
+
+        val baseDir = File(AppDirsFactory.getInstance().getUserLogDir("maestro", appVersion(), "mobiledev"))
+        val logDirectory = File(baseDir, date)
+        logDirectory.mkdirs()
+        removeOldLogs(baseDir)
+        println("Debug logs are stored in $logDirectory")
+        return logDirectory
+    }
+
+    private fun removeOldLogs(baseDir: File) {
+        if (!baseDir.isDirectory) { return }
+
+        val existing = baseDir.listFiles() ?: return
+        val toDelete = existing.sortedByDescending { it.name }
+            .drop(KEEP_LOG_COUNT)
+            .toList()
+
+        toDelete.forEach { it.deleteRecursively() }
+    }
+
+    private fun appVersion(): String {
+        val props = App::class.java.classLoader.getResourceAsStream("version.properties").use {
+            Properties().apply { load(it) }
+        }
+
+        return props["version"].toString()
+    }
+
+    private const val KEEP_LOG_COUNT = 5
+}

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -6,6 +6,7 @@ import io.grpc.ManagedChannelBuilder
 import ios.idb.IdbIOSDevice
 import maestro.MaestroTimer
 import maestro.cli.CliError
+import maestro.cli.debuglog.DebugLogStore
 import maestro.cli.device.ios.Simctl
 import maestro.cli.device.ios.SimctlList
 import maestro.cli.util.EnvUtils
@@ -89,10 +90,9 @@ object DeviceService {
             error("idb_companion is already running. Stop idb_companion and run maestro again")
         }
 
-        val idbProcess = ProcessBuilder("idb_companion", "--udid", device.instanceId)
-            .redirectError(ProcessBuilder.Redirect.to(NULL_FILE))
-            .redirectOutput(ProcessBuilder.Redirect.to(NULL_FILE))
-            .start()
+        val idbProcessBuilder = ProcessBuilder("idb_companion", "--udid", device.instanceId)
+        DebugLogStore.logOutputOf(idbProcessBuilder)
+        val idbProcess = idbProcessBuilder.start()
 
         Runtime.getRuntime().addShutdownHook(thread(start = false) {
             idbProcess.destroy()

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -13,6 +13,7 @@ import maestro.cli.util.EnvUtils
 import java.io.File
 import java.net.Socket
 import java.util.concurrent.TimeUnit
+import java.util.logging.Logger
 import kotlin.concurrent.thread
 
 object DeviceService {
@@ -22,6 +23,8 @@ object DeviceService {
                 .startsWith("Windows")
         ) "NUL" else "/dev/null"
     )
+
+    private val logger = DebugLogStore.loggerFor(DeviceService::class.java)
 
     fun startDevice(device: Device.AvailableForLaunch): Device.Connected {
         when (device.platform) {
@@ -79,6 +82,8 @@ object DeviceService {
     }
 
     private fun startIdbCompanion(device: Device.Connected) {
+        logger.info("startIDBCompanion on $device")
+
         val idbHost = "localhost"
         val idbPort = 10882
 


### PR DESCRIPTION
## Proposed Changes

- DebugLogStore stores log files in $HOME/Library/Logs/maestro/ (similar but different dirs for Linux and Windows).
- Add method to DebugLogStore to capture all output of a subprocess
- DebugLogStore deletes any logs except the last 5 (this run included)
- Store idb_companion logs using DebugLogStore

## Testing
Tested locally

## Issues Fixed

