### PR TITLE
WebDriver: Use element title as id correctly

### DIFF
--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -34,7 +34,7 @@
       }
 
       if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor) {
-        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.htmlFor
+        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.title || node.htmlFor
       }
 
       if (node.tagName.toLowerCase() === 'body') {


### PR DESCRIPTION
Fixes a bug where the element title was checked for truthiness but was not then selected as the node id.