### PR TITLE
A small debug output typo fix

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -284,7 +284,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
             val hierarchyAfterTap = waitForAppToSettle()
 
             if (hierarchyAfterTap == null || hierarchyBeforeTap != hierarchyAfterTap) {
-                LOGGER.info("Something have changed in the UI judging by view hierarchy. Proceed.")
+                LOGGER.info("Something has changed in the UI judging by view hierarchy. Proceed.")
                 return
             }
         }


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c89328b</samp>

Fix a grammatical error in a log message in `Maestro.kt`. This change improves the readability and clarity of the log output.


