### PR TITLE
Fix "Overload resolution ambiguity" in Java 17

### DIFF
--- a/maestro-client/src/main/java/maestro/android/ApkDebuggable.kt
+++ b/maestro-client/src/main/java/maestro/android/ApkDebuggable.kt
@@ -6,6 +6,7 @@ import pxb.android.axml.AxmlVisitor
 import pxb.android.axml.AxmlWriter
 import pxb.android.axml.NodeVisitor
 import java.io.File
+import java.lang.ClassLoader
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
@@ -44,7 +45,7 @@ object ApkDebuggable {
     }
 
     private fun getOriginalManifestBytes(apkFile: File): ByteArray {
-        FileSystems.newFileSystem(apkFile.toPath(), null).use { fs ->
+        FileSystems.newFileSystem(apkFile.toPath(), null as ClassLoader?).use { fs ->
             val manifestPath = fs.getPath("AndroidManifest.xml")
             return Files.readAllBytes(manifestPath)
         }


### PR DESCRIPTION
## Testing
Test locally by running the maestro command

## Issues Fixed

In [java17](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/file/FileSystems.html#newFileSystem(java.nio.file.Path,java.lang.ClassLoader)) there is two `newFileSystem` which will make the build failed with `Overload resolution ambiguity`