### PR TITLE
Evaluate JS scripts with element selector in SwipeCommand

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -66,7 +66,9 @@ data class SwipeCommand(
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): SwipeCommand {
-        return this
+        return copy(
+            elementSelector = elementSelector?.evaluateScripts(jsEngine),
+        )
     }
 
     companion object {


### PR DESCRIPTION
## Proposed Changes
JS scripts are not evaluated with the selector of the swipe command, leading to situations where users are not able to use the js output in the swipe command.

## Testing

JS file:
```
output.home = {
    languageList: 'org.wikipedia:id/option_label',
    languageText: "1.		English"
}
```
Flow:

```
appId: com.example 
---
- runScript: output.js
- swipe:
    from: 
      id: ${output.home.languageList}
      text: ${output.home.languageText}
    direction: LEFT
```

#Fix

https://user-images.githubusercontent.com/12881364/213127460-3edda2b9-c434-4e4d-8d49-6d6e5fa603f0.mp4



## Issues Fixed