### PR TITLE
iOS: Reset app permissions on reset app state

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -492,12 +492,12 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         private const val SCREENSHOT_DIFF_THRESHOLD = 0.005 // 0.5%
         private const val ANIMATION_TIMEOUT_MS: Long = 15000
 
-        fun ios(host: String, port: Int): Maestro {
+        fun ios(udid: String, host: String, port: Int): Maestro {
             val channel = ManagedChannelBuilder.forAddress(host, port)
                 .usePlaintext()
                 .build()
 
-            return ios(channel)
+            return ios(udid, channel)
         }
 
         fun ios(channel: ManagedChannel): Maestro {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -24,6 +24,7 @@ import com.github.michaelbull.result.getOr
 import com.github.michaelbull.result.getOrThrow
 import ios.IOSDevice
 import ios.idb.IdbIOSDevice
+import ios.xcrun.Simctl
 import maestro.DeviceInfo
 import maestro.Driver
 import maestro.KeyCode
@@ -44,6 +45,9 @@ class IOSDriver(
     private val iosDevice: IOSDevice,
 ) : Driver {
 
+    var udid: String? = null
+        private set
+
     private var widthPixels: Int? = null
     private var heightPixels: Int? = null
 
@@ -56,6 +60,7 @@ class IOSDriver(
     override fun open() {
         val response = iosDevice.deviceInfo().expect {}
 
+        udid = response.id
         widthPixels = response.widthPixels
         heightPixels = response.heightPixels
     }
@@ -95,6 +100,11 @@ class IOSDriver(
 
     override fun clearAppState(appId: String) {
         iosDevice.clearAppState(appId)
+        resetPermissions(appId)
+    }
+
+    private fun resetPermissions(appId: String) {
+        Simctl.resetPermissions(udid, appId)
     }
 
     override fun clearKeychain() {

--- a/maestro-ios/src/main/java/ios/device/DeviceInfo.kt
+++ b/maestro-ios/src/main/java/ios/device/DeviceInfo.kt
@@ -20,6 +20,7 @@
 package ios.device
 
 data class DeviceInfo(
+    val id: String,
     val widthPixels: Int,
     val heightPixels: Int,
     val widthPoints: Int,

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -82,6 +82,7 @@ class IdbIOSDevice(
             val screenDimensions = response.targetDescription.screenDimensions
 
             DeviceInfo(
+                id = response.targetDescription.udid,
                 widthPixels = screenDimensions.width.toInt(),
                 heightPixels = screenDimensions.height.toInt(),
                 widthPoints = screenDimensions.widthPoints.toInt(),

--- a/maestro-ios/src/main/java/ios/xcrun/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/xcrun/Simctl.kt
@@ -106,4 +106,18 @@ object Simctl {
         reboot(deviceId)
     }
 
+    fun resetPermissions(deviceId: String, bundleId: String?) {
+        runCommand(
+            listOfNotNull(
+                "xcrun",
+                "simctl",
+                "privacy",
+                deviceId,
+                "reset",
+                "all",
+                bundleId
+            ),
+            waitForCompletion = true
+        )
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Call `xcrun simctl privacy <udid> reset all <appId>` on clearState.

