### PR TITLE
idb_companion fails to start due to gRPC timeout exception

### DIFF
--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -466,9 +466,9 @@ class IdbIOSDevice(
     }
 
     override fun close() {
-        channel.shutdown()
+        channel.shutdownNow()
 
-        if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
+        if (!channel.awaitTermination(10, TimeUnit.SECONDS)) {
             throw TimeoutException("Couldn't close Maestro iOS driver due to gRPC timeout")
         }
     }


### PR DESCRIPTION
## Proposed Changes
Use `shutdownNow` now instead of `shutdown` to close the grpc channel.

From documentation:
Initiates a forceful shutdown in which preexisting and new calls are cancelled. Although forceful, the shutdown process is still not instantaneous; {@link #isTerminated()} will likely return {@code false} immediately after this method returns.

## Testing
Tested:
- [x] executing several test commands with different flows in a row
- [x] maestro studio
- [x] starting `maestro test` flow while `maestro studio` is running
 
## Issues Fixed
https://github.com/mobile-dev-inc/maestro/issues/624