### PR TITLE
Fail on timeout when --fail-on-cancellation is passed

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -127,6 +127,7 @@ class CloudCommand : Callable<Int> {
     override fun call(): Int {
         return CloudInteractor(
             client = ApiClient(apiUrl),
+            failOnTimeout = failOnCancellation,
         ).upload(
             async = async,
             flowFile = flowFile,


### PR DESCRIPTION
## Proposed Changes

Return failure when a maestro cloud flow run times out and `--fail-on-cancellation` is passed.
