### PR TITLE
Remove SetLocationCommand

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -567,20 +567,6 @@ data class RunFlowCommand(
 
 }
 
-data class SetLocationCommand(
-    val latitude: Double,
-    val longitude: Double,
-) : Command {
-
-    override fun description(): String {
-        return "Set location (${latitude}, ${longitude})"
-    }
-
-    override fun evaluateScripts(jsEngine: JsEngine): SetLocationCommand {
-        return this
-    }
-}
-
 data class RepeatCommand(
     val times: String? = null,
     val condition: Condition? = null,

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -49,7 +49,6 @@ data class MaestroCommand(
     val clearStateCommand: ClearStateCommand? = null,
     val clearKeychainCommand: ClearKeychainCommand? = null,
     val runFlowCommand: RunFlowCommand? = null,
-    val setLocationCommand: SetLocationCommand? = null,
     val repeatCommand: RepeatCommand? = null,
     val copyTextCommand: CopyTextFromCommand? = null,
     val pasteTextCommand: PasteTextCommand? = null,
@@ -83,7 +82,6 @@ data class MaestroCommand(
         clearStateCommand = command as? ClearStateCommand,
         clearKeychainCommand = command as? ClearKeychainCommand,
         runFlowCommand = command as? RunFlowCommand,
-        setLocationCommand = command as? SetLocationCommand,
         repeatCommand = command as? RepeatCommand,
         copyTextCommand = command as? CopyTextFromCommand,
         pasteTextCommand = command as? PasteTextCommand,
@@ -117,7 +115,6 @@ data class MaestroCommand(
         clearStateCommand != null -> clearStateCommand
         clearKeychainCommand != null -> clearKeychainCommand
         runFlowCommand != null -> runFlowCommand
-        setLocationCommand != null -> setLocationCommand
         repeatCommand != null -> repeatCommand
         copyTextCommand != null -> copyTextCommand
         pasteTextCommand != null -> pasteTextCommand

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -185,7 +185,6 @@ class Orchestra(
             is ClearStateCommand -> clearAppStateCommand(command)
             is ClearKeychainCommand -> clearKeychainCommand()
             is RunFlowCommand -> runFlowCommand(command)
-            is SetLocationCommand -> setLocationCommand(command)
             is RepeatCommand -> repeatCommand(command, maestroCommand)
             is DefineVariablesCommand -> defineVariablesCommand(command)
             is RunScriptCommand -> runScriptCommand(command)
@@ -254,12 +253,6 @@ class Orchestra(
         }
 
         return false
-    }
-
-    private fun setLocationCommand(command: SetLocationCommand): Boolean {
-        maestro.setLocation(command.latitude, command.longitude)
-
-        return true
     }
 
     private fun clearAppStateCommand(command: ClearStateCommand): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -46,7 +46,6 @@ import maestro.orchestra.RunFlowCommand
 import maestro.orchestra.RunScriptCommand
 import maestro.orchestra.ScrollCommand
 import maestro.orchestra.ScrollUntilVisibleCommand
-import maestro.orchestra.SetLocationCommand
 import maestro.orchestra.StopAppCommand
 import maestro.orchestra.SwipeCommand
 import maestro.orchestra.TakeScreenshotCommand
@@ -167,14 +166,6 @@ data class YamlFluentCommand(
                         commands = runFlow(flowPath, runFlow),
                         condition = runFlow.`when`?.toCondition(),
                         sourceDescription = runFlow.file,
-                    )
-                )
-            )
-            setLocation != null -> listOf(
-                MaestroCommand(
-                    SetLocationCommand(
-                        latitude = setLocation.latitude,
-                        longitude = setLocation.longitude,
                     )
                 )
             )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -82,7 +82,6 @@ data class YamlFluentCommand(
     val stopApp: YamlStopApp? = null,
     val clearState: YamlClearState? = null,
     val runFlow: YamlRunFlow? = null,
-    val setLocation: YamlSetLocation? = null,
     val repeat: YamlRepeatCommand? = null,
     val copyTextFrom: YamlElementSelectorUnion? = null,
     val runScript: YamlRunScript? = null,

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1418,30 +1418,31 @@ class IntegrationTest {
         driver.assertEventCount(Event.Tap(Point(50, 50)), 1)
     }
 
-    @Test
-    fun `Case 051 - Set location`() {
-        // Given
-        val commands = readCommands("051_set_location")
+    // NOTE setLocation is removed until properly supported
+    // @Test
+    // fun `Case 051 - Set location`() {
+    //     // Given
+    //     val commands = readCommands("051_set_location")
 
-        val driver = driver {
-        }
+    //     val driver = driver {
+    //     }
 
-        driver.addInstalledApp("com.example.app")
+    //     driver.addInstalledApp("com.example.app")
 
-        // When
-        Maestro(driver).use {
-            orchestra(it).runFlow(commands)
-        }
+    //     // When
+    //     Maestro(driver).use {
+    //         orchestra(it).runFlow(commands)
+    //     }
 
-        // Then
-        // No test failure
-        driver.assertEvents(
-            listOf(
-                Event.LaunchApp("com.example.app"),
-                Event.SetLocation(12.5266, 78.2150),
-            )
-        )
-    }
+    //     // Then
+    //     // No test failure
+    //     driver.assertEvents(
+    //         listOf(
+    //             Event.LaunchApp("com.example.app"),
+    //             Event.SetLocation(12.5266, 78.2150),
+    //         )
+    //     )
+    // }
 
     @Test
     fun `Case 052 - Input random`() {


### PR DESCRIPTION
## Proposed Changes
This removes support for `setLocation` since this command is not implemented on Android/Web and not properly supported on iOS. It does leave the iOS code implementation though so whenever we do decide to tackle this down the road we can reuse the existing implementation. 

## Testing
Tested locally, entering `setLocation` is not considered a valid command.