### PR TITLE
Tweak: report generation for single test runs

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -73,7 +73,7 @@ class TestCommand : Callable<Int> {
 
         val (maestro, device) = MaestroFactory.createMaestro(parent?.host, parent?.port, parent?.deviceId)
 
-        return if (flowFile.isDirectory) {
+        return if (flowFile.isDirectory || format != ReportFormat.NOOP) {
             if (continuous) {
                 throw CommandLine.ParameterException(
                     commandSpec.commandLine(),


### PR DESCRIPTION
## Proposed Changes

When running a single test with `--format`, produce the same output as if running a directory