### PR TITLE
Maestro fails to launch on iOS if --device parameter is present

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -20,6 +20,8 @@ import kotlin.concurrent.thread
 object DeviceService {
 
     private val logger = DebugLogStore.loggerFor(DeviceService::class.java)
+    private const val idbHost = "localhost"
+    private const val idbPort = 10882
 
     fun startDevice(device: Device.AvailableForLaunch): Device.Connected {
         when (device.platform) {
@@ -74,20 +76,18 @@ object DeviceService {
         }
     }
 
-    private fun startIdbCompanion(device: Device.Connected) {
-        logger.info("startIDBCompanion on $device")
-
-        val idbHost = "localhost"
-        val idbPort = 10882
-
-        val isIdbCompanionRunning =
-            try {
+    private fun isIdbCompanionRunning(): Boolean {
+        return try {
                 Socket(idbHost, idbPort).use { true }
             } catch (_: Exception) {
                 false
             }
+    }
 
-        if (isIdbCompanionRunning && SessionStore.activeSessions().isEmpty()) {
+    private fun startIdbCompanion(device: Device.Connected) {
+        logger.info("startIDBCompanion on $device")
+
+        if (isIdbCompanionRunning() && SessionStore.activeSessions().isEmpty()) {
             error("idb_companion is already running. Stop idb_companion and run maestro again")
         }
 

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceInteractor.kt
@@ -6,9 +6,14 @@ object PickDeviceInteractor {
 
     fun pickDevice(deviceId: String? = null): Device.Connected {
         if (deviceId != null) {
-            return DeviceService.listConnectedDevices()
-                .find { it.instanceId == deviceId }
-                ?: throw CliError("Device with id $deviceId is not connected")
+            val device = DeviceService.listConnectedDevices()
+                .find {
+                    it.instanceId == deviceId
+                } ?: throw CliError("Device with id $deviceId is not connected")
+
+            DeviceService.prepareDevice(device)
+
+            return device
         }
 
         return pickDeviceInternal()


### PR DESCRIPTION
## Proposed Changes

`prepareDevice` also needs to be called when deviceId is present

## Testing

Tested:
- `maestro test` with --device provided
- `maestro test` with --udid provided
- `maestro test` without arguments

## Issues Fixed
https://github.com/mobile-dev-inc/maestro/issues/509