### PR TITLE
Tweak: speed up Maestro

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -164,30 +164,8 @@ class IOSDriver(
     override fun contentDescriptor(): TreeNode {
         val accessibilityNodes = iosDevice.contentDescriptor().expect {}
 
-        // This is a workaround for an idb issue that doesn't return children of a Tab Bar view
-        // We are locating such a view and then scan it for children by probing individual points on the screen
-        val groupChildren = accessibilityNodes
-            .filter { it.type == "Group" }
-            .filter { (it.frame?.width ?: 0F) > 50F }
-            .maxByOrNull { it.frame?.y ?: 0F }
-            ?.let { node ->
-                node.frame
-                    ?.let { frame ->
-                        (frame.x.toInt()..(frame.x + frame.width).toInt())
-                            .step((frame.width / 5).toInt())
-                            .flatMap { x ->
-                                iosDevice
-                                    .describePoint(x, (frame.y + frame.height / 2).toInt())
-                                    .getOr(emptyList())
-                            }
-                    }
-            }
-            ?: emptyList()
-
-        val allNodes = accessibilityNodes + groupChildren
-
         return TreeNode(
-            children = allNodes.map { node ->
+            children = accessibilityNodes.map { node ->
                 val attributes = mutableMapOf<String, String>()
 
                 (node.title

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -26,7 +26,6 @@ import maestro.Filters.asFilter
 import maestro.Maestro
 import maestro.MaestroException
 import maestro.MaestroTimer
-import maestro.TreeNode
 import maestro.UiElement
 import maestro.js.JsEngine
 import maestro.networkproxy.NetworkProxy
@@ -46,8 +45,8 @@ class Orchestra(
     private val maestro: Maestro,
     private val stateDir: File? = null,
     private val screenshotsDir: File? = null,
-    private val lookupTimeoutMs: Long = 15000L,
-    private val optionalLookupTimeoutMs: Long = 5000L,
+    private val lookupTimeoutMs: Long = 17000L,
+    private val optionalLookupTimeoutMs: Long = 7000L,
     private val networkProxy: NetworkProxy = NetworkProxy(port = 8085),
     private val onFlowStart: (List<MaestroCommand>) -> Unit = {},
     private val onCommandStart: (Int, MaestroCommand) -> Unit = { _, _ -> },
@@ -630,7 +629,6 @@ class Orchestra(
         val (description, filterFunc) = buildFilter(
             selector,
             deviceInfo(),
-            maestro.viewHierarchy().aggregate(),
         )
 
         return maestro.findElementWithTimeout(
@@ -648,7 +646,6 @@ class Orchestra(
     private fun buildFilter(
         selector: ElementSelector,
         deviceInfo: DeviceInfo,
-        allNodes: List<TreeNode>,
     ): FilterWithDescription {
         val filters = mutableListOf<ElementFilter>()
         val descriptions = mutableListOf<String>()
@@ -678,25 +675,25 @@ class Orchestra(
         selector.below
             ?.let {
                 descriptions += "Below: ${it.description()}"
-                filters += Filters.below(buildFilter(it, deviceInfo, allNodes).filterFunc)
+                filters += Filters.below(buildFilter(it, deviceInfo).filterFunc)
             }
 
         selector.above
             ?.let {
                 descriptions += "Above: ${it.description()}"
-                filters += Filters.above(buildFilter(it, deviceInfo, allNodes).filterFunc)
+                filters += Filters.above(buildFilter(it, deviceInfo).filterFunc)
             }
 
         selector.leftOf
             ?.let {
                 descriptions += "Left of: ${it.description()}"
-                filters += Filters.leftOf(buildFilter(it, deviceInfo, allNodes).filterFunc)
+                filters += Filters.leftOf(buildFilter(it, deviceInfo).filterFunc)
             }
 
         selector.rightOf
             ?.let {
                 descriptions += "Right of: ${it.description()}"
-                filters += Filters.rightOf(buildFilter(it, deviceInfo, allNodes).filterFunc)
+                filters += Filters.rightOf(buildFilter(it, deviceInfo).filterFunc)
             }
 
         selector.containsChild


### PR DESCRIPTION
## Proposed Changes

About 2x speed up of Maestro:

- Fixed bug in `waitForAppToSettle` that was always doing 10 iterations
- Removed redundant describePoint calls from iOS Driver (soon to be replaced with XCUITest driver anyway)
- Removed redundant calls to `viewHierarchy()`