### PR TITLE
Tweak: Remove XCTestIOSDevice dependency on xcrun

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -33,6 +33,7 @@ import maestro.cli.device.Platform
 import maestro.debuglog.IOSDriverLogger
 import maestro.drivers.IOSDriver
 import org.slf4j.LoggerFactory
+import util.XCRunnerSimctl
 import xcuitest.XCTestDriverClient
 import xcuitest.installer.LocalXCTestInstaller
 import java.util.UUID
@@ -166,6 +167,7 @@ object MaestroSessionManager {
                                             deviceId = selectedDevice.device.instanceId,
                                             driverClient = xcTestDriverClient
                                         ),
+                                        getInstalledApps = { XCRunnerSimctl.listApps() },
                                         logger = IOSDriverLogger(),
                                     ),
                                     xcRunIOSDevice = XCRunIOSDevice(selectedDevice.device.instanceId),
@@ -282,6 +284,7 @@ object MaestroSessionManager {
                         deviceId = device.instanceId,
                         driverClient = xcTestDriverClient
                     ),
+                    getInstalledApps = { XCRunnerSimctl.listApps() },
                     logger = IOSDriverLogger(),
                 ),
                 xcRunIOSDevice = XCRunIOSDevice(device.instanceId),

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -13,7 +13,6 @@ import ios.IOSScreenRecording
 import ios.device.DeviceInfo
 import maestro.logger.Logger
 import okio.Sink
-import util.XCRunnerSimctl
 import xcuitest.XCTestDriverClient
 import xcuitest.api.GetRunningAppIdResponse
 import xcuitest.installer.XCTestInstaller
@@ -25,6 +24,7 @@ class XCTestIOSDevice(
     private val client: XCTestDriverClient,
     private val installer: XCTestInstaller,
     private val logger: Logger,
+    private val getInstalledApps: () -> Set<String>,
 ) : IOSDevice {
 
     private var closed: Boolean = false
@@ -185,7 +185,7 @@ class XCTestIOSDevice(
     }
 
     private fun activeAppId(): String? {
-        val appIds = XCRunnerSimctl.listApps()
+        val appIds = getInstalledApps()
         logger.info("installed apps: $appIds")
 
         return client.runningAppId(appIds).use { response ->


### PR DESCRIPTION
The last dependency that relies on a local device