### PR TITLE
Support for permission parameter on launchApp

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -89,5 +89,6 @@ interface Driver {
     fun waitForAppToSettle(initialHierarchy: ViewHierarchy?): ViewHierarchy?
 
     fun capabilities(): List<Capability>
+
     fun setPermissions(appId: String, permissions: Map<String, String>)
 }

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -89,4 +89,5 @@ interface Driver {
     fun waitForAppToSettle(initialHierarchy: ViewHierarchy?): ViewHierarchy?
 
     fun capabilities(): List<Capability>
+    fun setPermissions(appId: String, permissions: Map<String, String>)
 }

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -77,6 +77,10 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         driver.clearAppState(appId)
     }
 
+    fun setPermissions(appId: String, permissions: Map<String, String>) {
+        driver.setPermissions(appId, permissions)
+    }
+
     fun clearKeychain() {
         LOGGER.info("Clearing keychain")
 

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -41,8 +41,8 @@ import maestro.ViewHierarchy
 import maestro.android.AndroidAppFiles
 import maestro.android.asManifest
 import maestro.android.resolveLauncherActivity
-import maestro.utils.ScreenshotUtils
 import maestro.utils.MaestroTimer
+import maestro.utils.ScreenshotUtils
 import maestro.utils.StringUtils.toRegexSafe
 import maestro_android.MaestroDriverGrpc
 import maestro_android.deviceInfoRequest
@@ -530,23 +530,23 @@ class AndroidDriver(
     }
 
     private fun setAllPermissions(appId: String, value: String) {
-        val argument = argumentForPermissionValue(value)
-        shell("pm $argument -g $appId")
+        val translated = translatePermissionValue(value)
+        shell("pm $translated -g $appId")
     }
 
     private fun setPermission(appId: String, permission: String, value: String) {
         val name = permission.replace("[^A-Za-z0-9._]+".toRegex(), "")
-        val argument = argumentForPermissionValue(value)
+        val translated = translatePermissionValue(value)
 
-        shell("pm $argument $appId $name")
+        shell("pm $translated $appId $name")
     }
 
-    private fun argumentForPermissionValue(value: String): String {
+    private fun translatePermissionValue(value: String): String {
         return when (value) {
             "allow" -> "grant"
             "deny" -> "revoke"
             "unset" -> "revoke"
-            else -> throw IllegalArgumentException("Permission 'all' can be set to 'allow', 'deny' or 'unset', not '$value'")
+            else -> throw IllegalArgumentException("Permissions can be set to 'allow', 'deny' or 'unset' on Android, not '$value'")
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -449,6 +449,10 @@ class IOSDriver(
         return emptyList()
     }
 
+    override fun setPermissions(appId: String, permissions: Map<String, String>) {
+        iosDevice.setPermissions(appId, permissions)
+    }
+
     private fun isScreenStatic(): Boolean {
         return iosDevice.isScreenStatic().expect {}
     }

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -371,6 +371,10 @@ class WebDriver(val isStudio: Boolean) : Driver {
         )
     }
 
+    override fun setPermissions(appId: String, permissions: Map<String, String>) {
+        TODO("Not yet implemented")
+    }
+
     companion object {
         private const val SCREENSHOT_DIFF_THRESHOLD = 0.005
     }

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -372,7 +372,7 @@ class WebDriver(val isStudio: Boolean) : Driver {
     }
 
     override fun setPermissions(appId: String, permissions: Map<String, String>) {
-        TODO("Not yet implemented")
+        // no-op for web
     }
 
     companion object {

--- a/maestro-ios/src/main/java/ios/IOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/IOSDevice.kt
@@ -156,6 +156,8 @@ interface IOSDevice : AutoCloseable {
      * @return false if 2 consequent screenshots are equal, true if screen is static
      */
     fun isScreenStatic(): Result<Boolean, Throwable>
+
+    fun setPermissions(id: String, permissions: Map<String, String>)
 }
 
 interface IOSScreenRecording : AutoCloseable

--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -133,4 +133,8 @@ class LocalIOSDevice(
     override fun isScreenStatic(): Result<Boolean, Throwable> {
         return xcTestDevice.isScreenStatic()
     }
+
+    override fun setPermissions(id: String, permissions: Map<String, String>) {
+        simctlIOSDevice.setPermissions(id, permissions)
+    }
 }

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -486,6 +486,10 @@ class IdbIOSDevice(
         TODO("Not yet implemented")
     }
 
+    override fun setPermissions(id: String, permissions: Map<String, String>) {
+        TODO("Not yet implemented")
+    }
+
     companion object {
         // 4Mb, the default max read for gRPC
         private const val CHUNK_SIZE = 1024 * 1024 * 3

--- a/maestro-ios/src/main/java/ios/simctl/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/simctl/Simctl.kt
@@ -278,6 +278,7 @@ object Simctl {
         }
 
         val argument = mutable
+            .filter { allPermissions.contains(it.key) }
             .map { "${it.key}=${translatePermissionValue(it.value)}" }
             .joinToString(",")
 

--- a/maestro-ios/src/main/java/ios/simctl/Simctl.kt
+++ b/maestro-ios/src/main/java/ios/simctl/Simctl.kt
@@ -263,25 +263,23 @@ object Simctl {
         )
     }
 
-    fun grantPermissions(deviceId: String, bundleId: String) {
-        val permissions = listOf(
-            "calendar=YES",
-            "camera=YES",
-            "contacts=YES",
-            "faceid=YES",
-            "health=YES",
-            "homekit=YES",
-            "location=always",
-            "medialibrary=YES",
-            "microphone=YES",
-            "motion=YES",
-            "notifications=YES",
-            "photos=YES",
-            "reminders=YES",
-            "siri=YES",
-            "speech=YES",
-            "userTracking=YES",
-        )
+    fun setPermissions(deviceId: String, bundleId: String, permissions: Map<String, String>) {
+        val mutable = permissions.toMutableMap()
+        if (mutable.containsKey("all")) {
+            val value = mutable.remove("all")
+            allPermissions.forEach {
+                when (value) {
+                    "allow" -> mutable.putIfAbsent(it, allowValueForPermission(it))
+                    "deny" -> mutable.putIfAbsent(it, denyValueForPermission(it))
+                    "unset" -> mutable.putIfAbsent(it, "unset")
+                    else -> throw IllegalArgumentException("Permission 'all' can be set to 'allow', 'deny' or 'unset', not '$value'")
+                }
+            }
+        }
+
+        val argument = mutable
+            .map { "${it.key}=${translatePermissionValue(it.value)}" }
+            .joinToString(",")
 
         runCommand(
             listOf(
@@ -291,8 +289,49 @@ object Simctl {
                 "--bundle",
                 bundleId,
                 "--setPermissions",
-                permissions.joinToString(", ")
+                argument
             )
         )
+    }
+
+    private val allPermissions = listOf(
+        "calendar",
+        "camera",
+        "contacts",
+        "faceid",
+        "health",
+        "homekit",
+        "location",
+        "medialibrary",
+        "microphone",
+        "motion",
+        "notifications",
+        "photos",
+        "reminders",
+        "siri",
+        "speech",
+        "usertracking",
+    )
+
+    private fun translatePermissionValue(value: String): String {
+        return when (value) {
+            "allow" -> "YES"
+            "deny" -> "NO"
+            else -> value
+        }
+    }
+
+    private fun allowValueForPermission(permission: String): String {
+        return when (permission) {
+            "location" -> "always"
+            else -> "YES"
+        }
+    }
+
+    private fun denyValueForPermission(permission: String): String {
+        return when (permission) {
+            "location" -> "never"
+            else -> "NO"
+        }
     }
 }

--- a/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
@@ -72,8 +72,6 @@ class SimctlIOSDevice(
 
     override fun clearAppState(id: String): Result<Unit, Throwable> {
         Simctl.clearAppState(deviceId, id)
-        Simctl.grantPermissions(deviceId, id)
-        xcTestDevice.restartXCTestRunnerService()
         return Ok(Unit)
     }
 
@@ -121,6 +119,11 @@ class SimctlIOSDevice(
 
     override fun isScreenStatic(): Result<Boolean, Throwable> {
         TODO("Not yet implemented")
+    }
+
+    override fun setPermissions(id: String, permissions: Map<String, String>) {
+        Simctl.setPermissions(deviceId, id, permissions)
+        xcTestDevice.restartXCTestRunnerService()
     }
 
     override fun close() {

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -227,6 +227,10 @@ class XCTestIOSDevice(
         }
     }
 
+    override fun setPermissions(id: String, permissions: Map<String, String>) {
+        error("Not supported")
+    }
+
     private fun activeAppId(): String? {
         val appIds = getInstalledApps()
         logger.info("installed apps: $appIds")

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -476,7 +476,6 @@ data class StopAppCommand(
 
 data class ClearStateCommand(
     val appId: String,
-    val permissions: Map<String, String>?,
 ) : Command {
 
     override fun description(): String {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -347,6 +347,7 @@ data class LaunchAppCommand(
     val clearState: Boolean? = null,
     val clearKeychain: Boolean? = null,
     val stopApp: Boolean? = null,
+    var permissions: Map<String, String>? = null,
 ) : Command {
 
     override fun description(): String {
@@ -475,6 +476,7 @@ data class StopAppCommand(
 
 data class ClearStateCommand(
     val appId: String,
+    val permissions: Map<String, String>?,
 ) : Command {
 
     override fun description(): String {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -267,6 +267,9 @@ class Orchestra(
 
     private fun clearAppStateCommand(command: ClearStateCommand): Boolean {
         maestro.clearAppState(command.appId)
+        command.permissions?.let {
+            maestro.setPermissions(command.appId, it)
+        }
 
         return true
     }
@@ -527,22 +530,25 @@ class Orchestra(
         return true
     }
 
-    private fun launchAppCommand(it: LaunchAppCommand): Boolean {
+    private fun launchAppCommand(command: LaunchAppCommand): Boolean {
         try {
-            if (it.clearKeychain == true) {
+            if (command.clearKeychain == true) {
                 maestro.clearKeychain()
             }
-            if (it.clearState == true) {
-                maestro.clearAppState(it.appId)
+            if (command.clearState == true) {
+                maestro.clearAppState(command.appId)
             }
+
+            maestro.setPermissions(command.appId, command.permissions ?: mapOf("all" to "allow"))
+
         } catch (e: Exception) {
-            throw MaestroException.UnableToClearState("Unable to clear state for app ${it.appId}")
+            throw MaestroException.UnableToClearState("Unable to clear state for app ${command.appId}")
         }
 
         try {
-            maestro.launchApp(it.appId, stopIfRunning = it.stopApp ?: true)
+            maestro.launchApp(command.appId, stopIfRunning = command.stopApp ?: true)
         } catch (e: Exception) {
-            throw MaestroException.UnableToLaunchApp("Unable to launch app ${it.appId}: ${e.message}")
+            throw MaestroException.UnableToLaunchApp("Unable to launch app ${command.appId}: ${e.message}")
         }
 
         return true

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -267,9 +267,9 @@ class Orchestra(
 
     private fun clearAppStateCommand(command: ClearStateCommand): Boolean {
         maestro.clearAppState(command.appId)
-        command.permissions?.let {
-            maestro.setPermissions(command.appId, it)
-        }
+        // Android's clear command also resets permissions
+        // Reset all permissions to unset so both platforms behave the same
+        maestro.setPermissions(command.appId, mapOf("all" to "unset"))
 
         return true
     }
@@ -539,7 +539,9 @@ class Orchestra(
                 maestro.clearAppState(command.appId)
             }
 
-            maestro.setPermissions(command.appId, command.permissions ?: mapOf("all" to "allow"))
+            // For testing convenience, default to allow all on app launch
+            val permissions = command.permissions ?: mapOf("all" to "allow")
+            maestro.setPermissions(command.appId, permissions)
 
         } catch (e: Exception) {
             throw MaestroException.UnableToClearState("Unable to clear state for app ${command.appId}")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlClearState.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlClearState.kt
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.annotation.JsonCreator
 
 data class YamlClearState(
     val appId: String? = null,
-    val permissions: Map<String, String>?,
 ) {
     companion object {
         @JvmStatic
         @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
         fun parse(appId: String) = YamlClearState(
             appId = appId,
-            permissions = null
         )
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlClearState.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlClearState.kt
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonCreator
 
 data class YamlClearState(
     val appId: String? = null,
+    val permissions: Map<String, String>?,
 ) {
-
     companion object {
-
         @JvmStatic
         @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-        fun parse(appId: String) = YamlClearState(appId)
-
+        fun parse(appId: String) = YamlClearState(
+            appId = appId,
+            permissions = null
+        )
     }
-
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -159,6 +159,7 @@ data class YamlFluentCommand(
                 MaestroCommand(
                     maestro.orchestra.ClearStateCommand(
                         appId = clearState.appId ?: appId,
+                        permissions = clearState.permissions,
                     )
                 )
             )
@@ -299,6 +300,7 @@ data class YamlFluentCommand(
                 clearState = command.clearState,
                 clearKeychain = command.clearKeychain,
                 stopApp = command.stopApp,
+                permissions = command.permissions,
             )
         )
     }
@@ -472,6 +474,7 @@ data class YamlFluentCommand(
                         clearState = null,
                         clearKeychain = null,
                         stopApp = null,
+                        permissions = null,
                     )
                 )
 
@@ -480,7 +483,10 @@ data class YamlFluentCommand(
                 )
 
                 "clearState" -> YamlFluentCommand(
-                    clearState = YamlClearState()
+                    clearState = YamlClearState(
+                        appId = null,
+                        permissions = null,
+                    )
                 )
 
                 "clearKeychain" -> YamlFluentCommand(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -159,7 +159,6 @@ data class YamlFluentCommand(
                 MaestroCommand(
                     maestro.orchestra.ClearStateCommand(
                         appId = clearState.appId ?: appId,
-                        permissions = clearState.permissions,
                     )
                 )
             )
@@ -485,7 +484,6 @@ data class YamlFluentCommand(
                 "clearState" -> YamlFluentCommand(
                     clearState = YamlClearState(
                         appId = null,
-                        permissions = null,
                     )
                 )
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlLaunchApp.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlLaunchApp.kt
@@ -26,6 +26,7 @@ data class YamlLaunchApp(
     val clearState: Boolean?,
     val clearKeychain: Boolean?,
     val stopApp: Boolean?,
+    val permissions: Map<String, String>?
 ) {
 
     companion object {
@@ -38,6 +39,7 @@ data class YamlLaunchApp(
                 clearState = null,
                 clearKeychain = null,
                 stopApp = null,
+                permissions = null,
             )
         }
     }

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -32,7 +32,6 @@ import maestro.ScreenRecording
 import maestro.SwipeDirection
 import maestro.TreeNode
 import maestro.ViewHierarchy
-import maestro.orchestra.MaestroConfig
 import maestro.utils.ScreenshotUtils
 import okio.Sink
 import okio.buffer
@@ -358,6 +357,12 @@ class FakeDriver : Driver {
         )
     }
 
+    override fun setPermissions(appId: String, permissions: Map<String, String>) {
+        ensureOpen()
+
+        events.add(Event.SetPermissions(appId, permissions))
+    }
+
     sealed class Event {
 
         data class Tap(
@@ -445,6 +450,10 @@ class FakeDriver : Driver {
 
         object ResetProxy : Event()
 
+        data class SetPermissions(
+            val appId: String,
+            val permissions: Map<String, String>,
+        ) : Event()
     }
 
     interface UserInteraction

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2389,6 +2389,61 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `086 - launchApp sets all permissions to allow`() {
+        val commands = readCommands("086_launchApp_sets_all_permissions_to_allow")
+        val driver = driver {}
+        driver.addInstalledApp("com.example.app")
+
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        driver.assertEvents(
+            listOf(
+                Event.SetPermissions("com.example.app", mapOf("all" to "allow")),
+                Event.LaunchApp("com.example.app"),
+            )
+        )
+    }
+
+    @Test
+    fun `087 - launchApp with all permissions to deny`() {
+        val commands = readCommands("087_launchApp_with_all_permissions_to_deny")
+        val driver = driver {}
+        driver.addInstalledApp("com.example.app")
+
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        driver.assertEvents(
+            listOf(
+                Event.SetPermissions("com.example.app", mapOf("all" to "deny")),
+                Event.LaunchApp("com.example.app"),
+            )
+        )
+    }
+
+    @Test
+    fun `088 - launchApp with all permissions to deny and notification to allow`() {
+        val commands = readCommands("088_launchApp_with_all_permissions_to_deny_and_notification_to_allow")
+        val driver = driver {}
+        driver.addInstalledApp("com.example.app")
+
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        driver.assertEvents(
+            listOf(
+                Event.SetPermissions("com.example.app", mapOf("all" to "deny", "notifications" to "allow")),
+                Event.LaunchApp("com.example.app"),
+            )
+        )
+    }
+
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/086_launchApp_sets_all_permissions_to_allow.yaml
+++ b/maestro-test/src/test/resources/086_launchApp_sets_all_permissions_to_allow.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-test/src/test/resources/087_launchApp_with_all_permissions_to_deny.yaml
+++ b/maestro-test/src/test/resources/087_launchApp_with_all_permissions_to_deny.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- launchApp:
+    permissions: { all: deny }

--- a/maestro-test/src/test/resources/088_launchApp_with_all_permissions_to_deny_and_notification_to_allow.yaml
+++ b/maestro-test/src/test/resources/088_launchApp_with_all_permissions_to_deny_and_notification_to_allow.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+---
+- launchApp:
+    permissions:
+      all: deny
+      notifications: allow


### PR DESCRIPTION
## Proposed Changes

Allow to set permissions in `launchApp`:
```
- launchApp:
      permissions: { notifications: deny }
```

## Testing

Tested on customer app flows.

## Issues Fixed

* https://github.com/mobile-dev-inc/maestro/issues/133
* There is a difference in permission handling on maestro cloud vs maestro cli on iOS, this PR is a step to close that gap

