### PR TITLE
feat: add reverse indexing

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -216,10 +216,15 @@ object Filters {
 
     fun index(idx: Int): ElementFilter {
         return { nodes ->
+            val index = if (idx >= 0) {
+                idx
+            } else {
+                nodes.size + idx
+            }
             listOfNotNull(
                 nodes
                     .sortedWith(INDEX_COMPARATOR)
-                    .getOrNull(idx)
+                    .getOrNull(index)
             )
         }
     }

--- a/samples/wikipedia-android-advanced/onboarding/remove-language.yml
+++ b/samples/wikipedia-android-advanced/onboarding/remove-language.yml
@@ -5,7 +5,7 @@ appId: org.wikipedia
 - tapOn: "Remove language"
 - tapOn:
     id: ".*wiki_language_checkbox"
-    index: 1
+    index: -1
 - tapOn:
     id: ".*menu_delete_selected"
 - tapOn: "OK"


### PR DESCRIPTION
## Proposed Changes
- Add reverse indexing. Example:
```yaml
# Tapping the second to last element with the same text
- tapOn:
   text: "text"
   index: -2 
```

## Testing
- Updated Wikipedia Advanced Android Sample to use the feature. 

## Limitation
- Both for Android and iOS, this would only work for **visible** elements. More specifically, **rendered** elements. 