### PR TITLE
Use deviceId when spawning xctest worker to a device

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -125,7 +125,7 @@ class LocalXCTestInstaller(
     }
 
     private fun startXCTestRunner() {
-        val processOutput = ProcessBuilder(listOf("xcrun", "simctl", "spawn", "booted", "launchctl", "list"))
+        val processOutput = ProcessBuilder(listOf("xcrun", "simctl", "spawn", deviceId, "launchctl", "list"))
             .start()
             .inputStream.source().buffer().readUtf8()
             .trim()


### PR DESCRIPTION
## Proposed Changes

maestro used to try and spawn xctest runner on the 'booted' simulator device. When multiple or no simulator devices are booted, this operation may get maestro in a bad state.
By specifying the deviceId explicitly, the bad state can be avoided.

## Testing

Tested manually

## Issues Fixed

Potentially fixes https://github.com/mobile-dev-inc/maestro/issues/880
