### PR TITLE
Feature: evalScript

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -598,3 +598,16 @@ data class WaitForAnimationToEndCommand(
     }
 }
 
+data class EvalScriptCommand(
+    val scriptString: String,
+) : Command {
+
+    override fun description(): String {
+        return "Run $scriptString"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+
+}

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -54,7 +54,8 @@ data class MaestroCommand(
     val pasteTextCommand: PasteTextCommand? = null,
     val defineVariablesCommand: DefineVariablesCommand? = null,
     val runScriptCommand: RunScriptCommand? = null,
-    val waitForAnimationToEndCommand: WaitForAnimationToEndCommand? = null
+    val waitForAnimationToEndCommand: WaitForAnimationToEndCommand? = null,
+    val evalScriptCommand: EvalScriptCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -85,6 +86,7 @@ data class MaestroCommand(
         defineVariablesCommand = command as? DefineVariablesCommand,
         runScriptCommand = command as? RunScriptCommand,
         waitForAnimationToEndCommand = command as? WaitForAnimationToEndCommand,
+        evalScriptCommand = command as? EvalScriptCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -115,6 +117,7 @@ data class MaestroCommand(
         defineVariablesCommand != null -> defineVariablesCommand
         runScriptCommand != null -> runScriptCommand
         waitForAnimationToEndCommand != null -> waitForAnimationToEndCommand
+        evalScriptCommand != null -> evalScriptCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -33,6 +33,7 @@ import maestro.js.JsEngine
 import maestro.orchestra.error.UnicodeNotSupportedError
 import maestro.orchestra.filter.FilterWithDescription
 import maestro.orchestra.filter.TraitFilters
+import maestro.orchestra.util.Env.evaluateScripts
 import maestro.orchestra.yaml.YamlCommandReader
 import org.jsoup.Jsoup
 import org.jsoup.safety.Safelist
@@ -184,6 +185,7 @@ class Orchestra(
             is RepeatCommand -> repeatCommand(command, maestroCommand)
             is DefineVariablesCommand -> defineVariablesCommand(command)
             is RunScriptCommand -> runScriptCommand(command)
+            is EvalScriptCommand -> evalScriptCommand(command)
             is ApplyConfigurationCommand -> false
             is WaitForAnimationToEndCommand -> waitForAnimationToEndCommand(command)
             else -> true
@@ -203,6 +205,13 @@ class Orchestra(
         }
 
         return false
+    }
+
+    private fun evalScriptCommand(command: EvalScriptCommand): Boolean {
+        command.scriptString.evaluateScripts(jsEngine)
+
+        // We do not actually know if there were any mutations, but we assume there were
+        return true
     }
 
     private fun runScriptCommand(command: RunScriptCommand): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -31,6 +31,7 @@ import maestro.orchestra.CopyTextFromCommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.ElementTrait
 import maestro.orchestra.EraseTextCommand
+import maestro.orchestra.EvalScriptCommand
 import maestro.orchestra.HideKeyboardCommand
 import maestro.orchestra.InputRandomCommand
 import maestro.orchestra.InputRandomType
@@ -86,7 +87,8 @@ data class YamlFluentCommand(
     val repeat: YamlRepeatCommand? = null,
     val copyTextFrom: YamlElementSelectorUnion? = null,
     val runScript: YamlRunScript? = null,
-    val waitForAnimationToEnd: YamlWaitForAnimationToEndCommand? = null
+    val waitForAnimationToEnd: YamlWaitForAnimationToEndCommand? = null,
+    val evalScript: String? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -198,6 +200,13 @@ data class YamlFluentCommand(
                 MaestroCommand(
                     WaitForAnimationToEndCommand(
                         timeout = waitForAnimationToEnd.timeout
+                    )
+                )
+            )
+            evalScript != null -> listOf(
+                MaestroCommand(
+                    EvalScriptCommand(
+                        scriptString = evalScript,
                     )
                 )
             )

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1861,7 +1861,7 @@ class IntegrationTest {
     }
 
     @Test
-    fun `Case068 - Erase all text`() {
+    fun `Case 068 - Erase all text`() {
         // given
         val commands = readCommands("068_erase_all_text")
         val driver = driver {
@@ -1876,7 +1876,7 @@ class IntegrationTest {
     }
 
     @Test
-    fun `Case069 - Wait for animation to end`() {
+    fun `Case 069 - Wait for animation to end`() {
         // given
         val commands = readCommands("069_wait_for_animation_to_end")
         val driver = driver {
@@ -1893,6 +1893,29 @@ class IntegrationTest {
             listOf(
                 Event.TakeScreenshot,
                 Event.TakeScreenshot
+            )
+        )
+    }
+
+    @Test
+    fun `Case 070 - Evaluate JS inline`() {
+        // Given
+        val commands = readCommands("070_evalScript")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.InputText("2"),
+                Event.InputText("Result is: 2"),
             )
         )
     }

--- a/maestro-test/src/test/resources/070_evalScript.yaml
+++ b/maestro-test/src/test/resources/070_evalScript.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+---
+- evalScript: ${output.number = 1 + 1}
+- evalScript: "${output.text = 'Result is: ' + output.number}"
+- inputText: ${output.number}
+- inputText: ${output.text}


### PR DESCRIPTION
## Proposed Changes

`evalScript` is a convenience command for evaluating one-liner snippets of JS code. That comes in particularly handy when working with `copyTextFrom` command:

```
- copyTextFrom:
      id: "myField"
- evalScript: ${output.result = 'Hello ' + maestro.copiedText}
- inputText: ${output.result}
```
