### PR TITLE
add SMS group permission

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -612,6 +612,11 @@ class AndroidDriver(
                 "android.permission.WRITE_CALENDAR",
                 "android.permission.READ_CALENDAR"
             )
+            "sms" -> listOf(
+                "android.permission.READ_SMS",
+                "android.permission.RECEIVE_SMS",
+                "android.permission.SEND_SMS"
+            )
             else -> listOf(name.replace("[^A-Za-z0-9._]+".toRegex(), ""))
         }
     }

--- a/maestro-test/src/test/resources/089_launchApp_with_sms_permission_group_to_allow.yaml
+++ b/maestro-test/src/test/resources/089_launchApp_with_sms_permission_group_to_allow.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- launchApp:
+    permissions: sms

--- a/maestro-test/src/test/resources/090_launchApp_with_permission_is_not_in_list.yaml
+++ b/maestro-test/src/test/resources/090_launchApp_with_permission_is_not_in_list.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- launchApp:
+    permissions:
+        android.permission.BODY_SENSORS_BACKGROUND: allow


### PR DESCRIPTION
## Proposed Changes
- add SMS group permission
```yaml
appId: com.example.app
---
- launchApp:
    permissions: sms
```
- add more tests
```bash
089_launchApp_with_sms_permission_group_to_allow.yaml
090_launchApp_with_permission_is_not_in_list.yaml
```

## Issues Fixed
#889 

