### PR TITLE
Feature: generating test report for maestro cloud

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -240,7 +240,12 @@ class CloudInteractor(
         }
     }
 
-    private fun saveReport(reportFormat: ReportFormat, passed: Boolean, upload: UploadStatus, reportOutputSink: BufferedSink?) {
+    private fun saveReport(
+        reportFormat: ReportFormat,
+        passed: Boolean,
+        upload: UploadStatus,
+        reportOutputSink: BufferedSink
+    ) {
         ReporterFactory.buildReporter(reportFormat)
             .report(
                 TestExecutionSummary(

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -22,6 +22,7 @@ package maestro.cli.command
 import maestro.cli.DisableAnsiMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.cloud.CloudInteractor
+import maestro.cli.report.ReportFormat
 import picocli.CommandLine
 import picocli.CommandLine.Option
 import java.io.File
@@ -85,7 +86,7 @@ class CloudCommand : Callable<Int> {
         description = ["List of tags that will remove the Flows that does not have the provided tags"],
         split = ",",
 
-    )
+        )
     private var includeTags: List<String> = emptyList()
 
     @Option(
@@ -95,6 +96,20 @@ class CloudCommand : Callable<Int> {
         split = ",",
     )
     private var excludeTags: List<String> = emptyList()
+
+    @Option(
+        order = 13,
+        names = ["--format"],
+        description = ["Test report format (default=\${DEFAULT-VALUE}): \${COMPLETION-CANDIDATES}"],
+    )
+    private var format: ReportFormat = ReportFormat.NOOP
+
+    @Option(
+        order = 14,
+        names = ["--output"],
+        description = ["File to write report into (default=report.xml)"],
+    )
+    private var output: File? = null
 
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
@@ -117,6 +132,8 @@ class CloudCommand : Callable<Int> {
             androidApiLevel = androidApiLevel,
             includeTags = includeTags,
             excludeTags = excludeTags,
+            reportFormat = format,
+            reportOutput = output,
             failOnCancellation = failOnCancellation,
         )
     }

--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -13,7 +13,7 @@ data class TestExecutionSummary(
 
     data class FlowResult(
         val name: String,
-        val fileName: String,
+        val fileName: String?,
         val status: FlowStatus,
         val failure: Failure? = null,
     )

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -39,7 +39,7 @@ class JUnitTestSuiteReporter(
                                 testCases = suite.flows
                                     .map { flow ->
                                         TestCase(
-                                            id = flow.fileName,
+                                            id = flow.fileName ?: flow.name,
                                             name = flow.name,
                                             failure = flow.failure?.let { failure ->
                                                 Failure(


### PR DESCRIPTION
## Proposed Changes

Same `--format` flag and same output format as with `maestro test`. The only caveat is that we do not actually print out why test failed exactly as we do not have an error message (yet)