### PR TITLE
Fix uninitialized jsEngine in Orchestra; Respect duration in relative swipe command

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -123,6 +123,8 @@ class Orchestra(
     fun executeCommands(
         commands: List<MaestroCommand>,
     ): Boolean {
+        jsEngine.init()
+
         commands
             .forEachIndexed { index, command ->
                 onCommandStart(index, command)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -355,7 +355,7 @@ data class YamlFluentCommand(
             }
             is YamlRelativeCoordinateSwipe -> {
                 return MaestroCommand(
-                    SwipeCommand(startRelative = swipe.start, endRelative = swipe.end)
+                    SwipeCommand(startRelative = swipe.start, endRelative = swipe.end, duration = swipe.duration)
                 )
             }
             is YamlSwipeElement -> return swipeElementCommand(swipe)

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2143,7 +2143,7 @@ class IntegrationTest {
         val expectedStart = Point(deviceInfo.widthGrid / 2, deviceInfo.heightGrid * 30 / 100)
         val expectedEnd = Point(deviceInfo.widthGrid / 2, deviceInfo.heightGrid * 60 / 100)
         driver.assertHasEvent(
-            Event.Swipe(start = expectedStart, End = expectedEnd, durationMs = 400)
+            Event.Swipe(start = expectedStart, End = expectedEnd, durationMs = 3000)
         )
     }
 


### PR DESCRIPTION
Fixes the following issues:
- Use specified duration instead of default 400 ms for relative swipe command
- Initialize `jsEngine` in `Orchestra.executeCommand` to avoid an unhandled exception thrown as part of executing repeat commands from Studio:

```
kotlin.UninitializedPropertyAccessException: lateinit property currentScope has not been initialized
```

## Testing
This has been tested locally and I also update test case `078` to have a correct assertion.