### PR TITLE
Add screen recording commands

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -771,6 +771,28 @@ data class AssertOutgoingRequestsCommand(
     }
 }
 
+data class StartRecordingCommand(val path: String) : Command {
+
+    override fun description(): String {
+        return "Start recording $path"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): StartRecordingCommand {
+        return copy(
+            path = path.evaluateScripts(jsEngine),
+        )
+    }
+}
+
+class StopRecordingCommand : Command {
+
+    override fun description(): String {
+        return "Stop recording"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+}
+
 internal fun tapOrLong(isLongPress: Boolean?): String = if (isLongPress == true) "Long press" else "Tap"
-
-

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -61,6 +61,8 @@ data class MaestroCommand(
     val scrollUntilVisible: ScrollUntilVisibleCommand? = null,
     val travelCommand: TravelCommand? = null,
     val assertOutgoingRequestsCommand: AssertOutgoingRequestsCommand? = null,
+    val startRecordingCommand: StartRecordingCommand? = null,
+    val stopRecordingCommand: StopRecordingCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -97,6 +99,8 @@ data class MaestroCommand(
         scrollUntilVisible = command as? ScrollUntilVisibleCommand,
         travelCommand = command as? TravelCommand,
         assertOutgoingRequestsCommand = command as? AssertOutgoingRequestsCommand,
+        startRecordingCommand = command as? StartRecordingCommand,
+        stopRecordingCommand = command as? StopRecordingCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -133,6 +137,8 @@ data class MaestroCommand(
         scrollUntilVisible != null -> scrollUntilVisible
         travelCommand != null -> travelCommand
         assertOutgoingRequestsCommand != null -> assertOutgoingRequestsCommand
+        startRecordingCommand != null -> startRecordingCommand
+        stopRecordingCommand != null -> stopRecordingCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -48,7 +48,9 @@ import maestro.orchestra.RunScriptCommand
 import maestro.orchestra.ScrollCommand
 import maestro.orchestra.ScrollUntilVisibleCommand
 import maestro.orchestra.SetLocationCommand
+import maestro.orchestra.StartRecordingCommand
 import maestro.orchestra.StopAppCommand
+import maestro.orchestra.StopRecordingCommand
 import maestro.orchestra.SwipeCommand
 import maestro.orchestra.TakeScreenshotCommand
 import maestro.orchestra.TapOnElementCommand
@@ -96,6 +98,8 @@ data class YamlFluentCommand(
     val scrollUntilVisible: YamlScrollUntilVisible? = null,
     val travel: YamlTravelCommand? = null,
     val assertOutgoingRequest: YamlAssertOutgoingRequestsCommand? = null,
+    val startRecording: YamlStartRecording? = null,
+    val stopRecording: YamlStopRecording? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -214,6 +218,8 @@ data class YamlFluentCommand(
             scrollUntilVisible != null -> listOf(scrollUntilVisibleCommand(scrollUntilVisible))
             travel != null -> listOf(travelCommand(travel))
             assertOutgoingRequest != null -> listOf(assertOutgoingRequestsCommand(assertOutgoingRequest))
+            startRecording != null -> listOf(MaestroCommand(StartRecordingCommand(startRecording.path)))
+            stopRecording != null -> listOf(MaestroCommand(StopRecordingCommand()))
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }
     }
@@ -605,6 +611,10 @@ data class YamlFluentCommand(
 
                 "waitForAnimationToEnd" -> YamlFluentCommand(
                     waitForAnimationToEnd = YamlWaitForAnimationToEndCommand(null)
+                )
+
+                "stopRecording" -> YamlFluentCommand(
+                    stopRecording = YamlStopRecording()
                 )
 
                 else -> throw SyntaxError("Invalid command: \"$stringCommand\"")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlStartRecording.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlStartRecording.kt
@@ -1,0 +1,21 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlStartRecording(
+    val path: String
+) {
+
+    companion object {
+
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(path: String): YamlStartRecording {
+            return YamlStartRecording(
+                path = path,
+            )
+        }
+    }
+}
+
+class YamlStopRecording

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -247,8 +247,16 @@ class FakeDriver : Driver {
     }
 
     override fun startScreenRecording(out: Sink): ScreenRecording {
+        ensureOpen()
+
+        out.buffer().writeUtf8("Screen recording").close()
+
+        events += Event.StartRecording
+
         return object : ScreenRecording {
-            override fun close() {}
+            override fun close() {
+                events += Event.StopRecording
+            }
         }
     }
 
@@ -481,6 +489,10 @@ class FakeDriver : Driver {
             val appId: String,
             val permissions: Map<String, String>,
         ) : Event()
+
+        object StartRecording : Event()
+
+        object StopRecording : Event()
     }
 
     interface UserInteraction

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -41,6 +41,7 @@ class IntegrationTest {
     @AfterEach
     internal fun tearDown() {
         File("screenshot.png").delete()
+        File("recording.mp4").delete()
     }
 
     @Test
@@ -2703,6 +2704,29 @@ class IntegrationTest {
         assertThat(receivedLogs).containsExactly(
             "Log from runScript",
         ).inOrder()
+    }
+
+    @Test
+    fun `Case 099 - Screen recording`() {
+        // Given
+        val commands = readCommands("099_screen_recording")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.StartRecording,
+                Event.StopRecording,
+            )
+        )
     }
 
     private fun orchestra(

--- a/maestro-test/src/test/resources/099_screen_recording.yaml
+++ b/maestro-test/src/test/resources/099_screen_recording.yaml
@@ -1,0 +1,4 @@
+appId: com.other.app
+---
+- startRecording: recording
+- stopRecording


### PR DESCRIPTION
## Proposed Changes

- This PR adds the `startRecording: <recording_path>` and `stopRecording` commands as suggested in #336 
- The recording logic was already implemented so it was quite easy to add

## Testing

- Wrote an integration test
- Built maestro and ran it locally both on an Android emulator and an iOS simulator

## Issues Fixed

Fixes #336 