### PR TITLE
Add maestro mockserver setup command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerCommand.kt
@@ -7,7 +7,8 @@ import picocli.CommandLine
     name = "mockserver",
     subcommands = [
         MockServerDeployCommand::class,
-        MockServerOpenCommand::class
+        MockServerOpenCommand::class,
+        MockServerSetupCommand::class
     ]
 )
 class MockServerCommand {

--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerSetupCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerSetupCommand.kt
@@ -1,0 +1,28 @@
+package maestro.cli.command.mockserver
+
+import maestro.cli.util.PrintUtils
+import maestro.cli.util.PrintUtils.err
+import maestro.studio.MockInteractor
+import picocli.CommandLine.Command
+import picocli.CommandLine.ParentCommand
+import java.util.concurrent.Callable
+
+@Command(
+    name = "setup",
+)
+class MockServerSetupCommand : Callable<Int> {
+
+    @ParentCommand
+    lateinit var parent: MockServerCommand
+
+    private val interactor = MockInteractor()
+
+    override fun call(): Int {
+        val projectId = interactor.getProjectId() ?: err("Could not retrieve project id")
+
+        PrintUtils.message("Project id: $projectId")
+        PrintUtils.message("Run `maestro mockserver open` to get started with Maestro Mock Server!")
+
+        return 0
+    }
+}

--- a/maestro-studio/server/src/main/java/maestro/studio/MockInteractor.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/MockInteractor.kt
@@ -38,7 +38,7 @@ class MockInteractor(
     }
 
     fun getProjectId(): UUID? {
-        val authToken = getCachedAuthToken()
+        val authToken = getCachedAuthToken() ?: error("Not logged in. Please run `maestro login` and try again.")
 
         val request = try {
             Request.Builder()


### PR DESCRIPTION
Adds a new `maestro mockserver setup` command that prints out the project id that is needed to initialize the Maestro SDK when wanting to integrate with mock server. If the user is not logged in an error message is displayed that prompts them to run `maestro login` and then try again.

```
➜  maestro git:(MOB-1902) ✗ ./maestro mockserver setup

Project id: 37e06c0c-8300-4c46-a81a-2352ca5ff57d

Run maestro mockserver open to get started with Maestro Mock Server!
```