### PR TITLE
fix: Error shows on flow runs "Failed to reach out XCUITest Server"

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -226,7 +226,11 @@ class XCTestDriverClient(
                     .code(200)
                     .build()
             } else {
-                throw XCTestDriverUnreachable("Failed to reach out XCUITest Server in ReturnOkOnShutdown")
+                Response.Builder()
+                    .request(it.request())
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(400)
+                    .build()
             }
         }
     })


### PR DESCRIPTION
## Proposed Changes

Throwing a custom exception inside network interceptor makes OkHttpClient library logging it. To fix it we need to return an error response instead.