### PR TITLE
Hide keyboard on iOS

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -54,6 +54,10 @@ object Filters {
         nodes.filter { this(it) }
     }
 
+    fun nonClickable(): ElementFilter {
+        return  { nodes -> nodes.filter { it.clickable == false } }
+    }
+
     fun textMatches(regex: Regex): ElementFilter {
         return { nodes ->
             val textMatches = nodes.filter {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -31,6 +31,7 @@ import ios.IOSDevice
 import maestro.Capability
 import maestro.DeviceInfo
 import maestro.Driver
+import maestro.Filters
 import maestro.KeyCode
 import maestro.MaestroException
 import maestro.Platform
@@ -38,6 +39,8 @@ import maestro.Point
 import maestro.ScreenRecording
 import maestro.SwipeDirection
 import maestro.TreeNode
+import maestro.UiElement.Companion.toUiElement
+import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.ViewHierarchy
 import maestro.utils.FileUtils
 import maestro.utils.MaestroTimer
@@ -224,6 +227,7 @@ class IOSDriver(
         val text = xcUiElement.title?.ifEmpty {
             xcUiElement.value
         }
+        val clickable = if (xcUiElement.elementType == ELEMENT_TYPE_STATIC_TEXT) false else null
         attributes["accessibilityText"] = xcUiElement.label
         attributes["text"] = text ?: ""
         attributes["hintText"] = xcUiElement.placeholderValue ?: ""
@@ -248,6 +252,7 @@ class IOSDriver(
 
         return TreeNode(
             attributes = attributes,
+            clickable = clickable,
             children = children,
             enabled = xcUiElement.enabled,
             focused = xcUiElement.hasFocus,
@@ -373,7 +378,28 @@ class IOSDriver(
     override fun backPress() {}
 
     override fun hideKeyboard() {
-        pressKey(KeyCode.ENTER)
+        tapOnNonClickableText()
+    }
+
+    private fun tapOnNonClickableText() {
+        val filter = Filters.nonClickable()
+        MaestroTimer.retryUntilTrue(10000) {
+            val result = filter(contentDescriptor().aggregate()).map { it.toUiElement() }
+                .any {
+                    tap(it.bounds.center())
+                    isKeyboardHidden()
+                }
+            return@retryUntilTrue result
+        }
+    }
+
+    private fun isKeyboardHidden(): Boolean {
+        val filter = Filters.textMatches("[rR]".toRegex())
+        val element = MaestroTimer.withTimeout(2000) {
+            filter(contentDescriptor().aggregate()).firstOrNull()
+        }?.toUiElementOrNull()
+
+        return element == null
     }
 
     override fun takeScreenshot(out: Sink, compressed: Boolean) {
@@ -463,6 +489,7 @@ class IOSDriver(
         private const val ELEMENT_TYPE_CHECKBOX = 12
         private const val ELEMENT_TYPE_SWITCH = 40
         private const val ELEMENT_TYPE_TOGGLE = 41
+        private const val ELEMENT_TYPE_STATIC_TEXT = 48
 
         private val CHECKABLE_ELEMENTS = setOf(
             ELEMENT_TYPE_CHECKBOX,

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -378,10 +378,30 @@ class IOSDriver(
     override fun backPress() {}
 
     override fun hideKeyboard() {
-        tapOnNonClickableText()
+        swipe(
+            start = Point(widthPercentToPoint(0.5), heightPercentToPoint(0.5)),
+            end = Point(widthPercentToPoint(0.5), heightPercentToPoint(0.47)),
+            durationMs = 50,
+        )
+
+        if (isKeyboardHidden()) {
+            return
+        }
+
+        swipe(
+            start = Point(widthPercentToPoint(0.5), heightPercentToPoint(0.5)),
+            end = Point(widthPercentToPoint(0.47), heightPercentToPoint(0.5)),
+            durationMs = 50,
+        )
+
+        if (isKeyboardHidden()) {
+            return
+        }
+
+        tapOnStaticTexts()
     }
 
-    private fun tapOnNonClickableText() {
+    private fun tapOnStaticTexts() {
         val filter = Filters.nonClickable()
         MaestroTimer.retryUntilTrue(10000) {
             val result = filter(contentDescriptor().aggregate()).map { it.toUiElement() }
@@ -394,7 +414,7 @@ class IOSDriver(
     }
 
     private fun isKeyboardHidden(): Boolean {
-        val filter = Filters.textMatches("[rR]".toRegex())
+        val filter = Filters.idMatches("delete".toRegex())
         val element = MaestroTimer.withTimeout(2000) {
             filter(contentDescriptor().aggregate()).firstOrNull()
         }?.toUiElementOrNull()


### PR DESCRIPTION
## Proposed Changes

There are no straightforward APIs to hide the keyboard on iOS. This PR attempts to hide the keyboard as a user through maestro. Three attempts at how maestro tries hiding the keyboard:

1. Scroll with a small delta on y axis
2. Scroll with a small delta on x axis
3. Clicking on static texts XCUIElement

## Testing
Tested on multiple client apps.

## Issues Fixed