### PR TITLE
[MOB 1869] Auto verify opening deeplinks on Android

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ squareOkio = "3.2.0"
 squareRetrofit = "2.9.0"
 webdrivermanager = "5.3.1"
 wiremock = "2.35.0"
+apkParser =  "2.6.10"
 
 [libraries]
 android-tools-apkparser = { module = "com.android.tools.apkparser:apkanalyzer", version.ref = "androidToolsApkParser" }
@@ -104,6 +105,7 @@ square-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "s
 square-retrofit-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "squareRetrofit" }
 webdrivermanager = { module = "io.github.bonigarcia:webdrivermanager", version.ref = "webdrivermanager" }
 wiremock-jre8 = { module = "com.github.tomakehurst:wiremock-jre8", version.ref = "wiremock" }
+apk-parser = { module = "net.dongliu:apk-parser", version.ref = "apkParser" }
 
 [bundles]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ androidxCore = "1.9.0"
 androidxEspresso = "3.4.0"
 androidxTestJunit = "1.1.3"
 androidxUiautomator = "2.2.0"
+apkParser =  "2.6.10"
 appdirs = "1.2.1"
 axml = "2.1.2"
 dadb = "1.2.6"
@@ -44,7 +45,6 @@ squareOkio = "3.2.0"
 squareRetrofit = "2.9.0"
 webdrivermanager = "5.3.1"
 wiremock = "2.35.0"
-apkParser =  "2.6.10"
 
 [libraries]
 android-tools-apkparser = { module = "com.android.tools.apkparser:apkanalyzer", version.ref = "androidToolsApkParser" }
@@ -55,6 +55,7 @@ androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxEspresso" }
 androidx-test-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestJunit" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidxUiautomator" }
+apk-parser = { module = "net.dongliu:apk-parser", version.ref = "apkParser" }
 appdirs = { module = "net.harawata:appdirs", version.ref = "appdirs" }
 axml = { module = "de.upb.cs.swt:axml", version.ref = "axml" }
 dadb = { module = "dev.mobile:dadb", version.ref = "dadb" }
@@ -105,7 +106,6 @@ square-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "s
 square-retrofit-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "squareRetrofit" }
 webdrivermanager = { module = "io.github.bonigarcia:webdrivermanager", version.ref = "webdrivermanager" }
 wiremock-jre8 = { module = "com.github.tomakehurst:wiremock-jre8", version.ref = "wiremock" }
-apk-parser = { module = "net.dongliu:apk-parser", version.ref = "apkParser" }
 
 [bundles]
 

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     api(libs.jackson.module.kotlin)
     api(libs.jackson.dataformat.yaml)
     api(libs.jackson.dataformat.xml)
