### PR TITLE
Fix maestro mockserver open command exiting

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
@@ -1,6 +1,7 @@
 package maestro.cli.command.mockserver
 
 import maestro.cli.session.MaestroSessionManager
+import maestro.cli.session.SessionStore
 import maestro.cli.view.blue
 import maestro.cli.view.bold
 import maestro.cli.view.box
@@ -13,6 +14,7 @@ import java.awt.Desktop
 import java.net.ServerSocket
 import java.net.URI
 import java.util.concurrent.Callable
+import kotlin.concurrent.thread
 
 @Command(
     name = "open",
@@ -27,21 +29,20 @@ class MockServerOpenCommand : Callable<Int> {
     override fun call(): Int {
         interactor.getProjectId() ?: error("Not logged in. Please run `maestro login` and try again.")
 
-        MaestroSessionManager.newSession(null, null, null, true) { _ ->
-            val port = getFreePort()
-            MaestroStudio.start(port, null)
+        val port = getFreePort()
+        MaestroStudio.start(port, null)
 
-            val studioUrl = "http://localhost:${port}/mock"
-            val message = ("Maestro Studio".bold() + " Mock Server is running at " + studioUrl.blue()).box()
-            println()
-            println(message)
-            tryOpenUrl(studioUrl)
+        val studioUrl = "http://localhost:${port}/mock"
+        val message = ("Maestro Studio".bold() + " Mock Server is running at " + studioUrl.blue()).box()
+        println()
+        println(message)
+        tryOpenUrl(studioUrl)
 
-            println()
-            println("Navigate to $studioUrl in your browser to open Maestro Studio Mock Server. Ctrl-C to exit.".faint())
+        println()
+        println("Navigate to $studioUrl in your browser to open Maestro Studio Mock Server. Ctrl-C to exit.".faint())
 
-            Thread.currentThread().join()
-        }
+        Thread.currentThread().join()
+
         return 0
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
@@ -1,7 +1,5 @@
 package maestro.cli.command.mockserver
 
-import maestro.Driver
-import maestro.Maestro
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.view.blue
 import maestro.cli.view.bold
@@ -29,18 +27,21 @@ class MockServerOpenCommand : Callable<Int> {
     override fun call(): Int {
         interactor.getProjectId() ?: error("Not logged in. Please run `maestro login` and try again.")
 
-        val port = getFreePort()
-        MaestroStudio.start(port, null)
+        MaestroSessionManager.newSession(null, null, null, true) { _ ->
+            val port = getFreePort()
+            MaestroStudio.start(port, null)
 
-        val studioUrl = "http://localhost:${port}/mock"
-        val message = ("Maestro Studio".bold() + " Mock Server is running at " + studioUrl.blue()).box()
-        println()
-        println(message)
-        tryOpenUrl(studioUrl)
+            val studioUrl = "http://localhost:${port}/mock"
+            val message = ("Maestro Studio".bold() + " Mock Server is running at " + studioUrl.blue()).box()
+            println()
+            println(message)
+            tryOpenUrl(studioUrl)
 
-        println()
-        println("Navigate to $studioUrl in your browser to open Maestro Studio Mock Server. Ctrl-C to exit.".faint())
+            println()
+            println("Navigate to $studioUrl in your browser to open Maestro Studio Mock Server. Ctrl-C to exit.".faint())
 
+            Thread.currentThread().join()
+        }
         return 0
     }
 

--- a/maestro-studio/server/src/main/java/maestro/studio/MockInteractor.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/MockInteractor.kt
@@ -55,6 +55,8 @@ class MockInteractor(
         }
         val response = client.newCall(request).execute()
 
+        if (response.code >= 400) error("Invalid token. Please run `maestro logout` and then `maestro login` to retrieve a valid token.")
+
         response.use {
             try {
                 val auth = JSON.readValue(response.body?.bytes(), Auth::class.java)

--- a/maestro-studio/web/src/MockPage.tsx
+++ b/maestro-studio/web/src/MockPage.tsx
@@ -37,7 +37,7 @@ const safeParse = (res: any, fallback: Object): Object => {
 const MockPage = () => {
   const [selectedEvent, setSelectedEvent] = useState<MockEvent | undefined>()
   const [query, setQuery] = useState<string>('')
-  const {data, isLoading} = API.useMockData()
+  const {data, isLoading} = API.useMockData({ refreshInterval: 5000 })
 
   const filteredEvents = useMemo(() => {
     return data?.events?.filter(event => {

--- a/maestro-studio/web/src/MockServerInstructions.tsx
+++ b/maestro-studio/web/src/MockServerInstructions.tsx
@@ -12,7 +12,7 @@ const MockServerInstructions = ({ projectId }: { projectId?: string }) => (
 
       <div>
         <p className="text-md">Then, initialize the Maestro SDK in your app:</p>
-        <CodeSnippet>{`MaestroSdk.init('${projectId || '<your_project_id>'}')`}</CodeSnippet>
+        <CodeSnippet>{`MaestroSdk.init("${projectId || '<your_project_id>'}")`}</CodeSnippet>
         <p className="text-md">You can retrieve your project id by running <span className="italic">maestro mockserver projectid</span>.</p>
       </div>
 

--- a/maestro-studio/web/src/MockServerInstructions.tsx
+++ b/maestro-studio/web/src/MockServerInstructions.tsx
@@ -18,16 +18,17 @@ const MockServerInstructions = ({ projectId }: { projectId?: string }) => (
 
       <div>
         <p className="text-md">Next step is to update your app to use the API base url provided by Maestro SDK:</p>
-        <CodeSnippet>{`val baseUrl = MaestroSdk.mockServer().url("<normal_api_url>")`}</CodeSnippet>
+        <CodeSnippet>{`val baseUrl = MaestroSdk.mockServer().url("https://api.yourdomain.com")`}</CodeSnippet>
         <p className="text-md">You can then use <span className="italic">baseUrl</span> as you would normally do in your app. Requests will be sent to <span className="italic">https://mock.mobile.dev</span> and forwarded to your original API if no mock rules are found.</p>
       </div>
+      
+      <p className="font-semibold">That's it! Now, build and run your app and you should start seeing events come in!</p>
 
       <div>
-        <p className="text-md">Lastly, deploy a set of rules to the Maestro Mock Server. You can either write your own rules or use the following command to scaffold a sample rule to get started:</p>
+        <p className="text-md mb-2">(Optional) If you want to get started with writing rules right away, you can run the following command to scaffold and deploy a sample rule:</p>
         <CodeSnippet>{`maestro mockserver init`}</CodeSnippet>
       </div>
 
-      <p className="font-semibold">That's it! Now, build and run your app and you should start seeing events come in!</p>
     </div>
   </div>
 )

--- a/maestro-studio/web/src/api.ts
+++ b/maestro-studio/web/src/api.ts
@@ -82,8 +82,8 @@ export const API = {
       return makeRequest('POST', '/api/repl/command/format', { ids })
     },
   },
-  useMockData: () => {
-    return useSWR<GetMockDataResponse>('/api/mock-server/data', fetcher)
+  useMockData: (config?: SWRConfiguration) => {
+    return useSWR<GetMockDataResponse>('/api/mock-server/data', fetcher, config)
   }
 }
 


### PR DESCRIPTION
- Fix a bug causing mock server UI to exit right after opening instead of waiting on Ctrl  + C
- Fix syntax error in welcome instructions