### PR TITLE
Add capacity of filtering flows based on the --include-tags and --exclude-tags for maestro cloud command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -41,6 +41,8 @@ class CloudInteractor(
         env: Map<String, String> = emptyMap(),
         androidApiLevel: Int? = null,
         failOnCancellation: Boolean = false,
+        includeTags: List<String> = emptyList(),
+        excludeTags: List<String> = emptyList(),
     ): Int {
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
         if (mapping?.exists() == false) throw CliError("File does not exist: ${mapping.absolutePath}")
@@ -53,7 +55,7 @@ class CloudInteractor(
 
         TemporaryDirectory.use { tmpDir ->
             val workspaceZip = tmpDir.resolve("workspace.zip")
-            WorkspaceUtils.createWorkspaceZip(flowFile.toPath().absolute(), workspaceZip)
+            WorkspaceUtils.createWorkspaceZip(flowFile.toPath().absolute(), workspaceZip, includeTags, excludeTags)
             println()
             val progressBar = ProgressBar(20)
 

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -79,6 +79,20 @@ class CloudCommand : Callable<Int> {
     @Option(order = 10, names = ["--android-api-level"], description = ["Android API level to run your flow against"])
     private var androidApiLevel: Int? = null
 
+    @Option(
+        order = 11,
+        names = ["--include-tags"],
+        description = ["List of tags that will remove the Flows that does not have the provided tags"]
+    )
+    private var includeTags: List<String> = emptyList()
+
+    @Option(
+        order = 12,
+        names = ["--exclude-tags"],
+        description = ["List of tags that will remove the Flows containing the provided tags"]
+    )
+    private var excludeTags: List<String> = emptyList()
+
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
 
@@ -98,6 +112,8 @@ class CloudCommand : Callable<Int> {
             pullRequestId = pullRequestId,
             apiKey = apiKey,
             androidApiLevel = androidApiLevel,
+            includeTags = includeTags,
+            excludeTags = excludeTags,
             failOnCancellation = failOnCancellation,
         )
     }

--- a/maestro-cli/src/main/java/maestro/cli/util/WorkspaceUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/WorkspaceUtils.kt
@@ -26,8 +26,6 @@ object WorkspaceUtils {
             excludeTags = excludeTags,
         )
 
-        println(flowsMatchingTagsRule)
-
         val outUri = URI.create("jar:file:${out.toAbsolutePath()}")
         FileSystems.newFileSystem(outUri, mapOf("create" to "true")).use { fs ->
             flowsMatchingTagsRule.forEach {

--- a/maestro-cli/src/main/java/maestro/cli/util/WorkspaceUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/WorkspaceUtils.kt
@@ -1,5 +1,6 @@
 package maestro.cli.util
 
+import maestro.orchestra.yaml.YamlCommandReader
 import java.io.FileNotFoundException
 import java.net.URI
 import java.nio.file.FileSystems
@@ -13,15 +14,23 @@ import kotlin.streams.toList
 
 object WorkspaceUtils {
 
-    fun createWorkspaceZip(file: Path, out: Path) {
+    fun createWorkspaceZip(file: Path, out: Path, includeTags: List<String>, excludeTags: List<String>) {
         if (!file.exists()) throw FileNotFoundException(file.absolutePathString())
         if (out.exists()) throw FileAlreadyExistsException(out.toFile())
         val files = Files.walk(file).filter { !it.isDirectory() }.toList()
         val relativeTo = if (file.isDirectory()) file else file.parent
 
+        val flowsMatchingTagsRule = filterFlowFilesBasedOnTags(
+            files,
+            includeTags = includeTags,
+            excludeTags = excludeTags,
+        )
+
+        println(flowsMatchingTagsRule)
+
         val outUri = URI.create("jar:file:${out.toAbsolutePath()}")
         FileSystems.newFileSystem(outUri, mapOf("create" to "true")).use { fs ->
-            files.forEach {
+            flowsMatchingTagsRule.forEach {
                 val outPath = fs.getPath(relativeTo.relativize(it).toString())
                 if (outPath.parent != null) {
                     Files.createDirectories(outPath.parent)
@@ -30,4 +39,37 @@ object WorkspaceUtils {
             }
         }
     }
+
+    fun filterFlowFilesBasedOnTags(
+        files: List<Path>,
+        includeTags: List<String> = emptyList(),
+        excludeTags: List<String> = emptyList(),
+    ): List<Path> {
+
+        val flowFiles = files
+            .filter {
+                it.toFile().isFile
+                    && it.toFile().extension in setOf("yaml", "yml")
+                    && it.toFile().nameWithoutExtension != "config"
+            }
+
+        val flowsMatchingTagRule = mutableListOf<Path>()
+        flowFiles.forEach {
+            val config = YamlCommandReader.getConfig(YamlCommandReader.readCommands(it))
+            val tags = config?.tags ?: emptyList()
+
+            if (excludeTags.isNotEmpty() && tags.any(excludeTags::contains)) {
+                return@forEach
+            }
+
+            if (includeTags.isNotEmpty() && !tags.any(includeTags::contains)) {
+                return@forEach
+            }
+
+            flowsMatchingTagRule.add(it)
+        }
+
+        return flowsMatchingTagRule
+    }
+
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/WorkspaceUtilsTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/WorkspaceUtilsTest.kt
@@ -1,0 +1,50 @@
+package maestro.cli.util
+
+import com.google.common.truth.Truth
+import org.apache.commons.io.FileUtils
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class WorkspaceUtilsTest {
+
+    private fun flowFiles(): List<Path> {
+        val flowA = FileUtils.toFile(this.javaClass.getResource("/tags/flowA.yaml"))
+        val flowB = FileUtils.toFile(this.javaClass.getResource("/tags/flowB.yaml"))
+        return listOf(flowA.toPath(), flowB.toPath())
+    }
+
+    @Test
+    fun `Test filterFlowsFilesBasedOnTags only include-tags`() {
+        val result = WorkspaceUtils.filterFlowFilesBasedOnTags(
+            flowFiles(),
+            includeTags = listOf("dev"),
+        )
+
+        Truth.assertThat(result).hasSize(2)
+        Truth.assertThat(result.first().fileName.toString()).isEqualTo("flowA.yaml")
+        Truth.assertThat(result[1].fileName.toString()).isEqualTo("flowB.yaml")
+    }
+
+    @Test
+    fun `Test filterFlowsFilesBasedOnTags only exclude-tags`() {
+        val result = WorkspaceUtils.filterFlowFilesBasedOnTags(
+            flowFiles(),
+            excludeTags = listOf("pull-request"),
+        )
+
+        Truth.assertThat(result).hasSize(1)
+        Truth.assertThat(result.first().fileName.toString()).isEqualTo("flowB.yaml")
+    }
+
+    @Test
+    fun `Test filterFlowsFilesBasedOnTags proving both`() {
+        val result = WorkspaceUtils.filterFlowFilesBasedOnTags(
+            flowFiles(),
+            includeTags = listOf("dev"),
+            excludeTags = listOf("pull-request"),
+        )
+
+        Truth.assertThat(result).hasSize(1)
+        Truth.assertThat(result.first().fileName.toString()).isEqualTo("flowB.yaml")
+    }
+}

--- a/maestro-cli/src/test/resources/tags/flowA.yaml
+++ b/maestro-cli/src/test/resources/tags/flowA.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+tags:
+  - dev
+  - pull-request
+---
+- launchApp

--- a/maestro-cli/src/test/resources/tags/flowB.yaml
+++ b/maestro-cli/src/test/resources/tags/flowB.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+tags:
+  - dev
+---
+- launchApp

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -8,6 +8,7 @@ import maestro.orchestra.util.Env.evaluateScripts
 data class MaestroConfig(
     val appId: String? = null,
     val name: String? = null,
+    val tags: List<String>? = emptyList(),
     val initFlow: MaestroInitFlow? = null,
     val ext: Map<String, Any?> = emptyMap(),
 ) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -14,6 +14,7 @@ data class YamlConfig(
     val name: String?,
     val appId: String,
     val initFlow: YamlInitFlowUnion?,
+    val tags: List<String>? = emptyList(),
     val env: Map<String, String> = emptyMap(),
 ) {
 
@@ -28,6 +29,7 @@ data class YamlConfig(
         val config = MaestroConfig(
             appId = appId,
             name = name,
+            tags = tags,
             initFlow = initFlow(flowPath),
             ext = ext.toMap()
         )

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -313,6 +313,7 @@ internal class MaestroCommandSerializationTest {
                 "config" : {
                   "appId" : "com.twitter.android",
                   "name" : "Twitter",
+                  "tags" : [ ],
                   "ext" : { }
                 }
               }


### PR DESCRIPTION
This PR adds the `--include-tags` and `--exclude-tags` parameters for the `cloud` command [1]. With these options, the users are able to filter the Flows containing (or not) those tags.

Usage example:
The `--include-tags` should look for all flows that contain the provided tag and it doesn't matter if those Flows also contain other tags. On the other hand, the `--exclude-tags` would remove from the list of Flows to run any Flow that contains the provided tags.

Let's say a user has two flows:

```
# flowA.yaml
appId: com.example.app
tags: dev,pull-request
```

```
# flowB.yaml
appId: com.example.app
tags: dev
```

In the scenario above:
- If they use `--include-tags=dev` we would run flowA and flowB. 
- If they use `--exclude-tags=pull-request` we would run only flowB.
- If they use `--exclude-tags=dev` we wouldn't run any Flow.
- If they use `--include-tags=dev --exclude-tags=pull-request` we would run only flowB

[1] I didn't add to the `upload` command too to push the users to not use it so we can deprecate it soon.