### PR TITLE
Tweak: test that assertVisible respects index

### DIFF
--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2496,6 +2496,34 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `091 - Assert visible by index`() {
+        // Given
+        val commands = readCommands("091_assert_visible_by_index")
+        val driver = driver {
+
+            element {
+                text = "Item"
+                bounds = Bounds.ofSize(100, 100)
+            }
+
+            element {
+                text = "Item"
+                bounds = Bounds.ofSize(100, 100)
+                    .translate(y = 100)
+            }
+
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No failures
+    }
+
     private fun orchestra(maestro: Maestro) = Orchestra(
         maestro,
         lookupTimeoutMs = 0L,

--- a/maestro-test/src/test/resources/091_assert_visible_by_index.yaml
+++ b/maestro-test/src/test/resources/091_assert_visible_by_index.yaml
@@ -1,0 +1,11 @@
+appId: com.example.app
+---
+- assertVisible:
+    text: Item
+    index: 0
+- assertVisible:
+    text: Item
+    index: 1
+- assertNotVisible:
+    text: Item
+    index: 2


### PR DESCRIPTION
## Proposed Changes

No new functionality or fixes, just ensuring that `assertVisible` indeed respects element index