### PR TITLE
WebDriver: Only scroll to elements outside of the window before tapping

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -106,7 +106,8 @@ class WebDriver(val isStudio: Boolean) : Driver {
     private fun scrollToPoint(point: Point): Long {
         ensureOpen()
         val windowHeight = executeJS("return window.innerHeight") as Long
-        if (point.y > 0 && point.y.toLong() <= windowHeight - 50) return 0L
+
+        if (point.y >= 0 && point.y.toLong() <= windowHeight) return 0L
 
         val scrolledPixels =
             executeJS("const delta = ${point.y} - Math.floor(window.innerHeight / 2); window.scrollBy({ top: delta, left: 0, behavior: 'smooth' }); return delta") as Long


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d2a0fa8</samp>

Fixed a bug in `WebDriver.kt` that caused incorrect scrolling and clicking behavior. Adjusted the visibility check to include the bottom edge of the window.

