### PR TITLE
Feature: Inline Javascript

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -130,7 +130,7 @@ object MaestroCommandRunner {
             .filter { it.asCommand() !is ApplyConfigurationCommand }
             .mapIndexed { _, command ->
                 CommandState(
-                    command = command,
+                    command = commandMetadata[command]?.evaluatedCommand ?: command,
                     status = commandStatuses[command] ?: CommandStatus.PENDING,
                     numberOfRuns = commandMetadata[command]?.numberOfRuns,
                     subCommands = (command.asCommand() as? CompositeCommand)

--- a/maestro-cli/src/main/java/maestro/cli/runner/ResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/ResultView.kt
@@ -87,7 +87,12 @@ class ResultView(
                 }
                 render(statusSymbol)
                 render(String(CharArray(statusColumnWidth - statusSymbol.length) { ' ' }))
-                render(it.command.description())
+                render(
+                    it.command.description()
+                        .replace("(?<!\\\\)\\\$\\{.*}".toRegex()) { match ->
+                            "@|cyan ${match.value} |@"
+                        }
+                )
 
                 if (it.status == CommandStatus.SKIPPED) {
                     render(" (skipped)")

--- a/maestro-cli/src/main/java/maestro/cli/runner/ResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/ResultView.kt
@@ -76,35 +76,37 @@ class ResultView(
         indent: Int = 0,
     ) {
         val statusColumnWidth = 3
-        commands.forEach {
-            val statusSymbol = status(it.status)
-            fgDefault()
-            render(" ║    ")
-            repeat(indent) {
-                render("  ")
-            }
-            render(statusSymbol)
-            render(String(CharArray(statusColumnWidth - statusSymbol.length) { ' ' }))
-            render(it.command.description())
+        commands
+            .filter { it.command.asCommand()?.visible() ?: true }
+            .forEach {
+                val statusSymbol = status(it.status)
+                fgDefault()
+                render(" ║    ")
+                repeat(indent) {
+                    render("  ")
+                }
+                render(statusSymbol)
+                render(String(CharArray(statusColumnWidth - statusSymbol.length) { ' ' }))
+                render(it.command.description())
 
-            if (it.status == CommandStatus.SKIPPED) {
-                render(" (skipped)")
-            } else if (it.numberOfRuns != null) {
-                val timesWord = if (it.numberOfRuns == 1) "time" else "times"
-                render(" (completed ${it.numberOfRuns} $timesWord)")
-            }
+                if (it.status == CommandStatus.SKIPPED) {
+                    render(" (skipped)")
+                } else if (it.numberOfRuns != null) {
+                    val timesWord = if (it.numberOfRuns == 1) "time" else "times"
+                    render(" (completed ${it.numberOfRuns} $timesWord)")
+                }
 
-            render("\n")
+                render("\n")
 
-            val expand = it.status in setOf(CommandStatus.RUNNING, CommandStatus.FAILED) &&
-                (it.subCommands?.any { subCommand -> subCommand.status != CommandStatus.PENDING } ?: false)
+                val expand = it.status in setOf(CommandStatus.RUNNING, CommandStatus.FAILED) &&
+                    (it.subCommands?.any { subCommand -> subCommand.status != CommandStatus.PENDING } ?: false)
 
-            if (expand) {
-                it.subCommands?.let { subCommands ->
-                    renderCommands(subCommands, indent + 1)
+                if (expand) {
+                    it.subCommands?.let { subCommands ->
+                        renderCommands(subCommands, indent + 1)
+                    }
                 }
             }
-        }
     }
 
     private fun status(status: CommandStatus): String {

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -12,10 +12,7 @@ import maestro.cli.view.ErrorViewUtils
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroInitFlow
 import maestro.orchestra.OrchestraAppState
-import maestro.orchestra.error.InvalidInitFlowFile
-import maestro.orchestra.error.NoInputException
-import maestro.orchestra.error.SyntaxError
-import maestro.orchestra.error.UnicodeNotSupportedError
+import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.yaml.YamlCommandReader
 import java.io.File
 import kotlin.concurrent.thread
@@ -31,7 +28,8 @@ object TestRunner {
         val view = ResultView()
         val result = runCatching(view) {
             val commands = YamlCommandReader.readCommands(flowFile.toPath())
-                .map { it.injectEnv(env) }
+                .withEnv(env)
+
             MaestroCommandRunner.runCommands(
                 maestro,
                 device,
@@ -66,7 +64,7 @@ object TestRunner {
                 }
 
                 val commands = YamlCommandReader.readCommands(flowFile.toPath())
-                    .map { it.injectEnv(env) }
+                    .withEnv(env)
                 val initFlow = getInitFlow(commands)
 
                 // Restart the flow if anything has changed

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -10,6 +10,7 @@ import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
 import maestro.orchestra.Orchestra
+import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.yaml.YamlCommandReader
 import okio.Sink
 import java.io.File
@@ -118,7 +119,7 @@ class TestSuiteInteractor(
 
         try {
             val commands = YamlCommandReader.readCommands(flowFile.toPath())
-                .map { it.injectEnv(env) }
+                .withEnv(env)
 
             val config = YamlCommandReader.getConfig(commands)
 

--- a/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
@@ -5,6 +5,7 @@ import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.NoInputException
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.error.UnicodeNotSupportedError
+import org.mozilla.javascript.EcmaError
 
 object ErrorViewUtils {
 
@@ -16,6 +17,7 @@ object ErrorViewUtils {
             is UnicodeNotSupportedError -> "Unicode character input is not supported: ${e.text}. Please use ASCII characters. Follow the issue: https://github.com/mobile-dev-inc/maestro/issues/146"
             is InterruptedException -> "Interrupted"
             is MaestroException -> e.message
+            is EcmaError -> "${e.name}: ${e.message}}"
             else -> e.stackTraceToString()
         }
     }

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -62,6 +62,9 @@ dependencies {
     api 'com.github.romankh3:image-comparison:4.4.0'
     api "com.android.tools:sdk-common:30.3.0"
     api "com.android.tools.apkparser:apkanalyzer:30.3.0"
+    api 'org.apache.groovy:groovy-all:4.0.6'
+    api 'org.mozilla:rhino:1.7.14'
+    api 'org.jsoup:jsoup:1.15.3'
 
     implementation project(':maestro-ios')
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/maestro-client/src/main/java/maestro/GroovyExample.kt
+++ b/maestro-client/src/main/java/maestro/GroovyExample.kt
@@ -1,0 +1,35 @@
+package maestro
+
+import groovy.lang.Binding
+import groovy.lang.GroovyShell
+
+fun main() {
+    val shell = GroovyShell(
+        Binding(
+            mutableMapOf(
+                "ext" to { println("Hello from Groovy") },
+                "VALUE" to "Injected Value",
+            )
+        )
+    )
+
+    // Defining a convenience json parser
+    shell.evaluate(
+        """
+        def json(text) {
+            def jsonSlurper = new groovy.json.JsonSlurper()
+            return jsonSlurper.parseText(text)
+        }
+        json = this::json
+    """.trimIndent()
+    )
+
+    // Parse JSON and use a field
+    println(shell.evaluate("json('{ \"name\": \"John Doe\" }').name"))
+
+    // Inject VALUE env parameter
+    println(shell.evaluate("\"\${VALUE}\""))
+
+    // Call Java from Groovy (but only the function that we defined)
+    shell.evaluate("ext.invoke()")
+}

--- a/maestro-client/src/main/java/maestro/JavascriptExample.kt
+++ b/maestro-client/src/main/java/maestro/JavascriptExample.kt
@@ -1,0 +1,127 @@
+package maestro
+
+import org.mozilla.javascript.Context
+import org.mozilla.javascript.Scriptable
+import org.mozilla.javascript.ScriptableObject
+
+class Script : ScriptableObject() {
+
+    override fun getClassName(): String {
+        return Script::class.qualifiedName!!
+    }
+
+    companion object {
+
+        fun run() {
+            Context.enter().use { ctx ->
+                val script = Script()
+                ctx.initSafeStandardObjects(script)
+
+                script.defineFunctionProperties(
+                    arrayOf("ext", "json"),
+                    Script::class.java,
+                    DONTENUM
+                )
+
+                ctx.evaluateString(
+                    script,
+                    """
+                        function json(text) {
+                            return JSON.parse(text)
+                        }
+                        
+                        var x = 'Outer'
+                    """.trimIndent(),
+                    "script",
+                    1,
+                    null
+                )
+
+                val result = ctx.evaluateString(
+                    script,
+                    """
+                    json(ext()).name
+                """.trimIndent(),
+                    "script",
+                    1,
+                    null
+                )
+
+                println(result)
+
+                val subScript = Script()
+                subScript.parentScope = script
+
+                println(
+                    ctx.evaluateString(
+                        subScript,
+                        "x",
+                        "script",
+                        1,
+                        null
+                    )
+                )
+
+                ctx.evaluateString(
+                    subScript,
+                    """ 
+                        var x = 'Inner'
+                    """.trimIndent(),
+                    "subScript",
+                    1,
+                    null
+                )
+
+                println(
+                    ctx.evaluateString(
+                        subScript,
+                        "x",
+                        "script",
+                        1,
+                        null
+                    )
+                )
+
+                println(
+                    ctx.evaluateString(
+                        script,
+                        "x",
+                        "script",
+                        1,
+                        null
+                    )
+                )
+            }
+        }
+
+        @JvmStatic
+        fun ext(
+            ctx: Context,
+            thisObj: Scriptable,
+            args: Array<Any>,
+            funObj: org.mozilla.javascript.Function
+        ): String {
+            return """
+                {
+                    "name": "John Doe"
+                }
+            """.trimIndent()
+        }
+
+        @JvmStatic
+        fun json(
+            ctx: Context,
+            thisObj: Scriptable,
+            args: Array<Any>,
+            funObj: org.mozilla.javascript.Function
+        ): Any {
+            return mapOf("name" to "Test")
+        }
+
+    }
+
+}
+
+fun main() {
+    Script.run()
+}

--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -1,0 +1,48 @@
+package maestro.js
+
+import org.mozilla.javascript.Context
+
+class JsEngine {
+
+    private lateinit var context: Context
+    private lateinit var currentScope: JsScope
+
+    fun init() {
+        context = Context.enter()
+        currentScope = JsScope()
+        context.initSafeStandardObjects(currentScope)
+
+        context.evaluateString(
+            currentScope,
+            """
+                function json(text) {
+                    return JSON.parse(text)
+                }
+            """.trimIndent(),
+            "maestro-runtime",
+            1,
+            null
+        )
+    }
+
+    fun enterScope() {
+        val subScope = JsScope()
+        subScope.parentScope = currentScope
+        currentScope = subScope
+    }
+
+    fun leaveScope() {
+        currentScope = currentScope.parentScope as JsScope
+    }
+
+    fun evaluateScript(script: String): String {
+        return context.evaluateString(
+            currentScope,
+            script,
+            "inline-script",
+            1,
+            null
+        ).toString()
+    }
+
+}

--- a/maestro-client/src/main/java/maestro/js/JsScope.kt
+++ b/maestro-client/src/main/java/maestro/js/JsScope.kt
@@ -1,0 +1,9 @@
+package maestro.js
+
+import org.mozilla.javascript.ScriptableObject
+
+class JsScope : ScriptableObject() {
+    override fun getClassName(): String {
+        return "JsScope"
+    }
+}

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -22,14 +22,17 @@ package maestro.orchestra
 import maestro.KeyCode
 import maestro.Point
 import maestro.SwipeDirection
-import maestro.orchestra.util.Env.injectEnv
+import maestro.js.JsEngine
+import maestro.orchestra.util.Env.evaluateScripts
 import maestro.orchestra.util.InputRandomTextHelper
 
 sealed interface Command {
 
     fun description(): String
 
-    fun injectEnv(env: Map<String, String>): Command
+    fun evaluateScripts(jsEngine: JsEngine): Command
+
+    fun visible(): Boolean = true
 
 }
 
@@ -58,7 +61,7 @@ data class SwipeCommand(
         }
     }
 
-    override fun injectEnv(env: Map<String, String>): SwipeCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): SwipeCommand {
         return this
     }
 
@@ -87,10 +90,9 @@ class ScrollCommand : Command {
         return "Scroll vertically"
     }
 
-    override fun injectEnv(env: Map<String, String>): ScrollCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): ScrollCommand {
         return this
     }
-
 }
 
 class BackPressCommand : Command {
@@ -113,7 +115,7 @@ class BackPressCommand : Command {
         return "Press back"
     }
 
-    override fun injectEnv(env: Map<String, String>): BackPressCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): BackPressCommand {
         return this
     }
 }
@@ -138,11 +140,10 @@ class HideKeyboardCommand : Command {
         return "Hide Keyboard"
     }
 
-    override fun injectEnv(env: Map<String, String>): HideKeyboardCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): HideKeyboardCommand {
         return this
     }
 }
-
 
 data class CopyTextFromCommand(
     val selector: ElementSelector,
@@ -152,9 +153,9 @@ data class CopyTextFromCommand(
         return "Copy text from element with ${selector.description()}"
     }
 
-    override fun injectEnv(env: Map<String, String>): CopyTextFromCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): CopyTextFromCommand {
         return copy(
-            selector = selector.injectEnv(env)
+            selector = selector.evaluateScripts(jsEngine)
         )
     }
 }
@@ -165,7 +166,7 @@ class PasteTextCommand : Command {
         return "Paste text"
     }
 
-    override fun injectEnv(env: Map<String, String>): PasteTextCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): PasteTextCommand {
         return this
     }
 }
@@ -181,9 +182,9 @@ data class TapOnElementCommand(
         return "Tap on ${selector.description()}"
     }
 
-    override fun injectEnv(env: Map<String, String>): TapOnElementCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): TapOnElementCommand {
         return copy(
-            selector = selector.injectEnv(env),
+            selector = selector.evaluateScripts(jsEngine),
         )
     }
 }
@@ -200,7 +201,7 @@ data class TapOnPointCommand(
         return "Tap on point ($x, $y)"
     }
 
-    override fun injectEnv(env: Map<String, String>): TapOnPointCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): TapOnPointCommand {
         return this
     }
 }
