### PR TITLE
Use logger.warning to send a message to the console

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/debuglog/DebugLogStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/debuglog/DebugLogStore.kt
@@ -9,6 +9,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Properties
 import java.util.logging.FileHandler
+import java.util.logging.Level
 import java.util.logging.LogRecord
 import java.util.logging.Logger
 import java.util.logging.SimpleFormatter
@@ -30,6 +31,17 @@ object DebugLogStore {
         logDirectory.mkdirs()
         removeOldLogs(baseDir)
         println("Debug log store $logDirectory.zip")
+
+        val console = Logger.getLogger("")
+        console.level = Level.WARNING
+        console.handlers.map {
+            it.formatter = object : SimpleFormatter() {
+                override fun format(record: LogRecord): String {
+                    val level = if (record.level.intValue() > 900) "Error: " else ""
+                    return "$level${record.message}\n"
+                }
+            }
+        }
 
         maestroLogFile = logFile("maestro")
         logSystemInfo()

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -108,14 +108,14 @@ object DeviceService {
             .build()
 
         IdbIOSDevice(channel).use { iosDevice ->
-            println("Waiting for idb service to start..")
+            logger.warning("Waiting for idb service to start..")
             MaestroTimer.retryUntilTrue(timeoutMs = 60000, delayMs = 100) {
                 Socket(idbHost, idbPort).use { true }
             } || error("idb_companion did not start in time")
 
             // The first time a simulator boots up, it can
             // take 10's of seconds to complete.
-            println("Waiting for Simulator to boot..")
+            logger.warning("Waiting for Simulator to boot..")
             MaestroTimer.retryUntilTrue(timeoutMs = 120000, delayMs = 100) {
                 val process = ProcessBuilder("xcrun", "simctl", "bootstatus", device.instanceId)
                     .start()
@@ -125,7 +125,7 @@ object DeviceService {
             } || error("Simulator failed to boot")
 
             // Test if idb can get accessibility info elements with non-zero frame with
-            println("Waiting for Accessibility info to become available..")
+            logger.warning("Waiting for Accessibility info to become available..")
             MaestroTimer.retryUntilTrue(timeoutMs = 20000, delayMs = 100) {
                 val nodes = iosDevice
                     .contentDescriptor()
@@ -134,7 +134,7 @@ object DeviceService {
                 nodes?.any { it.frame?.width != 0F } == true
             } || error("idb_companion is not able to fetch accessibility info")
 
-            println("Simulator ${device.description} ready")
+            logger.warning("Simulator ready")
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Use `logger.warning()` to message both to the console as well as to the debug log.
If this is accepted I'll update all the println() lines to use `logger.warning()` instead.

`logger.severe()` will print "Error: <message>" to the console.

