### PR TITLE
Allow launchApp with permissions on Android

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -590,7 +590,7 @@ class AndroidDriver(
             "allow" -> "grant"
             "deny" -> "revoke"
             "unset" -> "revoke"
-            else -> throw IllegalArgumentException("Permissions can be set to 'allow', 'deny' or 'unset' on Android, not '$value'")
+            else -> "revoke"
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -549,7 +549,7 @@ class AndroidDriver(
     private fun setPermissionInternal(appId: String, permission: String, permissionValue: String) {
         try {
             dadb.shell("pm $permissionValue $appId $permission")
-        } catch (securityException: SecurityException) {
+        } catch (exception: Exception) {
             /* no-op */
         }
     }
@@ -569,6 +569,9 @@ class AndroidDriver(
                 "android.permission.CALL_PHONE",
                 "android.permission.ANSWER_PHONE_CALLS",
             )
+            "microphone" -> listOf(
+                "android.permission.RECORD_AUDIO"
+            )
             "bluetooth" -> listOf(
                 "android.permission.BLUETOOTH_CONNECT",
                 "android.permission.BLUETOOTH_SCAN",
@@ -576,6 +579,16 @@ class AndroidDriver(
             "storage" -> listOf(
                 "android.permission.WRITE_EXTERNAL_STORAGE",
                 "android.permission.READ_EXTERNAL_STORAGE"
+            )
+            "notifications" -> listOf(
+                "android.permission.POST_NOTIFICATIONS"
+            )
+            "medialibrary" -> listOf(
+                "android.permission.WRITE_EXTERNAL_STORAGE",
+                "android.permission.READ_EXTERNAL_STORAGE",
+                "android.permission.READ_MEDIA_AUDIO",
+                "android.permission.READ_MEDIA_IMAGES",
+                "android.permission.READ_MEDIA_VIDEO"
             )
             "calendar" -> listOf(
                 "android.permission.WRITE_CALENDAR",

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -571,7 +571,7 @@ class AndroidDriver(
         if (permissionsResult.isSuccess) {
             permissionsResult.getOrNull()?.let {
                 it.forEach { permission ->
-                    setPermissionInternal(appId, permission, permissionValue)
+                    setPermissionInternal(appId, permission, translatePermissionValue(permissionValue))
                 }
             }
         }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -559,7 +559,7 @@ class AndroidDriver(
                 "android.permission.WRITE_CALENDAR",
                 "android.permission.READ_CALENDAR"
             )
-            else -> listOf(name)
+            else -> listOf(name.replace("[^A-Za-z0-9._]+".toRegex(), ""))
         }
     }
 


### PR DESCRIPTION
Allow launching android apps with permission id's or as a group

For example, allowing read/write storage could be:

```
- launchApp:
     permissions: storage
```

and for user permissions or which are not in list:

```
- launchApp:
    permissions:
      android.permission.BODY_SENSORS_BACKGROUND: allow
```
