### PR TITLE
Feature/deterministic order

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/WorkspaceExecutionPlanner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/WorkspaceExecutionPlanner.kt
@@ -40,6 +40,13 @@ object WorkspaceExecutionPlanner {
                 matchers.any { matcher -> matcher.matches(path) }
             }
             .toList()
+            .let { list ->
+                if (workspaceConfig.local?.deterministicOrder == true) {
+                    list.sortedBy { it.name }
+                } else {
+                    list
+                }
+            }
 
         val globalIncludeTags = workspaceConfig.includeTags?.toList() ?: emptyList()
         val globalExcludeTags = workspaceConfig.excludeTags?.toList() ?: emptyList()

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/WorkspaceExecutionPlannerTest.kt
@@ -198,6 +198,23 @@ internal class WorkspaceExecutionPlannerTest {
         )
     }
 
+    @Test
+    internal fun `012 - Deterministic order for local tests`() {
+        // When
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = path("/workspaces/012_local_deterministic_order"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+        )
+
+        // Then
+        assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/012_local_deterministic_order/flowA.yaml"),
+            path("/workspaces/012_local_deterministic_order/flowB.yaml"),
+            path("/workspaces/012_local_deterministic_order/flowC.yaml"),
+        ).inOrder()
+    }
+
     private fun path(pathStr: String): Path {
         return Paths.get(WorkspaceExecutionPlannerTest::class.java.getResource(pathStr).toURI())
     }

--- a/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/config.yaml
+++ b/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/config.yaml
@@ -1,0 +1,2 @@
+local:
+  deterministicOrder: true

--- a/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/flowA.yaml
+++ b/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/flowA.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/flowB.yaml
+++ b/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/flowB.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/flowC.yaml
+++ b/maestro-cli/src/test/resources/workspaces/012_local_deterministic_order/flowC.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
@@ -7,12 +7,17 @@ data class WorkspaceConfig(
     val flows: StringList? = null,
     val includeTags: StringList? = null,
     val excludeTags: StringList? = null,
+    val local: Local? = null,
 ) {
 
     @JsonAnySetter
     fun setOtherField(key: String, other: Any?) {
         // Do nothing
     }
+
+    data class Local(
+        val deterministicOrder: Boolean? = null,
+    )
 
     class StringList : ArrayList<String>() {
 


### PR DESCRIPTION
## Proposed Changes

Forcing tests to be executed in a deterministic order when running _locally_ by updating `config.yaml`:

```
# config.yaml

local:
    deterministicOrder: true
```