### PR TITLE
[WIP] Add `defineSelectors` command

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -650,6 +650,25 @@ data class DefineVariablesCommand(
 
 }
 
+data class DefineSelectorsCommand(
+    val selectors: Map<String, ElementSelector>,
+) : Command {
+
+    override fun description(): String {
+        return "Define selectors"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): DefineSelectorsCommand {
+        return copy(
+            selectors = selectors.mapValues { (_, value) ->
+                value.evaluateScripts(jsEngine)
+            }
+        )
+    }
+
+    override fun visible(): Boolean = false
+}
+
 data class RunScriptCommand(
     val script: String,
     val env: Map<String, String> = emptyMap(),

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -23,6 +23,7 @@ import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
 
 data class ElementSelector(
+    val selector: String? = null,
     val textRegex: String? = null,
     val idRegex: String? = null,
     val size: SizeSelector? = null,
@@ -63,6 +64,10 @@ data class ElementSelector(
 
     fun description(): String {
         val descriptions = mutableListOf<String>()
+
+        selector?.let {
+            descriptions.add("Selector: $it")
+        }
 
         textRegex?.let {
             descriptions.add("\"$it\"")

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -61,6 +61,7 @@ data class MaestroCommand(
     val scrollUntilVisible: ScrollUntilVisibleCommand? = null,
     val travelCommand: TravelCommand? = null,
     val assertOutgoingRequestsCommand: AssertOutgoingRequestsCommand? = null,
+    val defineSelectorsCommand: DefineSelectorsCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -97,6 +98,7 @@ data class MaestroCommand(
         scrollUntilVisible = command as? ScrollUntilVisibleCommand,
         travelCommand = command as? TravelCommand,
         assertOutgoingRequestsCommand = command as? AssertOutgoingRequestsCommand,
+        defineSelectorsCommand = command as? DefineSelectorsCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -133,6 +135,7 @@ data class MaestroCommand(
         scrollUntilVisible != null -> scrollUntilVisible
         travelCommand != null -> travelCommand
         assertOutgoingRequestsCommand != null -> assertOutgoingRequestsCommand
+        defineSelectorsCommand != null -> defineSelectorsCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlDefineSelectors.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlDefineSelectors.kt
@@ -1,0 +1,15 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlDefineSelectors(
+    val selectors: Map<String, YamlElementSelectorUnion>
+) {
+    companion object {
+
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(selectors: Map<String, YamlElementSelectorUnion>) =
+            YamlDefineSelectors(selectors = selectors)
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -46,4 +46,5 @@ data class YamlElementSelector(
     val selected: Boolean? = null,
     val checked: Boolean? = null,
     val focused: Boolean? = null,
+    val selector: String? = null,
 ) : YamlElementSelectorUnion

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -28,6 +28,7 @@ import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
 import maestro.orchestra.Condition
 import maestro.orchestra.CopyTextFromCommand
+import maestro.orchestra.DefineSelectorsCommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.ElementTrait
 import maestro.orchestra.EraseTextCommand
@@ -96,6 +97,7 @@ data class YamlFluentCommand(
     val scrollUntilVisible: YamlScrollUntilVisible? = null,
     val travel: YamlTravelCommand? = null,
     val assertOutgoingRequest: YamlAssertOutgoingRequestsCommand? = null,
+    val defineSelectors: YamlDefineSelectors? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -213,6 +215,7 @@ data class YamlFluentCommand(
             scrollUntilVisible != null -> listOf(scrollUntilVisibleCommand(scrollUntilVisible))
             travel != null -> listOf(travelCommand(travel))
             assertOutgoingRequest != null -> listOf(assertOutgoingRequestsCommand(assertOutgoingRequest))
+            defineSelectors != null -> listOf(defineSelectorsCommand(defineSelectors))
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }
     }
@@ -254,6 +257,14 @@ data class YamlFluentCommand(
                 headersAndValues = command.headersAndValues,
                 httpMethodIs = command.httpMethodIs,
                 requestBodyContains = command.requestBodyContains,
+            )
+        )
+    }
+
+    private fun defineSelectorsCommand(command: YamlDefineSelectors): MaestroCommand {
+        return MaestroCommand(
+            DefineSelectorsCommand(
+                selectors = command.selectors.mapValues { (_, value) -> toElementSelector(value) },
             )
         )
     }
@@ -476,6 +487,7 @@ data class YamlFluentCommand(
         }
 
         return ElementSelector(
+            selector = selector.selector,
             textRegex = selector.text,
             idRegex = selector.id,
             size = size,

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2669,6 +2669,39 @@ class IntegrationTest {
         driver.assertNoInteraction()
     }
 
+    @Test
+    fun `Case 098 - Define selectors`() {
+        // Given
+        val commands = readCommands("098_define_selectors")
+
+        val driver = driver {
+            element {
+                id = "id_email_text"
+                text = "Email"
+                bounds = Bounds.ofSize(100, 100)
+            }
+            element {
+                id = "id_password_text"
+                text = "not password"
+                bounds = Bounds.ofSize(100, 100)
+                    .translate(y = 100)
+            }
+            element {
+                text = "Login"
+                bounds = Bounds.ofSize(100, 100)
+                    .translate(y = 200)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        driver.assertHasEvent(Event.Tap(Point(50, 250)))
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/098_define_selectors.yaml
+++ b/maestro-test/src/test/resources/098_define_selectors.yaml
@@ -1,0 +1,17 @@
+appId: com.example.app
+---
+- defineSelectors:
+    LoginScreen.EmailText:
+      id: id_email_text
+      text: Email
+    LoginButton: Login
+- defineSelectors:
+    PasswordText:
+      id: id_password_text
+- assertVisible:
+    selector: LoginScreen.EmailText
+- assertNotVisible:
+    selector: PasswordText
+    text: Password
+- tapOn:
+    selector: LoginButton


### PR DESCRIPTION
WIP. Working proof of concept, but API is subject to change and it's insufficiently tested.

## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82fe314</samp>

This pull request adds a new feature to the `maestro` framework that allows defining and using custom element selectors in YAML and Kotlin commands. Custom selectors can reference other selectors and filter elements based on nested criteria. The feature is implemented by a new `DefineSelectorsCommand` class and a corresponding `YamlDefineSelectors` class. The feature is tested by a new integration test case and a YAML file.

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
https://github.com/mobile-dev-inc/maestro/issues/1044