### PR TITLE
feat: update env var injection and propagate to cloud

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -73,7 +73,7 @@ class CloudCommand : Callable<Int> {
     private var pullRequestId: String? = null
 
     @Option(order = 8, names = ["-e", "--env"], description = ["Environment variables to inject into your Flows"])
-    private var env: MutableMap<String, String> = mutableMapOf()
+    private var env: Map<String, String> = emptyMap()
 
     @Option(order = 9, names = ["--name"], description = ["Name of the upload"])
     private var uploadName: String? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -23,6 +23,7 @@ import maestro.cli.DisableAnsiMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.cloud.CloudInteractor
 import maestro.cli.report.ReportFormat
+import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import picocli.CommandLine
 import picocli.CommandLine.Option
 import java.io.File
@@ -72,7 +73,7 @@ class CloudCommand : Callable<Int> {
     private var pullRequestId: String? = null
 
     @Option(order = 8, names = ["-e", "--env"], description = ["Environment variables to inject into your Flows"])
-    private var env: Map<String, String> = emptyMap()
+    private var env: MutableMap<String, String> = mutableMapOf()
 
     @Option(order = 9, names = ["--name"], description = ["Name of the upload"])
     private var uploadName: String? = null
@@ -131,7 +132,7 @@ class CloudCommand : Callable<Int> {
             flowFile = flowFile,
             appFile = appFile,
             mapping = mapping,
-            env = env,
+            env = env.withInjectedShellEnvVars(),
             uploadName = uploadName,
             repoOwner = repoOwner,
             repoName = repoName,

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -60,7 +60,7 @@ class TestCommand : Callable<Int> {
     private var continuous: Boolean = false
 
     @Option(names = ["-e", "--env"])
-    private var env: MutableMap<String, String> = mutableMapOf()
+    private var env: Map<String, String> = emptyMap()
 
     @Option(
         names = ["--format"],

--- a/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
@@ -69,7 +69,7 @@ class UploadCommand : Callable<Int> {
     private var pullRequestId: String? = null
 
     @Option(order = 7, names = ["-e", "--env"], description = ["Environment variables to inject into your Flows"])
-    private var env: MutableMap<String, String> = mutableMapOf()
+    private var env: Map<String, String> = emptyMap()
 
     @Option(order = 8, names = ["--name"], description = ["Name of the upload"])
     private var uploadName: String? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
@@ -22,6 +22,7 @@ package maestro.cli.command
 import maestro.cli.DisableAnsiMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.cloud.CloudInteractor
+import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import org.fusesource.jansi.Ansi.ansi
 import picocli.CommandLine
 import picocli.CommandLine.Option
@@ -68,7 +69,7 @@ class UploadCommand : Callable<Int> {
     private var pullRequestId: String? = null
 
     @Option(order = 7, names = ["-e", "--env"], description = ["Environment variables to inject into your Flows"])
-    private var env: Map<String, String> = emptyMap()
+    private var env: MutableMap<String, String> = mutableMapOf()
 
     @Option(order = 8, names = ["--name"], description = ["Name of the upload"])
     private var uploadName: String? = null
@@ -91,7 +92,7 @@ class UploadCommand : Callable<Int> {
             flowFile = flowFile,
             appFile = appFile,
             mapping = mapping,
-            env = env,
+            env = env.withInjectedShellEnvVars(),
             uploadName = uploadName,
             repoOwner = repoOwner,
             repoName = repoName,

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -32,15 +32,16 @@ object Env {
         return listOf(MaestroCommand(DefineVariablesCommand(env))) + this
     }
 
-    fun MutableMap<String, String>.withInjectedShellEnvVars(): MutableMap<String, String> {
+    fun Map<String, String>.withInjectedShellEnvVars(): Map<String, String> {
+        val mutable = this.toMutableMap()
         val sysEnv = System.getenv()
         for (sysEnvKey in sysEnv.keys.filter { it.startsWith("MAESTRO_") }) {
             val sysEnvValue = sysEnv[sysEnvKey]
-            if (this[sysEnvKey] == null && sysEnvValue != null) {
-                this[sysEnvKey] = sysEnvValue
+            if (mutable[sysEnvKey] == null && sysEnvValue != null) {
+                mutable[sysEnvKey] = sysEnvValue
             }
         }
 
-        return this
+        return mutable
     }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -34,7 +34,7 @@ object Env {
 
     fun MutableMap<String, String>.withInjectedShellEnvVars(): MutableMap<String, String> {
         val sysEnv = System.getenv()
-        for (sysEnvKey in sysEnv.keys) {
+        for (sysEnvKey in sysEnv.keys.filter { it.startsWith("MAESTRO_") }) {
             val sysEnvValue = sysEnv[sysEnvKey]
             if (this[sysEnvKey] == null && sysEnvValue != null) {
                 this[sysEnvKey] = sysEnvValue


### PR DESCRIPTION
## Proposed Changes
- Only inject shell env vars prefixed with `MAESTRO_`
- Also inject env vars when running `maestro cloud`, to avoid different results compared to running locally when Flows are depending on shell env vars.

Note that this changes the current behaviour, which is to inject _all_ env vars when running locally and _not_ propagate these env vars to Maestro Cloud.

## Testing
Tested locally.