### PR TITLE
Feature: assertTrue

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -206,6 +206,8 @@ data class TapOnPointCommand(
     }
 }
 
+// Do not delete this class. It might have been already serialized in the past and stored in DB.
+@Deprecated("Use AssertConditionCommand instead")
 data class AssertCommand(
     val visible: ElementSelector? = null,
     val notVisible: ElementSelector? = null,
@@ -229,6 +231,33 @@ data class AssertCommand(
         return copy(
             visible = visible?.evaluateScripts(jsEngine),
             notVisible = notVisible?.evaluateScripts(jsEngine),
+        )
+    }
+
+    fun toAssertConditionCommand(): AssertConditionCommand {
+        return AssertConditionCommand(
+            condition = Condition(
+                visible = visible,
+                notVisible = notVisible,
+            ),
+            timeout = timeout,
+        )
+    }
+
+}
+
+data class AssertConditionCommand(
+    val condition: Condition,
+    val timeout: Long? = null,
+) : Command {
+
+    override fun description(): String {
+        return "Assert that ${condition.description()}"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return copy(
+            condition = condition.evaluateScripts(jsEngine),
         )
     }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -33,7 +33,8 @@ data class MaestroCommand(
     val scrollCommand: ScrollCommand? = null,
     val swipeCommand: SwipeCommand? = null,
     val backPressCommand: BackPressCommand? = null,
-    val assertCommand: AssertCommand? = null,
+    @Deprecated("Use assertConditionCommand") val assertCommand: AssertCommand? = null,
+    val assertConditionCommand: AssertConditionCommand? = null,
     val inputTextCommand: InputTextCommand? = null,
     val inputRandomTextCommand: InputRandomCommand? = null,
     val launchAppCommand: LaunchAppCommand? = null,
@@ -62,6 +63,7 @@ data class MaestroCommand(
         swipeCommand = command as? SwipeCommand,
         backPressCommand = command as? BackPressCommand,
         assertCommand = command as? AssertCommand,
+        assertConditionCommand = command as? AssertConditionCommand,
         inputTextCommand = command as? InputTextCommand,
         inputRandomTextCommand = command as? InputRandomCommand,
         launchAppCommand = command as? LaunchAppCommand,
@@ -90,6 +92,7 @@ data class MaestroCommand(
         swipeCommand != null -> swipeCommand
         backPressCommand != null -> backPressCommand
         assertCommand != null -> assertCommand
+        assertConditionCommand != null -> assertConditionCommand
         inputTextCommand != null -> inputTextCommand
         inputRandomTextCommand != null -> inputRandomTextCommand
         launchAppCommand != null -> launchAppCommand

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import maestro.KeyCode
 import maestro.Point
 import maestro.orchestra.AssertCommand
+import maestro.orchestra.AssertConditionCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
 import maestro.orchestra.Condition
@@ -62,6 +63,7 @@ data class YamlFluentCommand(
     val longPressOn: YamlElementSelectorUnion? = null,
     val assertVisible: YamlElementSelectorUnion? = null,
     val assertNotVisible: YamlElementSelectorUnion? = null,
+    val assertTrue: String? = null,
     val action: String? = null,
     val inputText: String? = null,
     val inputRandomText: YamlInputRandomText? = null,
@@ -90,8 +92,33 @@ data class YamlFluentCommand(
             launchApp != null -> listOf(launchApp(launchApp, appId))
             tapOn != null -> listOf(tapCommand(tapOn))
             longPressOn != null -> listOf(tapCommand(longPressOn, longPress = true))
-            assertVisible != null -> listOf(MaestroCommand(AssertCommand(visible = toElementSelector(assertVisible))))
-            assertNotVisible != null -> listOf(MaestroCommand(AssertCommand(notVisible = toElementSelector(assertNotVisible))))
+            assertVisible != null -> listOf(
+                MaestroCommand(
+                    AssertConditionCommand(
+                        Condition(
+                            visible = toElementSelector(assertVisible),
+                        )
+                    )
+                )
+            )
+            assertNotVisible != null -> listOf(
+                MaestroCommand(
+                    AssertConditionCommand(
+                        Condition(
+                            notVisible = toElementSelector(assertNotVisible),
+                        )
+                    )
+                )
+            )
+            assertTrue != null -> listOf(
+                MaestroCommand(
+                    AssertConditionCommand(
+                        Condition(
+                            scriptCondition = assertTrue,
+                        )
+                    )
+                )
+            )
             inputText != null -> listOf(MaestroCommand(InputTextCommand(inputText)))
             inputRandomText != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT, length = inputRandomText.length)))
             inputRandomNumber != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.NUMBER, length = inputRandomNumber.length)))

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -122,7 +122,7 @@ class IntegrationTest {
         }
 
         // When & Then
-        assertThrows<MaestroException.ElementNotFound> {
+        assertThrows<MaestroException.AssertionFailure> {
             Maestro(driver).use {
                 orchestra(it).runFlow(commands)
             }
@@ -142,7 +142,7 @@ class IntegrationTest {
         }
 
         // When & Then
-        assertThrows<MaestroException.ElementNotFound> {
+        assertThrows<MaestroException.AssertionFailure> {
             Maestro(driver).use {
                 orchestra(it).runFlow(commands)
             }
@@ -162,7 +162,7 @@ class IntegrationTest {
         }
 
         // When & Then
-        assertThrows<MaestroException.ElementNotFound> {
+        assertThrows<MaestroException.AssertionFailure> {
             Maestro(driver).use {
                 orchestra(it).runFlow(commands)
             }
@@ -1800,7 +1800,6 @@ class IntegrationTest {
 
     @Test
     fun `Case 066 - Copy text into JS variable`() {
-
         // Given
         val commands = readCommands("066_copyText_jsVar")
 
@@ -1826,6 +1825,39 @@ class IntegrationTest {
                 Event.InputText("Hello, Maestro"),
             )
         )
+    }
+
+    @Test
+    fun `Case 067 - Assert True - Pass`() {
+        // Given
+        val commands = readCommands("067_assertTrue_pass")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+    }
+
+    @Test
+    fun `Case 067 - Assert True - Fail`() {
+        // Given
+        val commands = readCommands("067_assertTrue_fail")
+
+        val driver = driver {
+        }
+
+        // Then
+        assertThrows<MaestroException.AssertionFailure> {
+            Maestro(driver).use {
+                orchestra(it).runFlow(commands)
+            }
+        }
     }
 
     private fun orchestra(maestro: Maestro) = Orchestra(

--- a/maestro-test/src/test/resources/067_assertTrue_fail.yaml
+++ b/maestro-test/src/test/resources/067_assertTrue_fail.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- assertTrue: ${1-1}

--- a/maestro-test/src/test/resources/067_assertTrue_pass.yaml
+++ b/maestro-test/src/test/resources/067_assertTrue_pass.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- assertTrue: ${1+1}


### PR DESCRIPTION
## Proposed Changes

- `assertTrue` command that verifies that input is JS-truthy
- Internal refactoring - deprecated `AssertCommand` in favour of `AssertConditionCommand` so that we can encapsulate logic inside of `Condition` object and avoid duplication

Example:
```
- assertTrue: ${1 + 1}    # passes
- assertTrue: ${1 - 1}    # fails, since 0 is treated as False
```