### PR TITLE
Add `containsDescendants` selector

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -193,6 +193,19 @@ object Filters {
         }
     }
 
+    fun containsDescendants(filters: List<ElementFilter>): ElementFilter {
+        fun ElementFilter.matches(node: TreeNode): Boolean {
+            return invoke(listOf(node)).isNotEmpty() || node.children.any { matches(it) }
+        }
+        return { nodes ->
+            nodes.filter { node ->
+                filters.all { filter ->
+                    node.children.any { filter.matches(it) }
+                }
+            }
+        }
+    }
+
     fun hasText(): ElementLookupPredicate {
         return {
             it.attributes["text"] != null

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -31,6 +31,7 @@ data class ElementSelector(
     val leftOf: ElementSelector? = null,
     val rightOf: ElementSelector? = null,
     val containsChild: ElementSelector? = null,
+    val containsDescendants: List<ElementSelector>? = null,
     val optional: Boolean = false,
     val traits: List<ElementTrait>? = null,
     val index: String? = null,
@@ -55,6 +56,7 @@ data class ElementSelector(
             leftOf = leftOf?.evaluateScripts(jsEngine),
             rightOf = rightOf?.evaluateScripts(jsEngine),
             containsChild = containsChild?.evaluateScripts(jsEngine),
+            containsDescendants = containsDescendants?.map { it.evaluateScripts(jsEngine) },
             index = index?.evaluateScripts(jsEngine),
         )
     }
@@ -84,6 +86,15 @@ data class ElementSelector(
 
         rightOf?.let {
             descriptions.add("Right of ${it.description()}")
+        }
+
+        containsChild?.let {
+            descriptions.add("Contains child: ${it.description()}")
+        }
+
+        containsDescendants?.let { selectors ->
+            val descendantDescriptions = selectors.joinToString(", ") { it.description() }
+            descriptions.add("Contains descendants: [$descendantDescriptions]")
         }
 
         size?.let {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -783,6 +783,13 @@ class Orchestra(
                 filters += Filters.containsChild(findElement(it).element).asFilter()
             }
 
+        selector.containsDescendants
+            ?.let { descendantSelectors ->
+                val descendantDescriptions = descendantSelectors.joinToString("; ") { it.description() }
+                descriptions += "Contains descendants: $descendantDescriptions"
+                filters += Filters.containsDescendants(descendantSelectors.map { buildFilter(it, deviceInfo).filterFunc })
+            }
+
         selector.traits
             ?.map {
                 TraitFilters.buildFilter(it)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -39,6 +39,7 @@ data class YamlElementSelector(
     val leftOf: YamlElementSelectorUnion? = null,
     val rightOf: YamlElementSelectorUnion? = null,
     val containsChild: YamlElementSelectorUnion? = null,
+    val containsDescendants: List<YamlElementSelectorUnion>? = null,
     val traits: String? = null,
     val index: String? = null,
     val enabled: Boolean? = null,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -469,6 +469,7 @@ data class YamlFluentCommand(
             leftOf = selector.leftOf?.let { toElementSelector(it) },
             rightOf = selector.rightOf?.let { toElementSelector(it) },
             containsChild = selector.containsChild?.let { toElementSelector(it) },
+            containsDescendants = selector.containsDescendants?.map { toElementSelector(it) },
             traits = selector.traits
                 ?.split(" ")
                 ?.map { ElementTrait.valueOf(it.replace('-', '_').uppercase()) },

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2611,6 +2611,45 @@ class IntegrationTest {
         ))
     }
 
+    @Test
+    fun `Case 096 - Contains descendants`() {
+        // Given
+        val commands = readCommands("096_contains_descendants")
+
+        val driver = driver {
+            element {
+                id = "id1"
+                bounds = Bounds(0, 0, 200, 200)
+
+                element {
+                    bounds = Bounds(0, 0, 200, 200)
+                    element {
+                        id = "id2"
+                        bounds = Bounds(0, 0, 200, 200)
+                        element {
+                            text = "Child 1"
+                            bounds = Bounds(0, 0, 100, 50)
+                        }
+                    }
+                    element {
+                        text = "Child 2"
+                        bounds = Bounds(0, 0, 100, 100)
+                        enabled = false
+                    }
+                }
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failures
+        driver.assertNoInteraction()
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/096_contains_descendants.yaml
+++ b/maestro-test/src/test/resources/096_contains_descendants.yaml
@@ -1,0 +1,17 @@
+appId: com.example.app
+---
+- assertVisible:
+    id: id1
+    containsDescendants:
+      - text: "Child 1"
+      - text: "Child 2"
+        enabled: false
+- assertVisible:
+    id: id2
+    containsDescendants:
+      - text: "Child 1"
+- assertNotVisible:
+    id: id1
+    containsDescendants:
+      - text: "Child 1"
+      - text: "Child 3"


### PR DESCRIPTION
## Proposed Changes
Adds selector `containsDescendants` which allows selecting a view that has a selection of descendant elements. The motivation for this was to provide an easier way to verify the contents of individual list items.

## Testing
* Added integration tests
* Using in internal Maestro flows
* Tested in Wikipedia app
    <img width="1401" alt="Screenshot 2023-04-18 at 8 55 03 PM" src="https://user-images.githubusercontent.com/1311130/232938630-50ff5654-3dc6-43a0-ac86-58009a827ded.png">
