### PR TITLE
Fix: Maestro was extremely slow on iOS 14

### DIFF
--- a/maestro-xcuitest-driver/src/main/kotlin/util/XCRunnerSimctl.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/util/XCRunnerSimctl.kt
@@ -106,12 +106,20 @@ object XCRunnerSimctl {
             .drop(1)
             .toList()
             .map { line -> line.split("\\s+".toRegex()) }
-            .filter { parts -> parts.count() < 3 }
+            .filter { parts -> parts.count() <= 3 }
             .associate { parts -> parts[2] to parts[0].toIntOrNull() }
+            .mapKeys { (key, _) ->
+                // Fixes issue with iOS 14.0 where process names are sometimes prefixed with "UIKitApplication:"
+                // and ending with [stuff]
+                key
+                    .substringBefore("[")
+                    .replace("UIKitApplication:", "")
+            }
     }
 
     fun isAppAlive(bundleId: String): Boolean {
-        return runningApps().containsKey(bundleId)
+        return runningApps()
+            .containsKey(bundleId)
     }
 
     fun pidForApp(bundleId: String): Int? {

--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -109,7 +109,7 @@ class LocalXCTestInstaller(
                 .port(22087)
         }
         val url = xctestAPIBuilder("subTree")
-            .addQueryParameter("appId", UI_TEST_RUNNER_APP_BUNDLE_ID)
+            .addQueryParameter("appId", SPRINGBOARD_BUNDLE_ID)
             .build()
 
         val request = Request.Builder()
@@ -197,5 +197,6 @@ class LocalXCTestInstaller(
         private const val XCTEST_RUN_PATH = "/maestro-driver-ios-config.xctestrun"
         private const val UI_TEST_HOST_PATH = "/maestro-driver-ios.zip"
         private const val UI_TEST_RUNNER_APP_BUNDLE_ID = "dev.mobile.maestro-driver-iosUITests.xctrunner"
+        private const val SPRINGBOARD_BUNDLE_ID = "com.apple.springboard"
     }
 }


### PR DESCRIPTION
## Proposed Changes

Maestro was booting up extremely slow on iOS 14 (> 20 seconds). There are 3 causes for that:

- `xcrun simctl spawn booted launchctl list` returned value split into 3 columns instead of 2
- Process name for Maestro driver started with `UIApplicationKit` and ended with some gibberish in square brackets
- Request to get a view hierarchy of the driver's app failed because the process name was different each time. Switching to checking Springboard helped. 