### PR TITLE
Fix: repeat.times was not working with JS input

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -325,7 +325,7 @@ class Orchestra(
     }
 
     private fun repeatCommand(command: RepeatCommand, maestroCommand: MaestroCommand): Boolean {
-        val maxRuns = command.times?.toIntOrNull() ?: Int.MAX_VALUE
+        val maxRuns = command.times?.toDoubleOrNull()?.toInt() ?: Int.MAX_VALUE
 
         var counter = 0
         var metadata = getMetadata(maestroCommand)

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1519,6 +1519,9 @@ class IntegrationTest {
                 Event.Tap(Point(50, 50)),
                 Event.Tap(Point(50, 50)),
                 Event.Tap(Point(50, 50)),
+                Event.Tap(Point(50, 50)),
+                Event.Tap(Point(50, 50)),
+                Event.Tap(Point(50, 50)),
             )
         )
     }

--- a/maestro-test/src/test/resources/053_repeat_times.yaml
+++ b/maestro-test/src/test/resources/053_repeat_times.yaml
@@ -5,3 +5,9 @@ appId: com.other.app
     commands:
       - tapOn: Button
 - assertVisible: "3"
+- evalScript: ${output.list = [1, 2, 3]}
+- repeat:
+    times: ${output.list.length}
+    commands:
+      - tapOn: Button
+- assertVisible: "6"


### PR DESCRIPTION
## Proposed Changes

Rhino JS returns values as Double instead of Int, so we need to do conversion String->Double->Int instead of String->Int