### PR TITLE
Remove unused return value for onCommandFailed

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -89,7 +89,6 @@ object MaestroCommandRunner {
                 logger.info("${command.description()} FAILED")
                 commandStatuses[command] = CommandStatus.FAILED
                 refreshUi()
-                Orchestra.ErrorResolution.FAIL
             },
             onCommandSkipped = { _, command ->
                 logger.info("${command.description()} SKIPPED")

--- a/maestro-studio/server/src/main/java/maestro/studio/ReplService.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/ReplService.kt
@@ -218,7 +218,6 @@ object ReplService {
         var failure: Throwable? = null
         val result = Orchestra(maestro, onCommandFailed = { _, _, throwable ->
             failure = throwable
-            Orchestra.ErrorResolution.FAIL
         }).executeCommands(commands)
         return if (result) null else (failure ?: RuntimeException("Command execution failed"))
     }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1574,37 +1574,6 @@ class IntegrationTest {
     }
 
     @Test
-    fun `Case 056 - Ignore an error in Orchestra`() {
-        // Given
-        val commands = readCommands("056_ignore_error")
-
-        val driver = driver {
-            element {
-                text = "Button"
-                bounds = Bounds(0, 100, 100, 200)
-            }
-        }
-
-        // When
-        Maestro(driver).use {
-            orchestra(
-                maestro = it,
-                onCommandFailed = { _, command, _ ->
-                    if (command.tapOnElement?.selector?.textRegex == "Non existent text") {
-                        Orchestra.ErrorResolution.CONTINUE
-                    } else {
-                        Orchestra.ErrorResolution.FAIL
-                    }
-                },
-            ).runFlow(commands)
-        }
-
-        // Then
-        // No test failure
-        driver.assertHasEvent(Event.Tap(Point(50, 150)))
-    }
-
-    @Test
     fun `Case 057 - Pass inner env variables to runFlow`() {
         // Given
         val commands = readCommands("057_runFlow_env")
@@ -2192,7 +2161,7 @@ class IntegrationTest {
 
     private fun orchestra(
         maestro: Maestro,
-        onCommandFailed: (Int, MaestroCommand, Throwable) -> Orchestra.ErrorResolution,
+        onCommandFailed: (Int, MaestroCommand, Throwable) -> Unit,
     ) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,


### PR DESCRIPTION
## Proposed Changes

`ErrorResolution.CONTINUE` is never used. So it is safe to remove the condition and use the `ErrorResolution.FAIL` path.
I believe that the return code from onCommandFailed was used to make Orchestra continue on failure. If we need that feature then let's not use onCommandFailed for deciding that (a better is to pass a constructor argument `Orchestra(continueOnFailure:)`).
