### PR TITLE
Fix: do not fail studio command if Desktop.browse doesn't work

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -41,9 +41,7 @@ class StudioCommand : Callable<Int> {
             val message = ("Maestro Studio".bold() + " is running at " + studioUrl.blue()).box()
             println()
             println(message)
-            if (Desktop.isDesktopSupported()) {
-                Desktop.getDesktop().browse(URI(studioUrl))
-            }
+            tryOpenUrl(studioUrl)
 
             println()
             println("Note: Most Maestro CLI commands do not work while Maestro Studio is running. We will address this in an upcoming release.")
@@ -54,6 +52,16 @@ class StudioCommand : Callable<Int> {
             Thread.currentThread().join()
         }
         return 0
+    }
+
+    private fun tryOpenUrl(studioUrl: String) {
+        try {
+            if (Desktop.isDesktopSupported()) {
+                Desktop.getDesktop().browse(URI(studioUrl))
+            }
+        } catch (ignore: Exception) {
+            // Do nothing
+        }
     }
 
     private fun getFreePort(): Int {


### PR DESCRIPTION
## Issues Fixed

Fixes #579 