### PR TITLE
fix starting point for iOS swipe command

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -365,7 +365,7 @@ class IOSDriver(
             SwipeDirection.DOWN -> {
                 startPoint = PointF(
                     x = 0.5f,
-                    y = 0.1f,
+                    y = 0.2f,
                 )
                 endPoint = PointF(
                     x = 0.5F,


### PR DESCRIPTION
## Proposed Changes
Starting point needs to be slightly lower on iOS, because of [safe areas](https://developer.apple.com/design/human-interface-guidelines/foundations/layout/).

## Testing
tested on iPhoneSE (no-notch device) and iPhone14 simulators

## Issues Fixed
```
- swipe:
    direction: DOWN
```

was opening notifications screen all the time