### PR TITLE
Use CI provider as device UUID when available

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -9,6 +9,7 @@ import maestro.cli.CliError
 import maestro.cli.util.PrintUtils
 import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.update.Updates
+import maestro.cli.util.CiUtils
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
@@ -42,7 +43,6 @@ class ApiClient(
         .addInterceptor(SystemInformationInterceptor())
         .build()
 
-    private val knownCIEnvVars = listOf("CI", "JENKINS_HOME", "BITRISE_IO")
     private val BASE_RETRY_DELAY_MS = 3000L
 
     fun sendErrorReport(exception: Exception, commandLine: String) {
@@ -134,14 +134,7 @@ class ApiClient(
     }
 
     private fun getAgent(): String {
-        for (ciVar in knownCIEnvVars) {
-            try {
-                val value = System.getenv(ciVar).lowercase()
-                if (value.isNotEmpty() && value != "0" && value != "false") return "ci"
-            } catch (e: Exception) {}
-        }
-
-        return "cli"
+        return CiUtils.getCiProvider() ?: "cli"
     }
 
     fun uploadStatus(

--- a/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
+++ b/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
@@ -2,6 +2,7 @@ package maestro.cli.update
 
 import maestro.cli.api.ApiClient
 import maestro.cli.api.CliVersion
+import maestro.cli.util.CiUtils
 import maestro.cli.view.red
 import java.nio.file.Paths
 import java.util.Properties
@@ -41,10 +42,14 @@ object Updates {
             false
         } else {
             uuidPath.parent.createDirectories()
-            uuidPath.writeText(UUID.randomUUID().toString())
+            uuidPath.writeText(generateUUID())
             true
         }
         DEVICE_UUID = uuidPath.readText()
+    }
+
+    private fun generateUUID(): String {
+        return CiUtils.getCiProvider() ?: UUID.randomUUID().toString()
     }
 
     fun fetchUpdatesAsync() {

--- a/maestro-cli/src/main/java/maestro/cli/util/CiUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/CiUtils.kt
@@ -1,0 +1,33 @@
+package maestro.cli.util
+
+object CiUtils {
+    private val ciEnvVarMap = mapOf(
+        "JENKINS_HOME" to "jenkins",
+        "BITRISE_IO" to "bitrise",
+        "CIRCLECI" to "circleci",
+        "GITLAB_CI" to "gitlab",
+        "GITHUB_ACTIONS" to "github",
+        "BITBUCKET_BUILD_NUMBER" to "bitbucket",
+        "CI" to "ci"
+    )
+
+    private fun isTruthy(envVar: String?): Boolean {
+        if (envVar == null) return false
+        return envVar != "0" && envVar != "false"
+    }
+
+    fun getCiProvider(): String? {
+        val mdevCiEnvVar = System.getenv("MDEV_CI")
+        if (isTruthy(mdevCiEnvVar)) {
+            return mdevCiEnvVar
+        }
+
+        for (ciVar in ciEnvVarMap.entries) {
+            try {
+                if (isTruthy(System.getenv(ciVar.key).lowercase())) return ciVar.value
+            } catch (e: Exception) {}
+        }
+
+        return null
+    }
+}


### PR DESCRIPTION
Set device uuid according to the following logic
- If `MDEV_CI` is set, use whatever value is provided
- Check for known CI env vars and try to infer the right CI provider
- Fallback to check if `CI` is set to at least know we are in a CI environment