### PR TITLE
Add maestro runner status and crashes to debug log

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -84,15 +84,19 @@ private fun printVersion() {
 
 @Suppress("SpreadOperator")
 fun main(args: Array<String>) {
+    val logger = DebugLogStore.loggerFor(App::class.java)
+
     val commandLine = CommandLine(App())
         .setUsageHelpWidth(160)
         .setCaseInsensitiveEnumValuesAllowed(true)
-        .setExecutionExceptionHandler { ex, cmd, parseResult ->
+        .setExecutionExceptionHandler { ex, cmd, _ ->
             val message = if (ex is CliError) {
                 ex.message
             } else {
                 ex.stackTraceToString()
             }
+
+            logger.info(message)
             println()
             cmd.err.println(
                 cmd.colorScheme.errorText(message)

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -21,6 +21,7 @@ package maestro.cli.runner
 
 import maestro.Maestro
 import maestro.MaestroException
+import maestro.cli.debuglog.DebugLogStore
 import maestro.cli.device.Device
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.CompositeCommand
@@ -31,6 +32,8 @@ import maestro.orchestra.yaml.YamlCommandReader
 import java.util.IdentityHashMap
 
 object MaestroCommandRunner {
+
+    private val logger = DebugLogStore.loggerFor(MaestroCommand::class.java)
 
     fun runCommands(
         maestro: Maestro,
@@ -67,10 +70,12 @@ object MaestroCommandRunner {
         val orchestra = Orchestra(
             maestro,
             onCommandStart = { _, command ->
+                logger.info("${command.description()} RUNNING")
                 commandStatuses[command] = CommandStatus.RUNNING
                 refreshUi()
             },
             onCommandComplete = { _, command ->
+                logger.info("${command.description()} COMPLETED")
                 commandStatuses[command] = CommandStatus.COMPLETED
                 refreshUi()
             },
@@ -79,19 +84,23 @@ object MaestroCommandRunner {
                     throw e
                 }
 
+                logger.info("${command.description()} FAILED")
                 commandStatuses[command] = CommandStatus.FAILED
                 refreshUi()
                 Orchestra.ErrorResolution.FAIL
             },
             onCommandSkipped = { _, command ->
+                logger.info("${command.description()} SKIPPED")
                 commandStatuses[command] = CommandStatus.SKIPPED
                 refreshUi()
             },
             onCommandReset = { command ->
+                logger.info("${command.description()} PENDING")
                 commandStatuses[command] = CommandStatus.PENDING
                 refreshUi()
             },
             onCommandMetadataUpdate = { command, metadata ->
+                logger.info("${command.description()} metadata $metadata")
                 commandMetadata[command] = metadata
                 refreshUi()
             },


### PR DESCRIPTION
## Proposed Changes

Add maestro runner status:
```
cat maestro.log
[2022-11-17 14:31:20] [INFO   ] startIDBCompanion on Connected(instanceId=B2C43E91-5A2B-471E-8CC6-4EBD9427F528, description=mobiledev_iPhone11 - iOS 15.5 - B2C43E91-5A2B-471E-8CC6-4EBD9427F528, platform=IOS)
[2022-11-17 14:31:20] [WARNING] Waiting for idb service to start..
[2022-11-17 14:31:20] [WARNING] Waiting for Simulator to boot..
[2022-11-17 14:31:21] [WARNING] Waiting for Accessibility info to become available..
[2022-11-17 14:31:30] [WARNING] Simulator ready
[2022-11-17 14:31:30] [INFO   ] Apply configuration RUNNING
[2022-11-17 14:31:30] [INFO   ] Apply configuration COMPLETED
[2022-11-17 14:31:30] [INFO   ] Launch app "org.wikimedia.wikipedia" with clear state RUNNING
[2022-11-17 14:31:31] [INFO   ] Launch app "org.wikimedia.wikipedia" with clear state COMPLETED
[2022-11-17 14:31:31] [INFO   ] Tap on "Next" RUNNING
[2022-11-17 14:31:36] [INFO   ] Tap on "Next" COMPLETED
[2022-11-17 14:31:36] [INFO   ] Tap on "Next" RUNNING
[2022-11-17 14:31:42] [INFO   ] Tap on "Next" COMPLETED
[2022-11-17 14:31:42] [INFO   ] Tap on "Next" RUNNING
[2022-11-17 14:31:46] [INFO   ] Tap on "Next" COMPLETED
[2022-11-17 14:31:46] [INFO   ] Tap on "Get started" RUNNING
[2022-11-17 14:31:47] [INFO   ] Tap on "Get started" COMPLETED
[2022-11-17 14:31:47] [INFO   ] Tap on "Search Wikipedia" RUNNING
[2022-11-17 14:31:53] [INFO   ] Tap on "Search Wikipedia" COMPLETED
[2022-11-17 14:31:53] [INFO   ] Input text Automated testing RUNNING
[2022-11-17 14:32:02] [INFO   ] Input text Automated testing COMPLETED
[2022-11-17 14:32:02] [INFO   ] Tap on "Software testing.*" RUNNING
[2022-11-17 14:33:25] [INFO   ] Tap on "Software testing.*" COMPLETED
```

And crash reports:
```
cat maestro.log
[2022-11-17 14:59:26] [INFO   ] startIDBCompanion on Connected(instanceId=B2C43E91-5A2B-471E-8CC6-4EBD9427F528, description=mobiledev_iPhone11 - iOS 15.5 - B2C43E91-5A2B-471E-8CC6-4EBD9427F528, platform=IOS)
[2022-11-17 14:59:26] [INFO   ] java.lang.IllegalStateException: Unexpected foo happened! OH NO!
	at maestro.cli.device.DeviceService.startIdbCompanion(DeviceService.kt:87)
	at maestro.cli.device.DeviceService.prepareDevice(DeviceService.kt:80)
	at maestro.cli.device.PickDeviceInteractor.pickDevice(PickDeviceInteractor.kt:26)
	at maestro.cli.util.MaestroFactory.createMaestro(MaestroFactory.kt:35)
	at maestro.cli.command.TestCommand.call(TestCommand.kt:74)
	at maestro.cli.command.TestCommand.call(TestCommand.kt:36)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
	at picocli.CommandLine.access$1200(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2159)
	at picocli.CommandLine.execute(CommandLine.java:2058)
	at maestro.cli.AppKt.main(App.kt:109)
```
