### PR TITLE
Don't fail serialization on unknown properties in ApiClient

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -6,7 +6,6 @@ import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.map
-import jdk.nashorn.internal.parser.JSONParser
 import maestro.cli.CliError
 import maestro.cli.util.PrintUtils
 import maestro.cli.runner.resultview.AnsiResultView

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -1,10 +1,12 @@
 package maestro.cli.api
 
+import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.map
+import jdk.nashorn.internal.parser.JSONParser
 import maestro.cli.CliError
 import maestro.cli.util.PrintUtils
 import maestro.cli.runner.resultview.AnsiResultView
@@ -396,7 +398,7 @@ class ApiClient(
 
     companion object {
 
-        private val JSON = jacksonObjectMapper()
+        private val JSON = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92a759a</samp>

Improved JSON parsing in `ApiClient.kt`. This enables the `ApiClient` class to work with different types of JSON data from the Maestro API.

