### PR TITLE
Scroll swipe improvements

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -58,6 +58,8 @@ interface Driver {
 
     fun swipe(swipeDirection: SwipeDirection, durationMs: Long)
 
+    fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long)
+
     fun backPress()
 
     fun inputText(text: String)

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -119,6 +119,13 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
+    fun swipe(swipeDirection: SwipeDirection, uiElement: UiElement, durationMs: Long) {
+        LOGGER.info("Swiping ${swipeDirection.name} on element: $uiElement")
+        driver.swipe(uiElement.bounds.center(), swipeDirection, durationMs)
+
+        waitForAppToSettle()
+    }
+
     fun scrollVertical() {
         LOGGER.info("Scrolling vertically")
 

--- a/maestro-client/src/main/java/maestro/SwipeDirection.kt
+++ b/maestro-client/src/main/java/maestro/SwipeDirection.kt
@@ -6,3 +6,7 @@ enum class SwipeDirection {
     RIGHT,
     LEFT
 }
+
+inline fun <reified SwipeDirection : Enum<SwipeDirection>> directionValueOfOrNull(input: String): SwipeDirection? {
+    return enumValues<SwipeDirection>().find { it.name == input || it.name.lowercase() == input }
+}

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -33,6 +33,7 @@ import maestro.Point
 import maestro.ScreenRecording
 import maestro.SwipeDirection
 import maestro.TreeNode
+import maestro.UiElement
 import maestro.android.AndroidAppFiles
 import maestro.android.asManifest
 import maestro.android.resolveLauncherActivity
@@ -295,6 +296,10 @@ class AndroidDriver(
                 dadb.shell("input swipe $startX $startY $endX $startY $durationMs")
             }
         }
