### PR TITLE
Retry starting XCTest runner multiple times

### DIFF
--- a/maestro-xcuitest-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-xcuitest-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -178,15 +178,15 @@ class XCTestDriverClient(
             try {
                 return it.proceed(request)
             } catch (connectException: IOException) {
-                if (retryAttempt < retryCount) {
-                    retryAttempt += 1
-                    if (!installer.start()) {
-                        throw XCTestDriverUnreachable("Failed to start XCUITest Server in RetryOnError")
-                    }
-                    continue
-                } else {
+                if (retryAttempt >= retryCount) {
                     throw XCTestDriverUnreachable("Failed to reach out XCUITest Server in RetryOnError")
                 }
+
+                if (!installer.start()) {
+                    throw XCTestDriverUnreachable("Failed to start XCUITest Server in RetryOnError")
+                }
+
+                retryAttempt += 1
             }
         }
     }


### PR DESCRIPTION
## Proposed Changes

Retry the starting the XCTest runner on connection error.

## Testing

todo

## Issues Fixed

During an launchApp command, xctest may not be able to run for a while because the simulator is not fully initialised (due to permissions being set). This causes errors in the CLI to be reported about XCTest runner. This fix will retry starting XCTest runner multiple times, making it far more likely that the simulator is fully initialised before an error is emitted.