@@ -224,10 +225,10 @@ data class AssertCommand(
         return "No op"
     }
 
-    override fun injectEnv(env: Map<String, String>): AssertCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): AssertCommand {
         return copy(
-            visible = visible?.injectEnv(env),
-            notVisible = notVisible?.injectEnv(env),
+            visible = visible?.evaluateScripts(jsEngine),
+            notVisible = notVisible?.evaluateScripts(jsEngine),
         )
     }
 }
@@ -240,9 +241,9 @@ data class InputTextCommand(
         return "Input text $text"
     }
 
-    override fun injectEnv(env: Map<String, String>): InputTextCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): InputTextCommand {
         return copy(
-            text = text.injectEnv(env)
+            text = text.evaluateScripts(jsEngine)
         )
     }
 }
@@ -272,9 +273,9 @@ data class LaunchAppCommand(
         return result
     }
 
-    override fun injectEnv(env: Map<String, String>): LaunchAppCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): LaunchAppCommand {
         return copy(
-            appId = appId.injectEnv(env)
+            appId = appId.evaluateScripts(jsEngine)
         )
     }
 }
@@ -287,11 +288,13 @@ data class ApplyConfigurationCommand(
         return "Apply configuration"
     }
 
-    override fun injectEnv(env: Map<String, String>): ApplyConfigurationCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): ApplyConfigurationCommand {
         return copy(
-            config = config.injectEnv(env),
+            config = config.evaluateScripts(jsEngine),
         )
     }
