### PR TITLE
Prevent double log lines in IOSDriver

### DIFF
--- a/maestro-client/src/main/java/maestro/debuglog/IOSDriverLogger.kt
+++ b/maestro-client/src/main/java/maestro/debuglog/IOSDriverLogger.kt
@@ -4,7 +4,9 @@ import maestro.logger.Logger
 
 class IOSDriverLogger : Logger {
 
-    private val logger by lazy { DebugLogStore.loggerFor(IOSDriverLogger::class.java) }
+    companion object {
+        private val logger by lazy { DebugLogStore.loggerFor(IOSDriverLogger::class.java) }
+    }
 
     override fun info(message: String) {
         logger.info(message)


### PR DESCRIPTION
## Proposed Changes

Create only one logger for the IOSDriverLogger

## Testing

Locally 

## Issues Fixed

Log lines would show up duplicated