### PR TITLE
Add argument for remote allow origins to WebDriver

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -69,6 +69,7 @@ class WebDriver(val isStudio: Boolean) : Driver {
             driverService,
             ChromeOptions().apply {
                 logLevel = ChromeDriverLogLevel.OFF
+                addArguments("--remote-allow-origins=*")
                 if (isStudio) {
                     setHeadless(true)
                     addArguments("--window-size=1024,768")


### PR DESCRIPTION
## Proposed Changes

Because of a recent chrome update, when running the web driver we would get this error on our test runner machine:

```
org.openqa.selenium.remote.http.WebSocket$Listener onError
WARNING: Invalid Status code=403 text=Forbidden
java.io.IOException: Invalid Status code=403 text=Forbidden
	at org.asynchttpclient.netty.handler.WebSocketHandler.abort(WebSocketHandler.java:92)
	at org.asynchttpclient.netty.handler.WebSocketHandler.handleRead(WebSocketHandler.java:[11](https://github.com/foxtrotco/foxtrot-next/actions/runs/4426621340/jobs/7763296013#step:3:12)8)
	at org.asynchttpclient.netty.handler.AsyncHttpClientHandler.channelRead(AsyncHttpClientHandler.java:78)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:4[12](https://github.com/foxtrotco/foxtrot-next/actions/runs/4426621340/jobs/7763296013#step:3:13))
	at io.netty.channel.CombinedChannelDuplexHandler$DelegatingChannelHandlerContext.fireChannelRead(CombinedChannelDuplexHandler.java:436)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
	at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:333)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:454)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:290)
	at io.netty.channel.CombinedChannelDuplexHandler.channelRead(CombinedChannelDuplexHandler.java:251)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:442)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:[14](https://github.com/foxtrotco/foxtrot-next/actions/runs/4426621340/jobs/7763296013#step:3:15)10)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:440)
	at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
	at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724)
	at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562)
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
```

After doing some research, it seems that this is totally due chrome verison update v.1111 breaking default parameters, see this stack overflow: [https://stackoverflow.com/questions/75678572/java-io-ioexception-invalid-status-code-403-text-forbidden](https://stackoverflow.com/questions/75678572/java-io-ioexception-invalid-status-code-403-text-forbidden)

After adding this argument it seems that our tests are able to run without any issues.

## Testing

Ran the tests that were previously failing with this branch as the source and they were able to complete.

## Issues Fixed

(See stack trace above)