### PR TITLE
Feature: store copied text in a JS variable

### DIFF
--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -41,6 +41,9 @@ class JsEngine(
                 }
                 
                 const output = {}
+                const maestro = {
+                    copiedText: ''
+                }
             """.trimIndent(),
             "maestro-runtime",
             1,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -697,6 +697,9 @@ class Orchestra(
         val element = findElement(command.selector)
         copiedText = element.treeNode.attributes["text"]
             ?: throw MaestroException.UnableToCopyTextFromElement("Element does not contain text to copy: $element")
+
+        jsEngine.evaluateScript("maestro.copiedText = '${Jsoup.clean(copiedText, Safelist.none())}'")
+
         return true
     }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1798,6 +1798,36 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 066 - Copy text into JS variable`() {
+
+        // Given
+        val commands = readCommands("066_copyText_jsVar")
+
+        val myCopiedText = "Maestro"
+
+        val driver = driver {
+            element {
+                id = "Field"
+                text = myCopiedText
+                bounds = Bounds(0, 100, 100, 200)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.InputText("Hello, Maestro"),
+            )
+        )
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/066_copyText_jsVar.yaml
+++ b/maestro-test/src/test/resources/066_copyText_jsVar.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- copyTextFrom:
+    id: Field
+- inputText: ${'Hello, ' + maestro.copiedText}


### PR DESCRIPTION
## Proposed Changes

Store output of `copyTextFrom` command in `maestro.copiedText` JS variable