### PR TITLE
Just once in app element autoVerification

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -433,6 +433,9 @@ class AndroidDriver(
             val appNameElement = filterByText(appName)
             if (appNameElement != null) {
                 tap(appNameElement.bounds.center())
+                filterById("android:id/button_once")?.let {
+                    tap(it.bounds.center())
+                }
             } else {
                 val openWithAppElement = filterByText(".*$appName.*")
                 if (openWithAppElement != null) {


### PR DESCRIPTION
Clicking on just once button was missing in one of the cases when app name is present with multiple apps.