### PR TITLE
Add device API to allow listing and selecting devices

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -36,7 +36,10 @@ class StudioCommand : Callable<Int> {
 
     private fun launchStudio(session: MaestroSessionManager.MaestroSession? = null) {
         val port = getFreePort()
-        MaestroStudio.start(port, session?.maestro)
+        MaestroStudio.start(port)
+        if (session?.maestro != null) {
+            MaestroStudio.setMaestroInstance(session.maestro)
+        }
 
         val studioUrl = "https://studio.mobile.dev"
         val message = ("Maestro Studio".bold() + " is running at " + studioUrl.blue()).box()

--- a/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/mockserver/MockServerOpenCommand.kt
@@ -32,7 +32,7 @@ class MockServerOpenCommand : Callable<Int> {
         }
 
         val port = getFreePort()
-        MaestroStudio.start(port, null)
+        MaestroStudio.start(port)
 
         val studioUrl = "http://localhost:${port}/mock"
         val message = ("Maestro Studio".bold() + " Mock Server is running at " + studioUrl.blue()).box()

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -50,7 +50,7 @@ object MaestroSessionManager {
     private val executor = Executors.newScheduledThreadPool(1)
     private val logger = LoggerFactory.getLogger(MaestroSessionManager::class.java)
 
-    fun <T> newSession(
+     fun <T> newSession(
         host: String?,
         port: Int?,
         deviceId: String?,

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -50,7 +50,7 @@ object MaestroSessionManager {
     private val executor = Executors.newScheduledThreadPool(1)
     private val logger = LoggerFactory.getLogger(MaestroSessionManager::class.java)
 
-     fun <T> newSession(
+    fun <T> newSession(
         host: String?,
         port: Int?,
         deviceId: String?,

--- a/maestro-cli/src/main/java/maestro/cli/studio/DeviceScreenService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/DeviceScreenService.kt
@@ -34,7 +34,11 @@ object DeviceScreenService {
 
     private val savedScreenshots = mutableListOf<File>()
 
-    var maestro: Maestro? = null
+    private var maestro: Maestro? = null
+
+    fun setMaestroInstance(maestroInstance: Maestro) {
+        maestro = maestroInstance
+    }
 
     fun routes(routing: Routing) {
         routing.get("/api/device-screen") {

--- a/maestro-cli/src/main/java/maestro/cli/studio/DevicesService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/DevicesService.kt
@@ -72,9 +72,3 @@ object DevicesService {
         }
     }
 }
-
-fun main() {
-    val connected = DeviceService.listConnectedDevices()
-    val availableForLaunch = DeviceService.listAvailableForLaunchDevices()
-    println(connected.size)
-}

--- a/maestro-cli/src/main/java/maestro/cli/studio/DevicesService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/DevicesService.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
 import io.ktor.server.routing.Routing
 import io.ktor.server.routing.get
 import io.ktor.server.routing.post
@@ -20,8 +21,14 @@ private data class SelectDeviceRequest(
 object DevicesService {
     private var selectedDevice: Device.Connected? = null
 
-    fun routes(routing: Routing) {
-        routing.get("/api/devices") {
+    fun Route.devicesRoutes() {
+        devicesRoute()
+        getSelectedDeviceRoute()
+        selectDeviceRoute()
+    }
+
+    private fun Route.devicesRoute() {
+        get("/api/devices") {
             val connected = DeviceService.listConnectedDevices()
             val availableForLaunch = DeviceService.listAvailableForLaunchDevices()
             val data = Devices(connected, availableForLaunch)
@@ -32,42 +39,53 @@ object DevicesService {
                 .writeValueAsString(data)
             call.respondText(response)
         }
+    }
 
-        routing.get("/api/devices/selected") {
+    private fun Route.getSelectedDeviceRoute() {
+        get("/api/devices/selected") {
             val response = jacksonObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 .writerWithDefaultPrettyPrinter()
                 .writeValueAsString(selectedDevice)
             call.respondText(response)
         }
+    }
 
-        routing.post("api/devices/select") {
+    private fun Route.selectDeviceRoute() {
+        post("api/devices/select") {
             val request = call.parseBody<SelectDeviceRequest>()
-            if (selectedDevice?.instanceId == request.instanceId) throw HttpException(HttpStatusCode.BadRequest, "Device already selected")
 
-            var connectedDevice = DeviceService.listConnectedDevices()
-                .firstOrNull() { it.instanceId == request.instanceId }
-
-            if (connectedDevice == null) {
-                val deviceAvailableForLaunch = DeviceService.listAvailableForLaunchDevices()
-                    .firstOrNull() { it.modelId == request.modelId }
-                if (deviceAvailableForLaunch != null) {
-                    connectedDevice = DeviceService.startDevice(deviceAvailableForLaunch)
-                } else {
-                    throw HttpException(HttpStatusCode.BadRequest, "Specified device not found")
-                }
-
+            fun buildResponse(): String {
+                return jacksonObjectMapper()
+                    .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(selectedDevice)
             }
 
-            selectedDevice = connectedDevice
-            val response = jacksonObjectMapper()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .writerWithDefaultPrettyPrinter()
-                .writeValueAsString(selectedDevice)
-            call.respondText(response)
+            if (selectedDevice?.instanceId == request.instanceId) {
+                call.respondText(buildResponse())
+            } else {
+                var connectedDevice = DeviceService.listConnectedDevices()
+                    .firstOrNull() { it.instanceId == request.instanceId }
 
-            MaestroSessionManager.newSession(null, null, connectedDevice.instanceId, true) { session ->
-                MaestroStudio.setMaestroInstance(session.maestro)
+                if (connectedDevice == null) {
+                    val deviceAvailableForLaunch = DeviceService.listAvailableForLaunchDevices()
+                        .firstOrNull() { it.modelId == request.modelId }
+                    if (deviceAvailableForLaunch != null) {
+                        connectedDevice = DeviceService.startDevice(deviceAvailableForLaunch)
+                    } else {
+                        throw HttpException(HttpStatusCode.BadRequest, "Specified device not found")
+                    }
+
+                }
+
+                selectedDevice = connectedDevice
+
+                call.respondText(buildResponse())
+
+                MaestroSessionManager.newSession(null, null, connectedDevice.instanceId, true) { session ->
+                    MaestroStudio.setMaestroInstance(session.maestro)
+                }
             }
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/studio/DevicesService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/DevicesService.kt
@@ -1,0 +1,80 @@
+package maestro.cli.studio
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Routing
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import maestro.cli.device.Device
+import maestro.cli.device.DeviceService
+import maestro.cli.session.MaestroSessionManager
+
+private data class SelectDeviceRequest(
+    val instanceId: String?,
+    val modelId: String?,
+)
+
+object DevicesService {
+    private var selectedDevice: Device.Connected? = null
+
+    fun routes(routing: Routing) {
+        routing.get("/api/devices") {
+            val connected = DeviceService.listConnectedDevices()
+            val availableForLaunch = DeviceService.listAvailableForLaunchDevices()
+            val data = Devices(connected, availableForLaunch)
+
+            val response = jacksonObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .writerWithDefaultPrettyPrinter()
+                .writeValueAsString(data)
+            call.respondText(response)
+        }
+
+        routing.get("/api/devices/selected") {
+            val response = jacksonObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .writerWithDefaultPrettyPrinter()
+                .writeValueAsString(selectedDevice)
+            call.respondText(response)
+        }
+
+        routing.post("api/devices/select") {
+            val request = call.parseBody<SelectDeviceRequest>()
+            if (selectedDevice?.instanceId == request.instanceId) throw HttpException(HttpStatusCode.BadRequest, "Device already selected")
+
+            var connectedDevice = DeviceService.listConnectedDevices()
+                .firstOrNull() { it.instanceId == request.instanceId }
+
+            if (connectedDevice == null) {
+                val deviceAvailableForLaunch = DeviceService.listAvailableForLaunchDevices()
+                    .firstOrNull() { it.modelId == request.modelId }
+                if (deviceAvailableForLaunch != null) {
+                    connectedDevice = DeviceService.startDevice(deviceAvailableForLaunch)
+                } else {
+                    throw HttpException(HttpStatusCode.BadRequest, "Specified device not found")
+                }
+
+            }
+
+            selectedDevice = connectedDevice
+            val response = jacksonObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .writerWithDefaultPrettyPrinter()
+                .writeValueAsString(selectedDevice)
+            call.respondText(response)
+
+            MaestroSessionManager.newSession(null, null, connectedDevice.instanceId, true) { session ->
+                MaestroStudio.setMaestroInstance(session.maestro)
+            }
+        }
+    }
+}
+
+fun main() {
+    val connected = DeviceService.listConnectedDevices()
+    val availableForLaunch = DeviceService.listAvailableForLaunchDevices()
+    println(connected.size)
+}

--- a/maestro-cli/src/main/java/maestro/cli/studio/MaestroStudio.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/MaestroStudio.kt
@@ -15,6 +15,7 @@ import io.ktor.server.routing.routing
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import maestro.Maestro
+import maestro.cli.studio.DevicesService.devicesRoutes
 
 object MaestroStudio {
 
@@ -47,7 +48,8 @@ object MaestroStudio {
                 DeviceScreenService.routes(this)
                 ReplService.routes(this)
                 MockService.routes(this, MockInteractor())
-                DevicesService.routes(this)
+                this.devicesRoutes()
+
                 this.get("/") {
                     call.respondText("running")
                 }

--- a/maestro-cli/src/main/java/maestro/cli/studio/MaestroStudio.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/MaestroStudio.kt
@@ -19,8 +19,8 @@ import maestro.Maestro
 object MaestroStudio {
 
     fun setMaestroInstance(maestro: Maestro) {
-        DeviceScreenService.maestro = maestro
-        ReplService.maestro = maestro
+        DeviceScreenService.setMaestroInstance(maestro)
+        ReplService.setMaestroInstance(maestro)
     }
 
     fun start(port: Int) {

--- a/maestro-cli/src/main/java/maestro/cli/studio/MaestroStudio.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/MaestroStudio.kt
@@ -18,7 +18,12 @@ import maestro.Maestro
 
 object MaestroStudio {
 
-    fun start(port: Int, maestro: Maestro?) {
+    fun setMaestroInstance(maestro: Maestro) {
+        DeviceScreenService.maestro = maestro
+        ReplService.maestro = maestro
+    }
+
+    fun start(port: Int) {
         embeddedServer(Netty, port = port) {
             install(CORS) {
                 allowHost("localhost:3000")
@@ -39,11 +44,10 @@ object MaestroStudio {
                 }
             }
             routing {
-                if (maestro != null) {
-                    DeviceScreenService.routes(this, maestro)
-                    ReplService.routes(this, maestro)
-                }
+                DeviceScreenService.routes(this)
+                ReplService.routes(this)
                 MockService.routes(this, MockInteractor())
+                DevicesService.routes(this)
                 this.get("/") {
                     call.respondText("running")
                 }

--- a/maestro-cli/src/main/java/maestro/cli/studio/Models.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/Models.kt
@@ -51,3 +51,8 @@ data class Repl(
     val version: Int,
     val commands: List<ReplCommand>,
 )
+
+data class Devices(
+    val connected: List<Device.Connected>,
+    val availableForLaunch: List<Device.AvailableForLaunch>,
+)

--- a/maestro-cli/src/main/java/maestro/cli/studio/ReplService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/studio/ReplService.kt
@@ -114,8 +114,11 @@ object ReplService {
 
     private val executionLock = Object()
     private val state = ReplState()
+    private var maestro: Maestro? = null
 
-    var maestro: Maestro? = null
+    fun setMaestroInstance(maestroInstance: Maestro) {
+        maestro = maestroInstance
+    }
 
     fun routes(routing: Routing) {
         routing.get("/api/repl") {


### PR DESCRIPTION
## Proposed Changes
- Make it possible to start Studio without a selected device
- Add a device api with three routes:
  - `GET /api/devices` that returns connected devices as well as devices available for launch
  - `GET /api/devices/selected` that returns the currently selected device if any
  - `POST /api/devices/selected` that allows selecting a device via either `instanceId` or `modelId`

## Testing
Tested locally