### PR TITLE
Relatively swipe with percentage based start and end coordinates

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -110,10 +110,32 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-    fun swipe(swipeDirection: SwipeDirection? = null, start: Point? = null, end: Point? = null, duration: Long) {
+    fun swipe(
+        swipeDirection: SwipeDirection? = null,
+        startPoint: Point? = null,
+        endPoint: Point? = null,
+        startRelative: String? = null,
+        endRelative: String? = null,
+        duration: Long
+    ) {
         when {
             swipeDirection != null -> driver.swipe(swipeDirection, duration)
-            start != null && end != null -> driver.swipe(start, end, duration)
+            startPoint != null && endPoint != null -> driver.swipe(startPoint, endPoint, duration)
+            startRelative != null && endRelative != null -> {
+                val startPoints = startRelative.replace("%", "")
+                    .split(",").map { it.trim().toInt() }
+                val startX = cachedDeviceInfo.widthGrid * startPoints[0] / 100
+                val startY = cachedDeviceInfo.heightGrid * startPoints[1] / 100
+                val start = Point(startX, startY)
+
+                val endPoints = endRelative.replace("%", "")
+                    .split(",").map { it.trim().toInt() }
+                val endX = cachedDeviceInfo.widthGrid * endPoints[0] / 100
+                val endY = cachedDeviceInfo.heightGrid * endPoints[1] / 100
+                val end = Point(endX, endY)
+
+                driver.swipe(start, end, duration)
+            }
         }
 
         waitForAppToSettle()

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -283,7 +283,7 @@ class AndroidDriver(
             }
             SwipeDirection.DOWN -> {
                 val startX = (deviceInfo.widthGrid * 0.5f).toInt()
-                val startY = (deviceInfo.heightGrid * 0.1f).toInt()
+                val startY = (deviceInfo.heightGrid * 0.2f).toInt()
                 val endX = (deviceInfo.widthGrid * 0.5f).toInt()
                 val endY = (deviceInfo.heightGrid * 0.9f).toInt()
                 directionalSwipe(

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -47,6 +47,8 @@ data class SwipeCommand(
     val startPoint: Point? = null,
     val endPoint: Point? = null,
     val elementSelector: ElementSelector? = null,
+    val startRelative: String? = null,
+    val endRelative: String? = null,
     val duration: Long = DEFAULT_DURATION_IN_MILLIS
 ) : Command {
 
@@ -61,6 +63,9 @@ data class SwipeCommand(
             startPoint != null && endPoint != null -> {
                 "Swipe from (${startPoint.x},${startPoint.y}) to (${endPoint.x},${endPoint.y}) in $duration ms"
             }
+            startRelative != null && endRelative != null -> {
+                "Swipe from ($startRelative) to ($endRelative) in $duration ms"
+            }
             else -> "Invalid input to swipe command"
         }
     }
@@ -68,6 +73,8 @@ data class SwipeCommand(
     override fun evaluateScripts(jsEngine: JsEngine): SwipeCommand {
         return copy(
             elementSelector = elementSelector?.evaluateScripts(jsEngine),
+            startRelative = startRelative?.evaluateScripts(jsEngine),
+            endRelative = endRelative?.evaluateScripts(jsEngine)
         )
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -758,12 +758,21 @@ class Orchestra(
     private fun swipeCommand(command: SwipeCommand): Boolean {
         val elementSelector = command.elementSelector
         val direction = command.direction
+        val startRelative = command.startRelative
+        val endRelative = command.endRelative
+        val start = command.startPoint
+        val end = command.endPoint
         when {
             elementSelector != null && direction != null -> {
                 val uiElement = findElement(elementSelector)
                 maestro.swipe(direction, uiElement, command.duration)
             }
-            else -> maestro.swipe(direction, command.startPoint, command.endPoint, command.duration)
+            startRelative != null && endRelative != null -> {
+                maestro.swipe(startRelative = startRelative, endRelative = endRelative, duration = command.duration)
+            }
+            direction != null -> maestro.swipe(swipeDirection = direction, duration = command.duration)
+            start != null && end != null -> maestro.swipe(startPoint = start, endPoint = end, duration = command.duration)
+            else -> error("Illegal arguments for swiping")
         }
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -351,6 +351,11 @@ data class YamlFluentCommand(
 
                 return MaestroCommand(SwipeCommand(startPoint = startPoint, endPoint = endPoint, duration = swipe.duration))
             }
+            is YamlRelativeCoordinateSwipe -> {
+                return MaestroCommand(
+                    SwipeCommand(startRelative = swipe.start, endRelative = swipe.end)
+                )
+            }
             is YamlSwipeElement -> return swipeElementCommand(swipe)
             else -> {
                 throw IllegalStateException(

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -365,6 +365,12 @@ class FakeDriver : Driver {
 
         data class SwipeWithDirection(val swipeDirection: SwipeDirection, val durationMs: Long) : Event(), UserInteraction
 
+        data class SwipeRelative(
+            val startRelativeValue: Int,
+            val endRelativeValue: Int,
+            val durationMs: Long
+        ): Event(), UserInteraction
+
         data class SwipeElementWithDirection(
             val point: Point,
             val swipeDirection: SwipeDirection,

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2122,6 +2122,28 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 078 - Swipe with relative coordinates`() {
+        // given
+        val commands = readCommands("078_swipe_relative")
+        val driver = driver {
+        }
+        val deviceInfo = driver.deviceInfo()
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        val expectedStart = Point(deviceInfo.widthGrid / 2, deviceInfo.heightGrid * 30 / 100)
+        val expectedEnd = Point(deviceInfo.widthGrid / 2, deviceInfo.heightGrid * 60 / 100)
+        driver.assertHasEvent(
+            Event.Swipe(start = expectedStart, End = expectedEnd, durationMs = 400)
+        )
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/078_swipe_relative.yaml
+++ b/maestro-test/src/test/resources/078_swipe_relative.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+---
+- swipe:
+    start: "50%,30%"
+    end: "50%,60%"
+    duration: 3000


### PR DESCRIPTION
## Proposed Changes
Support percentage-based start and end coordinates that could help to be dimension agnostic and prevent giving absolute value.

Sample:
```
- swipe:
   start: 10%,50%
   end: 90%,50% 
```

## Testing

https://user-images.githubusercontent.com/12881364/213431391-f2f6ea5c-a095-426f-b52c-61a05f2c95be.mov

https://user-images.githubusercontent.com/12881364/213431409-c6989a8f-2d86-4764-a7ce-463fa262d466.mov

## Issues Fixed