### PR TITLE
Sort files by name before running

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -16,6 +16,7 @@ import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.yaml.YamlCommandReader
 import okio.Sink
 import java.io.File
+import kotlin.io.path.name
 
 class TestSuiteInteractor(
     private val maestro: Maestro,
@@ -43,7 +44,7 @@ class TestSuiteInteractor(
             }
 
             runTestSuite(
-                flowFiles.map { it.toFile() },
+                flowFiles.sortedBy { it.name }.map { it.toFile() },
                 reportOut,
                 env,
             )


### PR DESCRIPTION
## Proposed Changes

This PR is to sort files passed to `maestro test` by name before running.
I found it needed to make sure our flows run sequentially as expected.
## Testing

Before:
![Screenshot 2023-01-09 at 16 54 52](https://user-images.githubusercontent.com/19727534/211365962-b0b9d385-5038-44f4-ae33-7105ae3208ca.png)

After:
![Screenshot 2023-01-09 at 16 55 25](https://user-images.githubusercontent.com/19727534/211365974-719eae5f-2a1e-4a78-8af4-3826d1489ce2.png)
