### PR TITLE
Feature: make HTTP requests from Javascript

### DIFF
--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     api "com.android.tools.apkparser:apkanalyzer:30.3.0"
     api 'org.mozilla:rhino:1.7.14'
     api 'org.jsoup:jsoup:1.15.3'
+    api 'com.squareup.okhttp3:okhttp:4.10.0'
 
     implementation project(':maestro-ios')
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -3,6 +3,7 @@ package maestro.js
 import org.jsoup.Jsoup
 import org.jsoup.safety.Safelist
 import org.mozilla.javascript.Context
+import org.mozilla.javascript.ScriptableObject
 
 class JsEngine {
 
@@ -13,6 +14,15 @@ class JsEngine {
         context = Context.enter()
         currentScope = JsScope()
         context.initSafeStandardObjects(currentScope)
+
+        val jsHttp = JsHttp()
+        jsHttp.defineFunctionProperties(
+            arrayOf("request", "get", "post", "put", "delete"),
+            JsHttp::class.java,
+            ScriptableObject.DONTENUM
+        )
+        context.initSafeStandardObjects(jsHttp)
+        currentScope.put("http", currentScope, jsHttp)
 
         context.evaluateString(
             currentScope,

--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -1,11 +1,20 @@
 package maestro.js
 
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
 import org.jsoup.Jsoup
 import org.jsoup.safety.Safelist
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.ScriptableObject
+import java.util.concurrent.TimeUnit
 
-class JsEngine {
+class JsEngine(
+    private val httpClient: OkHttpClient = OkHttpClient.Builder()
+        .readTimeout(5, TimeUnit.MINUTES)
+        .writeTimeout(5, TimeUnit.MINUTES)
+        .protocols(listOf(Protocol.HTTP_1_1))
+        .build()
+) {
 
     private lateinit var context: Context
     private lateinit var currentScope: JsScope
@@ -15,7 +24,7 @@ class JsEngine {
         currentScope = JsScope()
         context.initSafeStandardObjects(currentScope)
 
-        val jsHttp = JsHttp()
+        val jsHttp = JsHttp(httpClient)
         jsHttp.defineFunctionProperties(
             arrayOf("request", "get", "post", "put", "delete"),
             JsHttp::class.java,

--- a/maestro-client/src/main/java/maestro/js/JsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/JsHttp.kt
@@ -1,20 +1,14 @@
 package maestro.js
 
 import okhttp3.OkHttpClient
-import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.mozilla.javascript.NativeObject
 import org.mozilla.javascript.ScriptableObject
 import org.mozilla.javascript.Undefined
-import java.util.concurrent.TimeUnit
 
 class JsHttp(
-    private val httpClient: OkHttpClient = OkHttpClient.Builder()
-        .readTimeout(5, TimeUnit.MINUTES)
-        .writeTimeout(5, TimeUnit.MINUTES)
-        .protocols(listOf(Protocol.HTTP_1_1))
-        .build()
+    private val httpClient: OkHttpClient
 ) : ScriptableObject() {
 
     fun get(

--- a/maestro-client/src/main/java/maestro/js/JsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/JsHttp.kt
@@ -1,0 +1,142 @@
+package maestro.js
+
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.mozilla.javascript.NativeObject
+import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.Undefined
+import java.util.concurrent.TimeUnit
+
+class JsHttp(
+    private val httpClient: OkHttpClient = OkHttpClient.Builder()
+        .readTimeout(5, TimeUnit.MINUTES)
+        .writeTimeout(5, TimeUnit.MINUTES)
+        .protocols(listOf(Protocol.HTTP_1_1))
+        .build()
+) : ScriptableObject() {
+
+    fun get(
+        url: String,
+        params: NativeObject?,
+    ): Any {
+        return executeRequest(url, "GET", params)
+    }
+
+    fun post(
+        url: String,
+        params: NativeObject?,
+    ): Any {
+        return executeRequest(url, "POST", params)
+    }
+
+    fun put(
+        url: String,
+        params: NativeObject?,
+    ): Any {
+        return executeRequest(url, "PUT", params)
+    }
+
+    fun delete(
+        url: String,
+        params: NativeObject?,
+    ): Any {
+        return executeRequest(url, "DELETE", params)
+    }
+
+    fun request(
+        url: String,
+        params: NativeObject?,
+    ): Any {
+        val method = params
+            ?.get("method")
+            ?.let {
+                if (Undefined.isUndefined(it)) {
+                    null
+                } else {
+                    it.toString()
+                }
+            }
+            ?: "GET"
+
+        return executeRequest(
+            url,
+            method,
+            params,
+        )
+    }
+
+    private fun executeRequest(
+        url: String,
+        method: String,
+        params: NativeObject?,
+    ): Any {
+        val requestBuilder = Request.Builder()
+            .url(url)
+
+        val body = params
+            ?.get("body")
+            ?.let {
+                if (Undefined.isUndefined(it)) {
+                    null
+                } else {
+                    it.toString()
+                }
+            }
+
+        requestBuilder.method(method, body?.toRequestBody())
+
+        params
+            ?.get("headers")
+            ?.let {
+                if (Undefined.isUndefined(it)) {
+                    null
+                } else {
+                    it as NativeObject
+                }
+            }
+            ?.let {
+                it.entries
+                    .forEach { (key, value) ->
+                        requestBuilder.addHeader(key.toString(), value.toString())
+                    }
+            }
+
+        val request = requestBuilder.build()
+
+        val response = httpClient
+            .newCall(request)
+            .execute()
+
+        val resultBuilder = JsObjectBuilder()
+        resultBuilder["ok"] = response.isSuccessful
+        resultBuilder["status"] = response.code
+        resultBuilder["body"] = response.body?.string()
+
+        return resultBuilder.build()
+    }
+
+    private class JsObjectBuilder {
+
+        private val obj = NativeObject()
+
+        operator fun set(key: String, value: Any?) {
+            if (value == null) {
+                return
+            }
+
+            obj.defineProperty(key, value, PERMANENT)
+        }
+
+        fun build(): NativeObject {
+            return obj
+        }
+
+    }
+
+    override fun getClassName(): String {
+        return "JsHttp"
+    }
+
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -53,9 +53,8 @@ class Orchestra(
     private val onCommandSkipped: (Int, MaestroCommand) -> Unit = { _, _ -> },
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
+    private val jsEngine: JsEngine = JsEngine(),
 ) {
-
-    private val jsEngine = JsEngine()
 
     private var copiedText: String? = null
 

--- a/maestro-test/build.gradle
+++ b/maestro-test/build.gradle
@@ -10,6 +10,8 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+
+    testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.0"
 }
 
 test {

--- a/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
@@ -1,0 +1,136 @@
+package maestro.test
+
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import com.google.common.truth.Truth.assertThat
+import maestro.js.JsEngine
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@WireMockTest
+class JsEngineTest {
+
+    lateinit var engine: JsEngine
+
+    @BeforeEach
+    fun setUp() {
+        engine = JsEngine()
+        engine.init()
+    }
+
+    @Test
+    fun `HTTP - Make GET request`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        stubFor(
+            get("/json").willReturn(
+                okJson(
+                    """
+                        {
+                            "message": "GET Endpoint"
+                        }
+                    """.trimIndent()
+                )
+            )
+        )
+
+        val script = """
+            var response = http.get('http://localhost:$port/json')
+            
+            json(response.body).message
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then
+        assertThat(result).isEqualTo("GET Endpoint")
+    }
+
+    @Test
+    fun `HTTP - Make GET request with headers`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        stubFor(
+            get("/json")
+                .withHeader("Authorization", equalTo("Bearer Token"))
+                .willReturn(
+                    okJson(
+                        """
+                            {
+                                "message": "GET Endpoint with auth"
+                            }
+                        """.trimIndent()
+                    )
+                )
+        )
+
+        val script = """
+            var response = http.get('http://localhost:$port/json', {
+                headers: {
+                    Authorization: 'Bearer Token'
+                }
+            })
+            
+            json(response.body).message
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then
+        assertThat(result).isEqualTo("GET Endpoint with auth")
+    }
+
+    @Test
+    fun `HTTP - Make POST request`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        stubFor(
+            post("/json")
+                .withRequestBody(
+                    equalToJson(
+                        """
+                            {
+                                "payload": "Value"
+                            }
+                        """.trimIndent()
+                    )
+                )
+                .willReturn(
+                    okJson(
+                        """
+                            {
+                                "message": "POST endpoint"
+                            }
+                        """.trimIndent()
+                    )
+                )
+        )
+
+        val script = """
+            var response = http.post('http://localhost:$port/json', {
+                body: JSON.stringify(
+                    {
+                        payload: 'Value'
+                    }
+                )
+            })
+            
+            json(response.body).message
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then
+        assertThat(result).isEqualTo("POST endpoint")
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes

Introducing an HTTP API for Javascript:

Sample usage:
```
var response = http.get('http://example.com')

json(response.body).myField
```

Extended usage:
```
var response = http.post('http://example.com', {
    headers: {
        Authorization: 'Bearer Token'
    },
    body: JSON.stringify({
        payload: 'Some value'
    })
})

if (response.ok) {
    output.myAction = json(response.data).someField
} else {
    throw "Failed to obtain response"
}
```

## Testing
- Introduced new `JsEngineTest` that test Javascript functionality in isolation
- Using Wiremock to test HTTP interations