### PR TITLE
Use textInput for enter pressKey

### DIFF
--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -48,7 +48,11 @@ class LocalIOSDevice(
     }
 
     override fun pressKey(code: Int): Result<Unit, Throwable> {
-        return idbIOSDevice.pressKey(code)
+        return if (code == 40) {
+            xcTestDevice.pressKey(code)
+        } else {
+            idbIOSDevice.pressKey(code)
+        }
     }
 
     override fun pressButton(code: Int): Result<Unit, Throwable> {

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -91,7 +91,9 @@ class XCTestIOSDevice(
     }
 
     override fun pressKey(code: Int): Result<Unit, Throwable> {
-        error("Not supported")
+        return runCatching {
+            client.inputText("\n")
+        }
     }
 
     override fun pressButton(code: Int): Result<Unit, Throwable> {


### PR DESCRIPTION
## Proposed Changes

Use `inputText "\n"` for `keyPress: enter` on iOS

## Testing


## Issues Fixed