### PR TITLE
Deprecate string splitting runCommand

### DIFF
--- a/maestro-xcuitest-driver/src/main/kotlin/util/CommandLineUtils.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/util/CommandLineUtils.kt
@@ -15,6 +15,7 @@ object CommandLineUtils {
         ) "NUL" else "/dev/null"
     )
 
+    @Deprecated("use runCommand(listOf(...)) instead")
     fun runCommand(command: String, waitForCompletion: Boolean = true, outputFile: File? = null): Process {
         LOGGER.info("Running command line operation: $command")
 

--- a/maestro-xcuitest-driver/src/main/kotlin/util/CommandLineUtils.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/util/CommandLineUtils.kt
@@ -15,6 +15,7 @@ object CommandLineUtils {
         ) "NUL" else "/dev/null"
     )
 
+    // Deprecated: `runCommand("foo $bar")` $bar may contain spaces and forms a security risk
     @Deprecated("use runCommand(listOf(...)) instead")
     fun runCommand(command: String, waitForCompletion: Boolean = true, outputFile: File? = null): Process {
         LOGGER.info("Running command line operation: $command")


### PR DESCRIPTION
## Proposed Changes

Deprecate the runCommand() that slits up the single string argument. Refer to the runCommand() accepts a list of arguments.
