### PR TITLE
[experimental] Implement WebDriver

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -33,7 +33,7 @@ class StudioCommand : Callable<Int> {
             throw CliError("--platform option was deprecated. You can remove it to run your test.")
         }
 
-        MaestroSessionManager.newSession(parent?.host, parent?.port, parent?.deviceId) { session ->
+        MaestroSessionManager.newSession(parent?.host, parent?.port, parent?.deviceId, launchWebDevice = false, isStudio = true) { session ->
             val port = getFreePort()
             MaestroStudio.start(port, session.maestro)
 
@@ -44,7 +44,7 @@ class StudioCommand : Callable<Int> {
             tryOpenUrl(studioUrl)
 
             println()
-            println("Tip: Maestro Studio can now run simultaneously alongside other Meastro CLI commands!")
+            println("Tip: Maestro Studio can now run simultaneously alongside other Maestro CLI commands!")
 
             println()
             println("Navigate to $studioUrl in your browser to open Maestro Studio. Ctrl-C to exit.".faint())

--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -33,7 +33,7 @@ class StudioCommand : Callable<Int> {
             throw CliError("--platform option was deprecated. You can remove it to run your test.")
         }
 
-        MaestroSessionManager.newSession(parent?.host, parent?.port, parent?.deviceId, launchWebDevice = false, isStudio = true) { session ->
+        MaestroSessionManager.newSession(parent?.host, parent?.port, parent?.deviceId, true) { session ->
             val port = getFreePort()
             MaestroStudio.start(port, session.maestro)
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -29,6 +29,7 @@ import maestro.cli.runner.TestSuiteInteractor
 import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.runner.resultview.PlainTextResultView
 import maestro.cli.session.MaestroSessionManager
+import maestro.cli.util.PrintUtils
 import maestro.orchestra.yaml.YamlCommandReader
 import okio.buffer
 import okio.sink
@@ -107,11 +108,11 @@ class TestCommand : Callable<Int> {
             throw CliError("--platform option was deprecated. You can remove it to run your test.")
         }
 
-        val launchWebDevice = isWebFlow().also {
-            if (it) println("WARNING! Web support is an experimental feature and may be removed in future versions.\n")
-        }
+        val deviceId =
+            if (isWebFlow()) "chromium".also { PrintUtils.warn("Web support is an experimental feature and may be removed in future versions.\n") }
+            else parent?.deviceId
         
-        return MaestroSessionManager.newSession(parent?.host, parent?.port, parent?.deviceId, launchWebDevice) { session ->
+        return MaestroSessionManager.newSession(parent?.host, parent?.port, deviceId) { session ->
             val maestro = session.maestro
             val device = session.device
 

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -14,6 +14,7 @@ import maestro.debuglog.DebugLogStore
 import maestro.utils.MaestroTimer
 import java.io.File
 import java.net.Socket
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.thread
 
@@ -64,6 +65,13 @@ object DeviceService {
                 return Device.Connected(
                     instanceId = dadb.toString(),
                     description = device.description,
+                    platform = device.platform,
+                )
+            }
+            Platform.WEB -> {
+                return Device.Connected(
+                    instanceId = "",
+                    description = "Selenium Chromium driver",
                     platform = device.platform,
                 )
             }
@@ -144,7 +152,15 @@ object DeviceService {
     }
 
     private fun listDevices(): List<Device> {
-        return listAndroidDevices() + listIOSDevices()
+        return listAndroidDevices() + listIOSDevices() + listWebDevices()
+    }
+
+    private fun listWebDevices(): List<Device> {
+        return listOf(Device.AvailableForLaunch(
+            platform = Platform.WEB,
+            description = "Chromium Desktop Browser (Experimental)",
+            modelId = "chromium"
+        ))
     }
 
     private fun listAndroidDevices(): List<Device> {

--- a/maestro-cli/src/main/java/maestro/cli/device/Platform.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/Platform.kt
@@ -3,4 +3,5 @@ package maestro.cli.device
 enum class Platform(val description: String) {
     ANDROID("Android"),
     IOS("iOS"),
+    WEB("Web")
 }

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -55,12 +55,11 @@ object MaestroSessionManager {
         deviceId: String?,
 
         // needed for experimental web support
-        launchWebDevice: Boolean = false,
         isStudio: Boolean = false,
 
         block: (MaestroSession) -> T,
     ): T {
-        val selectedDevice = selectDevice(host, port, deviceId, launchWebDevice)
+        val selectedDevice = selectDevice(host, port, deviceId)
         val sessionId = UUID.randomUUID().toString()
 
         val heartbeatFuture = executor.scheduleAtFixedRate(
@@ -102,9 +101,8 @@ object MaestroSessionManager {
         host: String?,
         port: Int?,
         deviceId: String?,
-        launchWebDevice: Boolean? = false,
     ): SelectedDevice {
-        if (launchWebDevice == true) {
+        if (deviceId == "chromium") {
             return SelectedDevice(
                 platform = Platform.WEB
             )

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -75,6 +75,8 @@ dependencies {
     implementation project(':maestro-ios')
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
     implementation 'de.upb.cs.swt:axml:2.1.2'
+    implementation 'org.seleniumhq.selenium:selenium-java:4.7.2'
+    implementation 'io.github.bonigarcia:webdrivermanager:5.3.1'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'

--- a/maestro-client/src/main/java/maestro/KeyCode.kt
+++ b/maestro-client/src/main/java/maestro/KeyCode.kt
@@ -1,5 +1,7 @@
 package maestro
 
+import org.openqa.selenium.Keys
+
 enum class KeyCode(
     val description: String,
 ) {
@@ -27,6 +29,14 @@ enum class KeyCode(
         fun getByName(name: String): KeyCode? {
             val lowercaseName = name.lowercase()
             return values().find { it.description.lowercase() == lowercaseName }
+        }
+
+        fun mapToSeleniumKey(code: KeyCode): Keys? {
+            return when (code) {
+                ENTER -> Keys.ENTER
+                BACKSPACE -> Keys.BACK_SPACE
+                else -> null
+            }
         }
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -25,6 +25,7 @@ import maestro.Filters.asFilter
 import maestro.UiElement.Companion.toUiElement
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.drivers.AndroidDriver
+import maestro.drivers.WebDriver
 import maestro.utils.MaestroTimer
 import maestro.utils.SocketUtils
 import okio.Buffer
@@ -357,7 +358,10 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         repeat(10) {
             val hierarchyAfter = viewHierarchy()
             if (latestHierarchy == hierarchyAfter) {
-                return hierarchyAfter
+                val isLoading = latestHierarchy.root.attributes.getOrDefault("is-loading", "false").toBoolean()
+                if (!isLoading) {
+                    return hierarchyAfter
+                }
             }
             latestHierarchy = hierarchyAfter
 
@@ -501,7 +505,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
 
         fun ios(
             driver: Driver,
-            openDriver: Boolean = true,
+            openDriver: Boolean = true
         ): Maestro {
             if (openDriver) {
                 driver.open()
@@ -518,6 +522,12 @@ class Maestro(private val driver: Driver) : AutoCloseable {
             if (openDriver) {
                 driver.open()
             }
+            return Maestro(driver)
+        }
+
+        fun web(isStudio: Boolean): Maestro {
+            val driver = WebDriver(isStudio)
+            driver.open()
             return Maestro(driver)
         }
     }

--- a/maestro-client/src/main/java/maestro/Platform.kt
+++ b/maestro-client/src/main/java/maestro/Platform.kt
@@ -1,5 +1,5 @@
 package maestro
 
 enum class Platform {
-    ANDROID, IOS
+    ANDROID, IOS, WEB
 }

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -1,0 +1,368 @@
+package maestro.drivers
+
+import io.github.bonigarcia.wdm.WebDriverManager
+import jdk.jfr.Timespan
+import maestro.DeviceInfo
+import maestro.Driver
+import maestro.KeyCode
+import maestro.Maestro
+import maestro.Platform
+import maestro.Point
+import maestro.ScreenRecording
+import maestro.SwipeDirection
+import maestro.TreeNode
+import okio.Sink
+import okio.buffer
+import org.apache.commons.io.output.NullOutputStream
+import org.openqa.selenium.By
+import org.openqa.selenium.JavascriptExecutor
+import org.openqa.selenium.Keys
+import org.openqa.selenium.OutputType
+import org.openqa.selenium.TakesScreenshot
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.ChromeDriverLogLevel
+import org.openqa.selenium.chrome.ChromeDriverService
+import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.interactions.Actions
+import org.openqa.selenium.interactions.PointerInput
+import org.openqa.selenium.remote.RemoteWebDriver
+import org.openqa.selenium.support.ui.Wait
+import org.openqa.selenium.support.ui.WebDriverWait
+import java.io.File
+import java.time.Duration
+import java.util.Random
+import java.util.logging.Level
+import java.util.logging.Logger
+
+class WebDriver(val isStudio: Boolean) : Driver {
+
+    private var seleniumDriver: org.openqa.selenium.WebDriver? = null
+    private var maestroWebScript: String? = null
+
+    init {
+        Maestro::class.java.getResourceAsStream("/maestro-web.js")?.let {
+            it.bufferedReader().use { br ->
+                maestroWebScript = br.readText()
+            }
+        } ?: error("Could not read maestro web script")
+    }
+
+    override fun name(): String {
+        return "Chromium Desktop Browser (Experimental)"
+    }
+
+    override fun open() {
+        System.setProperty("webdriver.chrome.silentOutput", "true");
+        System.setProperty(ChromeDriverService.CHROME_DRIVER_SILENT_OUTPUT_PROPERTY, "true");
+        Logger.getLogger("org.openqa.selenium").level = Level.OFF;
+        Logger.getLogger("org.openqa.selenium.devtools.CdpVersionFinder").level = Level.OFF;
+
+        WebDriverManager
+            .chromedriver()
+            .setup()
+
+        val driverService = ChromeDriverService.Builder().build()
+        driverService.sendOutputTo(NullOutputStream.NULL_OUTPUT_STREAM)
+
+        seleniumDriver = ChromeDriver(
+            driverService,
+            ChromeOptions().apply {
+                logLevel = ChromeDriverLogLevel.OFF
+                if (isStudio) {
+                    setHeadless(true)
+                    addArguments("--window-size=1024,768")
+                }
+            }
+        )
+
+        if (isStudio) {
+            seleniumDriver?.get("https://maestro.mobile.dev")
+        }
+    }
+
+    private fun ensureOpen(): org.openqa.selenium.WebDriver {
+        return seleniumDriver ?: error("Driver is not open")
+    }
+
+    private fun executeJS(js: String): Any? {
+        val executor = seleniumDriver as JavascriptExecutor
+
+        try {
+            executor.executeScript("$maestroWebScript")
+            Thread.sleep(100)
+            return executor.executeScript(js)
+        } catch (e: Exception) {
+            if (e.message?.contains("getContentDescription") == true) {
+                return executeJS(js)
+            }
+            return null
+        }
+    }
+
+    private fun scrollToPoint(point: Point): Long {
+        ensureOpen()
+        val windowHeight = executeJS("return window.innerHeight") as Long
+        if (point.y > 0 && point.y.toLong() <= windowHeight - 50) return 0L
+
+        val scrolledPixels =
+            executeJS("const delta = ${point.y} - Math.floor(window.innerHeight / 2); window.scrollBy({ top: delta, left: 0, behavior: 'smooth' }); return delta") as Long
+        sleep(3000L)
+        return scrolledPixels
+    }
+
+    private fun sleep(ms: Long) {
+        Thread.sleep(ms)
+    }
+
+    private fun scroll(top: String, left: String) {
+        executeJS("window.scroll({ top: $top, left: $left, behavior: 'smooth' });")
+    }
+
+    private fun random(start: Int, end: Int): Int {
+        return Random().nextInt((end + 1) - start) + start
+    }
+
+    override fun close() {
+        seleniumDriver?.quit()
+        seleniumDriver = null
+    }
+
+    override fun deviceInfo(): DeviceInfo {
+        val driver = ensureOpen()
+
+        val windowSize = driver.manage().window().size
+
+        return DeviceInfo(
+            platform = Platform.WEB,
+            widthPixels = windowSize.width,
+            heightPixels = windowSize.height,
+            widthGrid = windowSize.width,
+            heightGrid = windowSize.height,
+        )
+    }
+
+    override fun launchApp(appId: String) {
+        open()
+        val driver = ensureOpen()
+
+        driver.manage().timeouts().implicitlyWait(Duration.ofMillis(5000))
+        val wait = WebDriverWait(driver, Duration.ofSeconds(30L))
+
+        driver.get(appId)
+        wait.until { (it as JavascriptExecutor).executeScript("return document.readyState") == "complete" }
+    }
+
+    override fun stopApp(appId: String) {
+        val driver = ensureOpen()
+
+        driver.close()
+    }
+
+    override fun contentDescriptor(): TreeNode {
+        ensureOpen()
+
+        // retrieve view hierarchy from DOM
+        val contentDesc = executeJS("return window.maestro.getContentDescription()")
+            ?: throw IllegalStateException("Could not retrieve hierarchy through maestro.getContentDescription()")
+
+        // parse into TreeNodes
+        fun parse(domRepresentation: Map<String, Any>): TreeNode {
+            val attrs = domRepresentation["attributes"] as Map<String, Any>
+
+            val attributes = mutableMapOf(
+                "text" to attrs["text"] as String,
+                "bounds" to attrs["bounds"] as String,
+            )
+            if (attrs.containsKey("resource-id") && attrs["resource-id"] != null) {
+                attributes["resource-id"] = attrs["resource-id"] as String
+            }
+            val children = domRepresentation["children"] as List<Map<String, Any>>
+
+            return TreeNode(attributes = attributes, children = children.map { parse(it) })
+        }
+
+
+        return parse(contentDesc as Map<String, Any>)
+    }
+
+    override fun clearAppState(appId: String) {
+        // TODO
+    }
+
+    override fun clearKeychain() {
+        // Do nothing
+    }
+
+    override fun pullAppState(appId: String, outFile: File) {
+        TODO("Not yet implemented")
+        return
+    }
+
+    override fun pushAppState(appId: String, stateFile: File) {
+        TODO("Not yet implemented")
+    }
+
+    override fun tap(point: Point) {
+        val driver = ensureOpen()
+        val pixelsScrolled = scrollToPoint(point)
+
+        val mouse = PointerInput(PointerInput.Kind.MOUSE, "default mouse")
+        val actions = org.openqa.selenium.interactions.Sequence(mouse, 0)
+            .addAction(mouse.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), point.x, point.y - pixelsScrolled.toInt()))
+
+        (driver as RemoteWebDriver).perform(listOf(actions))
+
+        Actions(driver).click().build().perform()
+    }
+
+    override fun longPress(point: Point) {
+        val driver = ensureOpen()
+
+        val mouse = PointerInput(PointerInput.Kind.MOUSE, "default mouse")
+        val actions = org.openqa.selenium.interactions.Sequence(mouse, 0)
+            .addAction(mouse.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), point.x, point.y))
+        (driver as RemoteWebDriver).perform(listOf(actions))
+
+        Actions(driver).clickAndHold().pause(3000L).release().build().perform()
+    }
+
+    override fun pressKey(code: KeyCode) {
+        val driver = ensureOpen()
+
+        val xPath = executeJS("return window.maestro.createXPathFromElement(document.activeElement)") as String
+        val element = driver.findElement(By.ByXPath(xPath))
+        val key = KeyCode.mapToSeleniumKey(code)
+            ?: throw IllegalArgumentException("Keycode $code is not supported on web")
+        element.sendKeys(key)
+    }
+
+    override fun scrollVertical() {
+        scroll("window.scrollY + Math.round(window.innerHeight / 2)", "window.scrollX")
+    }
+
+    override fun swipe(start: Point, end: Point, durationMs: Long) {
+        // TODO validate implementation and ensure it works properly
+        val driver = ensureOpen()
+
+        val finger = PointerInput(PointerInput.Kind.TOUCH, "finger")
+        val swipe = org.openqa.selenium.interactions.Sequence(finger, 1)
+        swipe.addAction(
+            finger.createPointerMove(
+                Duration.ofMillis(0),
+                PointerInput.Origin.viewport(),
+                start.x,
+                start.y
+            )
+        )
+        swipe.addAction(finger.createPointerDown(PointerInput.MouseButton.LEFT.asArg()))
+        swipe.addAction(
+            finger.createPointerMove(
+                Duration.ofMillis(durationMs),
+                PointerInput.Origin.viewport(),
+                end.x,
+                end.y
+            )
+        )
+        swipe.addAction(finger.createPointerUp(PointerInput.MouseButton.LEFT.asArg()))
+        (driver as RemoteWebDriver).perform(listOf(swipe))
+    }
+
+    override fun swipe(swipeDirection: SwipeDirection, durationMs: Long) {
+        // TODO validate implementation and ensure it works properly
+        when (swipeDirection) {
+            SwipeDirection.UP -> scroll("window.scrollY + Math.round(window.innerHeight / 2)", "window.scrollX")
+            SwipeDirection.DOWN -> scroll("window.scrollY - Math.round(window.innerHeight / 2)", "window.scrollX")
+            SwipeDirection.LEFT -> scroll("window.scrollY", "window.scrollX + Math.round(window.innerWidth / 2)")
+            SwipeDirection.RIGHT -> scroll("window.scrollY", "window.scrollX - Math.round(window.innerWidth / 2)")
+        }
+    }
+
+    override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
+        TODO("Not yet implemented")
+    }
+
+    fun swipe(start: Point, end: Point) {
+        TODO("Not yet implemented")
+    }
+
+    override fun backPress() {
+        val driver = ensureOpen()
+        driver.navigate().back()
+    }
+
+    override fun inputText(text: String) {
+        val driver = ensureOpen()
+
+        val xPath = executeJS("return window.maestro.createXPathFromElement(document.activeElement)") as String
+        val element = driver.findElement(By.ByXPath(xPath))
+        for (c in text.toCharArray()) {
+            element.sendKeys("$c")
+            sleep(random(20, 100).toLong())
+        }
+    }
+
+    override fun openLink(link: String) {
+        val driver = ensureOpen()
+
+        driver.get(link)
+    }
+
+    override fun hideKeyboard() {
+        // no-op on web
+        return
+    }
+
+    override fun takeScreenshot(out: Sink) {
+        val driver = ensureOpen()
+
+        val src = (driver as TakesScreenshot).getScreenshotAs(OutputType.FILE)
+        out.buffer().use { it.write(src.readBytes()) }
+    }
+
+    override fun startScreenRecording(out: Sink): ScreenRecording {
+        TODO("Not yet implemented")
+    }
+
+    override fun setLocation(latitude: Double, longitude: Double) {
+        TODO("Not yet implemented")
+    }
+
+    override fun eraseText(charactersToErase: Int) {
+        val driver = ensureOpen()
+
+        val xPath = executeJS("return window.maestro.createXPathFromElement(document.activeElement)") as String
+        val element = driver.findElement(By.ByXPath(xPath))
+        for (i in 0 until charactersToErase) {
+            element.sendKeys(Keys.BACK_SPACE)
+            sleep(random(20, 50).toLong())
+        }
+
+        sleep(1000)
+    }
+
+    override fun setProxy(host: String, port: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun resetProxy() {
+        TODO("Not yet implemented")
+    }
+
+    override fun isShutdown(): Boolean {
+        close()
+        return true
+    }
+
+    override fun isUnicodeInputSupported(): Boolean {
+        return true
+    }
+}
+
+fun main() {
+    WebDriver(false).apply {
+        launchApp("https://ubereats.com")
+
+        val cd = contentDescriptor()
+        tap(Point(932, 1409))
+    }
+}

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -357,12 +357,3 @@ class WebDriver(val isStudio: Boolean) : Driver {
         return true
     }
 }
-
-fun main() {
-    WebDriver(false).apply {
-        launchApp("https://ubereats.com")
-
-        val cd = contentDescriptor()
-        tap(Point(932, 1409))
-    }
-}

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -186,7 +186,7 @@ class WebDriver(val isStudio: Boolean) : Driver {
     }
 
     override fun clearAppState(appId: String) {
-        // TODO
+        // Do nothing
     }
 
     override fun clearKeychain() {
@@ -194,12 +194,11 @@ class WebDriver(val isStudio: Boolean) : Driver {
     }
 
     override fun pullAppState(appId: String, outFile: File) {
-        TODO("Not yet implemented")
-        return
+        // Do nothing (for now)
     }
 
     override fun pushAppState(appId: String, stateFile: File) {
-        TODO("Not yet implemented")
+        // Do nothing (for now)
     }
 
     override fun tap(point: Point) {

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -1,7 +1,6 @@
 package maestro.drivers
 
 import io.github.bonigarcia.wdm.WebDriverManager
-import jdk.jfr.Timespan
 import maestro.DeviceInfo
 import maestro.Driver
 import maestro.KeyCode
@@ -26,7 +25,6 @@ import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.interactions.PointerInput
 import org.openqa.selenium.remote.RemoteWebDriver
-import org.openqa.selenium.support.ui.Wait
 import org.openqa.selenium.support.ui.WebDriverWait
 import java.io.File
 import java.time.Duration
@@ -206,8 +204,8 @@ class WebDriver(val isStudio: Boolean) : Driver {
         val pixelsScrolled = scrollToPoint(point)
 
         val mouse = PointerInput(PointerInput.Kind.MOUSE, "default mouse")
-        val actions = org.openqa.selenium.interactions.Sequence(mouse, 0)
-            .addAction(mouse.createPointerMove(Duration.ZERO, PointerInput.Origin.viewport(), point.x, point.y - pixelsScrolled.toInt()))
+        val actions = org.openqa.selenium.interactions.Sequence(mouse, 1)
+            .addAction(mouse.createPointerMove(Duration.ofMillis(400), PointerInput.Origin.viewport(), point.x, point.y - pixelsScrolled.toInt()))
 
         (driver as RemoteWebDriver).perform(listOf(actions))
 

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -1,0 +1,82 @@
+(function ( maestro ) {
+    const INVALID_TAGS = new Set(['noscript', 'script', 'br', 'img', 'svg', 'g', 'path'])
+
+    const isInvalidTag = (node) => {
+        return INVALID_TAGS.has(node.tagName.toLowerCase())
+    }
+
+    const getNodeText = (node) => {
+        switch (node.tagName.toLowerCase()) {
+            case 'input':
+                return node.value || node.placeholder || node.ariaLabel || ''
+
+            default:
+                const childNodes = [...(node.childNodes || [])].filter(node => node.nodeType === Node.TEXT_NODE)
+                return childNodes.map(node => node.textContent.replace('\n', '').replace('\t', '')).join('')
+        }
+    }
+
+    const getNodeBounds = (node) => {
+        const rect = node.getBoundingClientRect()
+
+        return `[${Math.round(rect.x)},${Math.round(rect.y)}][${Math.round(rect.x+rect.width)},${Math.round(rect.y+rect.height)}]`
+    }
+
+    const isDocumentLoading = () => document.readyState !== 'complete'
+
+    const traverse = (node) => {
+      if (!node || isInvalidTag(node)) return null
+
+      const children = [...node.children || []].map(child => traverse(child)).filter(el => !!el)
+      const attributes = {
+          text: getNodeText(node),
+          bounds: getNodeBounds(node),
+      }
+
+      if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor) {
+        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.htmlFor
+      }
+
+      if (node.tagName.toLowerCase() === 'body') {
+        attributes['is-loading'] = isDocumentLoading()
+      }
+
+      return {
+        attributes,
+        children,
+      }
+    }
+
+    // -------------- Public API --------------
+    maestro.getContentDescription = () => {
+        return traverse(document.body)
+    }
+
+    // https://stackoverflow.com/a/5178132
+    maestro.createXPathFromElement = (domElement) => {
+        var allNodes = document.getElementsByTagName('*');
+        for (var segs = []; domElement && domElement.nodeType == 1; domElement = domElement.parentNode)
+        {
+            if (domElement.hasAttribute('id')) {
+                    var uniqueIdCount = 0;
+                    for (var n=0;n < allNodes.length;n++) {
+                        if (allNodes[n].hasAttribute('id') && allNodes[n].id == domElement.id) uniqueIdCount++;
+                        if (uniqueIdCount > 1) break;
+                    };
+                    if ( uniqueIdCount == 1) {
+                        segs.unshift('id("' + domElement.getAttribute('id') + '")');
+                        return segs.join('/');
+                    } else {
+                        segs.unshift(domElement.localName.toLowerCase() + '[@id="' + domElement.getAttribute('id') + '"]');
+                    }
+            } else if (domElement.hasAttribute('class')) {
+                segs.unshift(domElement.localName.toLowerCase() + '[@class="' + domElement.getAttribute('class') + '"]');
+            } else {
+                for (i = 1, sib = domElement.previousSibling; sib; sib = sib.previousSibling) {
+                    if (sib.localName == domElement.localName)  i++; };
+                    segs.unshift(domElement.localName.toLowerCase() + '[' + i + ']');
+            };
+        };
+        return segs.length ? '/' + segs.join('/') : null;
+    }
+}( window.maestro = window.maestro || {} ));

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -58,6 +58,11 @@ object YamlCommandReader {
         listOfNotNull(config.toCommand(flowPath), *maestroCommands.toTypedArray())
     }
 
+    fun readConfig(flowPath: Path): YamlConfig {
+        val (config) = readConfigAndCommands(flowPath)
+        return config
+    }
+
     // Files to watch for changes. Includes any referenced files.
     fun getWatchFiles(flowPath: Path): List<Path> = mapParsingErrors {
         val (config, commands) = readConfigAndCommands(flowPath)


### PR DESCRIPTION
## Proposed Changes
Adds a `WebDriver` that allows running Maestro Flows against a web device (powered by Selenium + Chromium). 

## Testing
### Maestro Studio
Launch Maestro Studio and select the available web device and the Maestro documentation page will be opened and in which you can see all available elements, their selectors and so on.

### Writing a web flow
Simply enter a URL (including protocol) as the `appId` and the website will be loaded as part of the `launchApp` command.

Example flow:
```yaml
appId: https://maestro.mobile.dev
---
- launchApp
- tapOn:
    id: "Search…"
    index: 1
- tapOn: "Search content…"
- inputText: "Writing Your First Flow"
- tapOn:
    text: "Getting Started"
    index: 2
- assertVisible:
    text: "Writing Your First Flow"
    index: 1
```