### PR TITLE
Fix clearState issue on iOS

### DIFF
--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -342,7 +342,7 @@ class IdbIOSDevice(
         
         // Wait for the app to be stopped, unfortunately idb's stop()
         // does not wait for the process to finish
-        Thread.sleep(500)
+        Thread.sleep(1500)
 
         // deletes app data, including container folder
         val result = runCatching {


### PR DESCRIPTION
## Proposed Changes
Needed to increase the delay between stopApp and clearState, since flows were flaky with 500ms value

## Testing
Tested on local machine MacBook Pro (16-inch, 2019) 2,4 GHz 8-Core Intel Core i9, when setting a delay to ~800ms flakiness started to drop, at a value of 900ms 100% of the flows succeeded, decided to set it to 1500ms to be on a safe side with slower machines