### PR TITLE
Change the end coordinates for swipe element

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -321,24 +321,20 @@ class AndroidDriver(
         val deviceInfo = deviceInfo()
         when(direction) {
             SwipeDirection.UP -> {
-                val endX = (deviceInfo.widthGrid * 0.5f).toInt()
                 val endY = (deviceInfo.heightGrid * 0.1f).toInt()
-                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+                directionalSwipe(durationMs, elementPoint, Point(elementPoint.x, endY))
             }
             SwipeDirection.DOWN -> {
-                val endX = (deviceInfo.widthGrid * 0.5f).toInt()
                 val endY = (deviceInfo.heightGrid * 0.9f).toInt()
-                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+                directionalSwipe(durationMs, elementPoint, Point(elementPoint.x, endY))
             }
             SwipeDirection.RIGHT -> {
                 val endX = (deviceInfo.widthGrid * 0.9f).toInt()
-                val endY = (deviceInfo.heightGrid * 0.5f).toInt()
-                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+                directionalSwipe(durationMs, elementPoint, Point(endX, elementPoint.y))
             }
             SwipeDirection.LEFT -> {
                 val endX = (deviceInfo.widthGrid * 0.1f).toInt()
-                val endY = (deviceInfo.heightGrid * 0.5f).toInt()
-                directionalSwipe(durationMs, elementPoint, Point(endX, endY))
+                directionalSwipe(durationMs, elementPoint, Point(endX, elementPoint.y))
             }
         }
     }

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -372,23 +372,23 @@ class IOSDriver(
 
         when (direction) {
             SwipeDirection.UP -> {
-                val end = PointF(x = 0.5f, y = 0.1f)
                 val start = elementPoint.normalise(width, height)
+                val end = PointF(x = start.x, y = 0.1f)
                 directionalSwipe(durationMs, start, end)
             }
             SwipeDirection.DOWN -> {
-                val end = PointF(x = 0.5f, y = 0.9f)
                 val start = elementPoint.normalise(width, height)
+                val end = PointF(x = start.x, y = 0.9f)
                 directionalSwipe(durationMs, start, end)
             }
             SwipeDirection.RIGHT -> {
-                val end = PointF(x = 0.9f, y = 0.5f)
                 val start = elementPoint.normalise(width, height)
+                val end = PointF(x = 0.9f, y = start.y)
                 directionalSwipe(durationMs, start, end)
             }
             SwipeDirection.LEFT -> {
-                val end = PointF(x = 0.1f, y = 0.5f)
                 val start = elementPoint.normalise(width, height)
+                val end = PointF(x = 0.1f, y = start.y)
                 directionalSwipe(durationMs, start, end)
             }
         }


### PR DESCRIPTION
## Proposed Changes
Bug:

With the following command:

```
- swipe:
     from: 
       text: "Collections.*"
     direction: LEFT 
```
From the above, the list is expected to swipe but rather the command does scroll. 


https://user-images.githubusercontent.com/12881364/213436789-59e75ab7-d96e-4d3e-bc5a-5be9529b9a83.mov


We should pivot the x and y coordinates looking at the direction:

- LEFT, RIGHT should stay pivoted around the element Y coordinate
- UP, DOWN should stay pivoted around the element X coordinate

## Testing


https://user-images.githubusercontent.com/12881364/213437310-a21b3028-bca6-4964-91e1-9247047aa43b.mov


## Issues Fixed