+
+    override fun visible(): Boolean = false
 }
 
 data class OpenLinkCommand(
@@ -302,9 +305,9 @@ data class OpenLinkCommand(
         return "Open $link"
     }
 
-    override fun injectEnv(env: Map<String, String>): OpenLinkCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): OpenLinkCommand {
         return copy(
-            link = link.injectEnv(env),
+            link = link.evaluateScripts(jsEngine),
         )
     }
 }
@@ -316,7 +319,7 @@ data class PressKeyCommand(
         return "Press ${code.description} key"
     }
 
-    override fun injectEnv(env: Map<String, String>): PressKeyCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): PressKeyCommand {
         return this
     }
 
@@ -330,7 +333,7 @@ data class EraseTextCommand(
         return "Erase $charactersToErase characters"
     }
 
-    override fun injectEnv(env: Map<String, String>): EraseTextCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): EraseTextCommand {
         return this
     }
 
@@ -344,9 +347,9 @@ data class TakeScreenshotCommand(
         return "Take screenshot $path"
     }
 
-    override fun injectEnv(env: Map<String, String>): TakeScreenshotCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): TakeScreenshotCommand {
         return copy(
-            path = path.injectEnv(env),
+            path = path.evaluateScripts(jsEngine),
         )
     }
 }
@@ -359,9 +362,9 @@ data class StopAppCommand(
         return "Stop $appId"
     }
 
