### PR TITLE
Read API key from shell; Decorate env with shell env vars

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -215,8 +215,8 @@ class CloudInteractor(
         if (!workspace.exists()) throw CliError("Workspace does not exist: ${workspace.absolutePath}")
 
         val authToken = apiKey              // Check for API key
-            ?: EnvUtils.mdevApiKey()        // Resolve API key from shell if set
             ?: auth.getCachedAuthToken()    // Otherwise, if the user has already logged in, use the cached auth token
+            ?: EnvUtils.mdevApiKey()        // Resolve API key from shell if set
             ?: auth.triggerSignInFlow()     // Otherwise, trigger the sign-in flow
 
         PrintUtils.message("Deploying workspace to Maestro Mock Server...")

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -8,6 +8,7 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
 import maestro.cli.report.ReportFormat
 import maestro.cli.report.ReporterFactory
+import maestro.cli.util.EnvUtils
 import maestro.cli.util.FileUtils.isZip
 import maestro.cli.util.PrintUtils
 import maestro.cli.util.WorkspaceUtils
@@ -61,6 +62,7 @@ class CloudInteractor(
 
         val authToken = apiKey              // Check for API key
             ?: auth.getCachedAuthToken()    // Otherwise, if the user has already logged in, use the cached auth token
+            ?: EnvUtils.mdevApiKey()        // Resolve API key from shell if set
             ?: auth.triggerSignInFlow()     // Otherwise, trigger the sign-in flow
 
         PrintUtils.message("Uploading Flow(s)...")
@@ -213,6 +215,7 @@ class CloudInteractor(
         if (!workspace.exists()) throw CliError("Workspace does not exist: ${workspace.absolutePath}")
 
         val authToken = apiKey              // Check for API key
+            ?: EnvUtils.mdevApiKey()        // Resolve API key from shell if set
             ?: auth.getCachedAuthToken()    // Otherwise, if the user has already logged in, use the cached auth token
             ?: auth.triggerSignInFlow()     // Otherwise, trigger the sign-in flow
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -30,6 +30,7 @@ import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.runner.resultview.PlainTextResultView
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.util.PrintUtils
+import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import maestro.orchestra.yaml.YamlCommandReader
 import okio.buffer
 import okio.sink
@@ -59,7 +60,7 @@ class TestCommand : Callable<Int> {
     private var continuous: Boolean = false
 
     @Option(names = ["-e", "--env"])
-    private var env: Map<String, String> = emptyMap()
+    private var env: MutableMap<String, String> = mutableMapOf()
 
     @Option(
         names = ["--format"],
@@ -117,6 +118,8 @@ class TestCommand : Callable<Int> {
         val deviceId =
             if (isWebFlow()) "chromium".also { PrintUtils.warn("Web support is an experimental feature and may be removed in future versions.\n") }
             else parent?.deviceId
+
+        env = env.withInjectedShellEnvVars()
         
         return MaestroSessionManager.newSession(parent?.host, parent?.port, deviceId) { session ->
             val maestro = session.maestro

--- a/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
@@ -10,4 +10,7 @@ object EnvUtils {
             ?: System.getenv("ANDROID")
     }
 
+    fun mdevApiKey(): String? {
+        return System.getenv("MDEV_API_KEY")
+    }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -32,4 +32,15 @@ object Env {
         return listOf(MaestroCommand(DefineVariablesCommand(env))) + this
     }
 
+    fun MutableMap<String, String>.withInjectedShellEnvVars(): MutableMap<String, String> {
+        val sysEnv = System.getenv()
+        for (sysEnvKey in sysEnv.keys) {
+            val sysEnvValue = sysEnv[sysEnvKey]
+            if (this[sysEnvKey] == null && sysEnvValue != null) {
+                this[sysEnvKey] = sysEnvValue
+            }
+        }
+
+        return this
+    }
 }


### PR DESCRIPTION
## Proposed Changes
- If no API key is present as an option and the user is **not** logged in, use whatever value stored in `MDEV_API_KEY` in the current shell instead.
- When running `maestro test` **locally**, inject all shell environment variables and make them available for commands. Note that for security reasons, the injected shell variables won't be sent along to Maestro Cloud when running `maestro cloud`.

## Testing
Tested locally.