### PR TITLE
Visualize request body and headers in Mock Server UI; Update Mock Server instructions

### DIFF
--- a/maestro-studio/web/src/MockServerInstructions.tsx
+++ b/maestro-studio/web/src/MockServerInstructions.tsx
@@ -1,4 +1,14 @@
+import { ReactNode } from "react"
 import { CodeSnippet } from "./Examples"
+
+const Link = ({ href, children }: {href: string, children: ReactNode}) => (
+  <a
+    className="text-blue-400 underline underline-offset-2 whitespace-nowrap mb-4"
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+  >{children}</a>
+)
 
 const MockServerInstructions = ({ projectId }: { projectId?: string }) => (
   <div className="w-full h-full flex justify-center items-center dark:bg-slate-800 dark:text-white">
@@ -8,23 +18,16 @@ const MockServerInstructions = ({ projectId }: { projectId?: string }) => (
       </div>
       
       <div>
-        <p className="text-md">First, add the Maestro SDK dependency to your app:</p>
-        <CodeSnippet>{`implementation 'dev.mobile:maestro-sdk-android:+'`}</CodeSnippet>
+        <p className="text-lg">1. Set up Maestro SDK in your app following <Link href="https://maestro.mobile.dev/advanced/experimental/maestro-sdk">the instructions</Link>{!!projectId ? <> using your project id <span className="italic">{projectId}</span></> : null}.</p>
+        <p className="text-md">You can retrieve your project id at a later stage by running <span className="italic">maestro mockserver projectid</span>.</p>
       </div>
 
       <div>
-        <p className="text-md">Then, initialize the Maestro SDK in your app:</p>
-        <CodeSnippet>{`MaestroSdk.init("${projectId || '<your_project_id>'}")`}</CodeSnippet>
-        <p className="text-md">You can retrieve your project id by running <span className="italic">maestro mockserver projectid</span>.</p>
-      </div>
-
-      <div>
-        <p className="text-md">Next step is to update your app to use the API base url provided by Maestro SDK:</p>
-        <CodeSnippet>{`val baseUrl = MaestroSdk.mockServer().url("https://api.yourdomain.com")`}</CodeSnippet>
+        <p className="text-lg">2. Update your API base url to the one provided by Maestro SDK as outlined <Link href="https://maestro.mobile.dev/advanced/experimental/maestro-mock-server/getting-started">here</Link>.</p>
         <p className="text-md">You can then use <span className="italic">baseUrl</span> as you would normally do in your app. Requests will be sent to <span className="italic">https://mock.mobile.dev</span> and forwarded to your original API if no mock rules are found.</p>
       </div>
       
-      <p className="font-semibold">That's it! Now, build and run your app and you should start seeing events come in!</p>
+      <p className="text-lg font-semibold">That's it! Now, build and run your app and you should start seeing events come in!</p>
 
       <div>
         <p className="text-md mb-2">(Optional) If you want to get started with writing rules right away, you can run the following command to scaffold a sample rule:</p>

--- a/maestro-studio/web/src/mocks.ts
+++ b/maestro-studio/web/src/mocks.ts
@@ -1,5 +1,5 @@
 import { ResponseComposition, rest, RestContext, setupWorker } from 'msw';
-import { DeviceScreen, ReplCommand } from './models';
+import { DeviceScreen, MockEvent, ReplCommand } from './models';
 import { sampleElements } from './sampleElements';
 import { wait } from './api';
 
@@ -133,8 +133,8 @@ const handlers = [
         body: 'Lorem ipsum dolor sit amet'
       }
 
-      events.push({
-        timestamp: Date.now(),
+      const event: MockEvent = {
+        timestamp: new Date().toISOString(),
         path: i === 2 ?  `/posts/${i}/alksudhjioash78902qbnpiasy091g089qg978§1gs0789gq078gw180hgb1s8008sg1078g1s08g1s08s1jkshipasha0ish0aisha908sh80ash0asha0shas90-ha` : `/posts/${i}`,
         matched: i % 3 !== 0,
         response,
@@ -142,12 +142,22 @@ const handlers = [
         statusCode: simulateRuntimeError ? 500 : (i % 7 === 0 ? 401 : 200) ,
         sessionId: sessionId,
         projectId: projectId,
-        })
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer REDACTED'
+        }
+      }
+
+      if ((i + 1) % 3 === 0) {
+        event.bodyAsString = JSON.stringify({ foo: 'bar', body: true })
+      }
+
+      events.push(event)
     }
 
     return res(ctx.delay(500), ctx.status(200), ctx.json({
       projectId,
-      events: []
+      events
     }))
   })
 ]

--- a/maestro-studio/web/src/models.ts
+++ b/maestro-studio/web/src/models.ts
@@ -55,5 +55,7 @@ export type MockEvent = {
   statusCode: number,
   method: string,
   sessionId: string,
-  projectId: string
+  projectId: string,
+  bodyAsString?: string,
+  headers?: {[key: string]: string}
 }


### PR DESCRIPTION
- Surface outgoing request body and headers in Mock Server UI
- Refactor code a bit in `MockPage` to make it easier to follow plus some minor style changes
- Update Mock Server instructions page

**New Instructions page**
<img width="1230" alt="image" src="https://user-images.githubusercontent.com/6113675/233326733-782def4f-a411-41fa-a11c-9ebbbf5a9425.png">

**Mock page with request body and headers**
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/6113675/233326992-a3d5d35b-cfc3-4a8c-b21c-e0abbc206e8e.png">
