### PR TITLE
[MOB 1893] Handle line breaks in studio and matching

### DIFF
--- a/maestro-studio/web/src/Examples.tsx
+++ b/maestro-studio/web/src/Examples.tsx
@@ -75,7 +75,7 @@ const Section = ({ deviceScreen, element, title, documentationUrl, codeSnippets 
         {
           codeSnippet
             .replace('[id]', id)
-            .replace('[text]', text)
+            .replace('[text]', text.replace("\n", " "))
             .replace('[point]', point)
             .replace('[resource-id-index]', resourceIdIndex)
             .replace('[text-index]', textIndex)


### PR DESCRIPTION
## Proposed Changes

To reduce cognitive load while writing test. Match texts with \n as well.

## Testing

For the following screen:

<img width="267" alt="Screenshot 2023-02-06 at 1 25 54 PM" src="https://user-images.githubusercontent.com/12881364/216915758-4eea0406-2cf5-4286-a567-fe5772cd8175.png">

Maestro studio inspects an invalid command right now:

```
- tapOn: "LOGIN IS THIS 
WITH NEW LINE"
```

With the change now we can match this text with the following:

```
- tapOn: "LOGIN IS THIS WITH NEW LINE"
```

<img width="516" alt="Screenshot 2023-02-06 at 1 29 02 PM" src="https://user-images.githubusercontent.com/12881364/216917546-ed26470e-6ad9-499f-a043-e788063e4302.png">


## Issues Fixed