### PR TITLE
Adding --ios-version flag to configure iOS version to run in Maestro Cloud

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -220,6 +220,7 @@ class ApiClient(
         pullRequestId: String?,
         env: Map<String, String>? = null,
         androidApiLevel: Int?,
+        iOSVersion: String? = null,
         includeTags: List<String> = emptyList(),
         excludeTags: List<String> = emptyList(),
         maxRetryCount: Int = 3,
@@ -241,6 +242,7 @@ class ApiClient(
         env?.let { requestPart["env"] = it }
         requestPart["agent"] = getAgent()
         androidApiLevel?.let { requestPart["androidApiLevel"] = it }
+        iOSVersion?.let { requestPart["iOSVersion"] = it }
         if (includeTags.isNotEmpty()) requestPart["includeTags"] = includeTags
         if (excludeTags.isNotEmpty()) requestPart["excludeTags"] = excludeTags
 
@@ -283,6 +285,7 @@ class ApiClient(
                         pullRequestId,
                         env,
                         androidApiLevel,
+                        iOSVersion,
                         includeTags,
                         excludeTags,
                         maxRetryCount,

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -49,6 +49,7 @@ class CloudInteractor(
         pullRequestId: String? = null,
         env: Map<String, String> = emptyMap(),
         androidApiLevel: Int? = null,
+        iOSVersion: String? = null,
         failOnCancellation: Boolean = false,
         includeTags: List<String> = emptyList(),
         excludeTags: List<String> = emptyList(),
@@ -98,6 +99,7 @@ class CloudInteractor(
                 pullRequestId,
                 env,
                 androidApiLevel,
+                iOSVersion,
                 includeTags,
                 excludeTags,
             ) { totalBytes, bytesWritten ->

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -121,6 +121,9 @@ class CloudCommand : Callable<Int> {
     )
     private var output: File? = null
 
+    @Option(order = 16, names = ["--ios-version"], description = ["iOS version to run your flow against"])
+    private var iOSVersion: String? = null
+
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
 
@@ -142,6 +145,7 @@ class CloudCommand : Callable<Int> {
             pullRequestId = pullRequestId,
             apiKey = apiKey,
             androidApiLevel = androidApiLevel,
+            iOSVersion = iOSVersion,
             includeTags = includeTags,
             excludeTags = excludeTags,
             reportFormat = format,


### PR DESCRIPTION
Adds `--ios-version` flag to the CLI so the user can select which of the supported iOS versions they can run the Flow against. The error handling (what iOS versions are supported will be handled by the server).