### PR TITLE
Feature: allow to install a specific Maestro version

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,7 +88,13 @@ esac
 echo "* Create distribution directories..."
 mkdir -p "$maestro_tmp_folder"
 
-download_url="https://github.com/mobile-dev-inc/maestro/releases/latest/download/maestro.zip"
+
+if [ -z "$MAESTRO_VERSION" ]; then
+    download_url="https://github.com/mobile-dev-inc/maestro/releases/latest/download/maestro.zip"
+else
+    download_url="https://github.com/mobile-dev-inc/maestro/releases/download/cli-$MAESTRO_VERSION/maestro.zip"
+fi
+
 maestro_zip_file="${maestro_tmp_folder}/maestro.zip"
 echo "* Downloading..."
 curl --fail --location --progress-bar "$download_url" > "$maestro_zip_file"


### PR DESCRIPTION
## Proposed Changes

Once deployed to GCP, user would be able to run scripts like that to install a specific version:

```
export MAESTRO_VERSION=1.16.0
curl -Ls "https://get.maestro.mobile.dev" | bash
```

or one-liner

```
export MAESTRO_VERSION=1.16.0; curl -Ls "https://get.maestro.mobile.dev" | bash
```