### PR TITLE
Add default workspace directory to mockserver deploy command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerDeployCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerDeployCommand.kt
@@ -18,7 +18,7 @@ class MockServerDeployCommand : Callable<Int> {
     @ParentCommand
     lateinit var parent: MockServerCommand
 
-    @Parameters
+    @Parameters(arity = "0..1")
     lateinit var workspace: File
 
     @Option(order = 0, names = ["--apiKey"], description = ["API key"])
@@ -30,7 +30,18 @@ class MockServerDeployCommand : Callable<Int> {
     @CommandLine.Spec
     lateinit var commandSpec: CommandLine.Model.CommandSpec
 
+    private fun getDefaultMockserverDir(): File {
+        val currentDir = System.getProperty("user.dir")
+        val maestroDirPath = "$currentDir/.maestro/mockserver"
+
+        return File(maestroDirPath)
+    }
+
     override fun call(): Int {
+        if (!this::workspace.isInitialized) {
+            workspace = getDefaultMockserverDir()
+        }
+
         if (!workspace.isDirectory) {
             throw CommandLine.ParameterException(
                 commandSpec.commandLine(),
@@ -44,8 +55,6 @@ class MockServerDeployCommand : Callable<Int> {
             workspace = workspace,
             apiKey = apiKey,
         )
-
-        return 0
     }
 
 }

--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerDeployCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerDeployCommand.kt
@@ -32,9 +32,9 @@ class MockServerDeployCommand : Callable<Int> {
 
     private fun getDefaultMockserverDir(): File {
         val currentDir = System.getProperty("user.dir")
-        val maestroDirPath = "$currentDir/.maestro/mockserver"
+        val defaultWorkspaceDirPath = "$currentDir/.maestro/mockserver"
 
-        return File(maestroDirPath)
+        return File(defaultWorkspaceDirPath)
     }
 
     override fun call(): Int {


### PR DESCRIPTION
## Proposed Changes
Make `workspace` an optional argument and fallback to `./maestro/mockserver` when not specified. If that directory exists, use that when deploying the rules. It is still possible to specify the directory of rules by running `maestro mockserver deploy <directory>` so this is just for convenience.

## Testing
Tested locally.

## Issues Fixed