### PR TITLE
Reset permissions on clear app state

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -129,7 +129,7 @@ class IOSDriver(
     }
 
     override fun clearAppState(appId: String) {
-        iosDevice.deviceId?.let { Simctl.resetPermissions(it) }
+        iosDevice.deviceId?.let { Simctl.resetPermissions(it, appId) }
         iosDevice.clearAppState(appId)
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -129,7 +129,7 @@ class IOSDriver(
     }
 
     override fun clearAppState(appId: String) {
-        Simctl.resetPermissions()
+        iosDevice.deviceId?.let { Simctl.resetPermissions(it) }
         iosDevice.clearAppState(appId)
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -30,6 +30,7 @@ import hierarchy.IdbElementNode
 import hierarchy.XCUIElement
 import hierarchy.XCUIElementNode
 import ios.IOSDevice
+import ios.xcrun.Simctl
 import maestro.DeviceInfo
 import maestro.Driver
 import maestro.KeyCode
@@ -128,6 +129,7 @@ class IOSDriver(
     }
 
     override fun clearAppState(appId: String) {
+        Simctl.resetPermissions()
         iosDevice.clearAppState(appId)
     }
 

--- a/maestro-ios/src/main/java/ios/xcrun/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/xcrun/Simctl.kt
@@ -106,4 +106,15 @@ object Simctl {
 
         reboot(deviceId)
     }
+
+    fun resetPermissions() {
+        CommandLineUtils.runCommand(listOf(
+            "xcrun",
+            "simctl",
+            "privacy",
+            deviceId,
+            "reset",
+            "all"
+        ), waitForCompletion = true)
+    }
 }

--- a/maestro-ios/src/main/java/ios/xcrun/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/xcrun/Simctl.kt
@@ -107,7 +107,7 @@ object Simctl {
         reboot(deviceId)
     }
 
-    fun resetPermissions() {
+    fun resetPermissions(deviceId: String) {
         CommandLineUtils.runCommand(listOf(
             "xcrun",
             "simctl",


### PR DESCRIPTION
## Proposed Changes

Reset permissions when launchApp is called with `clearState`.
This is similar to how Android works.
