### PR TITLE
Fix openLink command to support extras

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -350,7 +350,7 @@ class AndroidDriver(
     }
 
     override fun openLink(link: String) {
-        dadb.shell("am start -d $link")
+        dadb.shell("am start -d \"$link\"")
     }
 
     override fun setLocation(latitude: Double, longitude: Double) {


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue with opening links that contain extras (example://deeplink?a=100&b=200)
Solution originated from [here](https://stackoverflow.com/questions/28802115/i-am-trying-to-test-android-deep-link-urls-through-adb-to-launch-my-app#comment118439409_58742435)

## Testing

Before:
![Screenshot 2023-01-11 at 12 21 13 (1)](https://user-images.githubusercontent.com/19727534/211806812-fb7e0e20-dd1d-452b-b228-52ca49de7aaf.png)

After:
![Screenshot 2023-01-11 at 12 20 31 (1)](https://user-images.githubusercontent.com/19727534/211806804-424ca5e6-5bec-45c2-adae-ea52b07997ea.png)
