### PR TITLE
Enter values in the javascript engine by wrapping them

### DIFF
--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -11,7 +11,7 @@ class JsEngine(
         .readTimeout(5, TimeUnit.MINUTES)
         .writeTimeout(5, TimeUnit.MINUTES)
         .protocols(listOf(Protocol.HTTP_1_1))
-        .build()
+        .build(),
 ) {
 
     private lateinit var context: Context
@@ -59,9 +59,9 @@ class JsEngine(
         script: String,
         env: Map<String, String> = emptyMap(),
         sourceName: String = "inline-script",
-        runInSubSope: Boolean = false
+        runInSubScope: Boolean = false,
     ): Any? {
-        val scope = if (runInSubSope) {
+        val scope = if (runInSubScope) {
             // We create a new scope for each evaluation to prevent local variables
             // from clashing with each other across multiple scripts.
             // Only 'output' is shared across scopes.
@@ -73,13 +73,8 @@ class JsEngine(
 
         if (env.isNotEmpty()) {
             env.forEach { (key, value) ->
-                context.evaluateString(
-                    scope,
-                    "var $key = '${Js.sanitizeJs(value)}'",
-                    sourceName,
-                    1,
-                    null
-                ).toString()
+                val wrappedValue = Context.javaToJS(value, scope)
+                ScriptableObject.putProperty(scope, key, wrappedValue)
             }
         }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -237,7 +237,7 @@ class Orchestra(
             script = command.script,
             env = command.env,
             sourceName = command.sourceDescription,
-            runInSubSope = true,
+            runInSubScope = true,
         )
 
         // We do not actually know if there were any mutations, but we assume there were


### PR DESCRIPTION
## Proposed Changes

Avoid javascript string parsing and javascript execution during value-setter,
by using rhino's api to wrap the java string and put it directly into the runtime's scope.

## Testing

Ran the test suite which covers this code

## Issues Fixed

Some customers have issues since 1.24.0, likely because their environment values are set to invalid javascript strings.