### PR TITLE
Feature scroll until view is visible

### DIFF
--- a/maestro-client/src/main/java/maestro/ScrollDirection.kt
+++ b/maestro-client/src/main/java/maestro/ScrollDirection.kt
@@ -1,0 +1,15 @@
+package maestro
+
+enum class ScrollDirection {
+    UP,
+    DOWN,
+    RIGHT,
+    LEFT
+}
+
+fun ScrollDirection.toSwipeDirection(): SwipeDirection = when (this) {
+    ScrollDirection.DOWN -> SwipeDirection.UP
+    ScrollDirection.UP -> SwipeDirection.DOWN
+    ScrollDirection.LEFT -> SwipeDirection.RIGHT
+    ScrollDirection.RIGHT -> SwipeDirection.LEFT
+}

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -21,6 +21,7 @@ package maestro.orchestra
 
 import maestro.KeyCode
 import maestro.Point
+import maestro.ScrollDirection
 import maestro.SwipeDirection
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
@@ -80,6 +81,25 @@ data class SwipeCommand(
 
     companion object {
         private const val DEFAULT_DURATION_IN_MILLIS = 400L
+    }
+}
+
+data class ScrollUntilVisibleCommand(
+    val selector: ElementSelector,
+    val direction: ScrollDirection,
+    val timeout: Long = DEFAULT_TIMEOUT_IN_MILLIS
+) : Command {
+
+    override fun description(): String {
+        return "Scrolling $direction until ${selector.description()} is visible."
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): ScrollUntilVisibleCommand {
+        return this
+    }
+
+    companion object {
+        const val DEFAULT_TIMEOUT_IN_MILLIS = 20 * 1000L
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -58,6 +58,7 @@ data class MaestroCommand(
     val waitForAnimationToEndCommand: WaitForAnimationToEndCommand? = null,
     val evalScriptCommand: EvalScriptCommand? = null,
     val mockNetworkCommand: MockNetworkCommand? = null,
+    val scrollUntilVisible: ScrollUntilVisibleCommand? = null
 ) {
 
     constructor(command: Command) : this(
@@ -91,6 +92,7 @@ data class MaestroCommand(
         waitForAnimationToEndCommand = command as? WaitForAnimationToEndCommand,
         evalScriptCommand = command as? EvalScriptCommand,
         mockNetworkCommand = command as? MockNetworkCommand,
+        scrollUntilVisible = command as? ScrollUntilVisibleCommand
     )
 
     fun asCommand(): Command? = when {
@@ -124,6 +126,7 @@ data class MaestroCommand(
         waitForAnimationToEndCommand != null -> waitForAnimationToEndCommand
         evalScriptCommand != null -> evalScriptCommand
         mockNetworkCommand != null -> mockNetworkCommand
+        scrollUntilVisible != null -> scrollUntilVisible
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -285,8 +285,7 @@ class Orchestra(
         do {
             try {
                 maestro.waitForAppToSettle()
-                val e =  findElement(command.selector, 500)
-                println("Bounds: ${e.bounds}")
+                findElement(command.selector, 500)
                 return true
             } catch (ignored: MaestroException.ElementNotFound) {
                 error = ignored

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -438,7 +438,7 @@ data class YamlFluentCommand(
 
         return MaestroCommand(
             ScrollUntilVisibleCommand(
-                selector = toElementSelector(yaml.element!!),
+                selector = toElementSelector(yaml.element),
                 direction = yaml.direction ?: ScrollDirection.DOWN,
                 timeout = timeout
             )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -22,7 +22,7 @@ package maestro.orchestra.yaml
 import com.fasterxml.jackson.annotation.JsonCreator
 import maestro.KeyCode
 import maestro.Point
-import maestro.orchestra.AssertCommand
+import maestro.ScrollDirection
 import maestro.orchestra.AssertConditionCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
@@ -46,6 +46,7 @@ import maestro.orchestra.RepeatCommand
 import maestro.orchestra.RunFlowCommand
 import maestro.orchestra.RunScriptCommand
 import maestro.orchestra.ScrollCommand
+import maestro.orchestra.ScrollUntilVisibleCommand
 import maestro.orchestra.SetLocationCommand
 import maestro.orchestra.StopAppCommand
 import maestro.orchestra.SwipeCommand
@@ -90,6 +91,7 @@ data class YamlFluentCommand(
     val waitForAnimationToEnd: YamlWaitForAnimationToEndCommand? = null,
     val evalScript: String? = null,
     val mockNetwork: String? = null,
+    val scrollUntilVisible: YamlScrollUntilVisible? = null
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -212,6 +214,7 @@ data class YamlFluentCommand(
                     )
                 )
             )
+            scrollUntilVisible != null -> listOf(scrollUntilVisibleCommand(scrollUntilVisible))
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }
     }
@@ -423,6 +426,21 @@ data class YamlFluentCommand(
         return MaestroCommand(
             CopyTextFromCommand(
                 selector = toElementSelector(copyText)
+            )
+        )
+    }
+
+    private fun scrollUntilVisibleCommand(yaml: YamlScrollUntilVisible): MaestroCommand {
+        val timeout =
+            if (yaml.timeout == null || yaml.timeout < ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS) {
+                ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS
+            } else yaml.timeout
+
+        return MaestroCommand(
+            ScrollUntilVisibleCommand(
+                selector = toElementSelector(yaml.element!!),
+                direction = yaml.direction ?: ScrollDirection.DOWN,
+                timeout = timeout
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -432,14 +432,14 @@ data class YamlFluentCommand(
 
     private fun scrollUntilVisibleCommand(yaml: YamlScrollUntilVisible): MaestroCommand {
         val timeout =
-            if (yaml.timeout == null || yaml.timeout < ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS) {
+            if (yaml.timeout < ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS) {
                 ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS
             } else yaml.timeout
 
         return MaestroCommand(
             ScrollUntilVisibleCommand(
                 selector = toElementSelector(yaml.element),
-                direction = yaml.direction ?: ScrollDirection.DOWN,
+                direction = yaml.direction,
                 timeout = timeout
             )
         )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -1,0 +1,9 @@
+package maestro.orchestra.yaml
+
+import maestro.ScrollDirection
+
+data class YamlScrollUntilVisible(
+    val direction: ScrollDirection ?= null,
+    val element: YamlElementSelectorUnion? = null,
+    val timeout: Long? = null,
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -2,10 +2,11 @@ package maestro.orchestra.yaml
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import maestro.ScrollDirection
+import maestro.orchestra.ScrollUntilVisibleCommand
 
 data class YamlScrollUntilVisible(
     @JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])
-    val direction: ScrollDirection ?= null,
+    val direction: ScrollDirection = ScrollDirection.DOWN,
     val element: YamlElementSelectorUnion,
-    val timeout: Long? = null,
+    val timeout: Long = ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS,
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -1,9 +1,11 @@
 package maestro.orchestra.yaml
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import maestro.ScrollDirection
 
 data class YamlScrollUntilVisible(
+    @JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])
     val direction: ScrollDirection ?= null,
-    val element: YamlElementSelectorUnion? = null,
+    val element: YamlElementSelectorUnion,
     val timeout: Long? = null,
 )

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2144,6 +2144,47 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 079 - Scroll until view is visible`() {
+        // Given
+        val commands = readCommands("079_scroll_until_visible")
+
+        // Without view
+        val driver1 = driver {
+            // No elements
+        }
+
+        // Then fail
+        assertThrows<MaestroException.ElementNotFound> {
+            Maestro(driver1).use {
+                assertThat(orchestra(it).runFlow(commands))
+            }
+        }
+
+
+        // With view
+        val elementBounds = Bounds(0, 100, 100, 100)
+        val driver2 = driver {
+            element {
+                text = "Test"
+                bounds = elementBounds
+            }
+        }
+
+        // When
+        Maestro(driver2).use {
+            assertThat(orchestra(it).runFlow(commands)).isTrue()
+        }
+
+        // Then
+        driver1.assertEvents(
+            listOf(
+                Event.SwipeWithDirection(SwipeDirection.UP, 600),
+            )
+        )
+    }
+
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2184,7 +2184,6 @@ class IntegrationTest {
         )
     }
 
-
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/079_scroll_until_visible.yaml
+++ b/maestro-test/src/test/resources/079_scroll_until_visible.yaml
@@ -1,0 +1,7 @@
+appId: com.example.app
+---
+- scrollUntilVisible:
+    element:
+      text: "Test"
+    direction: DOWN
+    timeout: 20000


### PR DESCRIPTION
## Proposed Changes
Adds new command to scroll until an element is visible.

Example
```yaml
- scrollUntilVisible:
    element:
      text: "MyElementText"
    direction: DOWN
    timeout: 50000
```

## Testing
- Manual testing with Wikipedia app (Android/iOS)
- Integration test