### PR TITLE
Feat: add error report mechanism

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -34,6 +34,7 @@ import maestro.cli.command.network.NetworkCommand
 import maestro.cli.update.Updates
 import maestro.cli.view.box
 import maestro.cli.command.StudioCommand
+import maestro.cli.util.ErrorReporter
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
@@ -99,7 +100,9 @@ fun main(args: Array<String>) {
         .setUsageHelpWidth(160)
         .setCaseInsensitiveEnumValuesAllowed(true)
         .setExecutionStrategy(DisableAnsiMixin::executionStrategy)
-        .setExecutionExceptionHandler { ex, cmd, _ ->
+        .setExecutionExceptionHandler { ex, cmd, cmdParseResult->
+            ErrorReporter.report(ex, cmdParseResult)
+
             val message = if (ex is CliError) {
                 ex.message
             } else {

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -101,7 +101,7 @@ fun main(args: Array<String>) {
         .setCaseInsensitiveEnumValuesAllowed(true)
         .setExecutionStrategy(DisableAnsiMixin::executionStrategy)
         .setExecutionExceptionHandler { ex, cmd, cmdParseResult->
-            ErrorReporter.report(ex, cmdParseResult)
+            runCatching { ErrorReporter.report(ex, cmdParseResult) }
 
             val message = if (ex is CliError) {
                 ex.message

--- a/maestro-cli/src/main/java/maestro/cli/command/BugReportCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/BugReportCommand.kt
@@ -1,5 +1,6 @@
 package maestro.cli.command
 
+import maestro.cli.CliError
 import maestro.cli.DisableAnsiMixin
 import maestro.debuglog.DebugLogStore
 import picocli.CommandLine

--- a/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
+++ b/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
@@ -25,7 +25,7 @@ object Updates {
         }
     }
 
-    private const val BASE_API_URL = "https://api.mobile.dev"
+    const val BASE_API_URL = "https://api.mobile.dev"
     private val FRESH_INSTALL: Boolean
 
     private val DEFAULT_THREAD_FACTORY = Executors.defaultThreadFactory()

--- a/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
+++ b/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
@@ -16,15 +16,17 @@ import kotlin.io.path.writeText
 
 object Updates {
 
-    private val BASE_API_URL = "https://api.mobile.dev"
-    private val OS_NAME = System.getProperty("os.name")
-    private val FRESH_INSTALL: Boolean
-    private val DEVICE_UUID: String
-    private val CLI_VERSION: CliVersion? = getVersion().apply {
+    val OS_NAME: String = System.getProperty("os.name")
+    val OS_ARCH: String = System.getProperty("os.arch")
+    val DEVICE_UUID: String
+    val CLI_VERSION: CliVersion? = getVersion().apply {
         if (this == null) {
             System.err.println("\nWarning: Failed to parse current version".red())
         }
     }
+
+    private const val BASE_API_URL = "https://api.mobile.dev"
+    private val FRESH_INSTALL: Boolean
 
     private val DEFAULT_THREAD_FACTORY = Executors.defaultThreadFactory()
     private val EXECUTOR = Executors.newCachedThreadPool {
@@ -63,9 +65,6 @@ object Updates {
         }
 
         val latestCliVersion = ApiClient(BASE_API_URL).getLatestCliVersion(
-            deviceUuid = DEVICE_UUID,
-            osName = OS_NAME,
-            currentVersion = CLI_VERSION,
             freshInstall = FRESH_INSTALL,
         )
 

--- a/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
@@ -1,6 +1,7 @@
 package maestro.cli.util
 
 import maestro.cli.api.ApiClient
+import maestro.cli.update.Updates.BASE_API_URL
 import picocli.CommandLine
 import java.security.MessageDigest
 import java.util.concurrent.Executors
@@ -9,7 +10,6 @@ import kotlin.Exception
 
 object ErrorReporter {
 
-    private const val BASE_API_URL = "https://api.mobile.dev"
     private val executor = Executors.newCachedThreadPool {
         Executors.defaultThreadFactory().newThread(it).apply { isDaemon = true }
     }
@@ -23,12 +23,14 @@ object ErrorReporter {
             } else arg
         }
 
-        executor.submit {
+        val task = executor.submit {
             ApiClient(BASE_API_URL).sendErrorReport(
                 exception,
                 scrubbedArgs.joinToString(" ")
             )
-        }.get(1, TimeUnit.SECONDS)
+        }
+
+        runCatching { task.get(1, TimeUnit.SECONDS) }
     }
 
     private fun hashString(input: String): String {

--- a/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
@@ -1,0 +1,43 @@
+package maestro.cli.util
+
+import maestro.cli.api.ApiClient
+import picocli.CommandLine
+import java.security.MessageDigest
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.Exception
+
+object ErrorReporter {
+
+    private const val BASE_API_URL = "https://api.mobile.dev"
+    private val executor = Executors.newCachedThreadPool {
+        Executors.defaultThreadFactory().newThread(it).apply { isDaemon = true }
+    }
+
+    fun report(exception: Exception, parseResult: CommandLine.ParseResult) {
+        val args = parseResult.expandedArgs()
+        val scrubbedArgs = args.mapIndexed { idx, arg ->
+            if (idx > 0 && args[idx - 1] in listOf("-e", "--env")) {
+                val (key, value) = arg.split("=", limit = 1)
+                key + "=" + hashString(value)
+            } else arg
+        }
+
+        executor.submit {
+            ApiClient(BASE_API_URL).sendErrorReport(
+                exception,
+                scrubbedArgs.joinToString(" ")
+            )
+        }.get(1, TimeUnit.SECONDS)
+    }
+
+    private fun hashString(input: String): String {
+        return MessageDigest
+            .getInstance("SHA-256")
+            .digest(input.toByteArray())
+            .fold(StringBuilder()) { sb, it ->
+                sb.append("%02x".format(it))
+            }.toString()
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes
- Add an error report mechanism: Every time an exception is detected by `picocli` it will send the exception details + the command executed to `api.mobile.dev`. 
    - This mechanism tries to not collect any PII information.
    - `-e/--env` can have PII information, so this PR also hash the values with SHA-256.
    - Also, there is a timeout of 1 second to complete the request to make sure that the user experience is not affected.
- Add `SystemInformationInterceptor` to `ApiClient` to simplify adding system information for each request.

### Testing
Tested manually:
- Modified an existing maestro command to always throw a CLIError
- Verified if the request went through

### Further possible improvements
- Send a _category_ of error. This could be made easier if there are custom exceptions for each _category_.
- Prompt the user to send all logs (saved by `DebugLogStore`) and flow file/workspace. 