### PR TITLE
Remove duplicate label "inputRandomText"

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -375,10 +375,6 @@ data class YamlFluentCommand(
                     inputRandomText = YamlInputRandomText(length = 8),
                 )
 
-                "inputRandomText" -> YamlFluentCommand(
-                    inputRandomText = YamlInputRandomText(length = 8),
-                )
-
                 "inputRandomNumber" -> YamlFluentCommand(
                     inputRandomNumber = YamlInputRandomNumber(length = 8),
                 )


### PR DESCRIPTION
`./gradlew build` fails due to a duplicate label in YamlFluentCommand.kt