### PR TITLE
Tweak: internal flag to fail on cancellations

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -40,6 +40,7 @@ class CloudInteractor(
         pullRequestId: String? = null,
         env: Map<String, String> = emptyMap(),
         androidApiLevel: Int? = null,
+        failOnCancellation: Boolean = false,
     ): Int {
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
         if (mapping?.exists() == false) throw CliError("File does not exist: ${mapping.absolutePath}")
@@ -100,6 +101,7 @@ class CloudInteractor(
                     uploadId = uploadId,
                     teamId = teamId,
                     appId = appId,
+                    failOnCancellation = failOnCancellation,
                 )
             }
         }
@@ -110,6 +112,7 @@ class CloudInteractor(
         uploadId: String,
         teamId: String,
         appId: String,
+        failOnCancellation: Boolean,
     ): Int {
         val startTime = System.currentTimeMillis()
 
@@ -161,6 +164,10 @@ class CloudInteractor(
                         )
                     )
                 )
+
+                if (upload.status == UploadStatus.Status.CANCELED && failOnCancellation) {
+                    return 1
+                }
 
                 return if (upload.status == UploadStatus.Status.ERROR) {
                     1

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -79,6 +79,9 @@ class CloudCommand : Callable<Int> {
     @Option(order = 10, names = ["--android-api-level"], description = ["Android API level to run your flow against"])
     private var androidApiLevel: Int? = null
 
+    @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
+    private var failOnCancellation: Boolean = false
+
     override fun call(): Int {
         return CloudInteractor(
             client = ApiClient(apiUrl),
@@ -95,6 +98,7 @@ class CloudCommand : Callable<Int> {
             pullRequestId = pullRequestId,
             apiKey = apiKey,
             androidApiLevel = androidApiLevel,
+            failOnCancellation = failOnCancellation,
         )
     }
 


### PR DESCRIPTION
## Proposed Changes

When testing our internal infra, it would be very convenient to let `maestro cloud` fail on `CANCELED` status ensure that the whole stack behaves correctly E2E.