### PR TITLE
Fix running on Samsung devices 

### DIFF
--- a/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
@@ -38,7 +38,7 @@ object AndroidAppFiles {
     }
 
     fun getApkFile(dadb: Dadb, appId: String): File {
-        val apkPath = dadb.shell("pm list packages -f | grep $appId | head -1")
+        val apkPath = dadb.shell("pm list packages -f --user 0 | grep $appId | head -1")
             .output.substringAfterLast("package:").substringBefore("=$appId")
         apkPath.substringBefore("=$appId")
         val dst = File.createTempFile("tmp", ".apk")

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -436,7 +436,7 @@ class AndroidDriver(
     }
 
     private fun isPackageInstalled(packageName: String): Boolean {
-        val output: String = shell("pm list packages $packageName")
+        val output: String = shell("pm list packages --user 0 $packageName")
         return output.split("\n".toRegex())
             .map { line -> line.split(":".toRegex()) }
             .filter { parts -> parts.size == 2 }


### PR DESCRIPTION
Samsung devices have a protected `user 150` which is basically a Samsung Secure Folder. Shell refuses to execute `pm list packages`

## Proposed Changes
Use a `--user 0` argument in both places in the code. This specifies usage only within system user, but not any others.

## Testing
Tried this command on my device locally

## Issues Fixed
#418 