+    api(libs.apk.parser)
 
     implementation project(':maestro-ios')
     implementation(libs.google.findbugs)

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -64,12 +64,7 @@ interface Driver {
 
     fun inputText(text: String)
 
-    fun openLink(link: String, appId: String?, autoVerify: Boolean)
-
-    /**
-     * Similar to open link. On Android it explicitly mentions the app id of web browsers and iOS remains same.
-     */
-    fun openBrowser(link: String)
+    fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean)
 
     fun hideKeyboard()
 

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -66,6 +66,8 @@ interface Driver {
 
     fun openLink(link: String)
 
+    fun openBrowser(link: String)
+
     fun hideKeyboard()
 
     fun takeScreenshot(out: Sink, compressed: Boolean)

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -64,7 +64,7 @@ interface Driver {
 
     fun inputText(text: String)
 
-    fun openLink(link: String)
+    fun openLink(link: String, autoVerify: Boolean)
 
     fun openBrowser(link: String)
 

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -64,8 +64,11 @@ interface Driver {
 
     fun inputText(text: String)
 
-    fun openLink(link: String, autoVerify: Boolean)
+    fun openLink(link: String, appId: String?, autoVerify: Boolean)
 
+    /**
+     * Similar to open link. On Android it explicitly mentions the app id of web browsers and iOS remains same.
+     */
     fun openBrowser(link: String)
 
     fun hideKeyboard()

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -25,8 +25,8 @@ import maestro.Filters.asFilter
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.drivers.AndroidDriver
 import maestro.drivers.WebDriver
-import maestro.utils.ScreenshotUtils
 import maestro.utils.MaestroTimer
+import maestro.utils.ScreenshotUtils
 import maestro.utils.SocketUtils
 import okio.Sink
 import okio.buffer
@@ -423,23 +423,11 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-    fun openLink(link: String, autoVerify: Boolean) {
-        driver.openLink(link, autoVerify)
+    fun openLink(link: String, appId: String?, autoVerify: Boolean) {
+        LOGGER.info("Opening link $link for app: $appId with autoVerify config as $autoVerify")
+
+        driver.openLink(link, appId, autoVerify)
         waitForAppToSettle()
-    }
-
-    fun autoVerifyApp(appId: String?) {
-        if (driver is AndroidDriver) {
-            driver.autoVerifyApp(appId)
-            waitForAppToSettle()
-        }
-    }
-
-    fun autoVerifyChromeAgreement(verifyGoogleChromeAgreement: () -> Unit) {
-        if (driver is AndroidDriver) {
-            verifyGoogleChromeAgreement()
-            waitForAppToSettle()
-        }
     }
 
     fun openBrowser(link: String) {

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -423,15 +423,10 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-    fun openLink(link: String, appId: String?, autoVerify: Boolean) {
+    fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
         LOGGER.info("Opening link $link for app: $appId with autoVerify config as $autoVerify")
 
-        driver.openLink(link, appId, autoVerify)
-        waitForAppToSettle()
-    }
-
-    fun openBrowser(link: String) {
-        driver.openBrowser(link)
+        driver.openLink(link, appId, autoVerify, browser)
         waitForAppToSettle()
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -24,7 +24,6 @@ import dadb.Dadb
 import maestro.Filters.asFilter
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.drivers.AndroidDriver
-import maestro.drivers.IOSDriver
 import maestro.drivers.WebDriver
 import maestro.utils.ScreenshotUtils
 import maestro.utils.MaestroTimer
@@ -427,6 +426,20 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun openLink(link: String, autoVerify: Boolean) {
         driver.openLink(link, autoVerify)
         waitForAppToSettle()
+    }
+
+    fun autoVerifyApp(appId: String?) {
+        if (driver is AndroidDriver) {
+            driver.autoVerifyApp(appId)
+            waitForAppToSettle()
+        }
+    }
+
+    fun autoVerifyChromeAgreement(verifyGoogleChromeAgreement: () -> Unit) {
+        if (driver is AndroidDriver) {
+            verifyGoogleChromeAgreement()
+            waitForAppToSettle()
+        }
     }
 
     fun openBrowser(link: String) {

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -424,8 +424,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
-    fun openLink(link: String) {
-        driver.openLink(link)
+    fun openLink(link: String, autoVerify: Boolean) {
+        driver.openLink(link, autoVerify)
         waitForAppToSettle()
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -429,6 +429,11 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitForAppToSettle()
     }
 
+    fun openBrowser(link: String) {
+        driver.openBrowser(link)
+        waitForAppToSettle()
+    }
+
     override fun close() {
         driver.close()
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -401,8 +401,24 @@ class AndroidDriver(
     }
 
     override fun openBrowser(link: String) {
-        TODO("Not yet implemented")
+        val installedPackages = installedPackages()
+        when {
+            installedPackages.contains("com.android.chrome") -> {
+                dadb.shell("am start -a android.intent.action.VIEW -d \"$link\" com.android.chrome")
+            }
+            installedPackages.contains("org.mozilla.firefox") -> {
+                dadb.shell("am start -a android.intent.action.VIEW -d \"$link\" org.mozilla.firefox")
+            }
+            else -> {
+                dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
+            }
+        }
     }
+
+    private fun installedPackages() = shell("pm list packages").split("\n")
+        .map { line: String -> line.split(":".toRegex()).toTypedArray() }
+        .filter { parts: Array<String> -> parts.size == 2 }
+        .map { parts: Array<String> -> parts[1] }
 
     override fun setLocation(latitude: Double, longitude: Double) {
         TODO("Not yet implemented")

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -402,8 +402,12 @@ class AndroidDriver(
         }) ?: throw IllegalStateException("Input Response can't be null")
     }
 
-    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
-        dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
+        if (browser) {
+            openBrowser(link)
+        } else {
+            dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
+        }
 
         if (autoVerify) {
             autoVerifyApp(appId)
@@ -451,7 +455,7 @@ class AndroidDriver(
         return filterFunc(contentDescriptor().aggregate()).firstOrNull()?.toUiElementOrNull()
     }
 
-    override fun openBrowser(link: String) {
+    private fun openBrowser(link: String) {
         val installedPackages = installedPackages()
         when {
             installedPackages.contains("com.android.chrome") -> {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -396,7 +396,7 @@ class AndroidDriver(
         }) ?: throw IllegalStateException("Input Response can't be null")
     }
 
-    override fun openLink(link: String) {
+    override fun openLink(link: String, autoVerify: Boolean) {
         dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -402,11 +402,15 @@ class AndroidDriver(
         }) ?: throw IllegalStateException("Input Response can't be null")
     }
 
-    override fun openLink(link: String, autoVerify: Boolean) {
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
         dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
+
+        if (autoVerify) {
+            autoVerifyApp(appId)
+        }
     }
 
-    fun autoVerifyApp(appId: String?) {
+    private fun autoVerifyApp(appId: String?) {
         if (appId != null) {
             autoVerifyWithAppName(appId)
         }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -400,6 +400,10 @@ class AndroidDriver(
         dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
     }
 
+    override fun openBrowser(link: String) {
+        TODO("Not yet implemented")
+    }
+
     override fun setLocation(latitude: Double, longitude: Double) {
         TODO("Not yet implemented")
     }

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -407,7 +407,7 @@ class IOSDriver(
     }
 
     override fun openBrowser(link: String) {
-        TODO("Not yet implemented")
+        iosDevice.openBrowser(link).expect{}
     }
 
     override fun setLocation(latitude: Double, longitude: Double) {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -402,7 +402,7 @@ class IOSDriver(
         )
     }
 
-    override fun openLink(link: String, autoVerify: Boolean) {
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
         iosDevice.openLink(link).expect {}
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -402,7 +402,7 @@ class IOSDriver(
         )
     }
 
-    override fun openLink(link: String) {
+    override fun openLink(link: String, autoVerify: Boolean) {
         iosDevice.openLink(link).expect {}
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -402,12 +402,8 @@ class IOSDriver(
         )
     }
 
-    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
         iosDevice.openLink(link).expect {}
-    }
-
-    override fun openBrowser(link: String) {
-        iosDevice.openBrowser(link).expect{}
     }
 
     override fun setLocation(latitude: Double, longitude: Double) {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -406,6 +406,10 @@ class IOSDriver(
         iosDevice.openLink(link).expect {}
     }
 
+    override fun openBrowser(link: String) {
+        TODO("Not yet implemented")
+    }
+
     override fun setLocation(latitude: Double, longitude: Double) {
         iosDevice.setLocation(latitude, longitude).expect {}
     }

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -307,6 +307,10 @@ class WebDriver(val isStudio: Boolean) : Driver {
         driver.get(link)
     }
 
+    override fun openBrowser(link: String) {
+        TODO("Not yet implemented")
+    }
+
     override fun hideKeyboard() {
         // no-op on web
         return

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -308,7 +308,9 @@ class WebDriver(val isStudio: Boolean) : Driver {
     }
 
     override fun openBrowser(link: String) {
-        TODO("Not yet implemented")
+        val driver = ensureOpen()
+
+        driver.get(link)
     }
 
     override fun hideKeyboard() {

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -301,13 +301,7 @@ class WebDriver(val isStudio: Boolean) : Driver {
         }
     }
 
-    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
-        val driver = ensureOpen()
-
-        driver.get(link)
-    }
-
-    override fun openBrowser(link: String) {
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
         val driver = ensureOpen()
 
         driver.get(link)

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -301,7 +301,7 @@ class WebDriver(val isStudio: Boolean) : Driver {
         }
     }
 
-    override fun openLink(link: String) {
+    override fun openLink(link: String, autoVerify: Boolean) {
         val driver = ensureOpen()
 
         driver.get(link)

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -301,7 +301,7 @@ class WebDriver(val isStudio: Boolean) : Driver {
         }
     }
 
-    override fun openLink(link: String, autoVerify: Boolean) {
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
         val driver = ensureOpen()
 
         driver.get(link)

--- a/maestro-ios/src/main/java/ios/IOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/IOSDevice.kt
@@ -126,6 +126,13 @@ interface IOSDevice : AutoCloseable {
     fun openLink(link: String): Result<Unit, Throwable>
 
     /**
+     * Opens link in web browser
+     *
+     * @param link - link to open
+     */
+    fun openBrowser(link: String): Result<Unit, Throwable>
+
+    /**
      * Takes a screenshot and writes it into output sink
      *
      * @param out - output sink

--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -109,6 +109,10 @@ class LocalIOSDevice(
         return simctlIOSDevice.openLink(link)
     }
 
+    override fun openBrowser(link: String): Result<Unit, Throwable> {
+        return simctlIOSDevice.openBrowser(link)
+    }
+
     override fun takeScreenshot(out: Sink, compressed: Boolean): Result<Unit, Throwable> {
         return xcTestDevice.takeScreenshot(out, compressed)
     }

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -400,6 +400,10 @@ class IdbIOSDevice(
         }
     }
 
+    override fun openBrowser(link: String): Result<Unit, Throwable> {
+        error("Not supported")
+    }
+
     override fun takeScreenshot(out: Sink, compressed: Boolean): Result<Unit, Throwable> {
         error("Not supported")
     }

--- a/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
@@ -103,6 +103,10 @@ class SimctlIOSDevice(
         }
     }
 
+    override fun openBrowser(link: String): Result<Unit, Throwable> {
+        return runCatching { Simctl.openURL(deviceId, link) }
+    }
+
     override fun takeScreenshot(out: Sink, compressed: Boolean): Result<Unit, Throwable> {
         TODO("Not yet implemented")
     }

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -10,6 +10,7 @@ import hierarchy.XCUIElement
 import ios.IOSDevice
 import ios.IOSScreenRecording
 import ios.device.DeviceInfo
+import ios.xcrun.Simctl
 import maestro.logger.Logger
 import okio.Sink
 import okio.buffer
@@ -169,6 +170,10 @@ class XCTestIOSDevice(
     }
 
     override fun openLink(link: String): Result<Unit, Throwable> {
+        error("Not supported")
+    }
+
+    override fun openBrowser(link: String): Result<Unit, Throwable> {
         error("Not supported")
     }
 

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -10,7 +10,6 @@ import hierarchy.XCUIElement
 import ios.IOSDevice
 import ios.IOSScreenRecording
 import ios.device.DeviceInfo
-import ios.xcrun.Simctl
 import maestro.logger.Logger
 import okio.Sink
 import okio.buffer

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -394,10 +394,15 @@ data class ApplyConfigurationCommand(
 data class OpenLinkCommand(
     val link: String,
     val autoVerify: Boolean? = null,
+    val browser: Boolean? = null
 ) : Command {
 
     override fun description(): String {
-        return if (autoVerify == true) "Open $link with auto verification" else "Open $link"
+        return if (browser == true) {
+            if (autoVerify == true) "Open $link with auto verification in browser" else "Open $link in browser"
+        } else {
+            if (autoVerify == true) "Open $link with auto verification" else "Open $link"
+        }
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): OpenLinkCommand {
@@ -405,22 +410,6 @@ data class OpenLinkCommand(
             link = link.evaluateScripts(jsEngine),
         )
     }
-}
-
-data class OpenBrowserCommand(
-    val link: String
-): Command {
-
-    override fun description(): String {
-        return "Open $link in browser"
-    }
-
-    override fun evaluateScripts(jsEngine: JsEngine): Command {
-        return copy(
-            link = link.evaluateScripts(jsEngine)
-        )
-    }
-
 }
 
 data class PressKeyCommand(

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -392,11 +392,12 @@ data class ApplyConfigurationCommand(
 }
 
 data class OpenLinkCommand(
-    val link: String
+    val link: String,
+    val autoVerify: Boolean? = null,
 ) : Command {
 
     override fun description(): String {
-        return "Open $link"
+        return if (autoVerify == true) "Open $link with auto verification" else "Open $link"
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): OpenLinkCommand {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -406,6 +406,22 @@ data class OpenLinkCommand(
     }
 }
 
+data class OpenBrowserCommand(
+    val link: String
+): Command {
+
+    override fun description(): String {
+        return "Open $link in browser"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return copy(
+            link = link.evaluateScripts(jsEngine)
+        )
+    }
+
+}
+
 data class PressKeyCommand(
     val code: KeyCode,
 ) : Command {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -41,7 +41,6 @@ data class MaestroCommand(
     val launchAppCommand: LaunchAppCommand? = null,
     val applyConfigurationCommand: ApplyConfigurationCommand? = null,
     val openLinkCommand: OpenLinkCommand? = null,
-    val openBrowserCommand: OpenBrowserCommand? = null,
     val pressKeyCommand: PressKeyCommand? = null,
     val eraseTextCommand: EraseTextCommand? = null,
     val hideKeyboardCommand: HideKeyboardCommand? = null,
@@ -76,7 +75,6 @@ data class MaestroCommand(
         launchAppCommand = command as? LaunchAppCommand,
         applyConfigurationCommand = command as? ApplyConfigurationCommand,
         openLinkCommand = command as? OpenLinkCommand,
-        openBrowserCommand = command as? OpenBrowserCommand,
         pressKeyCommand = command as? PressKeyCommand,
         eraseTextCommand = command as? EraseTextCommand,
         hideKeyboardCommand = command as? HideKeyboardCommand,
@@ -111,7 +109,6 @@ data class MaestroCommand(
         launchAppCommand != null -> launchAppCommand
         applyConfigurationCommand != null -> applyConfigurationCommand
         openLinkCommand != null -> openLinkCommand
-        openBrowserCommand != null -> openBrowserCommand
         pressKeyCommand != null -> pressKeyCommand
         eraseTextCommand != null -> eraseTextCommand
         hideKeyboardCommand != null -> hideKeyboardCommand

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -41,6 +41,7 @@ data class MaestroCommand(
     val launchAppCommand: LaunchAppCommand? = null,
     val applyConfigurationCommand: ApplyConfigurationCommand? = null,
     val openLinkCommand: OpenLinkCommand? = null,
+    val openBrowserCommand: OpenBrowserCommand? = null,
     val pressKeyCommand: PressKeyCommand? = null,
     val eraseTextCommand: EraseTextCommand? = null,
     val hideKeyboardCommand: HideKeyboardCommand? = null,
@@ -75,6 +76,7 @@ data class MaestroCommand(
         launchAppCommand = command as? LaunchAppCommand,
         applyConfigurationCommand = command as? ApplyConfigurationCommand,
         openLinkCommand = command as? OpenLinkCommand,
+        openBrowserCommand = command as? OpenBrowserCommand,
         pressKeyCommand = command as? PressKeyCommand,
         eraseTextCommand = command as? EraseTextCommand,
         hideKeyboardCommand = command as? HideKeyboardCommand,
@@ -109,6 +111,7 @@ data class MaestroCommand(
         launchAppCommand != null -> launchAppCommand
         applyConfigurationCommand != null -> applyConfigurationCommand
         openLinkCommand != null -> openLinkCommand
+        openBrowserCommand != null -> openBrowserCommand
         pressKeyCommand != null -> pressKeyCommand
         eraseTextCommand != null -> eraseTextCommand
         hideKeyboardCommand != null -> hideKeyboardCommand

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -181,7 +181,6 @@ class Orchestra(
             is InputRandomCommand -> inputTextRandomCommand(command)
             is LaunchAppCommand -> launchAppCommand(command)
             is OpenLinkCommand -> openLinkCommand(command, config)
-            is OpenBrowserCommand -> openBrowserCommand(command)
             is PressKeyCommand -> pressKeyCommand(command)
             is EraseTextCommand -> eraseTextCommand(command)
             is TakeScreenshotCommand -> takeScreenshotCommand(command)
@@ -523,13 +522,7 @@ class Orchestra(
     }
 
     private fun openLinkCommand(command: OpenLinkCommand, config: MaestroConfig?): Boolean {
-        maestro.openLink(command.link, config?.appId, command.autoVerify ?: false)
-
-        return true
-    }
-
-    private fun openBrowserCommand(command: OpenBrowserCommand): Boolean {
-        maestro.openBrowser(command.link)
+        maestro.openLink(command.link, config?.appId, command.autoVerify ?: false, command.browser ?: false)
 
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -522,7 +522,7 @@ class Orchestra(
     }
 
     private fun openLinkCommand(command: OpenLinkCommand): Boolean {
-        maestro.openLink(command.link)
+        maestro.openLink(command.link, command.autoVerify ?: false)
 
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -180,6 +180,7 @@ class Orchestra(
             is InputRandomCommand -> inputTextRandomCommand(command)
             is LaunchAppCommand -> launchAppCommand(command)
             is OpenLinkCommand -> openLinkCommand(command)
+            is OpenBrowserCommand -> openBrowserCommand(command)
             is PressKeyCommand -> pressKeyCommand(command)
             is EraseTextCommand -> eraseTextCommand(command)
             is TakeScreenshotCommand -> takeScreenshotCommand(command)
@@ -522,6 +523,12 @@ class Orchestra(
 
     private fun openLinkCommand(command: OpenLinkCommand): Boolean {
         maestro.openLink(command.link)
+
+        return true
+    }
+
+    private fun openBrowserCommand(command: OpenBrowserCommand): Boolean {
+        maestro.openBrowser(command.link)
 
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -26,7 +26,6 @@ import maestro.Filters.asFilter
 import maestro.FindElementResult
 import maestro.Maestro
 import maestro.MaestroException
-import maestro.UiElement
 import maestro.js.Js
 import maestro.js.JsEngine
 import maestro.networkproxy.NetworkProxy
@@ -524,20 +523,9 @@ class Orchestra(
     }
 
     private fun openLinkCommand(command: OpenLinkCommand, config: MaestroConfig?): Boolean {
-        maestro.openLink(command.link, command.autoVerify ?: false)
+        maestro.openLink(command.link, config?.appId, command.autoVerify ?: false)
 
-        if (command.autoVerify == true) {
-            maestro.autoVerifyApp(config?.appId)
-        }
         return true
-    }
-
-    private fun findElementOrNull(elementSelector: ElementSelector): UiElement? {
-        return try {
-            findElement(elementSelector).element
-        } catch (elementNotFoundException: MaestroException.ElementNotFound) {
-            null
-        }
     }
 
     private fun openBrowserCommand(command: OpenBrowserCommand): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -38,7 +38,6 @@ import maestro.orchestra.InputTextCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MockNetworkCommand
-import maestro.orchestra.OpenBrowserCommand
 import maestro.orchestra.OpenLinkCommand
 import maestro.orchestra.PasteTextCommand
 import maestro.orchestra.PressKeyCommand
@@ -134,8 +133,7 @@ data class YamlFluentCommand(
             inputRandomEmail != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT_EMAIL_ADDRESS)))
             inputRandomPersonName != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT_PERSON_NAME)))
             swipe != null -> listOf(swipeCommand(swipe))
-            openLink != null -> listOf(MaestroCommand(OpenLinkCommand(openLink.link, openLink.autoVerify)))
-            openBrowser != null -> listOf(MaestroCommand(OpenBrowserCommand(openBrowser)))
+            openLink != null -> listOf(MaestroCommand(OpenLinkCommand(openLink.link, openLink.autoVerify, openLink.browser)))
             pressKey != null -> listOf(MaestroCommand(PressKeyCommand(code = KeyCode.getByName(pressKey) ?: throw SyntaxError("Unknown key name: $pressKey"))))
             eraseText != null -> listOf(eraseCommand(eraseText))
             action != null -> listOf(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -38,6 +38,7 @@ import maestro.orchestra.InputTextCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MockNetworkCommand
+import maestro.orchestra.OpenBrowserCommand
 import maestro.orchestra.OpenLinkCommand
 import maestro.orchestra.PasteTextCommand
 import maestro.orchestra.PressKeyCommand
@@ -76,6 +77,7 @@ data class YamlFluentCommand(
     val launchApp: YamlLaunchApp? = null,
     val swipe: YamlSwipe? = null,
     val openLink: String? = null,
+    val openBrowser: String? = null,
     val pressKey: String? = null,
     val eraseText: YamlEraseText? = null,
     val takeScreenshot: YamlTakeScreenshot? = null,
@@ -133,6 +135,7 @@ data class YamlFluentCommand(
             inputRandomPersonName != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT_PERSON_NAME)))
             swipe != null -> listOf(swipeCommand(swipe))
             openLink != null -> listOf(MaestroCommand(OpenLinkCommand(openLink)))
+            openBrowser != null -> listOf(MaestroCommand(OpenBrowserCommand(openBrowser)))
             pressKey != null -> listOf(MaestroCommand(PressKeyCommand(code = KeyCode.getByName(pressKey) ?: throw SyntaxError("Unknown key name: $pressKey"))))
             eraseText != null -> listOf(eraseCommand(eraseText))
             action != null -> listOf(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -76,7 +76,7 @@ data class YamlFluentCommand(
     val inputRandomPersonName: YamlInputRandomPersonName? = null,
     val launchApp: YamlLaunchApp? = null,
     val swipe: YamlSwipe? = null,
-    val openLink: String? = null,
+    val openLink: YamlOpenLink? = null,
     val openBrowser: String? = null,
     val pressKey: String? = null,
     val eraseText: YamlEraseText? = null,
@@ -134,7 +134,7 @@ data class YamlFluentCommand(
             inputRandomEmail != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT_EMAIL_ADDRESS)))
             inputRandomPersonName != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT_PERSON_NAME)))
             swipe != null -> listOf(swipeCommand(swipe))
-            openLink != null -> listOf(MaestroCommand(OpenLinkCommand(openLink)))
+            openLink != null -> listOf(MaestroCommand(OpenLinkCommand(openLink.link, openLink.autoVerify)))
             openBrowser != null -> listOf(MaestroCommand(OpenBrowserCommand(openBrowser)))
             pressKey != null -> listOf(MaestroCommand(PressKeyCommand(code = KeyCode.getByName(pressKey) ?: throw SyntaxError("Unknown key name: $pressKey"))))
             eraseText != null -> listOf(eraseCommand(eraseText))

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOpenLink.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOpenLink.kt
@@ -1,0 +1,16 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlOpenLink(val link: String, val autoVerify: Boolean = false) {
+    companion object {
+
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(link: String): YamlOpenLink {
+            return YamlOpenLink(
+                link = link,
+            )
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOpenLink.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOpenLink.kt
@@ -2,7 +2,7 @@ package maestro.orchestra.yaml
 
 import com.fasterxml.jackson.annotation.JsonCreator
 
-data class YamlOpenLink(val link: String, val autoVerify: Boolean = false) {
+data class YamlOpenLink(val link: String, val browser: Boolean = false, val autoVerify: Boolean = false) {
     companion object {
 
         @JvmStatic

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -263,6 +263,12 @@ class FakeDriver : Driver {
         events += Event.OpenLink(link)
     }
 
+    override fun openBrowser(link: String) {
+        ensureOpen()
+
+        events += Event.OpenBrowser(link)
+    }
+
     override fun setProxy(host: String, port: Int) {
         ensureOpen()
 
@@ -381,12 +387,6 @@ class FakeDriver : Driver {
 
         data class SwipeWithDirection(val swipeDirection: SwipeDirection, val durationMs: Long) : Event(), UserInteraction
 
-        data class SwipeRelative(
-            val startRelativeValue: Int,
-            val endRelativeValue: Int,
-            val durationMs: Long
-        ): Event(), UserInteraction
-
         data class SwipeElementWithDirection(
             val point: Point,
             val swipeDirection: SwipeDirection,
@@ -416,6 +416,10 @@ class FakeDriver : Driver {
         ) : Event()
 
         data class OpenLink(
+            val link: String,
+        ) : Event()
+
+        data class OpenBrowser(
             val link: String,
         ) : Event()
 

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -257,10 +257,10 @@ class FakeDriver : Driver {
         events += Event.InputText(text)
     }
 
-    override fun openLink(link: String) {
+    override fun openLink(link: String, autoVerify: Boolean) {
         ensureOpen()
 
-        events += Event.OpenLink(link)
+        events += Event.OpenLink(link, autoVerify)
     }
 
     override fun openBrowser(link: String) {
@@ -417,6 +417,7 @@ class FakeDriver : Driver {
 
         data class OpenLink(
             val link: String,
+            val autoLink: Boolean = false
         ) : Event()
 
         data class OpenBrowser(

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -32,6 +32,7 @@ import maestro.ScreenRecording
 import maestro.SwipeDirection
 import maestro.TreeNode
 import maestro.ViewHierarchy
+import maestro.orchestra.MaestroConfig
 import maestro.utils.ScreenshotUtils
 import okio.Sink
 import okio.buffer
@@ -257,7 +258,7 @@ class FakeDriver : Driver {
         events += Event.InputText(text)
     }
 
-    override fun openLink(link: String, autoVerify: Boolean) {
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
         ensureOpen()
 
         events += Event.OpenLink(link, autoVerify)

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -258,16 +258,14 @@ class FakeDriver : Driver {
         events += Event.InputText(text)
     }
 
-    override fun openLink(link: String, appId: String?, autoVerify: Boolean) {
+    override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
         ensureOpen()
 
-        events += Event.OpenLink(link, autoVerify)
-    }
-
-    override fun openBrowser(link: String) {
-        ensureOpen()
-
-        events += Event.OpenBrowser(link)
+        if (browser) {
+            events += Event.OpenBrowser(link)
+        } else {
+            events += Event.OpenLink(link, autoVerify)
+        }
     }
 
     override fun setProxy(host: String, port: Int) {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2368,6 +2368,27 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `085 - Open link with auto verify`() {
+        // Given
+        val commands = readCommands("083_open_link_auto_verify")
+
+        val driver = driver {}
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.OpenLink("https://example.com", autoLink = true)
+            )
+        )
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2371,7 +2371,7 @@ class IntegrationTest {
     @Test
     fun `085 - Open link with auto verify`() {
         // Given
-        val commands = readCommands("083_open_link_auto_verify")
+        val commands = readCommands("085_open_link_auto_verify")
 
         val driver = driver {}
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2348,6 +2348,26 @@ class IntegrationTest {
         driver.assertHasEvent(Event.Tap(Point(50, 150)))
     }
 
+    @Test
+    fun `Case 084 - Open Browser`() {
+        // given
+        val commands = readCommands("084_open_browser")
+
+        val driver = driver {}
+
+        // when
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // then
+        driver.assertEvents(
+            listOf(
+                Event.OpenBrowser("https://example.com")
+            )
+        )
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/084_open_browser.yaml
+++ b/maestro-test/src/test/resources/084_open_browser.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- openBrowser: https://example.com

--- a/maestro-test/src/test/resources/084_open_browser.yaml
+++ b/maestro-test/src/test/resources/084_open_browser.yaml
@@ -1,3 +1,5 @@
 appId: com.example.app
 ---
-- openBrowser: https://example.com
+- openLink:
+    link: https://example.com
+    browser: true

--- a/maestro-test/src/test/resources/085_open_link_auto_verify.yaml
+++ b/maestro-test/src/test/resources/085_open_link_auto_verify.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- openLink:
+    link: https://example.com
+    autoVerify: true


### PR DESCRIPTION
## Proposed Changes

1. Add openBrowser command separately for opening the browser for https/http link. Sometimes different apps intercept these links which cause unexpected behavior.
2. Add autoVerify flag on openLink command which will optionally auto verify opening HTTP links to user app and also agree the chrome agreement.

```
appId: com.chatloop.my
---
- openLink: 
    link: https://something.com/linking
    autoVerify: true
```

By default this flag is false.

## Testing
Attaching internally.

## Issues Fixed

https://mobile-dev-inc.slack.com/archives/C041FU72T54/p1676539339478699