-    override fun injectEnv(env: Map<String, String>): Command {
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            appId = appId.injectEnv(env),
+            appId = appId.evaluateScripts(jsEngine),
         )
     }
 }
@@ -374,9 +377,9 @@ data class ClearStateCommand(
         return "Clear state of $appId"
     }
 
-    override fun injectEnv(env: Map<String, String>): Command {
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            appId = appId.injectEnv(env),
+            appId = appId.evaluateScripts(jsEngine),
         )
     }
 }
@@ -387,7 +390,7 @@ class ClearKeychainCommand : Command {
         return "Clear keychain"
     }
 
-    override fun injectEnv(env: Map<String, String>): Command {
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
         return this
     }
 
@@ -429,7 +432,7 @@ data class InputRandomCommand(
         return "Input text random $inputType"
     }
 
-    override fun injectEnv(env: Map<String, String>): InputRandomCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): InputRandomCommand {
         return this
     }
 }
@@ -458,10 +461,9 @@ data class RunFlowCommand(
         }
     }
 
-    override fun injectEnv(env: Map<String, String>): Command {
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            commands = commands.map { it.injectEnv(env) },
-            condition = condition?.injectEnv(env),
+            condition = condition?.evaluateScripts(jsEngine),
         )
     }
 
@@ -476,7 +478,7 @@ data class SetLocationCommand(
         return "Set location (${latitude}, ${longitude})"
     }
 
