### PR TITLE
Removes out of bound hierarchy elements

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -375,10 +375,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     ): FindElementResult? {
         var hierarchy = ViewHierarchy(TreeNode())
         val element = MaestroTimer.withTimeout(timeoutMs) {
-            val rootNode = driver.contentDescriptor()
-            hierarchy = ViewHierarchy(rootNode)
-
-            filter(rootNode.aggregate()).firstOrNull()
+            hierarchy = viewHierarchy()
+            filter(hierarchy.aggregate()).firstOrNull()
         }?.toUiElementOrNull()
 
         return if (element == null) {

--- a/maestro-client/src/main/java/maestro/UiElement.kt
+++ b/maestro-client/src/main/java/maestro/UiElement.kt
@@ -29,10 +29,20 @@ data class UiElement(
     }
 
     fun getVisiblePercentage(screenWidth: Int, screenHeight: Int): Double {
+        if (bounds.width == 0 && bounds.height == 0) {
+            return 0.0
+        }
+
+        val overflow = (bounds.x <= 0) && (bounds.y <= 0) && (bounds.x + bounds.width >= screenWidth) && (bounds.y + bounds.height >= screenHeight)
+        if (overflow) {
+            return 1.0
+        }
+
         val visibleX = maxOf(0, minOf(bounds.x + bounds.width, screenWidth) - maxOf(bounds.x, 0))
         val visibleY = maxOf(0, minOf(bounds.y + bounds.height, screenHeight) - maxOf(bounds.y, 0))
         val visibleArea = visibleX * visibleY
         val totalArea = bounds.width * bounds.height
+
         return visibleArea.toDouble() / totalArea.toDouble()
     }
 

--- a/maestro-client/src/main/java/maestro/UiElement.kt
+++ b/maestro-client/src/main/java/maestro/UiElement.kt
@@ -28,6 +28,14 @@ data class UiElement(
         return bounds.center().distance(other.bounds.center())
     }
 
+    fun getVisiblePercentage(screenWidth: Int, screenHeight: Int): Double {
+        val visibleX = maxOf(0, minOf(bounds.x + bounds.width, screenWidth) - maxOf(bounds.x, 0))
+        val visibleY = maxOf(0, minOf(bounds.y + bounds.height, screenHeight) - maxOf(bounds.y, 0))
+        val visibleArea = visibleX * visibleY
+        val totalArea = bounds.width * bounds.height
+        return visibleArea.toDouble() / totalArea.toDouble()
+    }
+
     fun isWithinViewPortBounds(info: DeviceInfo, paddingHorizontal: Float = 0f, paddingVertical: Float = 0f): Boolean {
         val paddingX = (info.widthGrid * paddingHorizontal).toInt()
         val paddingY = (info.heightGrid * paddingVertical).toInt()

--- a/maestro-client/src/main/java/maestro/ViewHierarchy.kt
+++ b/maestro-client/src/main/java/maestro/ViewHierarchy.kt
@@ -97,11 +97,9 @@ value class ViewHierarchy(val root: TreeNode) {
 }
 
 fun TreeNode.filterOutOfBounds(width: Int, height: Int): TreeNode? {
-    val element = toUiElement()
-    val isXWithinBounds = element.bounds.x in 0..width
-    val isYWithinBounds = element.bounds.y in 0..height
+    val visiblePercentage = toUiElement().getVisiblePercentage(width, height);
 
-    if (!isXWithinBounds || !isYWithinBounds) {
+    if (visiblePercentage < 0.1) {
         return null
     }
 
@@ -119,3 +117,5 @@ fun TreeNode.filterOutOfBounds(width: Int, height: Int): TreeNode? {
         selected = selected
     )
 }
+
+

--- a/maestro-client/src/main/java/maestro/ViewHierarchy.kt
+++ b/maestro-client/src/main/java/maestro/ViewHierarchy.kt
@@ -26,11 +26,14 @@ value class ViewHierarchy(val root: TreeNode) {
     companion object {
         fun from(driver: Driver): ViewHierarchy {
             val deviceInfo = driver.deviceInfo()
-            val filtered = driver.contentDescriptor().filterOutOfBounds(
-                width = deviceInfo.widthGrid,
-                height = deviceInfo.heightGrid
-            ) ?: throw IllegalArgumentException("Root should not be null")
-            return ViewHierarchy(filtered)
+            val root = driver.contentDescriptor().let {
+                val filtered = it.filterOutOfBounds(
+                    width = deviceInfo.widthGrid,
+                    height = deviceInfo.heightGrid
+                )
+                filtered ?: it
+            }
+            return ViewHierarchy(root)
         }
     }
 

--- a/maestro-client/src/main/java/maestro/ViewHierarchy.kt
+++ b/maestro-client/src/main/java/maestro/ViewHierarchy.kt
@@ -97,15 +97,18 @@ value class ViewHierarchy(val root: TreeNode) {
 }
 
 fun TreeNode.filterOutOfBounds(width: Int, height: Int): TreeNode? {
-    val visiblePercentage = toUiElement().getVisiblePercentage(width, height);
-
-    if (visiblePercentage < 0.1) {
-        return null
-    }
 
     val filtered = children.mapNotNull {
         it.filterOutOfBounds(width, height)
     }.toList()
+
+    // parent can have missing bounds
+    val element = kotlin.runCatching { toUiElement() }.getOrNull()
+    val visiblePercentage = element?.getVisiblePercentage(width, height) ?: 0.0
+
+    if (visiblePercentage < 0.1 && filtered.isEmpty()) {
+        return null
+    }
 
     return TreeNode(
         attributes = attributes,

--- a/maestro-client/src/test/java/maestro/UiElementTest.kt
+++ b/maestro-client/src/test/java/maestro/UiElementTest.kt
@@ -1,7 +1,7 @@
 package maestro
 
-import org.junit.jupiter.api.Test
 import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
 
 internal class UiElementTest {
 
@@ -37,7 +37,6 @@ internal class UiElementTest {
         val percent = element.getVisiblePercentage(screenWidth, screenHeight)
         assertThat(percent).isEqualTo(0.15)
     }
-
 
     @Test
     internal fun `check visible percentage on screen - right bottom 10 percent`() {

--- a/maestro-client/src/test/java/maestro/UiElementTest.kt
+++ b/maestro-client/src/test/java/maestro/UiElementTest.kt
@@ -1,0 +1,72 @@
+package maestro
+
+import org.junit.jupiter.api.Test
+import com.google.common.truth.Truth.assertThat
+
+internal class UiElementTest {
+
+    private val screenHeight = 1280
+    private val screenWidth = 720
+
+    @Test
+    internal fun `check visible percentage on screen - full`() {
+        val element = UiElement(
+            TreeNode(),
+            bounds = Bounds(
+                x = 50,
+                y = 50,
+                width = 200,
+                height = 100
+            )
+        )
+        val percent = element.getVisiblePercentage(screenWidth, screenHeight)
+        assertThat(percent).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `check visible percentage on screen - left bottom 15 percent`() {
+        val element = UiElement(
+            TreeNode(),
+            bounds = Bounds(
+                x = -50,
+                y = 1260,
+                width = 200,
+                height = 100
+            )
+        )
+        val percent = element.getVisiblePercentage(screenWidth, screenHeight)
+        assertThat(percent).isEqualTo(0.15)
+    }
+
+
+    @Test
+    internal fun `check visible percentage on screen - right bottom 10 percent`() {
+        val element = UiElement(
+            TreeNode(),
+            bounds = Bounds(
+                x = 680,
+                y = 1200,
+                width = 200,
+                height = 100
+            )
+        )
+        val percent = element.getVisiblePercentage(screenWidth, screenHeight)
+        assertThat(percent).isEqualTo(0.16)
+    }
+
+    @Test
+    internal fun `check visible percentage on screen - out of bounds`() {
+        val element = UiElement(
+            TreeNode(),
+            bounds = Bounds(
+                x = -200,
+                y = 1300,
+                width = 200,
+                height = 100
+            )
+        )
+
+        val percent = element.getVisiblePercentage(screenWidth, screenHeight)
+        assertThat(percent).isEqualTo(0)
+    }
+}

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2230,7 +2230,7 @@ class IntegrationTest {
     }
 
     @Test
-    fun `Case 081 - Assert not visible - no element with id`() {
+    fun `Case 081 - Hierarchy pruning assert not visible`() {
         // Given
         val commands = readCommands("081_hierarchy_pruning_assert_not_visible")
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -21,6 +21,7 @@ import maestro.test.drivers.FakeLayoutElement
 import maestro.test.drivers.FakeLayoutElement.Bounds
 import maestro.test.drivers.FakeTimer
 import maestro.utils.MaestroTimer
+import maestro_android.deviceInfo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -2182,6 +2183,94 @@ class IntegrationTest {
                 Event.SwipeElementWithDirection(Point(270, 480), SwipeDirection.UP, 600),
             )
         )
+    }
+
+    @Test
+    fun `Case 080 - Hierarchy pruning assert visible`() {
+        // Given
+        val commands = readCommands("080_hierarchy_pruning_assert_visible")
+
+        val info = driver{}.deviceInfo()
+
+        val driver = driver {
+            element {
+                id = "root"
+                bounds = Bounds(0, 0, 500, 500)
+
+                element {
+                    id = "visible_1"
+                    bounds = Bounds(0, 0, 100, 100)
+                }
+
+                element {
+                    id = "visible_2"
+                    bounds = Bounds(info.widthGrid - 50, 0, info.widthGrid + 100 , 100)
+                }
+
+                element {
+                    id = "visible_3"
+                    bounds = Bounds(0, info.heightGrid - 50, 100 , info.heightGrid + 100)
+                }
+
+                element {
+                    id = "visible_4"
+                    bounds = Bounds(-100, -100, info.widthGrid + 200 , info.heightGrid + 200)
+                }
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertNoInteraction()
+    }
+
+    @Test
+    fun `Case 081 - Assert not visible - no element with id`() {
+        // Given
+        val commands = readCommands("081_hierarchy_pruning_assert_not_visible")
+
+        val info = driver{}.deviceInfo()
+
+        val driver = driver {
+            element {
+                id = "root"
+                bounds = Bounds(0, 0, 500, 500)
+
+                element {
+                    id = "not_visible_1"
+                    bounds = Bounds(-100, -100, 0, 0)
+                }
+
+                element {
+                    id = "not_visible_2"
+                    bounds = Bounds(info.widthGrid, 0, info.widthGrid + 100, 100)
+                }
+
+                element {
+                    id = "not_visible_3"
+                    bounds = Bounds(0, info.heightGrid, 100, info.heightGrid + 100)
+                }
+
+                element {
+                    id = "not_visible_4"
+                    bounds = Bounds(0, info.heightGrid - 10 , 100, info.heightGrid + 100)
+                }
+            }
+        }
+
+        // When & Then
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertNoInteraction()
     }
 
     private fun orchestra(maestro: Maestro) = Orchestra(

--- a/maestro-test/src/test/resources/080_hierarchy_pruning_assert_visible.yaml
+++ b/maestro-test/src/test/resources/080_hierarchy_pruning_assert_visible.yaml
@@ -1,0 +1,10 @@
+appId: com.example.app
+---
+- assertVisible:
+    id: "visible_1"
+- assertVisible:
+      id: "visible_2"
+- assertVisible:
+    id: "visible_3"
+- assertVisible:
+    id: "visible_4"

--- a/maestro-test/src/test/resources/081_hierarchy_pruning_assert_not_visible.yaml
+++ b/maestro-test/src/test/resources/081_hierarchy_pruning_assert_not_visible.yaml
@@ -1,0 +1,10 @@
+appId: com.example.app
+---
+- assertNotVisible:
+    id: "not_visible_1"
+- assertNotVisible:
+      id: "not_visible_2"
+- assertNotVisible:
+      id: "not_visible_3"
+- assertNotVisible:
+      id: "not_visible_4"


### PR DESCRIPTION
## Proposed Changes
Currently view hierarchy might return out of bound elements. This change will filter elements out of screen bounds.

## Testing
iOS Webview pages

## Issues Fixed
`assertVisible`
