### PR TITLE
Tweak: allow JS injection for index selector

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -38,7 +38,7 @@ object Filters {
         filters
             .map { it(nodes).toSet() }
             .reduceOrNull { a, b -> a.intersect(b) }
-            ?.toList() ?: emptyList()
+            ?.toList() ?: nodes
     }
 
     fun compose(first: ElementFilter, second: ElementFilter): ElementFilter = compose(listOf(first, second))

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -33,7 +33,7 @@ data class ElementSelector(
     val containsChild: ElementSelector? = null,
     val optional: Boolean = false,
     val traits: List<ElementTrait>? = null,
-    val index: Int? = null,
+    val index: String? = null,
     val enabled: Boolean? = null,
 ) {
 
@@ -52,6 +52,7 @@ data class ElementSelector(
             leftOf = leftOf?.evaluateScripts(jsEngine),
             rightOf = rightOf?.evaluateScripts(jsEngine),
             containsChild = containsChild?.evaluateScripts(jsEngine),
+            index = index?.evaluateScripts(jsEngine),
         )
     }
 
@@ -98,7 +99,7 @@ data class ElementSelector(
         }
 
         index?.let {
-            descriptions.add("Index: $it")
+            descriptions.add("Index: ${it.toDoubleOrNull()?.toInt() ?: it}")
         }
 
         val combined = descriptions.joinToString(", ")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -761,6 +761,8 @@ class Orchestra(
 
         var resultFilter = Filters.intersect(filters)
         resultFilter = selector.index
+            ?.toDouble()
+            ?.toInt()
             ?.let {
                 Filters.compose(
                     resultFilter,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -40,6 +40,6 @@ data class YamlElementSelector(
     val rightOf: YamlElementSelectorUnion? = null,
     val containsChild: YamlElementSelectorUnion? = null,
     val traits: String? = null,
-    val index: Int? = null,
+    val index: String? = null,
     val enabled: Boolean? = null,
 ) : YamlElementSelectorUnion

--- a/maestro-test/src/test/resources/032_element_index.yaml
+++ b/maestro-test/src/test/resources/032_element_index.yaml
@@ -6,5 +6,5 @@ appId: com.example.app
     retryTapIfNoChange: false
 - tapOn:
     text: Item.*
-    index: 1
+    index: ${0 + 1}
     retryTapIfNoChange: false


### PR DESCRIPTION
Additionally, fixed a small issue that prevented usage of `index` without any other selector