### PR TITLE
Use the XCTest runner version of keyPress() buttonPress() and eraseText()

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -145,34 +145,28 @@ class IOSDriver(
     }
 
     override fun pressKey(code: KeyCode) {
-        return when (code) {
-            KeyCode.ENTER -> pressKey(40)  // keyboardReturnOrEnter
-            KeyCode.BACKSPACE -> pressKey(42)   // keyboardDeleteOrBackspace
-            KeyCode.VOLUME_UP -> pressKey(128)  // keyboardVolumeUp
-            KeyCode.VOLUME_DOWN -> pressKey(129)    // keyboardVolumeDown
-            KeyCode.HOME -> pressButton(1)  // idb.HIDButtonType.HOME
-            KeyCode.LOCK -> pressButton(2)  // idb.HIDButtonType.LOCK
-            KeyCode.BACK -> Unit // Do nothing, back key is not available on iOS
-            KeyCode.REMOTE_UP -> pressKey(82)
-            KeyCode.REMOTE_DOWN -> pressKey(81)
-            KeyCode.REMOTE_LEFT -> pressKey(80)
-            KeyCode.REMOTE_RIGHT -> pressKey(79)
-            KeyCode.REMOTE_CENTER -> Unit
-            KeyCode.REMOTE_PLAY_PAUSE -> Unit
-            KeyCode.REMOTE_STOP -> Unit
-            KeyCode.REMOTE_NEXT -> Unit
-            KeyCode.REMOTE_PREVIOUS -> Unit
-            KeyCode.REMOTE_REWIND -> Unit
-            KeyCode.REMOTE_FAST_FORWARD -> Unit
+        val keyCodeNameMap = mapOf(
+            KeyCode.BACKSPACE to "delete",
+            KeyCode.ENTER to "enter",
+            // Supported by iOS but not yet by maestro:
+//        KeyCode.RETURN to "return",
+//        KeyCode.TAP to "tab",
+//        KeyCode.SPACE to "space",
+//        KeyCode.ESCAPE to "escape",
+        )
+
+        val buttonNameMap = mapOf(
+            KeyCode.HOME to "home",
+            KeyCode.LOCK to "lock",
+        )
+
+        keyCodeNameMap[code]?.let { name ->
+            iosDevice.pressKey(name)
         }
-    }
 
-    private fun pressKey(code: Int) {
-        iosDevice.pressKey(code).expect {}
-    }
-
-    private fun pressButton(code: Int) {
-        iosDevice.pressButton(code).expect {}
+        buttonNameMap[code]?.let { name ->
+            iosDevice.pressButton(name)
+        }
     }
 
     override fun contentDescriptor(): TreeNode {
@@ -379,7 +373,7 @@ class IOSDriver(
     override fun backPress() {}
 
     override fun hideKeyboard() {
-        iosDevice.pressKey(40).expect {}
+        pressKey(KeyCode.ENTER)
     }
 
     override fun takeScreenshot(out: Sink, compressed: Boolean) {
@@ -409,9 +403,7 @@ class IOSDriver(
     }
 
     override fun eraseText(charactersToErase: Int) {
-        repeat(charactersToErase) {
-            pressKey(KeyCode.BACKSPACE)
-        }
+        iosDevice.eraseText(charactersToErase)
     }
 
     override fun setProxy(host: String, port: Int) {

--- a/maestro-ios/src/main/java/ios/IOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/IOSDevice.kt
@@ -40,8 +40,10 @@ interface IOSDevice : AutoCloseable {
 
     fun longPress(x: Int, y: Int, durationMs: Long): Result<Unit, Throwable>
 
+    @Deprecated("Use pressKey(name) instead")
     fun pressKey(code: Int): Result<Unit, Throwable>
 
+    @Deprecated("Use pressButton(name) instead")
     fun pressButton(code: Int): Result<Unit, Throwable>
 
     fun scroll(
@@ -158,6 +160,12 @@ interface IOSDevice : AutoCloseable {
     fun isScreenStatic(): Result<Boolean, Throwable>
 
     fun setPermissions(id: String, permissions: Map<String, String>)
+
+    fun pressKey(name: String)
+
+    fun pressButton(name: String)
+
+    fun eraseText(charactersToErase: Int)
 }
 
 interface IOSScreenRecording : AutoCloseable

--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -55,8 +55,16 @@ class LocalIOSDevice(
         }
     }
 
+    override fun pressKey(name: String) {
+        xcTestDevice.pressKey(name)
+    }
+
     override fun pressButton(code: Int): Result<Unit, Throwable> {
         return idbIOSDevice.pressButton(code)
+    }
+
+    override fun pressButton(name: String) {
+        xcTestDevice.pressButton(name)
     }
 
     override fun scroll(
@@ -136,5 +144,9 @@ class LocalIOSDevice(
 
     override fun setPermissions(id: String, permissions: Map<String, String>) {
         simctlIOSDevice.setPermissions(id, permissions)
+    }
+
+    override fun eraseText(charactersToErase: Int) {
+        xcTestDevice.eraseText(charactersToErase)
     }
 }

--- a/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/idb/IdbIOSDevice.kt
@@ -141,6 +141,10 @@ class IdbIOSDevice(
         }
     }
 
+    override fun pressKey(name: String) {
+        TODO("Not yet implemented")
+    }
+
     override fun pressButton(code: Int): Result<Unit, Throwable> {
         return runWithRestartRecovery {
             val responseObserver = BlockingStreamObserver<Idb.HIDResponse>()
@@ -156,6 +160,10 @@ class IdbIOSDevice(
 
             stream.onCompleted()
         }
+    }
+
+    override fun pressButton(name: String) {
+        TODO("Not yet implemented")
     }
 
     override fun scroll(xStart: Double, yStart: Double, xEnd: Double, yEnd: Double, duration: Double): Result<Unit, Throwable> {
@@ -493,6 +501,10 @@ class IdbIOSDevice(
     }
 
     override fun setPermissions(id: String, permissions: Map<String, String>) {
+        TODO("Not yet implemented")
+    }
+
+    override fun eraseText(charactersToErase: Int) {
         TODO("Not yet implemented")
     }
 

--- a/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
@@ -38,7 +38,15 @@ class SimctlIOSDevice(
         TODO("Not yet implemented")
     }
 
+    override fun pressKey(name: String) {
+        TODO("Not yet implemented")
+    }
+
     override fun pressButton(code: Int): Result<Unit, Throwable> {
+        TODO("Not yet implemented")
+    }
+
+    override fun pressButton(name: String) {
         TODO("Not yet implemented")
     }
 
@@ -123,6 +131,10 @@ class SimctlIOSDevice(
 
     override fun setPermissions(id: String, permissions: Map<String, String>) {
         Simctl.setPermissions(deviceId, id, permissions)
+    }
+
+    override fun eraseText(charactersToErase: Int) {
+        TODO("Not yet implemented")
     }
 
     override fun close() {

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -103,8 +103,16 @@ class XCTestIOSDevice(
         }
     }
 
+    override fun pressKey(name: String) {
+        client.pressKey(name).use {}
+    }
+
     override fun pressButton(code: Int): Result<Unit, Throwable> {
         error("Not supported")
+    }
+
+    override fun pressButton(name: String) {
+        client.pressButton(name).use {}
     }
 
     override fun scroll(
@@ -232,6 +240,10 @@ class XCTestIOSDevice(
 
     override fun setPermissions(id: String, permissions: Map<String, String>) {
         error("Not supported")
+    }
+
+    override fun eraseText(charactersToErase: Int) {
+        client.eraseText(charactersToErase).use {}
     }
 
     private fun activeAppId(): String? {

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -10,7 +10,10 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import xcuitest.api.EraseTextRequest
 import xcuitest.api.InputTextRequest
+import xcuitest.api.PressButtonRequest
+import xcuitest.api.PressKeyRequest
 import xcuitest.api.SwipeRequest
 import xcuitest.api.TouchRequest
 import java.io.IOException
@@ -115,6 +118,18 @@ class XCTestDriverClient(
             y = y,
             duration = duration
         ))
+    }
+
+    fun pressKey(name: String): Response {
+        return executeJsonRequest("pressKey", PressKeyRequest(name))
+    }
+
+    fun pressButton(name: String): Response {
+        return executeJsonRequest("pressButton", PressButtonRequest(name))
+    }
+
+    fun eraseText(charactersToErase: Int): Response {
+        return executeJsonRequest("eraseText", EraseTextRequest(charactersToErase))
     }
 
     private fun xctestAPIBuilder(pathSegment: String): HttpUrl.Builder {

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/api/EraseTextRequest.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/api/EraseTextRequest.kt
@@ -1,0 +1,3 @@
+package xcuitest.api
+
+data class EraseTextRequest(val charactersToErase: Int)

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/api/PressButtonRequest.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/api/PressButtonRequest.kt
@@ -1,0 +1,3 @@
+package xcuitest.api
+
+data class PressButtonRequest(val button: String)

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/api/PressKeyRequest.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/api/PressKeyRequest.kt
@@ -1,0 +1,3 @@
+package xcuitest.api
+
+data class PressKeyRequest(val key: String)


### PR DESCRIPTION
## Proposed Changes

Use the XCTest runner version of keyPress() buttonPress() and eraseText()

## Testing

Ran customer flows and crafter flows which execute these commands.

## Issues Fixed

IDB crashes when commands are executed on an app with a big view hierarchy. The XCTest runner implementation of these commands should also work on apps with big view hierarchies.