### PR TITLE
Feature: Wait for animation end command

### DIFF
--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -44,4 +44,6 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
     class DestinationIsNotWritable(message: String) : MaestroException(message)
 
     class UnableToCopyTextFromElement(message: String): MaestroException(message)
+
+    class AnimationDidTimeout(message: String): MaestroException(message)
 }

--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -44,6 +44,4 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
     class DestinationIsNotWritable(message: String) : MaestroException(message)
 
     class UnableToCopyTextFromElement(message: String): MaestroException(message)
-
-    class AnimationDidTimeout(message: String): MaestroException(message)
 }

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -388,10 +388,11 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         driver.eraseText(charactersToErase)
     }
     
-    fun waitForAnimationToEnd() {
-        LOGGER.info("Waiting for animation to end")
+    fun waitForAnimationToEnd(timeout: Long?) {
+        val timeout = timeout ?: ANIMATION_TIMEOUT_MS
+        LOGGER.info("Waiting for animation to end with timeout $timeout")
 
-        MaestroTimer.retryUntilTrue(ANIMATION_TIMEOUT_MS) {
+        MaestroTimer.retryUntilTrue(timeout) {
             val startScreenshot: BufferedImage? = tryTakingScreenshot()
             val endScreenshot: BufferedImage? = tryTakingScreenshot()
 
@@ -416,7 +417,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
 
         private val LOGGER = LoggerFactory.getLogger(Maestro::class.java)
         private const val SCREENSHOT_DIFF_THRESHOLD = 0.005 // 0.5%
-        private const val ANIMATION_TIMEOUT_MS: Long = 5000
+        private const val ANIMATION_TIMEOUT_MS: Long = 15000
 
         fun ios(host: String, port: Int): Maestro {
             val channel = ManagedChannelBuilder.forAddress(host, port)

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -410,7 +410,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
             }
 
             return@retryUntilTrue false
-        } || throw MaestroException.AnimationDidTimeout("Animation did timeout, took longer than $ANIMATION_TIMEOUT_MS ms")
+        }
     }
 
     companion object {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -586,27 +586,15 @@ data class RunScriptCommand(
 
 }
 
-class WaitForAnimationToEndCommand : Command {
+data class WaitForAnimationToEndCommand(
+    val timeout: Long?
+) : Command {
     override fun description(): String {
         return "Wait for animation to end"
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return this
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return javaClass.hashCode()
-    }
-
-    override fun toString(): String {
-        return "WaitForAnimationToEndCommand()"
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -586,3 +586,27 @@ data class RunScriptCommand(
 
 }
 
+class WaitForAnimationToEndCommand : Command {
+    override fun description(): String {
+        return "Wait for animation to end"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+
+    override fun toString(): String {
+        return "WaitForAnimationToEndCommand()"
+    }
+}
+

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -54,6 +54,7 @@ data class MaestroCommand(
     val pasteTextCommand: PasteTextCommand? = null,
     val defineVariablesCommand: DefineVariablesCommand? = null,
     val runScriptCommand: RunScriptCommand? = null,
+    val waitForAnimationToEndCommand: WaitForAnimationToEndCommand? = null
 ) {
 
     constructor(command: Command) : this(
@@ -83,6 +84,7 @@ data class MaestroCommand(
         pasteTextCommand = command as? PasteTextCommand,
         defineVariablesCommand = command as? DefineVariablesCommand,
         runScriptCommand = command as? RunScriptCommand,
+        waitForAnimationToEndCommand = command as? WaitForAnimationToEndCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -112,6 +114,7 @@ data class MaestroCommand(
         pasteTextCommand != null -> pasteTextCommand
         defineVariablesCommand != null -> defineVariablesCommand
         runScriptCommand != null -> runScriptCommand
+        waitForAnimationToEndCommand != null -> waitForAnimationToEndCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -185,7 +185,7 @@ class Orchestra(
             is DefineVariablesCommand -> defineVariablesCommand(command)
             is RunScriptCommand -> runScriptCommand(command)
             is ApplyConfigurationCommand -> false
-            is WaitForAnimationToEndCommand -> waitForAnimationToEndCommand(command)
+            is WaitForAnimationToEndCommand -> waitForAnimationToEndCommand()
             else -> true
         }.also { mutating ->
             if (mutating) {
@@ -217,8 +217,9 @@ class Orchestra(
         return true
     }
 
-    private fun waitForAnimationToEndCommand(command: WaitForAnimationToEndCommand): Boolean {
-        // TODO: implement me
+    private fun waitForAnimationToEndCommand(): Boolean {
+        maestro.waitForAnimationToEnd()
+
         return true
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -185,6 +185,7 @@ class Orchestra(
             is DefineVariablesCommand -> defineVariablesCommand(command)
             is RunScriptCommand -> runScriptCommand(command)
             is ApplyConfigurationCommand -> false
+            is WaitForAnimationToEndCommand -> waitForAnimationToEndCommand(command)
             else -> true
         }.also { mutating ->
             if (mutating) {
@@ -213,6 +214,11 @@ class Orchestra(
         )
 
         // We do not actually know if there were any mutations, but we assume there were
+        return true
+    }
+
+    private fun waitForAnimationToEndCommand(command: WaitForAnimationToEndCommand): Boolean {
+        // TODO: implement me
         return true
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -185,7 +185,7 @@ class Orchestra(
             is DefineVariablesCommand -> defineVariablesCommand(command)
             is RunScriptCommand -> runScriptCommand(command)
             is ApplyConfigurationCommand -> false
-            is WaitForAnimationToEndCommand -> waitForAnimationToEndCommand()
+            is WaitForAnimationToEndCommand -> waitForAnimationToEndCommand(command)
             else -> true
         }.also { mutating ->
             if (mutating) {
@@ -217,8 +217,8 @@ class Orchestra(
         return true
     }
 
-    private fun waitForAnimationToEndCommand(): Boolean {
-        maestro.waitForAnimationToEnd()
+    private fun waitForAnimationToEndCommand(command: WaitForAnimationToEndCommand): Boolean {
+        maestro.waitForAnimationToEnd(command.timeout)
 
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -50,6 +50,7 @@ import maestro.orchestra.SwipeCommand
 import maestro.orchestra.TakeScreenshotCommand
 import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointCommand
+import maestro.orchestra.WaitForAnimationToEndCommand
 import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.util.Env.withEnv
@@ -135,6 +136,7 @@ data class YamlFluentCommand(
                     "scroll" -> MaestroCommand(ScrollCommand())
                     "clearKeychain" -> MaestroCommand(ClearKeychainCommand())
                     "pasteText" -> MaestroCommand(PasteTextCommand())
+                    "waitForAnimationToEnd" -> MaestroCommand(WaitForAnimationToEndCommand())
                     else -> error("Unknown navigation target: $action")
                 }
             )
@@ -454,6 +456,10 @@ data class YamlFluentCommand(
 
                 "scroll" -> YamlFluentCommand(
                     action = "scroll"
+                )
+
+                "waitForAnimationToEnd" -> YamlFluentCommand(
+                    action = "waitForAnimationToEnd"
                 )
 
                 else -> throw SyntaxError("Invalid command: \"$stringCommand\"")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -54,6 +54,7 @@ import maestro.orchestra.WaitForAnimationToEndCommand
 import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.util.Env.withEnv
+import org.yaml.snakeyaml.Yaml
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
@@ -85,6 +86,7 @@ data class YamlFluentCommand(
     val repeat: YamlRepeatCommand? = null,
     val copyTextFrom: YamlElementSelectorUnion? = null,
     val runScript: YamlRunScript? = null,
+    val waitForAnimationToEnd: YamlWaitForAnimationToEndCommand? = null
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -136,7 +138,6 @@ data class YamlFluentCommand(
                     "scroll" -> MaestroCommand(ScrollCommand())
                     "clearKeychain" -> MaestroCommand(ClearKeychainCommand())
                     "pasteText" -> MaestroCommand(PasteTextCommand())
-                    "waitForAnimationToEnd" -> MaestroCommand(WaitForAnimationToEndCommand())
                     else -> error("Unknown navigation target: $action")
                 }
             )
@@ -190,6 +191,13 @@ data class YamlFluentCommand(
                             .readText(),
                         env = runScript.env,
                         sourceDescription = runScript.file,
+                    )
+                )
+            )
+            waitForAnimationToEnd != null -> listOf(
+                MaestroCommand(
+                    WaitForAnimationToEndCommand(
+                        timeout = waitForAnimationToEnd.timeout
                     )
                 )
             )
@@ -459,7 +467,7 @@ data class YamlFluentCommand(
                 )
 
                 "waitForAnimationToEnd" -> YamlFluentCommand(
-                    action = "waitForAnimationToEnd"
+                    waitForAnimationToEnd = YamlWaitForAnimationToEndCommand(null)
                 )
 
                 else -> throw SyntaxError("Invalid command: \"$stringCommand\"")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlWaitForAnimationToEndCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlWaitForAnimationToEndCommand.kt
@@ -1,0 +1,5 @@
+package maestro.orchestra.yaml
+
+data class YamlWaitForAnimationToEndCommand(
+    val timeout: Long?
+)

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -504,6 +504,30 @@ internal class MaestroCommandSerializationTest {
             .isEqualTo(command)
     }
 
+    @Test
+    fun `serialize WaitForAnimationToEndCommand`() {
+        // given
+        val command = MaestroCommand(
+            WaitForAnimationToEndCommand()
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+        val deserializedCommand = objectMapper.readValue(serializedCommandJson, MaestroCommand::class.java)
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "waitForAnimationToEndCommand" : { }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+        assertThat(deserializedCommand)
+            .isEqualTo(command)
+    }
+
     private fun MaestroCommand.toJson(): String =
         objectMapper
             .writerWithDefaultPrettyPrinter()

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -508,7 +508,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize WaitForAnimationToEndCommand`() {
         // given
         val command = MaestroCommand(
-            WaitForAnimationToEndCommand()
+            WaitForAnimationToEndCommand(timeout = 9)
         )
 
         // when
@@ -519,7 +519,9 @@ internal class MaestroCommandSerializationTest {
         @Language("json")
         val expectedJson = """
             {
-              "waitForAnimationToEndCommand" : { }
+              "waitForAnimationToEndCommand" : {
+                "timeout" : 9
+              }
             }
           """.trimIndent()
         assertThat(serializedCommandJson)

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1875,6 +1875,28 @@ class IntegrationTest {
         driver.assertCurrentTextInput("")
     }
 
+    @Test
+    fun `Case069 - Wait for animation to end`() {
+        // given
+        val commands = readCommands("069_wait_for_animation_to_end")
+        val driver = driver {
+        }
+
+        // when
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.TakeScreenshot,
+                Event.TakeScreenshot
+            )
+        )
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/069_wait_for_animation_to_end.yaml
+++ b/maestro-test/src/test/resources/069_wait_for_animation_to_end.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- waitForAnimationToEnd:
+    timeout: 500


### PR DESCRIPTION
## Proposed Changes

Implement a command to wait until an animation has fully finished.

Some suitable use-cases: splash screen animation, animation is triggered as a side-effect of some action (i.e. scroll or swipe)

yaml example:
```
appId: org.wikimedia.wikipedia
---
- launchApp
- waitForAnimationToEnd
```

## Testing
Tested locally with apps that have splash screen animations