-    override fun injectEnv(env: Map<String, String>): SetLocationCommand {
+    override fun evaluateScripts(jsEngine: JsEngine): SetLocationCommand {
         return this
     }
 }
@@ -506,12 +508,31 @@ data class RepeatCommand(
         }
     }
 
-    override fun injectEnv(env: Map<String, String>): Command {
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            times = times?.injectEnv(env),
-            commands = commands.map { it.injectEnv(env) },
-            condition = condition?.injectEnv(env),
+            times = times?.evaluateScripts(jsEngine),
+            condition = condition?.evaluateScripts(jsEngine),
         )
     }
+
+}
+
+data class DefineVariablesCommand(
+    val env: Map<String, String>,
+) : Command {
+
+    override fun description(): String {
+        return "Define variables"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): DefineVariablesCommand {
+        return copy(
+            env = env.mapValues { (key, value) ->
+                value.evaluateScripts(jsEngine)
+            }
+        )
+    }
+
+    override fun visible(): Boolean = false
 
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
@@ -1,14 +1,16 @@
 package maestro.orchestra
 
+import maestro.js.JsEngine
+
 data class Condition(
     val visible: ElementSelector? = null,
     val notVisible: ElementSelector? = null,
 ) {
 
-    fun injectEnv(env: Map<String, String>): Condition {
+    fun evaluateScripts(jsEngine: JsEngine): Condition {
         return copy(
-            visible = visible?.injectEnv(env),
-            notVisible = notVisible?.injectEnv(env),
+            visible = visible?.evaluateScripts(jsEngine),
+            notVisible = notVisible?.evaluateScripts(jsEngine),
         )
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -19,7 +19,8 @@
 
 package maestro.orchestra
 
-import maestro.orchestra.util.Env.injectEnv
+import maestro.js.JsEngine
+import maestro.orchestra.util.Env.evaluateScripts
 
 data class ElementSelector(
     val textRegex: String? = null,
@@ -42,19 +43,15 @@ data class ElementSelector(
         val tolerance: Int? = null,
     )
 
-    fun injectEnv(env: Map<String, String>): ElementSelector {
-        if (env.isEmpty()) {
-            return this
-        }
-
+    fun evaluateScripts(jsEngine: JsEngine): ElementSelector {
         return copy(
-            textRegex = textRegex?.injectEnv(env),
-            idRegex = idRegex?.injectEnv(env),
-            below = below?.injectEnv(env),
-            above = above?.injectEnv(env),
-            leftOf = leftOf?.injectEnv(env),
-            rightOf = rightOf?.injectEnv(env),
-            containsChild = containsChild?.injectEnv(env),
+            textRegex = textRegex?.evaluateScripts(jsEngine),
+            idRegex = idRegex?.evaluateScripts(jsEngine),
+            below = below?.evaluateScripts(jsEngine),
+            above = above?.evaluateScripts(jsEngine),
+            leftOf = leftOf?.evaluateScripts(jsEngine),
+            rightOf = rightOf?.evaluateScripts(jsEngine),
+            containsChild = containsChild?.evaluateScripts(jsEngine),
         )
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -19,6 +19,8 @@
 
 package maestro.orchestra
 
+import maestro.js.JsEngine
+
 /**
  * The Mobile.dev platform uses this class in the backend and hence the custom
  * serialization logic. The earlier implementation of this class had a nullable field for
@@ -48,7 +50,8 @@ data class MaestroCommand(
     val setLocationCommand: SetLocationCommand? = null,
     val repeatCommand: RepeatCommand? = null,
     val copyTextCommand: CopyTextFromCommand? = null,
-    val pasteTextCommand: PasteTextCommand? = null
+    val pasteTextCommand: PasteTextCommand? = null,
+    val defineVariablesCommand: DefineVariablesCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -74,7 +77,8 @@ data class MaestroCommand(
         setLocationCommand = command as? SetLocationCommand,
         repeatCommand = command as? RepeatCommand,
         copyTextCommand = command as? CopyTextFromCommand,
-        pasteTextCommand = command as? PasteTextCommand
+        pasteTextCommand = command as? PasteTextCommand,
+        defineVariablesCommand = command as? DefineVariablesCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -101,12 +105,13 @@ data class MaestroCommand(
         repeatCommand != null -> repeatCommand
         copyTextCommand != null -> copyTextCommand
         pasteTextCommand != null -> pasteTextCommand
+        defineVariablesCommand != null -> defineVariablesCommand
         else -> null
     }
 
-    fun injectEnv(envParameters: Map<String, String>): MaestroCommand {
+    fun evaluateScripts(jsEngine: JsEngine): MaestroCommand {
         return asCommand()
-            ?.let { MaestroCommand(it.injectEnv(envParameters)) }
+            ?.let { MaestroCommand(it.evaluateScripts(jsEngine)) }
             ?: MaestroCommand()
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -1,6 +1,7 @@
 package maestro.orchestra
 
-import maestro.orchestra.util.Env.injectEnv
+import maestro.js.JsEngine
+import maestro.orchestra.util.Env.evaluateScripts
 
 // Note: The appId config is only a yaml concept for now. It'll be a larger migration to get to a point
 // where appId is part of MaestroConfig (and factored out of MaestroCommands - eg: LaunchAppCommand).
@@ -11,11 +12,11 @@ data class MaestroConfig(
     val ext: Map<String, Any?> = emptyMap(),
 ) {
 
-    fun injectEnv(env: Map<String, String>): MaestroConfig {
+    fun evaluateScripts(jsEngine: JsEngine): MaestroConfig {
         return copy(
-            appId = appId?.injectEnv(env),
-            name = name?.injectEnv(env),
-            initFlow = initFlow?.injectEnv(env),
+            appId = appId?.evaluateScripts(jsEngine),
+            name = name?.evaluateScripts(jsEngine),
+            initFlow = initFlow?.evaluateScripts(jsEngine),
         )
     }
 
@@ -26,10 +27,9 @@ data class MaestroInitFlow(
     val commands: List<MaestroCommand>,
 ) {
 
-    fun injectEnv(env: Map<String, String>): MaestroInitFlow {
+    fun evaluateScripts(jsEngine: JsEngine): MaestroInitFlow {
         return copy(
-            appId = appId.injectEnv(env),
-            commands = commands.map { it.injectEnv(env) },
+            appId = appId.evaluateScripts(jsEngine),
         )
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -1,5 +1,9 @@
 package maestro.orchestra.util
 
+import maestro.js.JsEngine
+import maestro.orchestra.DefineVariablesCommand
+import maestro.orchestra.MaestroCommand
+
 object Env {
 
     fun String.injectEnv(env: Map<String, String>): String {
@@ -18,6 +22,32 @@ object Env {
             .replace("\\\\\\$\\{.*}".toRegex()) { match ->
                 match.value.substringAfter('\\')
             }
+    }
+
+    fun String.evaluateScripts(jsEngine: JsEngine): String {
+        val result = "(?<!\\\\)\\$\\{(.*)}".toRegex()
+            .replace(this) { match ->
+                val script = match.groups[1]?.value ?: ""
+
+                if (script.isNotBlank()) {
+                    jsEngine.evaluateScript(script)
+                } else {
+                    ""
+                }
+            }
+
+        return result
+            .replace("\\\\\\$\\{.*}".toRegex()) { match ->
+                match.value.substringAfter('\\')
+            }
+    }
+
+    fun List<MaestroCommand>.withEnv(env: Map<String, String>): List<MaestroCommand> {
+        if (env.isEmpty()) {
+            return this
+        }
+
+        return listOf(MaestroCommand(DefineVariablesCommand(env))) + this
     }
 
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -30,6 +30,7 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.error.NoInputException
 import maestro.orchestra.error.SyntaxError
+import maestro.orchestra.util.Env.withEnv
 import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.inputStream
@@ -48,7 +49,7 @@ object YamlCommandReader {
         val (config, commands) = readConfigAndCommands(flowPath)
         val maestroCommands = commands
             .flatMap { it.toCommands(flowPath, config.appId) }
-            .map { it.injectEnv(config.env) }
+            .withEnv(config.env)
 
         listOfNotNull(config.toCommand(flowPath), *maestroCommands.toTypedArray())
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -50,6 +50,7 @@ import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointCommand
 import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.SyntaxError
+import maestro.orchestra.util.Env.withEnv
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
@@ -169,7 +170,7 @@ data class YamlFluentCommand(
     private fun runFlow(flowPath: Path, command: YamlRunFlow): List<MaestroCommand> {
         val runFlowPath = getRunFlowPath(flowPath, command.file)
         return YamlCommandReader.readCommands(runFlowPath)
-            .map { it.injectEnv(command.env) }
+            .withEnv(command.env)
     }
 
     private fun getRunFlowPath(flowPath: Path, runFlowPath: String): Path {
@@ -327,9 +328,11 @@ data class YamlFluentCommand(
     private fun copyTextFromCommand(
         copyText: YamlElementSelectorUnion
     ): MaestroCommand {
-        return MaestroCommand(CopyTextFromCommand(
-            selector = toElementSelector(copyText)
-        ))
+        return MaestroCommand(
+            CopyTextFromCommand(
+                selector = toElementSelector(copyText)
+            )
+        )
     }
 
     private fun YamlCondition.toCondition(): Condition {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -14,6 +14,7 @@ import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroInitFlow
 import maestro.orchestra.Orchestra
 import maestro.orchestra.error.UnicodeNotSupportedError
+import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.test.drivers.FakeDriver
 import maestro.test.drivers.FakeDriver.Event
@@ -810,19 +811,17 @@ class IntegrationTest {
     fun `Case 028 - Env`() {
         // Given
         val commands = readCommands("028_env")
-            .map {
-                it.injectEnv(
-                    envParameters = mapOf(
-                        "APP_ID" to "com.example.app",
-                        "BUTTON_ID" to "button_id",
-                        "BUTTON_TEXT" to "button_text",
-                        "PASSWORD" to "testPassword",
-                        "NON_EXISTENT_TEXT" to "nonExistentText",
-                        "NON_EXISTENT_ID" to "nonExistentId",
-                        "URL" to "secretUrl",
-                    )
+            .withEnv(
+                mapOf(
+                    "APP_ID" to "com.example.app",
+                    "BUTTON_ID" to "button_id",
+                    "BUTTON_TEXT" to "button_text",
+                    "PASSWORD" to "testPassword",
+                    "NON_EXISTENT_TEXT" to "nonExistentText",
+                    "NON_EXISTENT_ID" to "nonExistentId",
+                    "URL" to "secretUrl",
                 )
-            }
+            )
 
         val driver = driver {
 
@@ -1388,13 +1387,11 @@ class IntegrationTest {
     fun `Case 049 - Run flow conditionally`() {
         // Given
         val commands = readCommands("049_run_flow_conditionally")
-            .map {
-                it.injectEnv(
-                    mapOf(
-                        "NOT_CLICKED" to "Not Clicked"
-                    )
+            .withEnv(
+                mapOf(
+                    "NOT_CLICKED" to "Not Clicked"
                 )
-            }
+            )
 
         val driver = driver {
             val indicator = element {
@@ -1611,13 +1608,11 @@ class IntegrationTest {
     fun `Case 057 - Pass inner env variables to runFlow`() {
         // Given
         val commands = readCommands("057_runFlow_env")
-            .map {
-                it.injectEnv(
-                    mapOf(
-                        "OUTER_ENV" to "Outer Parameter"
-                    )
+            .withEnv(
+                mapOf(
+                    "OUTER_ENV" to "Outer Parameter"
                 )
-            }
+            )
 
         val driver = driver {
         }
@@ -1672,13 +1667,11 @@ class IntegrationTest {
     fun `Case 060 - Pass env param to an env param`() {
         // given
         val commands = readCommands("060_pass_env_to_env")
-            .map {
-                it.injectEnv(
-                    mapOf(
-                        "PARAM" to "Value"
-                    )
+            .withEnv(
+                mapOf(
+                    "PARAM" to "Value"
                 )
-            }
+            )
         val driver = driver { }
 
         // when
@@ -1734,6 +1727,28 @@ class IntegrationTest {
         // Then
         // No test failure
         driver.assertCurrentTextInput(myCopiedText)
+    }
+
+    @Test
+    fun `Case 063 - Javascript injection`() {
+        // given
+        val commands = readCommands("063_js_injection")
+        val driver = driver { }
+
+        // when
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // then
+        driver.assertEvents(
+            listOf(
+                Event.InputText("1"),
+                Event.InputText("2"),
+                Event.InputText("12"),
+                Event.InputText("3.0"),
+            )
+        )
     }
 
     private fun orchestra(maestro: Maestro) = Orchestra(

--- a/maestro-test/src/test/resources/063_js_injection.yaml
+++ b/maestro-test/src/test/resources/063_js_injection.yaml
@@ -1,0 +1,10 @@
+appId: com.example.app
+env:
+  A: 1
+  B: 2
+---
+- inputText: ${A}
+- inputText: ${B}
+- inputText: ${A + B}
+- inputText: ${parseInt(A) + parseInt(B)}
+


### PR DESCRIPTION
## Proposed Changes

This change adds a basic level of Javascript support. Every `${}` block is now evaluated as a Javascript. To make this change compatible with the existing API, `env` parameters of any sort are now declared as `var` in Javascript environment.

Apart from preparing ground for the upcoming features, this change also introduces some minor features of its own - it is now possible to run expressions as part of the flow. For example:

```
env:
    a: 1
    b: 2
---
- inputText: ${a + b}  # will print 12
- inputText: ${parseInt(a) + parseInt(b)}  # will print 3.0
```

### UX

Now that `${}` placeholders are evaluated dynamically, we do not know their values until a command reaches a certain execution point. As such, we will only print the value for placeholders once command starts the execution. See the video:


https://user-images.githubusercontent.com/2990722/203291011-e139971b-9106-4630-8799-a6f383455046.mov



### Implementation details

- Using embedded Mozilla Rhino framework.
- Javascript runs in a sandbox environment and has no access to an outer filesystem or execution environment.

## Testing
- Existing integration tests are passing
- Added tests for JS specifically
- Run sample flow locally

## Next steps

- Store value of `copyText` command in a variable
- Allow `condition` to evaluate Javascript as well
- Explore usability of running Javascript files