### PR TITLE
Support YAML validation through JSON schema

### DIFF
--- a/schema/schema.json
+++ b/schema/schema.json
@@ -1,0 +1,341 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "TODO: give unique ID",
+  "title": "Maestro flow",
+  "type": ["object", "array"],
+  "items": {
+    "additionalProperties": false,
+    "properties": {
+      "assertNotVisible": {
+        "title": "Assert whether an element is not visible.",
+        "type": ["string", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string" },
+          "id": { "type": "string" },
+          "enabled": { "type": "boolean" },
+          "checked": { "type": "boolean" },
+          "focused": { "type": "boolean" },
+          "selected": { "type": "boolean" },
+          "index": { "type": "integer" }
+        }
+      },
+      "assertVisible": {
+        "title": "Assert whether an element is visible.",
+        "type": ["string", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string" },
+          "id": { "type": "string" },
+          "index": { "type": "integer" },
+          "enabled": { "type": "boolean" },
+          "checked": { "type": "boolean" },
+          "focused": { "type": "boolean" },
+          "selected": { "type": "boolean" }
+        }
+      },
+      "eraseText": {
+        "title": "Remove up to n characters from the currently selected text field (if any)",
+        "type": ["null", "integer"]
+      },
+      "extendedWaitUntil": {
+        "title": "Waits until an element becomes visible. Fails if the element is not visible after the timeout expires.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "visible": { "$ref": "#/$defs/Element" },
+          "notVisible": { "$ref": "#/$defs/Element" },
+          "timeout": { "title": "Timeout in milliseconds", "type": "integer" }
+        }
+      },
+      "inputText": {
+        "title": "Inputs text (regardless of whether any text field is currently focused or not).",
+        "type": "string"
+      },
+      "launchApp": {
+        "title": "Launch the app.",
+        "type": ["null", "string", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "appId": { "type": "string" },
+          "clearState": { "type": "boolean" },
+          "clearKeychain": { "type": "boolean" },
+          "stopApp": { "type": "boolean" }
+        }
+      },
+      "pressKey": {
+        "title": "Press a set of special keys",
+        "type": "string",
+        "enum": [
+          "home",
+          "lock",
+          "enter",
+          "backspace",
+          "volume up",
+          "volume down",
+          "back",
+          "Remote Dpad Up",
+          "Remote Dpad Down",
+          "Remote Dpad Left",
+          "Remote Dpad Right",
+          "Remote Dpad Center",
+          "Remote Media Play Pause",
+          "Remote Media Stop",
+          "Remote Media Next",
+          "Remote Media Previous",
+          "Remote Media Rewind",
+          "Remote Media Fast Forward"
+        ]
+      },
+      "repeat": {
+        "title": "Repeat a set of commands.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "times": {
+            "title": "Repeat a set of commands N times.",
+            "type": "integer"
+          },
+          "while": {
+            "title": "Repeat a set of commands until a condition satisfies.",
+            "$ref": "#/$defs/Condition"
+          },
+          "commands": {
+            "type": "array",
+            "items": {
+              "$ref": "#/items"
+            }
+          }
+        },
+        "required": ["commands", "times"]
+      },
+      "runFlow": {
+        "title": "Runs a flow from a specified file.",
+        "type": ["object", "string"],
+        "additionalProperties": false,
+        "properties": {
+          "file": {
+            "type": "string"
+          },
+          "env": {
+            "type": "object"
+          },
+          "when": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "visible": { "$ref": "#/$defs/Element" },
+              "notVisible": { "$ref": "#/$defs/Element" }
+            }
+          }
+        }
+      },
+      "runScript": {
+        "title": "Run a provided JavaScript file.",
+        "properties": {
+          "file": {
+            "type": "string"
+          },
+          "env": {
+            "type": "object"
+          }
+        }
+      },
+      "scrollUntilVisible": {
+        "title": "Scroll towards a direction until an element becomes visible in the view hierarchy.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "element": {
+            "$ref": "#/$defs/Element"
+          },
+          "direction": {
+            "$ref": "#/$defs/Direction"
+          },
+          "timeout": { "type": "integer" },
+          "speed": { "type": "integer" },
+          "visibilityPercentage": { "type": "integer" }
+        }
+      },
+      "swipe": {
+        "title": "Perform a swipe gesture.",
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "direction": {
+            "$ref": "#/$defs/Direction"
+          },
+          "from": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string" }
+            },
+            "required": ["id"]
+          },
+          "start": {
+            "type": "string",
+            "pattern": "(\\d+%, \\d+%|\\d+, \\d+)$"
+          },
+          "end": {
+            "type": "string",
+            "pattern": "(\\d+%, \\d+%|\\d+, \\d+)$"
+          }
+        }
+      },
+      "tapOn": {
+        "title": "Tap on a view on the screen.",
+        "type": ["object", "string"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string" },
+          "id": { "type": "string" },
+          "index": { "type": "number" },
+          "width": { "type": "number" },
+          "height": { "type": "number" },
+          "tolerance": { "type": "number" },
+          "enabled": { "type": "boolean" },
+          "checked": { "type": "boolean" },
+          "focused": { "type": "boolean" },
+          "selected": { "type": "boolean" },
+          "optional": { "type": "boolean" },
+          "retryTapIfNoChange": { "type": "boolean" },
+          "below": { "$ref": "#/$defs/Element" },
+          "above": { "$ref": "#/$defs/Element" },
+          "leftOf": { "$ref": "#/$defs/Element" },
+          "rightOf": { "$ref": "#/$defs/Element" },
+          "containsChild": { "$ref": "#/$defs/Element" },
+          "point": { "type": "string" },
+          "containsDescendants": {
+            "title": "Searches for view that has all the descendant views given below",
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/Element"
+            }
+          },
+          "repeat": { "type": "number" },
+          "delay": { "type": "number" }
+        }
+      },
+      "longPressOn": {
+        "title": "Long press a view on the screen.",
+        "type": ["object", "string"],
+        "additionalProperties": false,
+        "properties": {
+          "text": { "type": "string" },
+          "id": { "type": "string" },
+          "index": { "type": "number" },
+          "width": { "type": "number" },
+          "height": { "type": "number" },
+          "tolerance": { "type": "number" },
+          "enabled": { "type": "boolean" },
+          "checked": { "type": "boolean" },
+          "focused": { "type": "boolean" },
+          "selected": { "type": "boolean" },
+          "optional": { "type": "boolean" },
+          "retryTapIfNoChange": { "type": "boolean" },
+          "below": { "$ref": "#/$defs/Element" },
+          "above": { "$ref": "#/$defs/Element" },
+          "leftOf": { "$ref": "#/$defs/Element" },
+          "rightOf": { "$ref": "#/$defs/Element" },
+          "containsChild": { "$ref": "#/$defs/Element" },
+          "point": { "type": "string" },
+          "containsDescendants": {
+            "title": "Searches for view that has all the descendant views given below",
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/Element"
+            }
+          }
+        }
+      },
+      "waitForAnimationToEnd": {
+        "title": "Waits until an ongoing animation/video is fully finished and screen becomes static.",
+        "type": ["null", "object"],
+        "additionalProperties": false,
+        "properties": {
+          "timeout": { "type": "number" }
+        }
+      }
+    }
+  },
+  "properties": {
+    "appId": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    },
+    "tags": {
+      "type": "array"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["appId"],
+  "$defs": {
+    "Condition": {
+      "type": "object",
+      "$comment": "`true` doesn't seem to work as a property, so we allow additional properties",
+      "additionalProperties": true,
+      "properties": {
+        "visible": { "$ref": "#/$defs/Element" },
+        "notVisible": { "$ref": "#/$defs/Element" }
+      }
+    },
+    "Direction": {
+      "type": "string",
+      "enum": ["UP", "DOWN", "LEFT", "RIGHT"]
+    },
+    "Element": {
+      "type": ["string", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "text": {
+          "type": "string",
+          "title": "Finds text that matches regexp"
+        },
+        "id": {
+          "type": "string",
+          "title": "Finds id that matches regexp"
+        },
+        "index": {
+          "type": "number",
+          "title": "0-based index of the view to select among those that match all other criteria"
+        },
+        "width": {
+          "type": "number",
+          "title": "Finds element of a given width"
+        },
+        "height": {
+          "type": "number",
+          "title": "Finds element of a given height"
+        },
+        "tolerance": {
+          "type": "number",
+          "title": "Tolerance to apply when comparing width and height"
+        },
+        "enabled": {
+          "type": "boolean",
+          "title": "Searches for view with a given \"enabled\" state"
+        },
+        "checked": {
+          "type": "boolean",
+          "title": "Searches for view with a given \"checked\" state"
+        },
+        "focused": {
+          "type": "boolean",
+          "title": "Searches for view with a given \"focused\" state"
+        },
+        "selected": {
+          "type": "boolean",
+          "title": "Searches for view with a given \"selected\" state"
+        },
+        "optional": {
+          "type": "boolean",
+          "title": "If set to true, test won't fail if view can't be found",
+          "default": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Proposed Changes

JSON schema can be used for [validating YAML files](https://json-schema-everywhere.github.io/yaml). This MR serves as a first draft to pour the Maestro docs in a JSON schema, which can be used for validating the syntax of Maestro flows.

It is far from complete, and I need some help on this because it is a lot of work 🙏 

If finished, the schema can be submitted to the [SchemaStore](https://github.com/SchemaStore/schemastore) so validation can be done automatically based on a file name.


## Testing
1. Install the VSCode [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) extension 
2. Copy the schema.json file into your project, next to your Maestro flows
3. Configure the schema in `.vscode/settings.json`

```
"yaml.schemas": {
    "./path/to/schema.json": "path/to/flows/**/*.yaml",
  }
```

## Issues Fixed

Fixes https://github.com/mobile-dev-inc/maestro/issues/467