### PR TITLE
Add quotes around string values; Better dark mode support for ReplView

### DIFF
--- a/maestro-studio/web/src/ReplView.tsx
+++ b/maestro-studio/web/src/ReplView.tsx
@@ -386,13 +386,13 @@ const ReplView = ({input, onInput, onError}: {
           }}
         >
           <AutosizingTextArea
-            className="resize-none p-4 pr-16 overflow-y-scroll overflow-hidden font-mono cursor-text outline-none border border-transparent border-b-slate-200 dark:border-slate-600 focus:border focus:border-slate-400 dark:focus:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-850 dark:text-white"
+            className="resize-none p-4 pr-16 overflow-y-scroll overflow-hidden font-mono cursor-text outline-none border border-transparent border-b-slate-200 dark:border-b-slate-600 focus:border focus:border-slate-400 dark:focus:border-slate-400 dark:bg-slate-800 dark:text-white"
             setValue={value => onInput(value)}
             value={input}
             placeholder="Enter a command, then press ENTER to run"
           />
           <button
-            className="absolute flex items-center right-1 top-1 rounded bottom-1 px-4 disabled:text-slate-400 enabled:text-blue-600 enabled:hover:bg-slate-200 enabled:active:bg-slate-300 cursor-default"
+            className="absolute flex items-center right-1 top-1 rounded bottom-1 px-4 disabled:text-slate-400 enabled:text-blue-600 enabled:hover:bg-slate-200 enabled:active:bg-slate-300 cursor-default dark:enabled:hover:bg-slate-850 dark:enabled:active:bg-slate-900 dark:enabled:text-blue-400"
             disabled={!input}
             onClick={() => runCommand()}
           >

--- a/maestro-studio/web/src/commandExample.ts
+++ b/maestro-studio/web/src/commandExample.ts
@@ -90,7 +90,7 @@ const getSelectors = (uiElement: UIElement, deviceScreen: DeviceScreen): Selecto
         title: 'Text',
         status: 'available',
         definition: {
-          text: uiElement.text,
+          text: `"${uiElement.text}"`,
           index: uiElement.textIndex,
         }
       })
@@ -98,7 +98,7 @@ const getSelectors = (uiElement: UIElement, deviceScreen: DeviceScreen): Selecto
       selectors.push({
         title: 'Text',
         status: 'available',
-        definition: uiElement.text
+        definition: `"${uiElement.text}"`
       })
     }
   }
@@ -109,7 +109,7 @@ const toTapExample = (selector: Selector): CommandExample => {
   return {
     status: selector.status,
     title: `Tap > ${selector.title}`,
-    content: selector.status === 'available' ? YAML.stringify([{ tapOn: selector.definition }]) : selector.message,
+    content: selector.status === 'available' ? YAML.stringify([{ tapOn: selector.definition }]).replaceAll('\'', '') : selector.message,
     documentation: selector.documentation || 'https://maestro.mobile.dev/reference/tap-on-view',
   }
 }
@@ -118,7 +118,7 @@ const toAssertExample = (selector: Selector): CommandExample => {
   return {
     status: selector.status,
     title: `Assert > ${selector.title}`,
-    content: selector.status === 'available' ? YAML.stringify([{ assertVisible: selector.definition }]) : selector.message,
+    content: selector.status === 'available' ? YAML.stringify([{ assertVisible: selector.definition }]).replaceAll('\'', '') : selector.message,
     documentation: selector.documentation || 'https://maestro.mobile.dev/reference/assertions',
   }
 }
@@ -127,7 +127,7 @@ const toConditionalExample = (selector: Selector): CommandExample => {
   return {
     status: selector.status,
     title: `Conditional > ${selector.title}`,
-    content: selector.status === 'available' ? YAML.stringify([{ runFlow: { when: { visible: selector.definition }, file: 'Subflow.yaml' } }]) : selector.message,
+    content: selector.status === 'available' ? YAML.stringify([{ runFlow: { when: { visible: selector.definition }, file: 'Subflow.yaml' } }]).replaceAll('\'', '') : selector.message,
     documentation: selector.documentation || 'https://maestro.mobile.dev/advanced/conditions',
   }
 }


### PR DESCRIPTION
## Proposed Changes
- Add proper dark mode support for play icon in `ReplView`
- All text values will now have double quotes around them to avoid values such as `yes`, `no`, `off`, `on` to be interpreted as booleans as defined in the [YAML 1.1 spec](https://yaml.org/type/bool.html).

**Screenshot**
See the `- tapOn: "25h 22m 22s"` command

| Before  | After |
| ------------- | ------------- |
|  <img width="1501" alt="before" src="https://user-images.githubusercontent.com/6113675/220643340-cd6866f1-d0fd-4c22-978f-1418cda45ee8.png"> |  <img width="1515" alt="after" src="https://user-images.githubusercontent.com/6113675/220643414-4b48ad7a-6e84-46b7-8c7b-4158b3cf7331.png"> |

## Testing
Tested locally.