### PR TITLE
Remove excessive hierarchy request for tapOn command

### DIFF
--- a/maestro-client/src/main/java/maestro/FindElementResult.kt
+++ b/maestro-client/src/main/java/maestro/FindElementResult.kt
@@ -1,0 +1,3 @@
+package maestro
+
+data class FindElementResult(val element: UiElement, val hierarchy: ViewHierarchy)

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -155,10 +155,6 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-//    fun tap(element: TreeNode) {
-//        tap(element.toUiElement())
-//    }
-
     fun tap(
         element: UiElement,
         hierarchyBeforeTap: ViewHierarchy,

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -157,12 +157,14 @@ class Maestro(private val driver: Driver) : AutoCloseable {
 
     fun tap(
         element: UiElement,
-        hierarchyBeforeTap: ViewHierarchy,
+        initialHierarchy: ViewHierarchy,
         retryIfNoChange: Boolean = true,
         waitUntilVisible: Boolean = false,
         longPress: Boolean = false,
     ) {
         LOGGER.info("Tapping on element: $element")
+
+        val hierarchyBeforeTap = waitForAppToSettle(initialHierarchy)
 
         val center = (
             hierarchyBeforeTap
@@ -382,8 +384,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return filter(viewHierarchy().aggregate())
     }
 
-    fun waitForAppToSettle(): ViewHierarchy {
-        var latestHierarchy = viewHierarchy()
+    fun waitForAppToSettle(initialHierarchy: ViewHierarchy? = null): ViewHierarchy {
+        var latestHierarchy = initialHierarchy ?: viewHierarchy()
         repeat(10) {
             val hierarchyAfter = viewHierarchy()
             if (latestHierarchy == hierarchyAfter) {


### PR DESCRIPTION
## Proposed Changes

`findElement` already fetches hierarchy tree that can be reused in subsequent `waitForAppToSettle` operation 

## Testing
tested with Wikipedia and food truck apps

verified that it saves 500-700ms per tapOn command