### PR TITLE
Fix: use updated urls to commands documentation within studio

### DIFF
--- a/maestro-studio/web/src/commandExample.ts
+++ b/maestro-studio/web/src/commandExample.ts
@@ -135,7 +135,7 @@ const toTapExample = (selector: Selector): CommandExample => {
     status: selector.status,
     title: `Tap > ${selector.title}`,
     content: selector.status === 'available' ? stringifyYaml([{ tapOn: selector.definition }]) : selector.message,
-    documentation: selector.documentation || 'https://maestro.mobile.dev/reference/tap-on-view',
+    documentation: selector.documentation || 'https://maestro.mobile.dev/api-reference/commands/tapon',
   }
 }
 
@@ -144,7 +144,7 @@ const toAssertExample = (selector: Selector): CommandExample => {
     status: selector.status,
     title: `Assert > ${selector.title}`,
     content: selector.status === 'available' ? stringifyYaml([{ assertVisible: selector.definition }]) : selector.message,
-    documentation: selector.documentation || 'https://maestro.mobile.dev/reference/assertions',
+    documentation: selector.documentation || 'https://maestro.mobile.dev/api-reference/commands/assertvisible',
   }
 }
 


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4878dff</samp>

Improved documentation for `tapOn` and `assertVisible` commands in `maestro-studio/web`. Fixed broken links to the new API reference in `commandExample.ts`.

## Issues Fixed
Fixes #1033
