### PR TITLE
Tweak: handle linebreaks

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -58,6 +58,7 @@ object Filters {
         return {
             it.attributes["text"]?.let { value ->
                 text == value
+                    || text == value.replace('\n', ' ')
             } ?: false
         }
     }
@@ -65,7 +66,12 @@ object Filters {
     fun textMatches(regex: Regex): ElementLookupPredicate {
         return {
             it.attributes["text"]?.let { value ->
-                regex.matches(value) || regex.pattern == value
+                val strippedValue = value.replace('\n', ' ')
+
+                regex.matches(value)
+                    || regex.pattern == value
+                    || regex.matches(strippedValue)
+                    || regex.pattern == strippedValue
             } ?: false
         }
     }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1982,6 +1982,37 @@ class IntegrationTest {
         driver.assertHasEvent(Event.Tap(Point(25, 25)))
     }
 
+    @Test
+    fun `Case 073 - Handle linebreaks`() {
+        // Given
+        val commands = readCommands("073_handle_linebreaks")
+
+        val driver = driver {
+            val indicator = element {
+                text = "Indicator"
+                bounds = Bounds(0, 100, 100, 100)
+            }
+
+            element {
+                text = "Hello\nWorld"
+                bounds = Bounds(0, 0, 100, 100)
+
+                onClick = {
+                    indicator.text += "!"
+                }
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 2)
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/073_handle_linebreaks.yaml
+++ b/maestro-test/src/test/resources/073_handle_linebreaks.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- tapOn: Hello World
+- tapOn: Hello\nWorld


### PR DESCRIPTION
## Proposed Changes

From user's perspective, linebreak might be interpreted as a whitespace when rendered on the screen. To reduce mental load on test's author, we are going to optionally treat linebreaks as a whitespace.