### PR TITLE
Changed upgrade instructions to include command instead of url

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -130,8 +130,8 @@ fun main(args: Array<String>) {
     if (newVersion != null) {
         System.err.println()
         System.err.println(
-            ("A new version of the Maestro CLI is available ($newVersion). Upgrade instructions:\n" +
-                "https://maestro.mobile.dev/getting-started/installing-maestro#upgrading-the-cli").box()
+            ("A new version of the Maestro CLI is available ($newVersion). Upgrade command:\n" +
+                "curl -Ls "https://get.maestro.mobile.dev" | bash").box()
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -131,7 +131,7 @@ fun main(args: Array<String>) {
         System.err.println()
         System.err.println(
             ("A new version of the Maestro CLI is available ($newVersion). Upgrade command:\n" +
-                "curl -Ls "https://get.maestro.mobile.dev" | bash").box()
+                "curl -Ls \"https://get.maestro.mobile.dev\" | bash").box()
         )
     }
 


### PR DESCRIPTION
## Proposed Changes
A simple quality of life change to update the upgrade instructions to contain the command for upgrading instead of a url to a page that has the command to upgrade, streamlining that process a bit.

## Testing
This is a simple text change

## Issues Fixed
None