### PR TITLE
Restart iOS simulator after permissions reset

### DIFF
--- a/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
@@ -161,6 +161,7 @@ class SimctlIOSDevice(
 
     override fun setPermissions(id: String, permissions: Map<String, String>) {
         Simctl.setPermissions(deviceId, id, permissions)
+        Simctl.killAndRestart(deviceId)
     }
 
     override fun eraseText(charactersToErase: Int) {


### PR DESCRIPTION
## Proposed Changes
This helps to mitigate some xctest runner / idb connection issues after applesimutils permissions reset

## Testing
- [x] tested all existing flows with maestro-flow-tester