### PR TITLE
Refactor unsafe subprocess calls to safer ones

### DIFF
--- a/maestro-ios/src/main/java/ios/simctl/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/simctl/Simctl.kt
@@ -45,14 +45,30 @@ object Simctl {
     }
 
     fun launchSimulator(deviceId: String) {
-        CommandLineUtils.runCommand("xcrun simctl boot $deviceId")
+        CommandLineUtils.runCommand(
+            listOf(
+                "xcrun",
+                "simctl",
+                "boot",
+                deviceId
+            )
+        )
 
         var exceptionToThrow: Exception? = null
 
         // Up to 10 iterations => max wait time of 1 second
         repeat(10) {
             try {
-                CommandLineUtils.runCommand("open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app --args -CurrentDeviceUDID $deviceId")
+                CommandLineUtils.runCommand(
+                    listOf(
+                        "open",
+                        "-a",
+                        "/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app",
+                        "--args",
+                        "-CurrentDeviceUDID",
+                        deviceId
+                    )
+                )
                 return
             } catch (e: Exception) {
                 exceptionToThrow = e

--- a/maestro-xcuitest-driver/src/main/kotlin/util/CommandLineUtils.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/util/CommandLineUtils.kt
@@ -9,26 +9,13 @@ import java.util.concurrent.TimeoutException
 
 object CommandLineUtils {
 
-    private val NULL_FILE = File(
-        if (System.getProperty("os.name")
-                .startsWith("Windows")
-        ) "NUL" else "/dev/null"
-    )
-
-    // Deprecated: `runCommand("foo $bar")` $bar may contain spaces and forms a security risk
-    @Deprecated("use runCommand(listOf(...)) instead")
-    fun runCommand(command: String, waitForCompletion: Boolean = true, outputFile: File? = null): Process {
-        LOGGER.info("Running command line operation: $command")
-
-        val parts = command.split("\\s".toRegex())
-            .map { it.trim() }
-
-        return runCommand(parts, waitForCompletion, outputFile)
-    }
+    private val isWindows = System.getProperty("os.name").startsWith("Windows")
+    private val nullFile = File(if (isWindows) "NUL" else "/dev/null")
+    private val logger = LoggerFactory.getLogger(CommandLineUtils::class.java)
 
     @Suppress("SpreadOperator")
     fun runCommand(parts: List<String>, waitForCompletion: Boolean = true, outputFile: File? = null): Process {
-        LOGGER.info("Running command line operation: $parts")
+        logger.info("Running command line operation: $parts")
 
         val process = if (outputFile != null) {
             ProcessBuilder(*parts.toTypedArray())
@@ -37,8 +24,8 @@ object CommandLineUtils {
                 .start()
         } else {
             ProcessBuilder(*parts.toTypedArray())
-                .redirectOutput(NULL_FILE)
-                .redirectError(NULL_FILE)
+                .redirectOutput(nullFile)
+                .redirectError(nullFile)
                 .start()
         }
 
@@ -53,8 +40,8 @@ object CommandLineUtils {
                     .buffer()
                     .readUtf8()
 
-                LOGGER.error("Process failed with exit code ${process.exitValue()}")
-                LOGGER.error(processOutput)
+                logger.error("Process failed with exit code ${process.exitValue()}")
+                logger.error(processOutput)
 
                 throw IllegalStateException(processOutput)
             }
@@ -62,6 +49,4 @@ object CommandLineUtils {
 
         return process
     }
-
-    private val LOGGER = LoggerFactory.getLogger(CommandLineUtils::class.java)
 }

--- a/maestro-xcuitest-driver/src/main/kotlin/util/XCRunnerSimctl.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/util/XCRunnerSimctl.kt
@@ -70,7 +70,15 @@ object XCRunnerSimctl {
     }
 
     fun uninstall(bundleId: String) {
-        CommandLineUtils.runCommand("xcrun simctl uninstall booted $bundleId")
+        CommandLineUtils.runCommand(
+            listOf(
+                "xcrun",
+                "simctl",
+                "uninstall",
+                "booted",
+                bundleId
+            )
+        )
     }
 
     fun ensureAppAlive(bundleId: String) {
@@ -81,9 +89,12 @@ object XCRunnerSimctl {
 
     fun isAppAlive(bundleId: String): Boolean {
         val process = ProcessBuilder(
-            "bash",
-            "-c",
-            "xcrun simctl spawn booted launchctl list | grep $bundleId | awk '/$bundleId/ {print \$3}'"
+            "xcrun",
+            "simctl",
+            "spawn",
+            "booted",
+            "launchctl",
+            "list"
         ).start()
 
         val processOutput = process.inputStream.source().buffer().readUtf8().trim()
@@ -95,7 +106,14 @@ object XCRunnerSimctl {
     fun runXcTestWithoutBuild(deviceId: String, xcTestRunFilePath: String): Process {
         val date = dateFormatter.format(LocalDateTime.now())
         return CommandLineUtils.runCommand(
-            "xcodebuild test-without-building -xctestrun $xcTestRunFilePath -destination id=$deviceId",
+            listOf(
+                "xcodebuild",
+                "test-without-building",
+                "-xctestrun",
+                xcTestRunFilePath,
+                "-destination",
+                "id=$deviceId",
+            ),
             waitForCompletion = false,
             outputFile = File(logDirectory, "xctest_runner_$date.log")
         )


### PR DESCRIPTION
## Proposed Changes

Refactor all subprocess calls which use string interpolation to pass separate arguments instead.

