### PR TITLE
Add test duration measurement and display

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -11,6 +11,7 @@ data class TestExecutionSummary(
     data class SuiteResult(
         val passed: Boolean,
         val flows: List<FlowResult>,
+        val duration: Duration? = null,
     )
 
     data class FlowResult(

--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -1,5 +1,7 @@
 package maestro.cli.model
 
+import kotlin.time.Duration
+
 data class TestExecutionSummary(
     val passed: Boolean,
     val suites: List<SuiteResult>,
@@ -16,6 +18,7 @@ data class TestExecutionSummary(
         val fileName: String?,
         val status: FlowStatus,
         val failure: Failure? = null,
+        val duration: Duration? = null,
     )
 
     data class Failure(

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -36,6 +36,7 @@ class JUnitTestSuiteReporter(
                                 name = testSuiteName ?: "Test Suite",
                                 device = summary.deviceName,
                                 failures = suite.flows.count { it.status == FlowStatus.ERROR },
+                                time = suite.duration?.inWholeSeconds?.toString(),
                                 tests = suite.flows.size,
                                 testCases = suite.flows
                                     .map { flow ->
@@ -70,6 +71,7 @@ class JUnitTestSuiteReporter(
         @JacksonXmlProperty(isAttribute = true) val device: String?,
         @JacksonXmlProperty(isAttribute = true) val tests: Int,
         @JacksonXmlProperty(isAttribute = true) val failures: Int,
+        @JacksonXmlProperty(isAttribute = true) val time: String? = null,
         @JacksonXmlElementWrapper(useWrapping = false)
         @JsonProperty("testcase")
         val testCases: List<TestCase>,

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -47,7 +47,8 @@ class JUnitTestSuiteReporter(
                                                 Failure(
                                                     message = failure.message,
                                                 )
-                                            }
+                                            },
+                                            time = flow.duration?.inWholeMilliseconds?.let{ (it / 1000.0).toString() }
                                         )
                                     }
                             )
@@ -78,6 +79,7 @@ class JUnitTestSuiteReporter(
         @JacksonXmlProperty(isAttribute = true) val id: String,
         @JacksonXmlProperty(isAttribute = true) val name: String,
         @JacksonXmlProperty(isAttribute = true) val classname: String,
+        @JacksonXmlProperty(isAttribute = true) val time: String? = null,
         val failure: Failure? = null,
     )
 

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -48,7 +48,7 @@ class JUnitTestSuiteReporter(
                                                     message = failure.message,
                                                 )
                                             },
-                                            time = flow.duration?.inWholeMilliseconds?.let{ (it / 1000.0).toString() }
+                                            time = flow.duration?.inWholeSeconds?.toString()
                                         )
                                     }
                             )

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -92,15 +92,18 @@ class TestSuiteInteractor(
             flowResults.add(result)
         }
 
