### PR TITLE
Adding androidApiLevel to maestro CLI

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -139,6 +139,7 @@ class ApiClient(
         branch: String?,
         pullRequestId: String?,
         env: Map<String, String>? = null,
+        androidApiLevel: Int?,
         progressListener: (totalBytes: Long, bytesWritten: Long) -> Unit = { _, _ -> },
     ): UploadResponse {
         if (!appFile.exists()) throw CliError("App file does not exist: ${appFile.absolutePathString()}")
@@ -154,6 +155,7 @@ class ApiClient(
         pullRequestId?.let { requestPart["pullRequestId"] = it }
         env?.let { requestPart["env"] = it }
         requestPart["agent"] = getAgent()
+        androidApiLevel?.let { requestPart["androidApiLevel"] = it }
 
         val bodyBuilder = MultipartBody.Builder()
             .setType(MultipartBody.FORM)

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -39,6 +39,7 @@ class CloudInteractor(
         branch: String? = null,
         pullRequestId: String? = null,
         env: Map<String, String> = emptyMap(),
+        androidApiLevel: Int? = null,
     ): Int {
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
         if (mapping?.exists() == false) throw CliError("File does not exist: ${mapping.absolutePath}")
@@ -78,6 +79,7 @@ class CloudInteractor(
                 branch,
                 pullRequestId,
                 env,
+                androidApiLevel,
             ) { totalBytes, bytesWritten ->
                 uploadProgress.set(totalBytes, bytesWritten)
             }

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -72,6 +72,9 @@ class CloudCommand : Callable<Int> {
     @Option(order = 9, names = ["--async"], description = ["Run the upload asynchronously"])
     private var async: Boolean = false
 
+    @Option(order = 10, names = ["--android-api-level"], description = ["Android API level to run your flow against"])
+    private var androidApiLevel: Int? = null
+
     override fun call(): Int {
         return CloudInteractor(
             client = ApiClient(apiUrl),
@@ -87,6 +90,7 @@ class CloudCommand : Callable<Int> {
             branch = branch,
             pullRequestId = pullRequestId,
             apiKey = apiKey,
+            androidApiLevel = androidApiLevel,
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
@@ -65,6 +65,9 @@ class UploadCommand : Callable<Int> {
     @Option(order = 8, names = ["--name"], description = ["Name of the upload"])
     private var uploadName: String? = null
 
+    @Option(order = 9, names = ["--android-api-level"], description = ["Android API level to run your flow against"])
+    private var androidApiLevel: Int? = null
+
     override fun call(): Int {
         println(
             ansi()
@@ -87,6 +90,7 @@ class UploadCommand : Callable<Int> {
             branch = branch,
             pullRequestId = pullRequestId,
             apiKey = apiKey,
+            androidApiLevel = androidApiLevel,
         )
     }
 


### PR DESCRIPTION
## Proposed Changes
Adds `android-api-level` flag to the CLI (in both `cloud` and `upload` commands) so the user can select which of the supported API levels they can run the Flow against. The error handling (what API versions are supported will be handled by the server).
