### PR TITLE
Set all permissions to allow when launchApp with clearState

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -187,6 +187,7 @@ object MaestroSessionManager {
                         val simctlIOSDevice = SimctlIOSDevice(
                             deviceId = selectedDevice.device.instanceId,
                             logger = IOSDriverLogger(),
+                            xcTestDevice = xcTestDevice,
                         )
 
                         Maestro.ios(
@@ -326,6 +327,7 @@ object MaestroSessionManager {
         val simctlIOSDevice = SimctlIOSDevice(
             deviceId = device.instanceId,
             logger = IOSDriverLogger(),
+            xcTestDevice = xcTestDevice,
         )
 
         val iosDriver = IOSDriver(

--- a/maestro-ios/src/main/java/ios/simctl/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/simctl/Simctl.kt
@@ -3,7 +3,7 @@ package ios.simctl
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import maestro.utils.MaestroTimer
-import util.CommandLineUtils
+import util.CommandLineUtils.runCommand
 import java.io.File
 
 object Simctl {
@@ -45,7 +45,7 @@ object Simctl {
     }
 
     fun launchSimulator(deviceId: String) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -59,7 +59,7 @@ object Simctl {
         // Up to 10 iterations => max wait time of 1 second
         repeat(10) {
             try {
-                CommandLineUtils.runCommand(
+                runCommand(
                     listOf(
                         "open",
                         "-a",
@@ -82,7 +82,7 @@ object Simctl {
     fun reboot(
         deviceId: String,
     ) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -93,7 +93,7 @@ object Simctl {
         )
         awaitShutdown(deviceId)
 
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -109,7 +109,7 @@ object Simctl {
         deviceId: String,
         certificate: File,
     ) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -182,7 +182,7 @@ object Simctl {
 
 
     fun launch(deviceId: String, bundleId: String) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -194,7 +194,7 @@ object Simctl {
     }
 
     fun setLocation(deviceId: String, latitude: Double, longitude: Double) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -205,9 +205,9 @@ object Simctl {
             )
         )
     }
-    
+
     fun openURL(deviceId: String, url: String) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -219,7 +219,7 @@ object Simctl {
     }
 
     fun uninstall(deviceId: String, bundleId: String) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -231,7 +231,7 @@ object Simctl {
     }
 
     fun clearKeychain(deviceId: String) {
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -243,14 +243,14 @@ object Simctl {
             )
         )
 
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "rm", "-rf",
                 "$homedir/Library/Developer/CoreSimulator/Devices/$deviceId/data/Library/Keychains"
             )
         )
 
-        CommandLineUtils.runCommand(
+        runCommand(
             listOf(
                 "xcrun",
                 "simctl",
@@ -259,6 +259,39 @@ object Simctl {
                 "launchctl",
                 "start",
                 "com.apple.securityd",
+            )
+        )
+    }
+
+    fun grantPermissions(deviceId: String, bundleId: String) {
+        val permissions = listOf(
+            "calendar=YES",
+            "camera=YES",
+            "contacts=YES",
+            "faceid=YES",
+            "health=YES",
+            "homekit=YES",
+            "location=always",
+            "medialibrary=YES",
+            "microphone=YES",
+            "motion=YES",
+            "notifications=YES",
+            "photos=YES",
+            "reminders=YES",
+            "siri=YES",
+            "speech=YES",
+            "userTracking=YES",
+        )
+
+        runCommand(
+            listOf(
+                "$homedir/.maestro/deps/applesimutils",
+                "--byId",
+                deviceId,
+                "--bundle",
+                bundleId,
+                "--setPermissions",
+                permissions.joinToString(", ")
             )
         )
     }

--- a/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
@@ -2,19 +2,21 @@ package ios.simctl
 
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.runCatching
 import hierarchy.XCUIElement
 import ios.IOSDevice
 import ios.IOSScreenRecording
 import ios.device.DeviceInfo
+import ios.xctest.XCTestIOSDevice
 import maestro.logger.Logger
 import okio.Sink
 import java.io.File
 import java.io.InputStream
-import com.github.michaelbull.result.runCatching
 
 class SimctlIOSDevice(
     override val deviceId: String,
     private val logger: Logger,
+    private val xcTestDevice: XCTestIOSDevice,
 ) : IOSDevice {
     override fun open() {
         TODO("Not yet implemented")
@@ -72,6 +74,8 @@ class SimctlIOSDevice(
 
     override fun clearAppState(id: String): Result<Unit, Throwable> {
         Simctl.clearAppState(deviceId, id)
+        Simctl.grantPermissions(deviceId, id)
+        xcTestDevice.restartXCTestRunnerService()
         return Ok(Unit)
     }
 

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -29,10 +29,10 @@ class XCTestIOSDevice(
 ) : IOSDevice {
 
     override fun open() {
-        ensureXCUITestChannel()
+        restartXCTestRunnerService()
     }
 
-    private fun ensureXCUITestChannel() {
+    fun restartXCTestRunnerService() {
         logger.info("[Start] Uninstalling xctest ui runner app on $deviceId")
         installer.killAndUninstall()
         logger.info("[Done] Uninstalling xctest ui runner app on $deviceId")


### PR DESCRIPTION
## Proposed Changes

Set the all permissions to allow when executing
```
- launchApp
    clearState: true
```

## Testing

Tested on apps with permissions.

## Issues Fixed
Permission prompts are not present on maestro cloud, but do happen on local maestro runs. By starting the flow with launchApp with clearState, the permissions will be in the same state both on cloud as on local runs.