+        val suiteDuration = flowResults.sumOf { it.duration?.inWholeSeconds ?: 0 }.seconds
+
         TestSuiteStatusView.showSuiteResult(
             TestSuiteViewModel(
                 status = if (passed) FlowStatus.SUCCESS else FlowStatus.ERROR,
+                duration = suiteDuration,
                 flows = flowResults
                     .map {
                         TestSuiteViewModel.FlowResult(
                             name = it.name,
                             status = it.status,
-                            duration = 42.seconds,
+                            duration = it.duration,
                         )
                     },
             )
@@ -112,7 +115,8 @@ class TestSuiteInteractor(
             suites = listOf(
                 TestExecutionSummary.SuiteResult(
                     passed = passed,
-                    flows = flowResults
+                    flows = flowResults,
+                    duration = suiteDuration
                 )
             )
         )

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -170,7 +170,7 @@ class TestSuiteInteractor(
                 val commands = YamlCommandReader.readCommands(flowFile.toPath())
                     .withEnv(env)
 
-                    val config = YamlCommandReader.getConfig(commands)
+                val config = YamlCommandReader.getConfig(commands)
 
                 val orchestra = Orchestra(
                     maestro = maestro,

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -22,8 +22,9 @@ import maestro.orchestra.yaml.YamlCommandReader
 import okio.Sink
 import org.slf4j.LoggerFactory
 import java.io.File
+import kotlin.math.roundToLong
 import kotlin.system.measureTimeMillis
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class TestSuiteInteractor(
     private val maestro: Maestro,
@@ -99,7 +100,7 @@ class TestSuiteInteractor(
                         TestSuiteViewModel.FlowResult(
                             name = it.name,
                             status = it.status,
-                            duration = 4200.milliseconds,
+                            duration = 42.seconds,
                         )
                     },
             )
@@ -165,7 +166,7 @@ class TestSuiteInteractor(
             return result.getOrNull()
         }
 
-        val flowTime = measureTimeMillis {
+        val flowTimeMillis = measureTimeMillis {
             try {
                 val commands = YamlCommandReader.readCommands(flowFile.toPath())
                     .withEnv(env)
@@ -225,7 +226,8 @@ class TestSuiteInteractor(
                 flowStatus = FlowStatus.ERROR
                 errorMessage = ErrorViewUtils.exceptionToMessage(e)
             }
-        }.milliseconds
+        }
+        val flowDuration = (flowTimeMillis / 1000f).roundToLong().seconds
 
         TestDebugReporter.saveFlow(flowName, debug)
 
@@ -233,7 +235,7 @@ class TestSuiteInteractor(
             TestSuiteViewModel.FlowResult(
                 name = flowName,
                 status = flowStatus,
-                duration = flowTime,
+                duration = flowDuration,
                 error = debug.exception?.message,
             )
         )
@@ -247,7 +249,7 @@ class TestSuiteInteractor(
                     message = errorMessage ?: debug.exception?.message ?: "Unknown error",
                 )
             } else null,
-            duration = flowTime,
+            duration = flowDuration,
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -22,6 +22,8 @@ import maestro.orchestra.yaml.YamlCommandReader
 import okio.Sink
 import org.slf4j.LoggerFactory
 import java.io.File
+import kotlin.system.measureTimeMillis
+import kotlin.time.Duration.Companion.milliseconds
 
 class TestSuiteInteractor(
     private val maestro: Maestro,
@@ -97,6 +99,7 @@ class TestSuiteInteractor(
                         TestSuiteViewModel.FlowResult(
                             name = it.name,
                             status = it.status,
+                            duration = 4200.milliseconds,
                         )
                     },
             )
@@ -162,65 +165,67 @@ class TestSuiteInteractor(
             return result.getOrNull()
         }
 
-        try {
-            val commands = YamlCommandReader.readCommands(flowFile.toPath())
-                .withEnv(env)
+        val flowTime = measureTimeMillis {
+            try {
+                val commands = YamlCommandReader.readCommands(flowFile.toPath())
+                    .withEnv(env)
 
-            val config = YamlCommandReader.getConfig(commands)
+                    val config = YamlCommandReader.getConfig(commands)
 
-            val orchestra = Orchestra(
-                maestro = maestro,
-                onCommandStart = { _, command ->
-                    logger.info("${command.description()} RUNNING")
-                    debugCommands[command] = CommandDebugMetadata(
-                        timestamp = System.currentTimeMillis(),
-                        status = CommandStatus.RUNNING
-                    )
-                },
-                onCommandComplete = { _, command ->
-                    logger.info("${command.description()} COMPLETED")
-                    debugCommands[command]?.let {
-                        it.status = CommandStatus.COMPLETED
-                        it.calculateDuration()
-                    }
-                },
-                onCommandFailed = { _, command, e ->
-                    logger.info("${command.description()} FAILED")
-                    if (e is MaestroException) debug.exception = e
-                    debugCommands[command]?.let {
-                        it.status = CommandStatus.FAILED
-                        it.calculateDuration()
-                        it.error = e
-                    }
+                val orchestra = Orchestra(
+                    maestro = maestro,
+                    onCommandStart = { _, command ->
+                        logger.info("${command.description()} RUNNING")
+                        debugCommands[command] = CommandDebugMetadata(
+                            timestamp = System.currentTimeMillis(),
+                            status = CommandStatus.RUNNING
+                        )
+                    },
+                    onCommandComplete = { _, command ->
+                        logger.info("${command.description()} COMPLETED")
+                        debugCommands[command]?.let {
+                            it.status = CommandStatus.COMPLETED
+                            it.calculateDuration()
+                        }
+                    },
+                    onCommandFailed = { _, command, e ->
+                        logger.info("${command.description()} FAILED")
+                        if (e is MaestroException) debug.exception = e
+                        debugCommands[command]?.let {
+                            it.status = CommandStatus.FAILED
+                            it.calculateDuration()
+                            it.error = e
+                        }
 
-                    takeDebugScreenshot(CommandStatus.FAILED)
-                    Orchestra.ErrorResolution.FAIL
-                },
-                onCommandSkipped = { _, command ->
-                    logger.info("${command.description()} SKIPPED")
-                    debugCommands[command]?.let {
-                        it.status = CommandStatus.SKIPPED
-                    }
-                },
-                onCommandReset = { command ->
-                    logger.info("${command.description()} PENDING")
-                    debugCommands[command]?.let {
-                        it.status = CommandStatus.PENDING
-                    }
-                },
-            )
+                        takeDebugScreenshot(CommandStatus.FAILED)
+                        Orchestra.ErrorResolution.FAIL
+                    },
+                    onCommandSkipped = { _, command ->
+                        logger.info("${command.description()} SKIPPED")
+                        debugCommands[command]?.let {
+                            it.status = CommandStatus.SKIPPED
+                        }
+                    },
+                    onCommandReset = { command ->
+                        logger.info("${command.description()} PENDING")
+                        debugCommands[command]?.let {
+                            it.status = CommandStatus.PENDING
+                        }
+                    },
+                )
 
-            config?.name?.let {
-                flowName = it
+                config?.name?.let {
+                    flowName = it
+                }
+
+                val flowSuccess = orchestra.runFlow(commands)
+                flowStatus = if (flowSuccess) FlowStatus.SUCCESS else FlowStatus.ERROR
+            } catch (e: Exception) {
+                logger.error("Failed to complete flow", e)
+                flowStatus = FlowStatus.ERROR
+                errorMessage = ErrorViewUtils.exceptionToMessage(e)
             }
-
-            val flowSuccess = orchestra.runFlow(commands)
-            flowStatus = if (flowSuccess) FlowStatus.SUCCESS else FlowStatus.ERROR
-        } catch (e: Exception) {
-            logger.error("Failed to complete flow", e)
-            flowStatus = FlowStatus.ERROR
-            errorMessage = ErrorViewUtils.exceptionToMessage(e)
-        }
+        }.milliseconds
 
         TestDebugReporter.saveFlow(flowName, debug)
 
@@ -228,7 +233,8 @@ class TestSuiteInteractor(
             TestSuiteViewModel.FlowResult(
                 name = flowName,
                 status = flowStatus,
-                error = debug.exception?.message
+                duration = flowTime,
+                error = debug.exception?.message,
             )
         )
 
@@ -241,6 +247,7 @@ class TestSuiteInteractor(
                     message = errorMessage ?: debug.exception?.message ?: "Unknown error",
                 )
             } else null,
+            duration = flowTime,
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -71,13 +71,13 @@ object TestSuiteStatusView {
         }
         println()
 
-        if (suite.uploadDetais != null) {
+        if (suite.uploadDetails != null) {
             println("==== View details in the console ====")
             PrintUtils.message(
                 uploadUrl(
-                    suite.uploadDetais.uploadId.toString(),
-                    suite.uploadDetais.teamId,
-                    suite.uploadDetais.appId,
+                    suite.uploadDetails.uploadId.toString(),
+                    suite.uploadDetails.teamId,
+                    suite.uploadDetails.appId,
                 )
             )
             println()
@@ -119,7 +119,7 @@ object TestSuiteStatusView {
     data class TestSuiteViewModel(
         val status: FlowStatus,
         val flows: List<FlowResult>,
-        val uploadDetais: UploadDetails? = null,
+        val uploadDetails: UploadDetails? = null,
     ) {
 
         data class FlowResult(
@@ -138,9 +138,9 @@ object TestSuiteStatusView {
         companion object {
 
             fun UploadStatus.toViewModel(
-                uploadDetais: UploadDetails
+                uploadDetails: UploadDetails
             ) = TestSuiteViewModel(
-                uploadDetais = uploadDetais,
+                uploadDetails = uploadDetails,
                 status = FlowStatus.from(status),
                 flows = flows.map {
                     it.toViewModel()
@@ -162,7 +162,7 @@ object TestSuiteStatusView {
 // Helped launcher to play around with presentation
 fun main() {
     val status = TestSuiteStatusView.TestSuiteViewModel(
-        uploadDetais = TestSuiteStatusView.TestSuiteViewModel.UploadDetails(
+        uploadDetails = TestSuiteStatusView.TestSuiteViewModel.UploadDetails(
             uploadId = UUID.randomUUID(),
             teamId = "teamid",
             appId = "appid",

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -56,8 +56,9 @@ object TestSuiteStatusView {
                 .filter { it.status == FlowStatus.CANCELED }
 
             if (passedFlows.isNotEmpty()) {
+                val durationMessage = suite.duration?.let { " in $it" } ?: ""
                 PrintUtils.success(
-                    "${passedFlows.size}/${suite.flows.size} ${flowWord(passedFlows.size)} Passed",
+                    "${passedFlows.size}/${suite.flows.size} ${flowWord(passedFlows.size)} Passed$durationMessage",
                     bold = true,
                 )
 
@@ -119,6 +120,7 @@ object TestSuiteStatusView {
     data class TestSuiteViewModel(
         val status: FlowStatus,
         val flows: List<FlowResult>,
+        val duration: Duration? = null,
         val uploadDetails: UploadDetails? = null,
     ) {
 
@@ -183,7 +185,8 @@ fun main() {
                 name = "C",
                 status = FlowStatus.CANCELED,
             )
-        )
+        ),
+        duration = 273.seconds,
     )
 
     status.flows

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -7,13 +7,15 @@ import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel.FlowResult
 import org.fusesource.jansi.Ansi
 import java.util.UUID
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 object TestSuiteStatusView {
 
     fun showFlowCompletion(result: FlowResult) {
         printStatus(result.status)
 
-        print(" ${result.name}")
+        val durationString = result.duration?.let { " ($it)" }.orEmpty()
+        print(" ${result.name}$durationString")
         if (result.status == FlowStatus.ERROR && result.error != null) {
             print(
                 Ansi.ansi()
@@ -170,10 +172,12 @@ fun main() {
             FlowResult(
                 name = "A",
                 status = FlowStatus.SUCCESS,
+                duration = 4200.milliseconds,
             ),
             FlowResult(
                 name = "B",
                 status = FlowStatus.SUCCESS,
+                duration = 1230.milliseconds,
             ),
             FlowResult(
                 name = "C",

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -8,13 +8,16 @@ import org.fusesource.jansi.Ansi
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 object TestSuiteStatusView {
 
     fun showFlowCompletion(result: FlowResult) {
         printStatus(result.status)
 
-        val durationString = result.duration?.let { " ($it)" }.orEmpty()
+        val durationString = result.duration?.let {
+            " (${it.toComponents { s, _ -> s.seconds }})"
+        }.orEmpty()
         print(" ${result.name}$durationString")
         if (result.status == FlowStatus.ERROR && result.error != null) {
             print(
@@ -177,7 +180,7 @@ fun main() {
             FlowResult(
                 name = "B",
                 status = FlowStatus.SUCCESS,
-                duration = 1230.milliseconds,
+                duration = 231.seconds,
             ),
             FlowResult(
                 name = "C",

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -6,6 +6,7 @@ import maestro.cli.util.PrintUtils
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel.FlowResult
 import org.fusesource.jansi.Ansi
 import java.util.UUID
+import kotlin.time.Duration
 
 object TestSuiteStatusView {
 
@@ -122,7 +123,8 @@ object TestSuiteStatusView {
         data class FlowResult(
             val name: String,
             val status: FlowStatus,
-            val error: String? = null
+            val duration: Duration? = null,
+            val error: String? = null,
         )
 
         data class UploadDetails(

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -7,7 +7,6 @@ import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel.FlowResult
 import org.fusesource.jansi.Ansi
 import java.util.UUID
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 object TestSuiteStatusView {
@@ -15,9 +14,7 @@ object TestSuiteStatusView {
     fun showFlowCompletion(result: FlowResult) {
         printStatus(result.status)
 
-        val durationString = result.duration?.let {
-            " (${it.toComponents { s, _ -> s.seconds }})"
-        }.orEmpty()
+        val durationString = result.duration?.let { " ($it)" }.orEmpty()
         print(" ${result.name}$durationString")
         if (result.status == FlowStatus.ERROR && result.error != null) {
             print(
@@ -175,7 +172,7 @@ fun main() {
             FlowResult(
                 name = "A",
                 status = FlowStatus.SUCCESS,
-                duration = 4200.milliseconds,
+                duration = 42.seconds,
             ),
             FlowResult(
                 name = "B",

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -52,8 +52,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" device="iPhone 14" tests="2" failures="0">
-                    <testcase id="flow_a" name="Flow A" classname="flow_a" time="42.1"/>
-                    <testcase id="flow_b" name="Flow B" classname="flow_b" time="149.4"/>
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="42.1"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="149.4"/>
                   </testsuite>
                 </testsuites>
                 
@@ -104,8 +104,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" tests="2" failures="1">
-                    <testcase id="flow_a" name="Flow A" classname="flow_a" time="42.1"/>
-                    <testcase id="flow_b" name="Flow B" classname="flow_b" time="1.31">
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="42.1"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1.31">
                       <failure>Error message</failure>
                     </testcase>
                   </testsuite>
@@ -157,8 +157,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0">
-                    <testcase id="flow_a" name="Flow A" classname="flow_a" time="42.1"/>
-                    <testcase id="flow_b" name="Flow B" classname="flow_b"/>
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="42.1"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B"/>
                   </testsuite>
                 </testsuites>
                 

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -5,7 +5,7 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
 import okio.Buffer
 import org.junit.jupiter.api.Test
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class JUnitTestSuiteReporterTest {
 
@@ -25,13 +25,13 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
-                            duration = 42100.milliseconds
+                            duration = 421.seconds
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
                             fileName = "flow_b",
                             status = FlowStatus.WARNING,
-                            duration = 149400.milliseconds
+                            duration = 1494.seconds
                         ),
                     )
                 )
@@ -52,8 +52,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" device="iPhone 14" tests="2" failures="0">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="42.1"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="149.4"/>
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494"/>
                   </testsuite>
                 </testsuites>
                 
@@ -76,14 +76,14 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
-                            duration = 42100.milliseconds
+                            duration = 421.seconds
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
                             fileName = "flow_b",
                             status = FlowStatus.ERROR,
                             failure = TestExecutionSummary.Failure("Error message"),
-                            duration = 1310.milliseconds
+                            duration = 131.seconds
                         ),
                     )
                 )
@@ -104,8 +104,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" tests="2" failures="1">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="42.1"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1.31">
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="131">
                       <failure>Error message</failure>
                     </testcase>
                   </testsuite>
@@ -131,7 +131,7 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
-                            duration = 42100.milliseconds
+                            duration = 421.seconds
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
@@ -157,7 +157,7 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="42.1"/>
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421"/>
                     <testcase id="Flow B" name="Flow B" classname="Flow B"/>
                   </testsuite>
                 </testsuites>

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -33,7 +33,8 @@ class JUnitTestSuiteReporterTest {
                             status = FlowStatus.WARNING,
                             duration = 1494.seconds
                         ),
-                    )
+                    ),
+                    duration = 1915.seconds,
                 )
             )
         )
@@ -51,7 +52,7 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Test Suite" device="iPhone 14" tests="2" failures="0">
+                  <testsuite name="Test Suite" device="iPhone 14" tests="2" failures="0" time="1915">
                     <testcase id="Flow A" name="Flow A" classname="Flow A" time="421"/>
                     <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494"/>
                   </testsuite>
@@ -85,7 +86,8 @@ class JUnitTestSuiteReporterTest {
                             failure = TestExecutionSummary.Failure("Error message"),
                             duration = 131.seconds
                         ),
-                    )
+                    ),
+                    duration = 552.seconds,
                 )
             )
         )
@@ -103,7 +105,7 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Test Suite" tests="2" failures="1">
+                  <testsuite name="Test Suite" tests="2" failures="1" time="552">
                     <testcase id="Flow A" name="Flow A" classname="Flow A" time="421"/>
                     <testcase id="Flow B" name="Flow B" classname="Flow B" time="131">
                       <failure>Error message</failure>
@@ -138,7 +140,8 @@ class JUnitTestSuiteReporterTest {
                             fileName = "flow_b",
                             status = FlowStatus.WARNING,
                         ),
-                    )
+                    ),
+                    duration = 421.seconds,
                 )
             )
         )
@@ -156,7 +159,7 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0">
+                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0" time="421">
                     <testcase id="Flow A" name="Flow A" classname="Flow A" time="421"/>
                     <testcase id="Flow B" name="Flow B" classname="Flow B"/>
                   </testsuite>

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -5,6 +5,7 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
 import okio.Buffer
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 class JUnitTestSuiteReporterTest {
 
@@ -24,11 +25,13 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
+                            duration = 42100.milliseconds
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
                             fileName = "flow_b",
                             status = FlowStatus.WARNING,
+                            duration = 149400.milliseconds
                         ),
                     )
                 )
@@ -49,8 +52,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" device="iPhone 14" tests="2" failures="0">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B"/>
+                    <testcase id="flow_a" name="Flow A" classname="flow_a" time="42.1"/>
+                    <testcase id="flow_b" name="Flow B" classname="flow_b" time="149.4"/>
                   </testsuite>
                 </testsuites>
                 
@@ -73,12 +76,14 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
+                            duration = 42100.milliseconds
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
                             fileName = "flow_b",
                             status = FlowStatus.ERROR,
-                            failure = TestExecutionSummary.Failure("Error message")
+                            failure = TestExecutionSummary.Failure("Error message"),
+                            duration = 1310.milliseconds
                         ),
                     )
                 )
@@ -99,8 +104,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" tests="2" failures="1">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B">
+                    <testcase id="flow_a" name="Flow A" classname="flow_a" time="42.1"/>
+                    <testcase id="flow_b" name="Flow B" classname="flow_b" time="1.31">
                       <failure>Error message</failure>
                     </testcase>
                   </testsuite>
@@ -126,6 +131,7 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
+                            duration = 42100.milliseconds
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
@@ -151,8 +157,8 @@ class JUnitTestSuiteReporterTest {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B"/>
+                    <testcase id="flow_a" name="Flow A" classname="flow_a" time="42.1"/>
+                    <testcase id="flow_b" name="Flow B" classname="flow_b"/>
                   </testsuite>
                 </testsuites>
                 


### PR DESCRIPTION
## Proposed Changes

- I added test duration measurement when running a flow
- Test durations are displayed for each test in the CLI output (only when running a test suite)
- Test durations are added to the `testcase` element as a `time` attribute conforming to the [JUnit XSD](https://llg.cubic.org/docs/junit/)

## Testing

- Ran the cli tests `:maestro-cli:test`
- Ran the integration tests `:maestro-tests:test` (These were failing for me unless I fixed a line in [ApkDebuggable.kt](https://github.com/mobile-dev-inc/maestro/blob/main/maestro-client/src/main/java/maestro/android/ApkDebuggable.kt#L47))
- Ran the `TestSuiteStatusView` main function
- Tested the build on my flows both in command line and with the junit reporter

## Issues Fixed

- Typo in variable name

## Sample outputs

```
Running on emulator-5554

Waiting for flows to complete...

[Failed] Login (39.568s)

1/1 Flow Failed
```

```
<?xml version='1.0' encoding='UTF-8'?>
<testsuites>
  <testsuite name="Test Suite" device="emulator-5554" tests="1" failures="0">
    <testcase id="login" name="Login" classname="login" time="39.568"/>
  </testsuite>
</testsuites>
```