### PR TITLE
Pass XCTestInstaller to XCTestDriverClient instead of XCTestIOSDevice

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -31,7 +31,6 @@ import maestro.Maestro
 import maestro.cli.device.Device
 import maestro.cli.device.PickDeviceInteractor
 import maestro.cli.device.Platform
-import maestro.cli.idb.IdbCompanion
 import maestro.debuglog.IOSDriverLogger
 import maestro.drivers.IOSDriver
 import org.slf4j.LoggerFactory
@@ -164,18 +163,13 @@ object MaestroSessionManager {
                         val xcTestDriverClient = XCTestDriverClient(
                             host = defaultHost,
                             port = defaultXcTestPort,
-                            restoreConnection = {
-                            if (SessionStore.activeSessions().isNotEmpty()) {
-                                IdbCompanion.setup(selectedDevice.device)
-                                return@XCTestDriverClient xcTestInstaller.start()
-                            }
-                            return@XCTestDriverClient false
-                        })
+                            installer = xcTestInstaller,
+                            logger = IOSDriverLogger(XCTestDriverClient::class.java),
+                        )
 
                         val xcTestDevice = XCTestIOSDevice(
                             deviceId = selectedDevice.device.instanceId,
                             client = xcTestDriverClient,
-                            installer = xcTestInstaller,
                             getInstalledApps = { XCRunnerSimctl.listApps() },
                             logger = IOSDriverLogger(XCTestIOSDevice::class.java),
                         )
@@ -317,17 +311,12 @@ object MaestroSessionManager {
         val xcTestDriverClient = XCTestDriverClient(
             host = defaultHost,
             port = defaultXcTestPort,
-            restoreConnection = {
-                if (SessionStore.activeSessions().isNotEmpty()) {
-                    return@XCTestDriverClient xcTestInstaller.start()
-                }
-                return@XCTestDriverClient false
-            }
+            installer = xcTestInstaller,
+            logger = IOSDriverLogger(XCTestDriverClient::class.java),
         )
         val xcTestDevice = XCTestIOSDevice(
             deviceId = device.instanceId,
             client = xcTestDriverClient,
-            installer = xcTestInstaller,
             getInstalledApps = { XCRunnerSimctl.listApps() },
             logger = IOSDriverLogger(XCTestIOSDevice::class.java),
         )
@@ -339,13 +328,7 @@ object MaestroSessionManager {
             LocalIOSDevice(
                 deviceId = device.instanceId,
                 idbIOSDevice = idbIOSDevice,
-                xcTestDevice = XCTestIOSDevice(
-                    deviceId = device.instanceId,
-                    client = xcTestDriverClient,
-                    installer = xcTestInstaller,
-                    getInstalledApps = { XCRunnerSimctl.listApps() },
-                    logger = IOSDriverLogger(LocalIOSDevice::class.java),
-                ),
+                xcTestDevice = xcTestDevice,
                 simctlIOSDevice = simctlIOSDevice,
             )
         )

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -16,27 +16,18 @@ import okio.buffer
 import xcuitest.XCTestDriverClient
 import xcuitest.api.GetRunningAppIdResponse
 import xcuitest.api.IsScreenStaticResponse
-import xcuitest.installer.XCTestInstaller
 import java.io.File
 import java.io.InputStream
 
 class XCTestIOSDevice(
     override val deviceId: String?,
     private val client: XCTestDriverClient,
-    private val installer: XCTestInstaller,
     private val logger: Logger,
     private val getInstalledApps: () -> Set<String>,
 ) : IOSDevice {
 
     override fun open() {
-        restartXCTestRunnerService()
-    }
-
-    private fun restartXCTestRunnerService() {
-        logger.info("[Start] Uninstalling xctest ui runner app on $deviceId")
-        installer.uninstall()
-        logger.info("[Done] Uninstalling xctest ui runner app on $deviceId")
-        installer.start()
+        client.restartXCTestRunnerService()
     }
 
     override fun deviceInfo(): Result<DeviceInfo, Throwable> {
@@ -226,11 +217,11 @@ class XCTestIOSDevice(
     }
 
     override fun isShutdown(): Boolean {
-        return !installer.isChannelAlive()
+        return !client.isChannelAlive()
     }
 
     override fun close() {
-        installer.close()
+        client.close()
     }
 
     override fun isScreenStatic(): Result<Boolean, Throwable> {


### PR DESCRIPTION
## Proposed Changes

This simplifies the setup:
* DriverClient already needs Installer to restart the service on error
* Device already needs DriverClient to perform the API calls
* With this change Device no longer needs to know about the Installer