+    }
+
+    override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
+        TODO("Not yet implemented")
     }
 
     override fun backPress() {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -283,13 +283,13 @@ class AndroidDriver(
                 dadb.shell("input swipe $startX $startY $startX $endY $durationMs")
             }
             SwipeDirection.RIGHT -> {
-                val startX = (deviceInfo.widthGrid * 0.5f).toInt()
+                val startX = (deviceInfo.widthGrid * 0.1f).toInt()
                 val startY = (deviceInfo.heightGrid * 0.5f).toInt()
                 val endX = (deviceInfo.widthGrid * 0.9f).toInt()
                 dadb.shell("input swipe $startX $startY $endX $startY $durationMs")
             }
             SwipeDirection.LEFT -> {
-                val startX = (deviceInfo.widthGrid * 0.5f).toInt()
+                val startX = (deviceInfo.widthGrid * 0.9f).toInt()
                 val startY = (deviceInfo.heightGrid * 0.5f).toInt()
                 val endX = (deviceInfo.widthGrid * 0.1f).toInt()
                 dadb.shell("input swipe $startX $startY $endX $startY $durationMs")

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -33,7 +33,6 @@ import maestro.Point
 import maestro.ScreenRecording
 import maestro.SwipeDirection
 import maestro.TreeNode
-import maestro.UiElement
 import maestro.android.AndroidAppFiles
 import maestro.android.asManifest
 import maestro.android.resolveLauncherActivity
@@ -270,36 +269,82 @@ class AndroidDriver(
 
     override fun swipe(swipeDirection: SwipeDirection, durationMs: Long) {
         val deviceInfo = deviceInfo()
-        when (swipeDirection) {
+        when(swipeDirection) {
             SwipeDirection.UP -> {
                 val startX = (deviceInfo.widthGrid * 0.5f).toInt()
                 val startY = (deviceInfo.heightGrid * 0.9f).toInt()
+                val endX = (deviceInfo.widthGrid * 0.5f).toInt()
                 val endY = (deviceInfo.heightGrid * 0.1f).toInt()
-                dadb.shell("input swipe $startX $startY $startX $endY $durationMs")
+                directionalSwipe(
+                    durationMs,
+                    Point(startX, startY),
+                    Point(endX, endY)
+                )
             }
             SwipeDirection.DOWN -> {
                 val startX = (deviceInfo.widthGrid * 0.5f).toInt()
                 val startY = (deviceInfo.heightGrid * 0.1f).toInt()
+                val endX = (deviceInfo.widthGrid * 0.5f).toInt()
                 val endY = (deviceInfo.heightGrid * 0.9f).toInt()
-                dadb.shell("input swipe $startX $startY $startX $endY $durationMs")
+                directionalSwipe(
+                    durationMs,
+                    Point(startX, startY),
+                    Point(endX, endY)
+                )
             }
             SwipeDirection.RIGHT -> {
                 val startX = (deviceInfo.widthGrid * 0.1f).toInt()
                 val startY = (deviceInfo.heightGrid * 0.5f).toInt()
                 val endX = (deviceInfo.widthGrid * 0.9f).toInt()
-                dadb.shell("input swipe $startX $startY $endX $startY $durationMs")
+                val endY = (deviceInfo.heightGrid * 0.5f).toInt()
+                directionalSwipe(
+                    durationMs,
+                    Point(startX, startY),
+                    Point(endX, endY)
+                )
             }
             SwipeDirection.LEFT -> {
                 val startX = (deviceInfo.widthGrid * 0.9f).toInt()
                 val startY = (deviceInfo.heightGrid * 0.5f).toInt()
                 val endX = (deviceInfo.widthGrid * 0.1f).toInt()
-                dadb.shell("input swipe $startX $startY $endX $startY $durationMs")
+                val endY = (deviceInfo.heightGrid * 0.5f).toInt()
+                directionalSwipe(
+                    durationMs,
+                    Point(startX, startY),
+                    Point(endX, endY)
+                )
             }
         }
     }
 
     override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
-        TODO("Not yet implemented")
+        val deviceInfo = deviceInfo()
+        when(direction) {
+            SwipeDirection.UP -> {
+                val endX = (deviceInfo.widthGrid * 0.5f).toInt()
+                val endY = (deviceInfo.heightGrid * 0.1f).toInt()
+                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+            }
+            SwipeDirection.DOWN -> {
+                val endX = (deviceInfo.widthGrid * 0.5f).toInt()
+                val endY = (deviceInfo.heightGrid * 0.9f).toInt()
+                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+            }
+            SwipeDirection.RIGHT -> {
+                val endX = (deviceInfo.widthGrid * 0.9f).toInt()
+                val endY = (deviceInfo.heightGrid * 0.5f).toInt()
+                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+            }
+            SwipeDirection.LEFT -> {
+                val endX = (deviceInfo.widthGrid * 0.1f).toInt()
+                val endY = (deviceInfo.heightGrid * 0.5f).toInt()
+                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+            }
+        }
+    }
+
+    private fun directionalSwipe(durationMs: Long, start: Point, end: Point) {
+        dadb.shell("input swipe ${start.x} ${start.y} ${end.x} ${end.y} $durationMs")
     }
 
     override fun backPress() {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -273,14 +273,14 @@ class AndroidDriver(
         when (swipeDirection) {
             SwipeDirection.UP -> {
                 val startX = (deviceInfo.widthGrid * 0.5f).toInt()
-                val startY = (deviceInfo.heightGrid * 0.5f).toInt()
-                val endY = (deviceInfo.heightGrid * 0.25f).toInt()
+                val startY = (deviceInfo.heightGrid * 0.9f).toInt()
+                val endY = (deviceInfo.heightGrid * 0.1f).toInt()
                 dadb.shell("input swipe $startX $startY $startX $endY $durationMs")
             }
             SwipeDirection.DOWN -> {
                 val startX = (deviceInfo.widthGrid * 0.5f).toInt()
-                val startY = (deviceInfo.heightGrid * 0.25f).toInt()
-                val endY = (deviceInfo.heightGrid * 0.5f).toInt()
+                val startY = (deviceInfo.heightGrid * 0.1f).toInt()
+                val endY = (deviceInfo.heightGrid * 0.9f).toInt()
                 dadb.shell("input swipe $startX $startY $startX $endY $durationMs")
             }
             SwipeDirection.RIGHT -> {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -288,9 +288,9 @@ class IOSDriver(
         iosDevice.scroll(
             appId = appId,
             xStart = 0.5f,
-            yStart = 0.5f,
+            yStart = 0.9f,
             xEnd = 0.5f,
-            yEnd = 0.25f,
+            yEnd = 0.1f,
             velocity = null
         ).expect {}
     }

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -378,7 +378,7 @@ class IOSDriver(
             }
             SwipeDirection.RIGHT -> {
                 startPoint = PointF(
-                    x = 0.5f,
+                    x = 0.1f,
                     y = 0.5f,
                 )
                 endPoint = PointF(
@@ -388,7 +388,7 @@ class IOSDriver(
             }
             SwipeDirection.LEFT -> {
                 startPoint = PointF(
-                    x = 0.5f,
+                    x = 0.9f,
                     y = 0.5f,
                 )
                 endPoint = PointF(

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -40,6 +40,7 @@ import maestro.PointF
 import maestro.ScreenRecording
 import maestro.SwipeDirection
 import maestro.TreeNode
+import maestro.UiElement
 import maestro.debuglog.IOSDriverLogger
 import maestro.logger.Logger
 import maestro.utils.FileUtils
@@ -413,6 +414,10 @@ class IOSDriver(
                 Float.MAX_VALUE
             }
         ).expect {}
+    }
+
+    override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
+        TODO()
     }
 
     override fun backPress() {}

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -360,21 +360,21 @@ class IOSDriver(
             SwipeDirection.UP -> {
                 startPoint = PointF(
                     x = 0.5f,
-                    y = 0.5f,
+                    y = 0.9f,
                 )
                 endPoint = PointF(
                     x = 0.5F,
-                    y = 0.25f,
+                    y = 0.1f,
                 )
             }
             SwipeDirection.DOWN -> {
                 startPoint = PointF(
                     x = 0.5f,
-                    y = 0.5f,
+                    y = 0.1f,
                 )
                 endPoint = PointF(
                     x = 0.5F,
-                    y = 0.75f,
+                    y = 0.9f,
                 )
             }
             SwipeDirection.RIGHT -> {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -46,7 +46,7 @@ data class SwipeCommand(
     val direction: SwipeDirection? = null,
     val startPoint: Point? = null,
     val endPoint: Point? = null,
-    val duration: Long = DEFAULT_DURATION_IN_MILLIS
+    val duration: Long
 ) : Command {
 
     override fun description(): String {
@@ -63,10 +63,6 @@ data class SwipeCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): SwipeCommand {
         return this
-    }
-
-    companion object {
-        const val DEFAULT_DURATION_IN_MILLIS = 2000L
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -47,7 +47,7 @@ data class SwipeCommand(
     val startPoint: Point? = null,
     val endPoint: Point? = null,
     val elementSelector: ElementSelector? = null,
-    val duration: Long
+    val duration: Long = DEFAULT_DURATION_IN_MILLIS
 ) : Command {
 
     override fun description(): String {
@@ -67,6 +67,10 @@ data class SwipeCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): SwipeCommand {
         return this
+    }
+
+    companion object {
+        private const val DEFAULT_DURATION_IN_MILLIS = 400L
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -46,11 +46,15 @@ data class SwipeCommand(
     val direction: SwipeDirection? = null,
     val startPoint: Point? = null,
     val endPoint: Point? = null,
+    val elementSelector: ElementSelector? = null,
     val duration: Long
 ) : Command {
 
     override fun description(): String {
         return when {
+            elementSelector != null && direction != null -> {
+                "Swiping in $direction direction on ${elementSelector.description()}"
+            }
             direction != null -> {
                 "Swiping in $direction direction in $duration ms"
             }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -34,7 +34,6 @@ import maestro.orchestra.filter.FilterWithDescription
 import maestro.orchestra.filter.TraitFilters
 import maestro.orchestra.util.Env.evaluateScripts
 import maestro.orchestra.yaml.YamlCommandReader
-import maestro.orchestra.yaml.YamlFluentCommand
 import maestro.utils.MaestroTimer
 import org.jsoup.Jsoup
 import org.jsoup.safety.Safelist
@@ -745,7 +744,15 @@ class Orchestra(
     }
 
     private fun swipeCommand(command: SwipeCommand): Boolean {
-        maestro.swipe(command.direction, command.startPoint, command.endPoint, command.duration)
+        val elementSelector = command.elementSelector
+        val direction = command.direction
+        when {
+            elementSelector != null && direction != null -> {
+                val uiElement = findElement(elementSelector)
+                maestro.swipe(direction, uiElement, command.duration)
+            }
+            else -> maestro.swipe(direction, command.startPoint, command.endPoint, command.duration)
+        }
         return true
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -344,6 +344,7 @@ data class YamlFluentCommand(
 
                 return MaestroCommand(SwipeCommand(startPoint = startPoint, endPoint = endPoint, duration = swipe.duration))
             }
+            is YamlSwipeElement -> return swipeElementCommand(swipe)
             else -> {
                 throw IllegalStateException(
                     "Provide swipe direction UP, DOWN, RIGHT OR LEFT or by giving explicit " +
@@ -351,6 +352,16 @@ data class YamlFluentCommand(
                 )
             }
         }
+    }
+
+    private fun swipeElementCommand(swipeElement: YamlSwipeElement): MaestroCommand {
+        return MaestroCommand(
+            swipeCommand = SwipeCommand(
+                direction = swipeElement.direction,
+                elementSelector = toElementSelector(swipeElement.element),
+                duration = swipeElement.duration
+            )
+        )
     }
 
     private fun toElementSelector(selectorUnion: YamlElementSelectorUnion): ElementSelector {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -358,7 +358,7 @@ data class YamlFluentCommand(
         return MaestroCommand(
             swipeCommand = SwipeCommand(
                 direction = swipeElement.direction,
-                elementSelector = toElementSelector(swipeElement.element),
+                elementSelector = toElementSelector(swipeElement.from),
                 duration = swipeElement.duration
             )
         )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
@@ -1,13 +1,16 @@
 package maestro.orchestra.yaml
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.core.TreeNode
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.json.JsonMapper
 import maestro.SwipeDirection
-import java.lang.IllegalArgumentException
+import maestro.directionValueOfOrNull
 
 @JsonDeserialize(using = YamlSwipeDeserializer::class)
 interface YamlSwipe {
@@ -16,54 +19,65 @@ interface YamlSwipe {
 
 data class YamlSwipeDirection(val direction: SwipeDirection, override val duration: Long = DEFAULT_DURATION_IN_MILLIS) : YamlSwipe
 data class YamlCoordinateSwipe(val start: String, val end: String, override val duration: Long = DEFAULT_DURATION_IN_MILLIS) : YamlSwipe
+@JsonDeserialize(`as` = YamlSwipeElement::class)
+data class YamlSwipeElement(
+    @JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])
+    val direction: SwipeDirection,
+    val element: YamlElementSelectorUnion,
+    override val duration: Long = DEFAULT_DURATION_IN_MILLIS
+) : YamlSwipe
 
 private const val DEFAULT_DURATION_IN_MILLIS = 400L
 
-class YamlSwipeDeserializer: JsonDeserializer<YamlSwipe>() {
+class YamlSwipeDeserializer : JsonDeserializer<YamlSwipe>() {
 
     override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): YamlSwipe {
-        val mapper = parser.codec as ObjectMapper
+        val mapper = (parser.codec as ObjectMapper)
         val root: TreeNode = mapper.readTree(parser)
         val input = root.fieldNames().asSequence().toList()
         val duration = getDuration(root)
-        val isDirectionalSwipe = input == listOf("direction", "duration") || input == listOf("direction")
-        val isCoordinateSwipe = input == listOf("start", "end", "duration") || input == listOf("start", "end")
-        return when {
-            isDirectionalSwipe ->  {
-                val direction = root.get("direction").toString().replace("\"", "")
-                val swipeDirection = runCatching { SwipeDirection.valueOf(direction) }.onFailure {
-                    if (it is IllegalArgumentException) {
-                        throw IllegalArgumentException("You provided an incorrect value for \"direction\": $direction, expected directions: \"RIGHT\", \"LEFT\", \"UP\", or \"DOWN\".")
-                    }
-                }.getOrThrow()
-
-                YamlSwipeDirection(swipeDirection, duration)
-            }
-            isCoordinateSwipe -> {
-                YamlCoordinateSwipe(
+        when {
+            input.contains("start") || input.contains("end") -> {
+                check(root.get("direction") == null) { "You cannot provide direction with start/end swipe." }
+                check(root.get("start") != null && root.get("end") != null) {
+                    "You need to provide both start and end coordinates, to swipe with coordinates"
+                }
+                return YamlCoordinateSwipe(
                     root.path("start").toString().replace("\"", ""),
                     root.path("end").toString().replace("\"", ""),
                     duration
                 )
             }
-            input == listOf("start", "duration") || input == listOf("start") -> {
-                throw IllegalArgumentException("You only provided a start coordinate for the swipe command. " +
-                    "Please specify an end coordinate as well.")
-            }
-            input == listOf("end", "duration") || input == listOf("end") -> {
-                throw IllegalArgumentException("You only provided an end coordinate for the swipe command. " +
-                    "Please specify a start coordinate as well.")
+            input.contains("direction") -> {
+                check(root.get("start") == null && root.get("end") == null) {
+                    "You cannot provide start/end coordinates with directional swipe"
+                }
+                val direction = root.get("direction").toString().replace("\"", "")
+                check(directionValueOfOrNull<SwipeDirection>(direction) != null) {
+                    "Invalid direction provided to directional swipe: $direction. Direction can be either:\n" +
+                        "1. RIGHT or right\n" +
+                        "2. LEFT or left\n" +
+                        "3. UP or up\n" +
+                        "4. DOWN or down"
+                }
+                val isDirectionalSwipe = input == listOf("direction", "duration") || input == listOf("direction")
+                return if (isDirectionalSwipe) {
+                    YamlSwipeDirection(SwipeDirection.valueOf(direction.uppercase()), duration)
+                } else {
+                    mapper.convertValue(root, YamlSwipeElement::class.java)
+                }
             }
             else -> {
                 throw IllegalArgumentException(
                     "Swipe command takes either: \n" +
                         "\t1. direction: Direction based swipe with: \"RIGHT\", \"LEFT\", \"UP\", or \"DOWN\" or \n" +
                         "\t2. start and end: Coordinates based swipe with: \"start\" and \"end\" coordinates \n" +
+                        "\t3. direction and element to swipe directionally on element\n" +
                         "It seems you provided invalid input with: $input"
                 )
             }
         }
-     }
+    }
 
     private fun getDuration(root: TreeNode): Long {
         return if (root.path("duration").isMissingNode) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
@@ -23,7 +23,7 @@ data class YamlCoordinateSwipe(val start: String, val end: String, override val 
 data class YamlSwipeElement(
     @JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])
     val direction: SwipeDirection,
-    val element: YamlElementSelectorUnion,
+    val from: YamlElementSelectorUnion,
     override val duration: Long = DEFAULT_DURATION_IN_MILLIS
 ) : YamlSwipe
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSwipe.kt
@@ -17,7 +17,7 @@ interface YamlSwipe {
 data class YamlSwipeDirection(val direction: SwipeDirection, override val duration: Long = DEFAULT_DURATION_IN_MILLIS) : YamlSwipe
 data class YamlCoordinateSwipe(val start: String, val end: String, override val duration: Long = DEFAULT_DURATION_IN_MILLIS) : YamlSwipe
 
-private const val DEFAULT_DURATION_IN_MILLIS = 2000L
+private const val DEFAULT_DURATION_IN_MILLIS = 400L
 
 class YamlSwipeDeserializer: JsonDeserializer<YamlSwipe>() {
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -167,7 +167,7 @@ internal class MaestroCommandSerializationTest {
                   "x" : 100,
                   "y" : 100
                 },
-                "duration" : 2000
+                "duration" : 400
               }
             }
           """.trimIndent()

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -30,6 +30,7 @@ import maestro.Point
 import maestro.ScreenRecording
 import maestro.SwipeDirection
 import maestro.TreeNode
+import maestro.UiElement
 import okio.Sink
 import okio.buffer
 import java.awt.image.BufferedImage
@@ -180,6 +181,12 @@ class FakeDriver : Driver {
         ensureOpen()
 
         events += Event.SwipeWithDirection(swipeDirection, durationMs)
+    }
+
+    override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
+        ensureOpen()
+
+        events += Event.SwipeElementWithDirection(elementPoint, direction, durationMs)
     }
 
     override fun backPress() {
@@ -354,6 +361,12 @@ class FakeDriver : Driver {
 
         data class SwipeWithDirection(val swipeDirection: SwipeDirection, val durationMs: Long) : Event(), UserInteraction
 
+        data class SwipeElementWithDirection(
+            val point: Point,
+            val swipeDirection: SwipeDirection,
+            val durationMs: Long
+        ) : Event(), UserInteraction
+
         data class LaunchApp(
             val appId: String
         ) : Event(), UserInteraction
@@ -393,7 +406,7 @@ class FakeDriver : Driver {
             val longitude: Double,
         ) : Event()
 
-        object EraseAllText: Event()
+        object EraseAllText : Event()
 
         data class SetProxy(
             val host: String,

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2013,6 +2013,33 @@ class IntegrationTest {
         driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 2)
     }
 
+    @Test
+    fun `Case 074 - Directional swipe on elements`() {
+        // given
+        val commands = readCommands("074_directional_swipe_element")
+        val elementBounds = Bounds(0, 100, 100, 100)
+        val driver = driver {
+            element {
+                text = "swiping element"
+                bounds = elementBounds
+            }
+        }
+
+        // when
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // then
+        driver.assertHasEvent(
+            Event.SwipeElementWithDirection(
+                Point(50, 100),
+                SwipeDirection.RIGHT,
+                400
+            )
+        )
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/074_directional_swipe_element.yaml
+++ b/maestro-test/src/test/resources/074_directional_swipe_element.yaml
@@ -2,5 +2,5 @@ appId: com.example.app
 ---
 - swipe:
     direction: RIGHT
-    element:
+    from:
         text: "swiping element"

--- a/maestro-test/src/test/resources/074_directional_swipe_element.yaml
+++ b/maestro-test/src/test/resources/074_directional_swipe_element.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+---
+- swipe:
+    direction: RIGHT
+    element:
+        text: "swiping element"


### PR DESCRIPTION
## Proposed Changes
1. Changing start and end points for directional swipe: LEFT, RIGHT, UP, DOWN
2. Changed default duration to swipe to 400 ms
3. Now it's going to be possible to directionally swipe on the element:
```
- swipe:
      direction: RIGHT
      element: 
          id: "@id/some_list_view"
```

## Testing

### Android:

#### Directional swiping
https://user-images.githubusercontent.com/12881364/211632725-62aadc6c-e227-46fb-8aae-068c65bbd745.mp4

#### Scroll
https://user-images.githubusercontent.com/12881364/211633875-00acdf40-653a-44d3-8472-7d28e1aebb12.mp4

#### Element Swipe
https://user-images.githubusercontent.com/12881364/211651142-a82d2e6a-efa9-434a-b42e-c3f0a1188c62.mp4

### iOS:

#### Scroll
https://user-images.githubusercontent.com/12881364/211653184-1b23de8d-76e8-4162-aee6-b40dda9f1d14.mp4

#### Directional Swiping
https://user-images.githubusercontent.com/12881364/211654038-44418f2a-cc87-49e3-8d08-e28c83a85fc9.mp4

#### Directional element swipe

https://user-images.githubusercontent.com/12881364/211655740-3e62bdf1-8ad9-4f90-8866-d12a87dfaf52.mp4


## Issues Fixed


