### PR TITLE
Allows extendedWaitUntil to use ENV variables in timeout

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -258,7 +258,7 @@ data class AssertCommand(
                 visible = visible,
                 notVisible = notVisible,
             ),
-            timeout = timeout,
+            timeout = timeout?.toString(),
         )
     }
 
@@ -266,8 +266,10 @@ data class AssertCommand(
 
 data class AssertConditionCommand(
     val condition: Condition,
-    val timeout: Long? = null,
+    private val timeout: String? = null,
 ) : Command {
+
+    fun timeoutMs() = timeout?.toLong()
 
     override fun description(): String {
         return "Assert that ${condition.description()}"
@@ -276,6 +278,7 @@ data class AssertConditionCommand(
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
             condition = condition.evaluateScripts(jsEngine),
+            timeout = timeout?.evaluateScripts(jsEngine)
         )
     }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
@@ -6,14 +6,14 @@ import maestro.orchestra.util.Env.evaluateScripts
 data class Condition(
     val visible: ElementSelector? = null,
     val notVisible: ElementSelector? = null,
-    val scriptCondition: String? = null,
+    val scriptCondition: String? = null
 ) {
 
     fun evaluateScripts(jsEngine: JsEngine): Condition {
         return copy(
             visible = visible?.evaluateScripts(jsEngine),
             notVisible = notVisible?.evaluateScripts(jsEngine),
-            scriptCondition = scriptCondition?.evaluateScripts(jsEngine)
+            scriptCondition = scriptCondition?.evaluateScripts(jsEngine),
         )
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -201,7 +201,8 @@ class Orchestra(
     }
 
     private fun assertConditionCommand(command: AssertConditionCommand): Boolean {
-        if (!evaluateCondition(command.condition, timeoutMs = command.timeout ?: lookupTimeoutMs)) {
+        val timeout = (command.timeoutMs() ?: lookupTimeoutMs)
+        if (!evaluateCondition(command.condition, timeoutMs = timeout)) {
             throw MaestroException.AssertionFailure(
                 "Assertion is false: ${command.condition.description()}",
                 maestro.viewHierarchy().root,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtendedWaitUntil.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlExtendedWaitUntil.kt
@@ -3,5 +3,5 @@ package maestro.orchestra.yaml
 data class YamlExtendedWaitUntil(
     val visible: YamlElementSelectorUnion? = null,
     val notVisible: YamlElementSelectorUnion? = null,
-    val timeout: Long? = null,
+    val timeout: String? = null,
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -273,10 +273,14 @@ data class YamlFluentCommand(
             throw SyntaxError("extendedWaitUntil expects either `visible` or `notVisible` to be provided")
         }
 
+        val condition = Condition(
+            visible = command.visible?.let { toElementSelector(it) },
+            notVisible = command.notVisible?.let { toElementSelector(it) },
+        )
+
         return MaestroCommand(
-            AssertCommand(
-                visible = command.visible?.let { toElementSelector(it) },
-                notVisible = command.notVisible?.let { toElementSelector(it) },
+            AssertConditionCommand(
+                condition = condition,
                 timeout = command.timeout,
             )
         )

--- a/maestro-test/src/test/resources/042_extended_wait.yaml
+++ b/maestro-test/src/test/resources/042_extended_wait.yaml
@@ -1,8 +1,10 @@
 appId: com.example.app
+env:
+    TIMEOUT: 1000
 ---
 - extendedWaitUntil:
     visible: Item
-    timeout: 1000
+    timeout: ${TIMEOUT}
 - extendedWaitUntil:
     notVisible: Another item
     timeout: 1000


### PR DESCRIPTION
## Proposed Changes
- Updates `extendedWaitUntil` to use AssertConditionCommand
- Updates `extendedWaitUntil` timeout to be parsed as a `String` in order to allow ENV variables & JS

## Testing
- Updated integration test
- Manual test

## Issues Fixed
- extendedWaitUntil timeout was not able to parse ENV variables