### PR TITLE
removes clipboardPaste command

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -66,8 +66,6 @@ interface Driver {
 
     fun hideKeyboard()
 
-    fun clipboardPaste()
-
     fun takeScreenshot(out: Sink)
 
     fun setLocation(latitude: Double, longitude: Double)

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -104,13 +104,6 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-    fun clipboardPaste() {
-        LOGGER.info("Paste from Clipboard")
-
-        driver.clipboardPaste()
-        waitForAppToSettle()
-    }
-
     fun swipe(swipeDirection: SwipeDirection? = null, start: Point? = null, end: Point? = null, duration: Long) {
         when {
             swipeDirection != null -> driver.swipe(swipeDirection, duration)

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -19,7 +19,6 @@
 
 package maestro.drivers
 
-import com.android.ide.common.xml.ManifestData
 import dadb.AdbShellResponse
 import dadb.AdbShellStream
 import dadb.Dadb
@@ -290,10 +289,6 @@ class AndroidDriver(
     override fun hideKeyboard() {
         dadb.shell("input keyevent 66")
         dadb.shell("input keyevent 111")
-    }
-
-    override fun clipboardPaste() {
-        dadb.shell("input keyevent 279")
     }
 
     override fun takeScreenshot(out: Sink) {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -259,12 +259,12 @@ class IOSDriver(
         val width = widthPixels ?: throw IllegalStateException("Device width not available")
         val height = heightPixels ?: throw IllegalStateException("Device height not available")
 
-        when(swipeDirection) {
+        when (swipeDirection) {
             SwipeDirection.UP -> {
                 iosDevice.scroll(
                     xStart = width / 4,
                     yStart = height,
-                    xEnd = width / 4 ,
+                    xEnd = width / 4,
                     yEnd = height / 4,
                     durationMs = durationMs,
                     IdbIOSDevice.ScrollType.SWIPE
@@ -282,9 +282,9 @@ class IOSDriver(
             }
             SwipeDirection.RIGHT -> {
                 iosDevice.scroll(
-                    xStart =  0,
+                    xStart = 0,
                     yStart = height / 4,
-                    xEnd =  width / 4 ,
+                    xEnd = width / 4,
                     yEnd = height / 4,
                     durationMs = durationMs,
                     IdbIOSDevice.ScrollType.SWIPE
@@ -292,9 +292,9 @@ class IOSDriver(
             }
             SwipeDirection.LEFT -> {
                 iosDevice.scroll(
-                    xStart = width / 4 ,
+                    xStart = width / 4,
                     yStart = height / 4,
-                    xEnd =  0,
+                    xEnd = 0,
                     yEnd = height / 4,
                     durationMs = durationMs,
                     IdbIOSDevice.ScrollType.SWIPE
@@ -307,10 +307,6 @@ class IOSDriver(
 
     override fun hideKeyboard() {
         iosDevice.pressKey(40).expect {}
-    }
-
-    override fun clipboardPaste() {
-        iosDevice.pressKey(125).expect {}
     }
 
     override fun takeScreenshot(out: Sink) {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -143,31 +143,6 @@ class HideKeyboardCommand : Command {
     }
 }
 
-class ClipboardPasteCommand : Command {
-
-    override fun equals(other: Any?): Boolean {
-        if (this == other) return true
-        if (javaClass != other?.javaClass) return false
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return javaClass.hashCode()
-    }
-
-    override fun toString(): String {
-        return "ClipboardPasteCommand()"
-    }
-
-    override fun description(): String {
-        return "Paste from Clipboard"
-    }
-
-    override fun injectEnv(env: Map<String, String>): ClipboardPasteCommand {
-        return this
-    }
-}
-
 data class TapOnElementCommand(
     val selector: ElementSelector,
     val retryIfNoChange: Boolean? = null,

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -40,7 +40,6 @@ data class MaestroCommand(
     val pressKeyCommand: PressKeyCommand? = null,
     val eraseTextCommand: EraseTextCommand? = null,
     val hideKeyboardCommand: HideKeyboardCommand? = null,
-    val clipboardPasteCommand: ClipboardPasteCommand? = null,
     val takeScreenshotCommand: TakeScreenshotCommand? = null,
     val stopAppCommand: StopAppCommand? = null,
     val clearStateCommand: ClearStateCommand? = null,
@@ -65,7 +64,6 @@ data class MaestroCommand(
         pressKeyCommand = command as? PressKeyCommand,
         eraseTextCommand = command as? EraseTextCommand,
         hideKeyboardCommand = command as? HideKeyboardCommand,
-        clipboardPasteCommand = command as? ClipboardPasteCommand,
         takeScreenshotCommand = command as? TakeScreenshotCommand,
         stopAppCommand = command as? StopAppCommand,
         clearStateCommand = command as? ClearStateCommand,
@@ -90,7 +88,6 @@ data class MaestroCommand(
         pressKeyCommand != null -> pressKeyCommand
         eraseTextCommand != null -> eraseTextCommand
         hideKeyboardCommand != null -> hideKeyboardCommand
-        clipboardPasteCommand != null -> clipboardPasteCommand
         takeScreenshotCommand != null -> takeScreenshotCommand
         stopAppCommand != null -> stopAppCommand
         clearStateCommand != null -> clearStateCommand

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -145,7 +145,6 @@ class Orchestra(
             is TapOnPointCommand -> tapOnPoint(command, command.retryIfNoChange ?: true)
             is BackPressCommand -> backPressCommand()
             is HideKeyboardCommand -> hideKeyboardCommand()
-            is ClipboardPasteCommand -> clipboardPasteCommand()
             is ScrollCommand -> scrollVerticalCommand()
             is SwipeCommand -> swipeCommand(command)
             is AssertCommand -> assertCommand(command)
@@ -191,11 +190,6 @@ class Orchestra(
 
     private fun scrollVerticalCommand(): Boolean {
         maestro.scrollVertical()
-        return true
-    }
-
-    private fun clipboardPasteCommand(): Boolean {
-        maestro.clipboardPaste()
         return true
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -25,7 +25,6 @@ import maestro.Point
 import maestro.orchestra.AssertCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
-import maestro.orchestra.ClipboardPasteCommand
 import maestro.orchestra.Condition
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.ElementTrait
@@ -99,7 +98,6 @@ data class YamlFluentCommand(
                 when (action) {
                     "back" -> MaestroCommand(BackPressCommand())
                     "hide keyboard" -> MaestroCommand(HideKeyboardCommand())
-                    "clipboard paste" -> MaestroCommand(ClipboardPasteCommand())
                     "scroll" -> MaestroCommand(ScrollCommand())
                     "clearKeychain" -> MaestroCommand(ClearKeychainCommand())
                     else -> error("Unknown navigation target: $action")
@@ -386,10 +384,6 @@ data class YamlFluentCommand(
 
                 "hide keyboard", "hideKeyboard" -> YamlFluentCommand(
                     action = "hide keyboard"
-                )
-
-                "clipboard paste", "clipboardPaste" -> YamlFluentCommand(
-                    action = "clipboard paste"
                 )
 
                 "scroll" -> YamlFluentCommand(

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -187,12 +187,6 @@ class FakeDriver : Driver {
         events += Event.HideKeyboard
     }
 
-    override fun clipboardPaste() {
-        ensureOpen()
-
-        events += Event.ClipboardPaste
-    }
-
     override fun takeScreenshot(out: Sink) {
         ensureOpen()
 
@@ -307,8 +301,6 @@ class FakeDriver : Driver {
         object BackPress : Event(), UserInteraction
 
         object HideKeyboard : Event(), UserInteraction
-        
-        object ClipboardPaste : Event(), UserInteraction
 
         data class InputText(
             val text: String
@@ -320,7 +312,7 @@ class FakeDriver : Driver {
             val durationMs: Long
         ) : Event(), UserInteraction
 
-        data class SwipeWithDirection(val swipeDirection: SwipeDirection, val durationMs: Long): Event(), UserInteraction
+        data class SwipeWithDirection(val swipeDirection: SwipeDirection, val durationMs: Long) : Event(), UserInteraction
 
         data class LaunchApp(
             val appId: String

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1422,29 +1422,6 @@ class IntegrationTest {
     }
 
     @Test
-    fun `Case 050 - Paste from Clipboard`() {
-        // Given
-        val commands = readCommands("050_clipboard_paste")
-
-        val driver = driver {
-        }
-
-        // When
-        Maestro(driver).use {
-            orchestra(it).runFlow(commands)
-        }
-
-        // Then
-        // No test failure
-        driver.assertEvents(
-            listOf(
-                Event.ClipboardPaste,
-                Event.ClipboardPaste,
-            )
-        )
-    }
-
-    @Test
     fun `Case 051 - Set location`() {
         // Given
         val commands = readCommands("051_set_location")

--- a/maestro-test/src/test/resources/050_clipboard_paste.yaml
+++ b/maestro-test/src/test/resources/050_clipboard_paste.yaml
@@ -1,4 +1,0 @@
-appId: com.example.app
----
-- action: clipboard paste
-- clipboardPaste


### PR DESCRIPTION
## Proposed Changes
- Removes clipboardPaste command

Reason: Does not work as intended. Substitute command copytextFrom/pasteText will be introduced to facilitate copy/paste