### PR TITLE
[iOS] runner app uninstall fails when multiple iOS simulators are launched

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -303,7 +303,7 @@ object MaestroSessionManager {
         val xcTestDevice = XCTestIOSDevice(
             deviceId = deviceId,
             client = xcTestDriverClient,
-            getInstalledApps = { XCRunnerCLIUtils.listApps() },
+            getInstalledApps = { XCRunnerCLIUtils.listApps(deviceId) },
             logger = IOSDriverLogger(XCTestIOSDevice::class.java),
         )
 

--- a/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
@@ -32,8 +32,8 @@ object XCRunnerCLIUtils {
         logsDirectory
     }
 
-    fun listApps(): Set<String> {
-        val process = Runtime.getRuntime().exec(arrayOf("bash", "-c", "xcrun simctl listapps booted | plutil -convert json - -o -"))
+    fun listApps(deviceId: String): Set<String> {
+        val process = Runtime.getRuntime().exec(arrayOf("bash", "-c", "xcrun simctl listapps $deviceId | plutil -convert json - -o -"))
 
         val json = String(process.inputStream.readBytes())
 
@@ -67,30 +67,30 @@ object XCRunnerCLIUtils {
             .waitFor()
     }
 
-    fun uninstall(bundleId: String) {
+    fun uninstall(bundleId: String, deviceId: String) {
         CommandLineUtils.runCommand(
             listOf(
                 "xcrun",
                 "simctl",
                 "uninstall",
-                "booted",
+                deviceId,
                 bundleId
             )
         )
     }
 
-    fun ensureAppAlive(bundleId: String) {
+    fun ensureAppAlive(bundleId: String, deviceId: String) {
         MaestroTimer.retryUntilTrue(timeoutMs = 4000, delayMs = 300) {
-            isAppAlive(bundleId)
+            isAppAlive(bundleId, deviceId)
         }
     }
 
-    private fun runningApps(): Map<String, Int?> {
+    private fun runningApps(deviceId: String): Map<String, Int?> {
         val process = ProcessBuilder(
             "xcrun",
             "simctl",
             "spawn",
-            "booted",
+            deviceId,
             "launchctl",
             "list"
         ).start()
@@ -117,13 +117,13 @@ object XCRunnerCLIUtils {
             }
     }
 
-    fun isAppAlive(bundleId: String): Boolean {
-        return runningApps()
+    fun isAppAlive(bundleId: String, deviceId: String): Boolean {
+        return runningApps(deviceId)
             .containsKey(bundleId)
     }
 
-    fun pidForApp(bundleId: String): Int? {
-        return runningApps()[bundleId]
+    fun pidForApp(bundleId: String, deviceId: String): Int? {
+        return runningApps(deviceId)[bundleId]
     }
 
     fun runXcTestWithoutBuild(deviceId: String, xcTestRunFilePath: String): Process {
@@ -139,13 +139,6 @@ object XCRunnerCLIUtils {
             ),
             waitForCompletion = false,
             outputFile = File(logDirectory, "xctest_runner_$date.log")
-        )
-    }
-
-    fun screenshot(path: String) {
-        CommandLineUtils.runCommand(
-            listOf("xcrun", "simctl", "io", "booted", "screenshot", path),
-            waitForCompletion = true
         )
     }
 }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -34,7 +34,7 @@ class LocalXCTestInstaller(
         stop()
 
         logger.info("[Start] Uninstall XCUITest runner")
-        XCRunnerCLIUtils.uninstall(UI_TEST_RUNNER_APP_BUNDLE_ID)
+        XCRunnerCLIUtils.uninstall(UI_TEST_RUNNER_APP_BUNDLE_ID, deviceId)
         logger.info("[Done] Uninstall XCUITest runner")
     }
 
@@ -45,7 +45,7 @@ class LocalXCTestInstaller(
             logger.info("[Done] Stop XCUITest runner")
         }
 
-        val pid = XCRunnerCLIUtils.pidForApp(UI_TEST_RUNNER_APP_BUNDLE_ID)
+        val pid = XCRunnerCLIUtils.pidForApp(UI_TEST_RUNNER_APP_BUNDLE_ID, deviceId)
         if (pid != null) {
             ProcessBuilder(listOf("kill", pid.toString()))
                 .start()
@@ -85,12 +85,12 @@ class LocalXCTestInstaller(
     }
 
     override fun isChannelAlive(): Boolean {
-        return XCRunnerCLIUtils.isAppAlive(UI_TEST_RUNNER_APP_BUNDLE_ID) &&
+        return XCRunnerCLIUtils.isAppAlive(UI_TEST_RUNNER_APP_BUNDLE_ID, deviceId) &&
             subTreeOfRunnerApp().use { it.isSuccessful }
     }
 
     private fun ensureOpen(): Boolean {
-        XCRunnerCLIUtils.ensureAppAlive(UI_TEST_RUNNER_APP_BUNDLE_ID)
+        XCRunnerCLIUtils.ensureAppAlive(UI_TEST_RUNNER_APP_BUNDLE_ID, deviceId)
         return MaestroTimer.retryUntilTrue(10_000, 100) {
             try {
                 subTreeOfRunnerApp().use { it.isSuccessful }


### PR DESCRIPTION
## Proposed Changes

when multiple simulators are launched, simctl command with booted parameter often fail

## Testing
- [x] maestro flow tester flows locally
