### PR TITLE
feat: extend JUnit test reports

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -53,6 +53,7 @@ class CloudInteractor(
         excludeTags: List<String> = emptyList(),
         reportFormat: ReportFormat = ReportFormat.NOOP,
         reportOutput: File? = null,
+        testSuiteName: String? = null
     ): Int {
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
         if (mapping?.exists() == false) throw CliError("File does not exist: ${mapping.absolutePath}")
@@ -120,6 +121,7 @@ class CloudInteractor(
                     failOnCancellation = failOnCancellation,
                     reportFormat = reportFormat,
                     reportOutput = reportOutput,
+                    testSuiteName = testSuiteName,
                 )
             }
         }
@@ -133,6 +135,7 @@ class CloudInteractor(
         failOnCancellation: Boolean,
         reportFormat: ReportFormat,
         reportOutput: File?,
+        testSuiteName: String?
     ): Int {
         val startTime = System.currentTimeMillis()
 
@@ -182,6 +185,7 @@ class CloudInteractor(
                     failOnCancellation = failOnCancellation,
                     reportFormat = reportFormat,
                     reportOutput = reportOutput,
+                    testSuiteName = testSuiteName,
                 )
             }
 
@@ -239,6 +243,7 @@ class CloudInteractor(
         failOnCancellation: Boolean,
         reportFormat: ReportFormat,
         reportOutput: File?,
+        testSuiteName: String?
     ): Int {
         TestSuiteStatusView.showSuiteResult(
             upload.toViewModel(
@@ -262,7 +267,7 @@ class CloudInteractor(
             }
 
         if (reportOutputSink != null) {
-            saveReport(reportFormat, passed, upload, reportOutputSink)
+            saveReport(reportFormat, passed, upload, reportOutputSink, testSuiteName)
         }
 
         return if (!passed) {
@@ -276,9 +281,10 @@ class CloudInteractor(
         reportFormat: ReportFormat,
         passed: Boolean,
         upload: UploadStatus,
-        reportOutputSink: BufferedSink
+        reportOutputSink: BufferedSink,
+        testSuiteName: String?
     ) {
-        ReporterFactory.buildReporter(reportFormat)
+        ReporterFactory.buildReporter(reportFormat, testSuiteName)
             .report(
                 TestExecutionSummary(
                     passed = passed,

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -108,6 +108,12 @@ class CloudCommand : Callable<Int> {
     private var format: ReportFormat = ReportFormat.NOOP
 
     @Option(
+        names = ["--testsuite-name"],
+        description = ["Test suite name"],
+    )
+    private var testSuiteName: String? = null
+
+    @Option(
         order = 15,
         names = ["--output"],
         description = ["File to write report into (default=report.xml)"],
@@ -139,6 +145,7 @@ class CloudCommand : Callable<Int> {
             reportFormat = format,
             reportOutput = output,
             failOnCancellation = failOnCancellation,
+            testSuiteName = testSuiteName
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -67,6 +67,12 @@ class TestCommand : Callable<Int> {
     )
     private var format: ReportFormat = ReportFormat.NOOP
 
+    @Option(
+        names = ["--test-suite-name"],
+        description = ["Test suite name"],
+    )
+    private var testSuiteName: String? = null
+
     @Option(names = ["--output"])
     private var output: File? = null
 
@@ -127,7 +133,7 @@ class TestCommand : Callable<Int> {
                 val suiteResult = TestSuiteInteractor(
                     maestro = maestro,
                     device = device,
-                    reporter = ReporterFactory.buildReporter(format),
+                    reporter = ReporterFactory.buildReporter(format, testSuiteName),
                     includeTags = includeTags,
                     excludeTags = excludeTags,
                 ).runTestSuite(

--- a/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
@@ -2,9 +2,9 @@ package maestro.cli.report
 
 object ReporterFactory {
 
-    fun buildReporter(format: ReportFormat): TestSuiteReporter {
+    fun buildReporter(format: ReportFormat, testSuiteName: String?): TestSuiteReporter {
         return when (format) {
-            ReportFormat.JUNIT -> JUnitTestSuiteReporter.xml()
+            ReportFormat.JUNIT -> JUnitTestSuiteReporter.xml(testSuiteName)
             ReportFormat.NOOP -> TestSuiteReporter.NOOP
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -108,7 +108,7 @@ class TestSuiteInteractor(
         if (reportOut != null) {
             reporter.report(
                 summary,
-                reportOut
+                reportOut,
             )
         }
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -49,8 +49,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" device="iPhone 14" tests="2" failures="0">
-                    <testcase id="flow_a" name="Flow A"/>
-                    <testcase id="flow_b" name="Flow B"/>
+                    <testcase id="flow_a" name="Flow A" classname="flow_a"/>
+                    <testcase id="flow_b" name="Flow B" classname="flow_b"/>
                   </testsuite>
                 </testsuites>
                 
@@ -99,10 +99,60 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" tests="2" failures="1">
-                    <testcase id="flow_a" name="Flow A"/>
-                    <testcase id="flow_b" name="Flow B">
+                    <testcase id="flow_a" name="Flow A" classname="flow_a"/>
+                    <testcase id="flow_b" name="Flow B" classname="flow_b">
                       <failure>Error message</failure>
                     </testcase>
+                  </testsuite>
+                </testsuites>
+                
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `XML - Custom test suite name is used when present`() {
+        // Given
+        val testee = JUnitTestSuiteReporter.xml("Custom test suite name")
+
+        val summary = TestExecutionSummary(
+            passed = true,
+            deviceName = "iPhone 14",
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = true,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow A",
+                            fileName = "flow_a",
+                            status = FlowStatus.SUCCESS,
+                        ),
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow B",
+                            fileName = "flow_b",
+                            status = FlowStatus.WARNING,
+                        ),
+                    )
+                )
+            )
+        )
+        val sink = Buffer()
+
+        // When
+        testee.report(
+            summary = summary,
+            out = sink
+        )
+        val resultStr = sink.readUtf8()
+
+        // Then
+        assertThat(resultStr).isEqualTo(
+            """
+                <?xml version='1.0' encoding='UTF-8'?>
+                <testsuites>
+                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0">
+                    <testcase id="flow_a" name="Flow A" classname="flow_a"/>
+                    <testcase id="flow_b" name="Flow B" classname="flow_b"/>
                   </testsuite>
                 </testsuites>
                 


### PR DESCRIPTION
## Proposed Changes
- Set `classname` attribute to test `testcase` node with the same value as `id` to make the report compatible with systems as Testrail
- Add an option `--test-suite-name` that can be used to specify a custom name for the generate test suite

## Testing
Tested locally and updated unit tests.