### PR TITLE
Add capacity of filtering flows based on the --include-tags and --exclude-tags for maestro test command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -66,6 +66,18 @@ class TestCommand : Callable<Int> {
     @Option(names = ["--output"])
     private var output: File? = null
 
+    @Option(
+        names = ["--include-tags"],
+        description = ["List of tags that will remove the Flows that does not have the provided tags"]
+    )
+    private var includeTags: List<String> = emptyList()
+
+    @Option(
+        names = ["--exclude-tags"],
+        description = ["List of tags that will remove the Flows containing the provided tags"]
+    )
+    private var excludeTags: List<String> = emptyList()
+
     @CommandLine.Spec
     lateinit var commandSpec: CommandLine.Model.CommandSpec
 
@@ -99,7 +111,9 @@ class TestCommand : Callable<Int> {
                 val suiteResult = TestSuiteInteractor(
                     maestro = maestro,
                     device = device,
-                    reporter = ReporterFactory.buildReporter(format)
+                    reporter = ReporterFactory.buildReporter(format),
+                    includeTags = includeTags,
+                    excludeTags = excludeTags,
                 ).runTestSuite(
                     input = flowFile,
                     env = env,

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -6,6 +6,7 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
 import maestro.cli.report.TestSuiteReporter
 import maestro.cli.util.PrintUtils
+import maestro.cli.util.WorkspaceUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
@@ -19,6 +20,8 @@ class TestSuiteInteractor(
     private val maestro: Maestro,
     private val device: Device? = null,
     private val reporter: TestSuiteReporter,
+    private val includeTags: List<String> = emptyList(),
+    private val excludeTags: List<String> = emptyList(),
 ) {
 
     fun runTestSuite(
@@ -33,24 +36,17 @@ class TestSuiteInteractor(
                 env,
             )
         } else {
-            val flowFiles = input
-                .listFiles()
-                .filter {
-                    it.isFile
-                        && it.extension in setOf("yaml", "yml")
-                        && it.nameWithoutExtension != "config"
-                }
-                .toList()
+            val flowFiles = WorkspaceUtils.filterFlowFilesBasedOnTags(input.listFiles().map { it.toPath() }, includeTags, excludeTags)
 
             runTestSuite(
-                flowFiles,
+                flowFiles.map { it.toFile() },
                 reportOut,
                 env,
             )
         }
     }
 
-    fun runTestSuite(
+    private fun runTestSuite(
         flows: List<File>,
         reportOut: Sink?,
         env: Map<String, String>,


### PR DESCRIPTION
For the full explanation of how the feature works, please see PR #545 