### PR TITLE
Updates scroll until visible to work within viewport bounds

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -149,6 +149,13 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
+    fun swipeFromCenter(swipeDirection: SwipeDirection, durationMs: Long) {
+        LOGGER.info("Swiping ${swipeDirection.name} from center")
+        val center = Point(x = cachedDeviceInfo.widthGrid / 2, y = cachedDeviceInfo.heightGrid / 2)
+        driver.swipe(center, swipeDirection, durationMs)
+        waitForAppToSettle()
+    }
+
     fun scrollVertical() {
         LOGGER.info("Scrolling vertically")
 

--- a/maestro-client/src/main/java/maestro/UiElement.kt
+++ b/maestro-client/src/main/java/maestro/UiElement.kt
@@ -28,6 +28,18 @@ data class UiElement(
         return bounds.center().distance(other.bounds.center())
     }
 
+    fun isWithinViewPortBounds(info: DeviceInfo, paddingHorizontal: Float = 0f, paddingVertical: Float = 0f): Boolean {
+        val paddingX = (info.widthGrid * paddingHorizontal).toInt()
+        val paddingY = (info.heightGrid * paddingVertical).toInt()
+        val xEnd = info.widthGrid - paddingX
+        val yEnd = info.heightGrid - paddingY
+
+        val isXWithinBounds = bounds.x in paddingX..xEnd
+        val isYWithinBounds = bounds.y in paddingY..yEnd
+
+        return isXWithinBounds && isYWithinBounds
+    }
+
     companion object {
 
         fun TreeNode.toUiElement(): UiElement {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -25,6 +25,7 @@ import maestro.Filters
 import maestro.Filters.asFilter
 import maestro.Maestro
 import maestro.MaestroException
+import maestro.SwipeDirection
 import maestro.UiElement
 import maestro.js.Js
 import maestro.js.JsEngine
@@ -281,22 +282,19 @@ class Orchestra(
 
     private fun scrollUntilVisible(command: ScrollUntilVisibleCommand): Boolean {
         val endTime = System.currentTimeMillis() + command.timeout
-        var error: MaestroException.ElementNotFound? = null
+        val direction = command.direction.toSwipeDirection()
+        val paddingH = if (direction == SwipeDirection.LEFT || direction == SwipeDirection.RIGHT) 0.1f else 0f
+        val paddingV = if (direction == SwipeDirection.DOWN || direction == SwipeDirection.UP) 0.1f else 0f
         do {
             try {
-                maestro.waitForAppToSettle()
-                findElement(command.selector, 500)
-                return true
+                val element = findElement(command.selector, 500)
+                if (element.isWithinViewPortBounds(maestro.deviceInfo(), paddingH, paddingV)) return true
             } catch (ignored: MaestroException.ElementNotFound) {
-                error = ignored
             }
-
-            maestro.swipe(command.direction.toSwipeDirection(), duration = 600L)
+            maestro.swipeFromCenter(direction, durationMs = 600L)
         } while (System.currentTimeMillis() < endTime)
 
-        if (error != null) throw error
-
-        return false
+        throw MaestroException.ElementNotFound("No visible element found: ${command.selector.description()}", maestro.viewHierarchy().root)
     }
 
     private fun hideKeyboardCommand(): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -432,7 +432,7 @@ data class YamlFluentCommand(
 
     private fun scrollUntilVisibleCommand(yaml: YamlScrollUntilVisible): MaestroCommand {
         val timeout =
-            if (yaml.timeout < ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS) {
+            if (yaml.timeout < 0) {
                 ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS
             } else yaml.timeout
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2163,7 +2163,7 @@ class IntegrationTest {
 
 
         // With view
-        val elementBounds = Bounds(0, 100, 100, 100)
+        val elementBounds = Bounds(100, 100, 100, 100)
         val driver2 = driver {
             element {
                 text = "Test"
@@ -2179,7 +2179,7 @@ class IntegrationTest {
         // Then
         driver1.assertEvents(
             listOf(
-                Event.SwipeWithDirection(SwipeDirection.UP, 600),
+                Event.SwipeElementWithDirection(Point(270, 480), SwipeDirection.UP, 600),
             )
         )
     }

--- a/maestro-test/src/test/resources/079_scroll_until_visible.yaml
+++ b/maestro-test/src/test/resources/079_scroll_until_visible.yaml
@@ -4,4 +4,4 @@ appId: com.example.app
     element:
       text: "Test"
     direction: DOWN
-    timeout: 20000
+    timeout: 100


### PR DESCRIPTION
## Proposed Changes
Improves ScrollUntilVisible & fixes issues with iOS / Webviews

## Testing
- iOS Safari: www.duckduckgo.com
- iOS Maps

## Issues Fixed
 - **Fix**: ScrollUntilVisible now checks if an element is visible within viewport bounds.
 - **Tweak**: Scrolling will now start from the center of the screen. Avoids side effects like dragging bottom drawers.
 - **Tweak**: Better element alignment towards the center i.e it will scroll a bit more if the element is barely visible at a corner.