### PR TITLE
Minor fixes to Mock server

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerCommand.kt
@@ -8,8 +8,8 @@ import picocli.CommandLine
     subcommands = [
         MockServerDeployCommand::class,
         MockServerOpenCommand::class,
-        MockServerSetupCommand::class,
-        MockServerScaffoldCommand::class,
+        MockServerProjectIdCommand::class,
+        MockServerInitCommand::class,
     ]
 )
 class MockServerCommand {

--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerInitCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerInitCommand.kt
@@ -11,9 +11,9 @@ import java.nio.file.Files
 import java.util.concurrent.Callable
 
 @Command(
-    name = "scaffold",
+    name = "init",
 )
-class MockServerScaffoldCommand : Callable<Int> {
+class MockServerInitCommand : Callable<Int> {
 
     @ParentCommand
     lateinit var parent: MockServerCommand

--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
@@ -1,5 +1,7 @@
 package maestro.cli.command.mockserver
 
+import maestro.Driver
+import maestro.Maestro
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.view.blue
 import maestro.cli.view.bold
@@ -27,21 +29,18 @@ class MockServerOpenCommand : Callable<Int> {
     override fun call(): Int {
         interactor.getProjectId() ?: error("Not logged in. Please run `maestro login` and try again.")
 
-        MaestroSessionManager.newSession(null, null, null, true) { session ->
-            val port = getFreePort()
-            MaestroStudio.start(port, session.maestro)
+        val port = getFreePort()
+        MaestroStudio.start(port, null)
 
-            val studioUrl = "http://localhost:${port}/mock"
-            val message = ("Maestro Studio".bold() + " Mock Server is running at " + studioUrl.blue()).box()
-            println()
-            println(message)
-            tryOpenUrl(studioUrl)
+        val studioUrl = "http://localhost:${port}/mock"
+        val message = ("Maestro Studio".bold() + " Mock Server is running at " + studioUrl.blue()).box()
+        println()
+        println(message)
+        tryOpenUrl(studioUrl)
 
-            println()
-            println("Navigate to $studioUrl in your browser to open Maestro Studio Mock Server. Ctrl-C to exit.".faint())
+        println()
+        println("Navigate to $studioUrl in your browser to open Maestro Studio Mock Server. Ctrl-C to exit.".faint())
 
-            Thread.currentThread().join()
-        }
         return 0
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerProjectIdCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerProjectIdCommand.kt
@@ -8,9 +8,9 @@ import picocli.CommandLine.ParentCommand
 import java.util.concurrent.Callable
 
 @Command(
-    name = "setup",
+    name = "projectid",
 )
-class MockServerSetupCommand : Callable<Int> {
+class MockServerProjectIdCommand : Callable<Int> {
 
     @ParentCommand
     lateinit var parent: MockServerCommand

--- a/maestro-studio/server/src/main/java/maestro/studio/MaestroStudio.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/MaestroStudio.kt
@@ -14,7 +14,7 @@ import maestro.Maestro
 
 object MaestroStudio {
 
-    fun start(port: Int, maestro: Maestro) {
+    fun start(port: Int, maestro: Maestro?) {
         embeddedServer(Netty, port = port) {
             install(StatusPages) {
                 exception<HttpException> { call, cause ->
@@ -30,9 +30,11 @@ object MaestroStudio {
                 }
             }
             routing {
-                DeviceScreenService.routes(this, maestro)
-                ReplService.routes(this, maestro)
-                MockService.routes(this, maestro, MockInteractor())
+                if (maestro != null) {
+                    DeviceScreenService.routes(this, maestro)
+                    ReplService.routes(this, maestro)
+                }
+                MockService.routes(this, MockInteractor())
                 singlePageApplication {
                     useResources = true
                     filesPath = "web"

--- a/maestro-studio/server/src/main/java/maestro/studio/MockService.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/MockService.kt
@@ -26,7 +26,7 @@ private data class GetMockDataResponse(
 
 object MockService {
 
-    fun routes(routing: Routing, maestro: Maestro, interactor: MockInteractor) {
+    fun routes(routing: Routing, interactor: MockInteractor) {
         routing.get("/api/mock-server/data") {
             val data = GetMockDataResponse(
                 projectId = interactor.getProjectId(),

--- a/maestro-studio/web/src/MockServerInstructions.tsx
+++ b/maestro-studio/web/src/MockServerInstructions.tsx
@@ -13,7 +13,7 @@ const MockServerInstructions = ({ projectId }: { projectId?: string }) => (
       <div>
         <p className="text-md">Then, initialize the Maestro SDK in your app:</p>
         <CodeSnippet>{`MaestroSdk.init('${projectId || '<your_project_id>'}')`}</CodeSnippet>
-        <p className="text-md">You can retrieve your project id by running <span className="italic">maestro mockserver setup</span>.</p>
+        <p className="text-md">You can retrieve your project id by running <span className="italic">maestro mockserver projectid</span>.</p>
       </div>
 
       <div>
@@ -24,7 +24,7 @@ const MockServerInstructions = ({ projectId }: { projectId?: string }) => (
 
       <div>
         <p className="text-md">Lastly, deploy a set of rules to the Maestro Mock Server. You can either write your own rules or use the following command to scaffold a sample rule to get started:</p>
-        <CodeSnippet>{`maestro mockserver scaffold`}</CodeSnippet>
+        <CodeSnippet>{`maestro mockserver init`}</CodeSnippet>
       </div>
 
       <p className="font-semibold">That's it! Now, build and run your app and you should start seeing events come in!</p>


### PR DESCRIPTION
- Don't require a running simulator/emulator when launching mockserver
- Rename `mockserver scaffold` and `mockserver setup` commands to be more descriptive