### PR TITLE
Replaces initFlowFile exception

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
@@ -1,6 +1,7 @@
 package maestro.cli.view
 
 import maestro.MaestroException
+import maestro.orchestra.error.InvalidFlowFile
 import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.NoInputException
 import maestro.orchestra.error.SyntaxError
@@ -14,6 +15,7 @@ object ErrorViewUtils {
             is SyntaxError -> "Could not parse Flow file:\n\n${e.message}"
             is NoInputException -> "No commands found in Flow file"
             is InvalidInitFlowFile -> "initFlow file is invalid: ${e.initFlowPath}"
+            is InvalidFlowFile -> "Flow file is invalid: ${e.flowPath}"
             is UnicodeNotSupportedError -> "Unicode character input is not supported: ${e.text}. Please use ASCII characters. Follow the issue: https://github.com/mobile-dev-inc/maestro/issues/146"
             is InterruptedException -> "Interrupted"
             is MaestroException -> e.message

--- a/maestro-orchestra/src/main/java/maestro/orchestra/error/InvalidFlowFile.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/error/InvalidFlowFile.kt
@@ -1,0 +1,8 @@
+package maestro.orchestra.error
+
+import java.nio.file.Path
+
+class InvalidFlowFile(
+    override val message: String,
+    val flowPath: Path
+) : RuntimeException()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -53,6 +53,7 @@ import maestro.orchestra.TakeScreenshotCommand
 import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointV2Command
 import maestro.orchestra.WaitForAnimationToEndCommand
+import maestro.orchestra.error.InvalidFlowFile
 import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.util.Env.withEnv
@@ -257,13 +258,13 @@ data class YamlFluentCommand(
             flowPath.resolveSibling(path).toAbsolutePath()
         }
         if (resolvedPath.equals(flowPath.toAbsolutePath())) {
-            throw InvalidInitFlowFile("initFlow file can't be the same as the Flow file: ${resolvedPath.toUri()}", resolvedPath)
+            throw InvalidFlowFile("Referenced Flow file can't be the same as the main Flow file: ${resolvedPath.toUri()}", resolvedPath)
         }
         if (!resolvedPath.exists()) {
-            throw InvalidInitFlowFile("initFlow file does not exist: ${resolvedPath.toUri()}", resolvedPath)
+            throw InvalidFlowFile("Flow file does not exist: ${resolvedPath.toUri()}", resolvedPath)
         }
         if (resolvedPath.isDirectory()) {
-            throw InvalidInitFlowFile("initFlow file can't be a directory: ${resolvedPath.toUri()}", resolvedPath)
+            throw InvalidFlowFile("Flow file can't be a directory: ${resolvedPath.toUri()}", resolvedPath)
         }
         return resolvedPath
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -54,7 +54,6 @@ import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointV2Command
 import maestro.orchestra.WaitForAnimationToEndCommand
 import maestro.orchestra.error.InvalidFlowFile
-import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.util.Env.withEnv
 import java.nio.file.Path


### PR DESCRIPTION
## Proposed Changes
Introduces new exception `InvalidFlowFile` for invalid flow files. Previously we were using `InvalidInitFlowFile`

## Testing
No need.

## Issues Fixed
Incorrect error message for invalid flows