### PR TITLE
Fix: JS values should be undefined by default

### DIFF
--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -21,7 +21,7 @@ class JsEngine(
 
     fun init() {
         context = Context.enter()
-        currentScope = JsScope()
+        currentScope = JsScope(root = true)
         context.initSafeStandardObjects(currentScope)
 
         val jsHttp = JsHttp(httpClient)
@@ -63,7 +63,7 @@ class JsEngine(
     }
 
     fun enterScope() {
-        val subScope = JsScope()
+        val subScope = JsScope(root = false)
         subScope.parentScope = currentScope
         currentScope = subScope
     }
@@ -82,7 +82,7 @@ class JsEngine(
             // We create a new scope for each evaluation to prevent local variables
             // from clashing with each other across multiple scripts.
             // Only 'output' is shared across scopes.
-            JsScope()
+            JsScope(root = false)
                 .apply { parentScope = currentScope }
         } else {
             currentScope

--- a/maestro-client/src/main/java/maestro/js/JsScope.kt
+++ b/maestro-client/src/main/java/maestro/js/JsScope.kt
@@ -1,9 +1,56 @@
 package maestro.js
 
+import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.ScriptableObject
 
-class JsScope : ScriptableObject() {
+class JsScope(
+    private val root: Boolean,
+) : ScriptableObject() {
+
+    override fun get(name: String?, start: Scriptable?): Any? {
+        if (!root) {
+            return super.get(name, start)
+        }
+
+        val original = super.get(name, start)
+
+        if (original == NOT_FOUND) {
+            return null
+        }
+
+        return original
+    }
+
+    override fun get(index: Int, start: Scriptable?): Any? {
+        if (!root) {
+            return super.get(index, start)
+        }
+
+        val original = super.get(index, start)
+
+        if (original == NOT_FOUND) {
+            return null
+        }
+
+        return original
+    }
+
+    override fun get(key: Any?): Any? {
+        if (!root) {
+            return super.get(key)
+        }
+
+        val original = super.get(key)
+
+        if (original == NOT_FOUND) {
+            return null
+        }
+
+        return original
+    }
+
     override fun getClassName(): String {
         return "JsScope"
     }
+
 }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2550,6 +2550,23 @@ class IntegrationTest {
         ).inOrder()
     }
 
+    @Test
+    fun `093 - JS default values`() {
+        // Given
+        val commands = readCommands("093_js_default_value")
+        val driver = driver {
+        }
+        driver.addInstalledApp("com.example.default")
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        driver.assertHasEvent(Event.LaunchApp("com.example.default"))
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/093_js_default_value.yaml
+++ b/maestro-test/src/test/resources/093_js_default_value.yaml
@@ -1,0 +1,5 @@
+appId: ${APP_ID}
+env:
+  APP_ID: ${APP_ID || 'com.example.default'}
+---
+- launchApp


### PR DESCRIPTION
## Proposed Changes

Accessing an undefined JavaScript value was causing an exception in Rhino's JS environment, which is not what you would normally expect. This PR tweaks the variable lookup logic to return `null` if a variable not found in the root scope