### PR TITLE
Adds speed and visibility percentage to scroll until visible

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -90,7 +90,7 @@ data class SwipeCommand(
 data class ScrollUntilVisibleCommand(
     val selector: ElementSelector,
     val direction: ScrollDirection,
-    val speed: Long,
+    val scrollDuration: Long,
     val visibilityPercentage: Int,
     val timeout: Long = DEFAULT_TIMEOUT_IN_MILLIS
 ) : Command {
@@ -109,7 +109,7 @@ data class ScrollUntilVisibleCommand(
 
     companion object {
         const val DEFAULT_TIMEOUT_IN_MILLIS = 20 * 1000L
-        const val DEFAULT_SCROLL_DURATION = 600L
+        const val DEFAULT_SCROLL_DURATION = 40
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
     }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -84,11 +84,18 @@ data class SwipeCommand(
     }
 }
 
+/**
+ * @param visibilityPercentage 0-1 Visibility within viewport bounds. 0 not within viewport and 1 fully visible within viewport.
+ */
 data class ScrollUntilVisibleCommand(
     val selector: ElementSelector,
     val direction: ScrollDirection,
+    val speed: Long,
+    val visibilityPercentage: Int,
     val timeout: Long = DEFAULT_TIMEOUT_IN_MILLIS
 ) : Command {
+
+    val visibilityPercentageNormalized = (visibilityPercentage / 100).toDouble()
 
     override fun description(): String {
         return "Scrolling $direction until ${selector.description()} is visible."
@@ -102,6 +109,8 @@ data class ScrollUntilVisibleCommand(
 
     companion object {
         const val DEFAULT_TIMEOUT_IN_MILLIS = 20 * 1000L
+        const val DEFAULT_SCROLL_DURATION = 600L
+        const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
     }
 }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -293,7 +293,7 @@ class Orchestra(
 
             } catch (ignored: MaestroException.ElementNotFound) {
             }
-            maestro.swipeFromCenter(direction, durationMs = command.speed)
+            maestro.swipeFromCenter(direction, durationMs = command.scrollDuration)
         } while (System.currentTimeMillis() < endTime)
 
         throw MaestroException.ElementNotFound("No visible element found: ${command.selector.description()}", maestro.viewHierarchy().root)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -22,7 +22,6 @@ package maestro.orchestra.yaml
 import com.fasterxml.jackson.annotation.JsonCreator
 import maestro.KeyCode
 import maestro.Point
-import maestro.ScrollDirection
 import maestro.orchestra.AssertConditionCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
@@ -436,11 +435,15 @@ data class YamlFluentCommand(
                 ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS
             } else yaml.timeout
 
+        val visibility = if (yaml.visibilityPercentage < 0) 0 else if (yaml.visibilityPercentage > 100) 100 else yaml.visibilityPercentage
+
         return MaestroCommand(
             ScrollUntilVisibleCommand(
                 selector = toElementSelector(yaml.element),
                 direction = yaml.direction,
-                timeout = timeout
+                timeout = timeout,
+                speed = yaml.speed,
+                visibilityPercentage = visibility
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -436,13 +436,12 @@ data class YamlFluentCommand(
             } else yaml.timeout
 
         val visibility = if (yaml.visibilityPercentage < 0) 0 else if (yaml.visibilityPercentage > 100) 100 else yaml.visibilityPercentage
-
         return MaestroCommand(
             ScrollUntilVisibleCommand(
                 selector = toElementSelector(yaml.element),
                 direction = yaml.direction,
                 timeout = timeout,
-                speed = yaml.speed,
+                scrollDuration = yaml.speedToDuration(),
                 visibilityPercentage = visibility
             )
         )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -9,4 +9,6 @@ data class YamlScrollUntilVisible(
     val direction: ScrollDirection = ScrollDirection.DOWN,
     val element: YamlElementSelectorUnion,
     val timeout: Long = ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS,
+    val speed: Long = ScrollUntilVisibleCommand.DEFAULT_SCROLL_DURATION,
+    val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -9,6 +9,10 @@ data class YamlScrollUntilVisible(
     val direction: ScrollDirection = ScrollDirection.DOWN,
     val element: YamlElementSelectorUnion,
     val timeout: Long = ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS,
-    val speed: Long = ScrollUntilVisibleCommand.DEFAULT_SCROLL_DURATION,
+    val speed: Int = ScrollUntilVisibleCommand.DEFAULT_SCROLL_DURATION,
     val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE
-)
+) {
+    fun speedToDuration(): Long {
+        return (1000 * (100 - speed).toDouble() / 100).toLong() + 1
+    }
+}

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2150,6 +2150,8 @@ class IntegrationTest {
         // Given
         val commands = readCommands("079_scroll_until_visible")
 
+        val info = driver {  }.deviceInfo()
+
         // Without view
         val driver1 = driver {
             // No elements
@@ -2164,7 +2166,7 @@ class IntegrationTest {
 
 
         // With view
-        val elementBounds = Bounds(100, 100, 100, 100)
+        val elementBounds = Bounds(0, info.heightGrid, 100, info.heightGrid+ 100)
         val driver2 = driver {
             element {
                 text = "Test"
@@ -2180,7 +2182,7 @@ class IntegrationTest {
         // Then
         driver1.assertEvents(
             listOf(
-                Event.SwipeElementWithDirection(Point(270, 480), SwipeDirection.UP, 600),
+                Event.SwipeElementWithDirection(Point(270, 480), SwipeDirection.UP, 1),
             )
         )
     }

--- a/maestro-test/src/test/resources/079_scroll_until_visible.yaml
+++ b/maestro-test/src/test/resources/079_scroll_until_visible.yaml
@@ -3,5 +3,7 @@ appId: com.example.app
 - scrollUntilVisible:
     element:
       text: "Test"
+    speed: 100
+    visibilityPercentage: 100
     direction: DOWN
-    timeout: 100
+    timeout: 10


### PR DESCRIPTION
## Proposed Changes
- Adds command configuration for scroll speed.
- Adds command configuration for element visibility on screen before assertion becomes true. (Helpful to scroll until element becomes fully visible)


## Testing
Manual & Existing integration tests

## Issues Fixed
FIx: Element detection didn't always work as intended