### PR TITLE
Use xcrun for clearKeychain

### DIFF
--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -92,7 +92,7 @@ class LocalIOSDevice(
     }
 
     override fun clearKeychain(): Result<Unit, Throwable> {
-        return idbIOSDevice.clearKeychain()
+        return simctlIOSDevice.clearKeychain()
     }
 
     override fun launch(id: String): Result<Unit, Throwable> {

--- a/maestro-ios/src/main/java/ios/simctl/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/simctl/Simctl.kt
@@ -9,6 +9,7 @@ import java.io.File
 object Simctl {
 
     data class SimctlError(override val message: String): Throwable(message)
+    private val homedir = System.getProperty("user.home")
 
     fun list(): SimctlList {
         val command = listOf("xcrun", "simctl", "list", "-j")
@@ -197,6 +198,39 @@ object Simctl {
                 "openurl",
                 deviceId,
                 url,
+            )
+        )
+    }
+
+    fun clearKeychain(deviceId: String) {
+        CommandLineUtils.runCommand(
+            listOf(
+                "xcrun",
+                "simctl",
+                "spawn",
+                deviceId,
+                "launchctl",
+                "stop",
+                "com.apple.securityd",
+            )
+        )
+
+        CommandLineUtils.runCommand(
+            listOf(
+                "rm", "-rf",
+                "$homedir/Library/Developer/CoreSimulator/Devices/$deviceId/data/Library/Keychains"
+            )
+        )
+
+        CommandLineUtils.runCommand(
+            listOf(
+                "xcrun",
+                "simctl",
+                "spawn",
+                deviceId,
+                "launchctl",
+                "start",
+                "com.apple.securityd",
             )
         )
     }

--- a/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
@@ -74,7 +74,9 @@ class SimctlIOSDevice(
     }
 
     override fun clearKeychain(): Result<Unit, Throwable> {
-        TODO("Not yet implemented")
+        return runCatching {
+            Simctl.clearKeychain(deviceId)
+        }
     }
 
     override fun launch(id: String): Result<Unit, Throwable> {


### PR DESCRIPTION
## Proposed Changes

## Testing
Tested using patch in Wikipedia app:

```
    func readKeychain() -> Bool {
        let query = [
            kSecClass: kSecClassGenericPassword,
            kSecReturnData: true
        ] as CFDictionary

        var result: AnyObject?
        SecItemCopyMatching(query, &result)

        return (result as? Data)?.isEmpty == false
    }

    func setKeychain() {
        let query = [
            kSecValueData: "data".data(using: .utf8)!,
            kSecClass: kSecClassGenericPassword
        ] as CFDictionary

        let status = SecItemAdd(query, nil)

        if status != errSecSuccess {
            print("Keychain error: \(status)")
        }
    }

    private func updateUIStrings() {

        let text = readKeychain() ? "Keychain set" : "Keychain cleared"
        setKeychain()
```

* launch app: Keychain cleared
* kill and relaunch app: Keychain set
* Run flow with launchApp with clearKeychain: Keychain cleared