### PR TITLE
Resolve crashes after clearState due to missing system directories

### DIFF
--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -336,15 +336,27 @@ class IdbIOSDevice(
         }
 
         // forces app container folder to be re-created
+        val paths = listOf(
+            "Documents",
+            "Library",
+            "Library/Caches",
+            "Library/Preferences",
+            "SystemData",
+            "tmp"
+        )
+
         runCatching {
-            blockingStub.mkdir(mkdirRequest {
-                container = fileContainer {
-                    kind = Idb.FileContainer.Kind.APPLICATION
-                    bundleId = id
-                }
-                path = "tmp"
-            })
+            paths.forEach { path ->
+                blockingStub.mkdir(mkdirRequest {
+                    container = fileContainer {
+                        kind = Idb.FileContainer.Kind.APPLICATION
+                        bundleId = id
+                    }
+                    this.path = path
+                })
+            }
         }
+
         return result
     }
 


### PR DESCRIPTION
## Proposed Changes

After removing the app's data folder, create all directories that are supplied by the OS by default.

## Testing

Ran flows on various customer apps that used to crash with clearState

## Issues Fixed

https://github.com/mobile-dev-inc/maestro/issues/732