### PR TITLE
Remove script variable scoping

### DIFF
--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -51,42 +51,18 @@ class JsEngine(
             1,
             null
         )
-        currentScope.sealObject()
-
-        // We are entering a sub-scope so that no more declarations can be made
-        // on the root scope that is now sealed.
-        enterScope()
     }
 
     fun onLogMessage(callback: (String) -> Unit) {
         onLogMessage = callback
     }
 
-    fun enterScope() {
-        val subScope = JsScope(root = false)
-        subScope.parentScope = currentScope
-        currentScope = subScope
-    }
-
-    fun leaveScope() {
-        currentScope = currentScope.parentScope as JsScope
-    }
-
     fun evaluateScript(
         script: String,
         env: Map<String, String> = emptyMap(),
         sourceName: String = "inline-script",
-        runInSubScope: Boolean = false,
     ): Any? {
-        val scope = if (runInSubScope) {
-            // We create a new scope for each evaluation to prevent local variables
-            // from clashing with each other across multiple scripts.
-            // Only 'output' is shared across scopes.
-            JsScope(root = false)
-                .apply { parentScope = currentScope }
-        } else {
-            currentScope
-        }
+        val scope = currentScope
 
         if (env.isNotEmpty()) {
             env.forEach { (key, value) ->


### PR DESCRIPTION
# Proposed Change

This change removes the internal "scope" behavior for Maestro javascript evaluation. The intention of scoping was to prevent pollution of the global namespace and to prevent naming collisions between scripts. Reasons for removing this behavior are listed below.

# Why?

1. We want to move to GraalJS instead of RhinoJS because:
    * GraalJS is ECMAScript 2022 compliant while RhinoJS only supports ES5
    * GraalJS is widely considered a modern replacement for RhinoJS
2. And there is no clear way to support the previously intended scoping behavior with GraalJS
3. Additionally, the scoping behavior today is not fully correct. For instance, it's possible today to define a global variable that persists between scripts. More on this below.

# What changes?

## (A) It's now possible to define variables that persist between scripts

Scopes were meant to prevent this, but it's actually possible today. For example, the following passes:

```yaml
appId: com.example
---
- evalScript: ${var foo = 'foo'}
- assertTrue: ${foo === 'foo'}
```

So in reality, this is not much of a behavior change at all. But this change explicitly does not support the original intention of scopes.

#### Question: Do we want to make an effort to properly prevent global variable definitions?

I don't believe it's something that we need to prioritize as it hasn't caused issues to date, and it would add friction and possibly prevent the migration to GraalJS - which I see as much more important in order to support modern javascript features.

## (B) This change will break any existing Flow that redefines a const variable within a subflow

For example, the following would have worked before, but will fail after this change:

```yaml
# entry.yaml
appId: com.example
---
- evalScript: ${const foo = 'foo'}
- runFlow: ./nested.yaml

# nested.yaml
appId: com.example
---
- evalScript: ${const foo = 'FOO'}
```

Error that the user will see:
```
TypeError: TypeError: TypeError: redeclaration of const foo. (JsEngine.kt#74)
```

*Note: This is only a problem with `const`, `let` does not have this issue*

#### Question: Is this a blocker?

I'm not sure - it might be since scripts could get quite complicated and it's easy to imagine a case where two separate scripts in the same flow want to reuse the same name for a top-level const variable.
