### PR TITLE
Stop XCTest runner before starting

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -167,7 +167,7 @@ object MaestroSessionManager {
                             restoreConnection = {
                             if (SessionStore.activeSessions().isNotEmpty()) {
                                 IdbCompanion.setup(selectedDevice.device)
-                                return@XCTestDriverClient xcTestInstaller.setup()
+                                return@XCTestDriverClient xcTestInstaller.start()
                             }
                             return@XCTestDriverClient false
                         })
@@ -323,7 +323,7 @@ object MaestroSessionManager {
             port = defaultXcTestPort,
             restoreConnection = {
                 if (SessionStore.activeSessions().isNotEmpty()) {
-                    return@XCTestDriverClient xcTestInstaller.setup()
+                    return@XCTestDriverClient xcTestInstaller.start()
                 }
                 return@XCTestDriverClient false
             }

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -34,9 +34,9 @@ class XCTestIOSDevice(
 
     private fun restartXCTestRunnerService() {
         logger.info("[Start] Uninstalling xctest ui runner app on $deviceId")
-        installer.killAndUninstall()
+        installer.uninstall()
         logger.info("[Done] Uninstalling xctest ui runner app on $deviceId")
-        installer.setup()
+        installer.start()
     }
 
     override fun deviceInfo(): Result<DeviceInfo, Throwable> {

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -144,7 +144,7 @@ class XCTestDriverClient(
             if (restoreConnection()) {
                 it.proceed(request)
             } else {
-                throw XCTestDriverUnreachable("Failed to reach out XCUITest Server")
+                throw XCTestDriverUnreachable("Failed to reach out XCUITest Server in RetryOnError")
             }
         }
     })
@@ -163,7 +163,7 @@ class XCTestDriverClient(
                     .code(200)
                     .build()
             } else {
-                throw XCTestDriverUnreachable("Failed to reach out XCUITest Server")
+                throw XCTestDriverUnreachable("Failed to reach out XCUITest Server in ReturnOkOnShutdown")
             }
         }
     })

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -33,16 +33,23 @@ class LocalXCTestInstaller(
 
         stop()
 
-        logger.info("[Start] Uninstalling the XCUITest runner app")
+        logger.info("[Start] Uninstall XCUITest runner")
         XCRunnerSimctl.uninstall(UI_TEST_RUNNER_APP_BUNDLE_ID)
-        logger.info("[Done] Uninstalling the XCUITest runner app")
+        logger.info("[Done] Uninstall XCUITest runner")
     }
 
     private fun stop() {
         if (xcTestProcess?.isAlive == true) {
-            logger.info("[Start] Killing the started XCUITest")
+            logger.info("[Start] Stop XCUITest runner")
             xcTestProcess?.destroy()
-            logger.info("[Done] Killing the started XCUITest")
+            logger.info("[Done] Stop XCUITest runner")
+        }
+
+        val pid = XCRunnerSimctl.pidForApp(UI_TEST_RUNNER_APP_BUNDLE_ID)
+        if (pid != null) {
+            ProcessBuilder(listOf("kill", pid.toString()))
+                .start()
+                .waitFor()
         }
     }
 
@@ -54,16 +61,16 @@ class LocalXCTestInstaller(
         stop()
 
         repeat(3) { i ->
-            logger.info("[Start] Installing xctest ui runner on $deviceId")
+            logger.info("[Start] Install XCUITest runner on $deviceId")
             startXCTestRunner()
-            logger.info("[Done] Installing xctest ui runner on $deviceId")
+            logger.info("[Done] Install XCUITest runner on $deviceId")
 
-            logger.info("[Start] Ensuring ui test runner app is launched on $deviceId")
+            logger.info("[Start] Ensure XCUITest runner is running on $deviceId")
             if (ensureOpen()) {
-                logger.info("[Done] Ensuring ui test runner app is launched on $deviceId")
+                logger.info("[Done] Ensure XCUITest runner is running on $deviceId")
                 return true
             } else {
-                logger.info("[Failed] Ensuring ui test runner app is launched on $deviceId")
+                logger.info("[Failed] Ensure XCUITest runner is running on $deviceId")
                 logger.info("[Retry] Retrying setup() ${i}th time")
             }
         }

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
@@ -2,9 +2,9 @@ package xcuitest.installer
 
 interface XCTestInstaller: AutoCloseable {
 
-    fun setup(): Boolean
+    fun start(): Boolean
 
-    fun killAndUninstall()
+    fun uninstall()
 
     fun isChannelAlive(): Boolean
 }


### PR DESCRIPTION
## Proposed Changes

Stop a running XCTest runner before starting it.

## Testing

## Issues Fixed

Exception where the XCTest runner is restarted but was already running: "Failed to reach out XCUITest Server".