### PR TITLE
Fix install.sh script trying to add the bin to the PATH

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -130,21 +130,21 @@ if [[ $darwin == true ]]; then
   touch "$maestro_bash_profile"
   if ! command -v maestro > /dev/null; then
     echo "Adding maestro to your PATH in $maestro_bash_profile"
-    echo 'export PATH=$PATH:'"$MAESTRO_BIN_DIR_RAW" >> "$maestro_bash_profile"
+    echo '\nexport PATH=$PATH:'"$MAESTRO_BIN_DIR_RAW" >> "$maestro_bash_profile"
   fi
 else
   echo "Attempt update of interactive bash profile on regular UNIX..."
   touch "${maestro_bashrc}"
   if ! command -v maestro > /dev/null; then
     echo "Adding maestro to your PATH in $maestro_bashrc"
-    echo 'export PATH=$PATH:'"$MAESTRO_BIN_DIR_RAW" >> "$maestro_bashrc"
+    echo '\nexport PATH=$PATH:'"$MAESTRO_BIN_DIR_RAW" >> "$maestro_bashrc"
   fi
 fi
 
 touch "$maestro_zshrc"
 if ! command -v maestro > /dev/null; then
   echo "Adding maestro to your PATH in $maestro_zshrc"
-  echo 'export PATH=$PATH:'"$MAESTRO_BIN_DIR_RAW" >> "$maestro_zshrc"
+  echo '\nexport PATH=$PATH:'"$MAESTRO_BIN_DIR_RAW" >> "$maestro_zshrc"
 fi
 
 echo ""


### PR DESCRIPTION
In my case my last line in the .zshrc was a comment and your script just appended it. Therefor the meastro bin could not be found

## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 061b580</samp>

This pull request improves the installation script `./scripts/install.sh` by adding newlines before export statements and removing a trailing whitespace.

## Testing

Run the script

## Issues Fixed
