### PR TITLE
Implement Experimental GraalJsEngine

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ googleProtobuf = "3.21.9"
 googleProtobufKotlinLite = "3.21.9"
 googleProtobufPlugin = "0.9.1"
 googleTruth = "1.1.3"
+graaljs = "22.0.0" # Latest version that supports Java 8
 grpc = "1.50.2"
 grpcKotlinStub = "1.3.0"
 imageComparison = "4.4.0"
@@ -68,6 +69,7 @@ google-protobuf = { module = "com.google.protobuf:protoc", version.ref = "google
 google-protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "googleProtobuf" }
 google-protobuf-kotlin-lite = { module = "com.google.protobuf:protobuf-kotlin-lite", version.ref = "googleProtobuf" }
 google-truth = { module = "com.google.truth:truth", version.ref = "googleTruth" }
+graaljs = { module = "org.graalvm.js:js", version.ref = "graaljs" }
 grpc-kotlin-stub = { module = "io.grpc:grpc-kotlin-stub", version.ref = "grpcKotlinStub" }
 grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
 grpc-netty-shaded = { module = "io.grpc:grpc-netty-shaded", version.ref = "grpc" }

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation project(':maestro-utils')
     implementation project(':maestro-ios-driver')
 
+    api(libs.graaljs)
     api(libs.grpc.kotlin.stub)
     api(libs.grpc.stub)
     api(libs.grpc.netty)

--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -1,0 +1,115 @@
+package maestro.js
+
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.Source
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyObject
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+import java.util.logging.Handler
+import java.util.logging.LogRecord
+
+private val NULL_HANDLER = object : Handler() {
+    override fun publish(record: LogRecord?) {}
+
+    override fun flush() {}
+
+    override fun close() {}
+}
+
+class GraalJsEngine(
+    httpClient: OkHttpClient = OkHttpClient.Builder()
+        .readTimeout(5, TimeUnit.MINUTES)
+        .writeTimeout(5, TimeUnit.MINUTES)
+        .protocols(listOf(Protocol.HTTP_1_1))
+        .build(),
+) : JsEngine {
+
+    private val openContexts = HashSet<Context>()
+
+    private val httpBinding = GraalJsHttp(httpClient)
+    private val outputBinding = HashMap<String, Any>()
+    private val maestroBinding = HashMap<String, Any?>()
+    private val envBinding = HashMap<String, String>()
+
+    private var onLogMessage: (String) -> Unit = {}
+
+    override fun close() {
+        openContexts.forEach { it.close() }
+    }
+
+    override fun onLogMessage(callback: (String) -> Unit) {
+        onLogMessage = callback
+    }
+
+    override fun enterScope() {}
+
+    override fun leaveScope() {}
+
+    override fun putEnv(key: String, value: String) {
+        this.envBinding[key] = value
+    }
+
+    override fun setCopiedText(text: String?) {
+        this.maestroBinding["copiedText"] = text
+    }
+
+    override fun evaluateScript(
+        script: String,
+        env: Map<String, String>,
+        sourceName: String,
+        runInSubScope: Boolean,
+    ): Value {
+        envBinding.putAll(env)
+        val source = Source.newBuilder("js", script, sourceName).build()
+        return createContext().eval(source)
+    }
+
+    private fun createContext(): Context {
+        val outputStream = object : ByteArrayOutputStream() {
+            override fun flush() {
+                super.flush()
+                val log = toByteArray().decodeToString().removeSuffix("\n")
+                onLogMessage(log)
+                reset()
+            }
+        }
+
+        val context = Context.newBuilder("js")
+            .option("js.strict", "true")
+            .logHandler(NULL_HANDLER)
+            .out(outputStream)
+            .build()
+
+        openContexts.add(context)
+
+        envBinding.forEach { (key, value) -> context.getBindings("js").putMember(key, value) }
+
+        context.getBindings("js").putMember("http", httpBinding)
+        context.getBindings("js").putMember("output", ProxyObject.fromMap(outputBinding))
+        context.getBindings("js").putMember("maestro", ProxyObject.fromMap(maestroBinding))
+
+        context.eval("js", """
+            // Prevent a reference error on referencing undeclared variables. Enables patterns like {MY_ENV_VAR || 'default-value'}.
+            // Instead of throwing an error, undeclared variables will evaluate to undefined.
+            Object.setPrototypeOf(globalThis, new Proxy(Object.prototype, {
+                has(target, key) {
+                    return true;
+                }
+            }))
+            function json(text) {
+                return JSON.parse(text)
+            }
+            function relativePoint(x, y) {
+                var xPercent = Math.ceil(x * 100) + '%'
+                var yPercent = Math.ceil(y * 100) + '%'
+                return xPercent + ',' + yPercent
+            }
+        """.trimIndent())
+
+        return context
+    }
+
+}

--- a/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
@@ -1,0 +1,93 @@
+package maestro.js
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.graalvm.polyglot.HostAccess.Export
+import org.graalvm.polyglot.proxy.ProxyObject
+
+class GraalJsHttp(
+    private val httpClient: OkHttpClient
+) {
+
+    @JvmOverloads
+    @Export
+    fun get(
+        url: String,
+        params: Map<String, Any>? = null,
+    ): Any {
+        return executeRequest(url, "GET", params)
+    }
+
+    @JvmOverloads
+    @Export
+    fun post(
+        url: String,
+        params: Map<String, Any>? = null,
+    ): Any {
+        return executeRequest(url, "POST", params)
+    }
+
+    @JvmOverloads
+    @Export
+    fun put(
+        url: String,
+        params: Map<String, Any>? = null,
+    ): Any {
+        return executeRequest(url, "PUT", params)
+    }
+
+    @JvmOverloads
+    @Export
+    fun delete(
+        url: String,
+        params: Map<String, Any>? = null,
+    ): Any {
+        return executeRequest(url, "DELETE", params)
+    }
+
+    @JvmOverloads
+    @Export
+    fun request(
+        url: String,
+        params: Map<String, Any>? = null,
+    ): Any {
+        val method = params?.get("method") as? String ?: "GET"
+        return executeRequest(
+            url,
+            method,
+            params,
+        )
+    }
+
+    private fun executeRequest(
+        url: String,
+        method: String,
+        params: Map<String, Any>?,
+    ): Any {
+        val requestBuilder = Request.Builder()
+            .url(url)
+
+        val body = params?.get("body") as? String
+
+        requestBuilder.method(method, body?.toRequestBody())
+
+        val headers: Map<*, *> = params?.get("headers") as? Map<*, *> ?: emptyMap<Any, Any>()
+
+        headers.forEach { (key, value) ->
+            requestBuilder.addHeader(key.toString(), value.toString())
+        }
+
+        val request = requestBuilder.build()
+
+        val response = httpClient
+            .newCall(request)
+            .execute()
+
+        return ProxyObject.fromMap(mapOf(
+            "ok" to response.isSuccessful,
+            "status" to response.code,
+            "body" to response.body?.string(),
+        ))
+    }
+}

--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -1,107 +1,15 @@
 package maestro.js
 
-import okhttp3.OkHttpClient
-import okhttp3.Protocol
-import org.mozilla.javascript.Context
-import org.mozilla.javascript.ScriptableObject
-import java.util.concurrent.TimeUnit
-
-class JsEngine(
-    private val httpClient: OkHttpClient = OkHttpClient.Builder()
-        .readTimeout(5, TimeUnit.MINUTES)
-        .writeTimeout(5, TimeUnit.MINUTES)
-        .protocols(listOf(Protocol.HTTP_1_1))
-        .build(),
-) {
-
-    private lateinit var context: Context
-    private lateinit var currentScope: JsScope
-
-    private var onLogMessage: (String) -> Unit = {}
-
-    fun init() {
-        context = Context.enter()
-        currentScope = JsScope(root = true)
-        context.initSafeStandardObjects(currentScope)
-
-        val jsHttp = JsHttp(httpClient)
-        jsHttp.defineFunctionProperties(
-            arrayOf("request", "get", "post", "put", "delete"),
-            JsHttp::class.java,
-            ScriptableObject.DONTENUM
-        )
-        context.initSafeStandardObjects(jsHttp)
-        currentScope.put("http", currentScope, jsHttp)
-
-        val jsConsole = JsConsole(
-            onLogMessage = { onLogMessage(it) }
-        )
-        jsConsole.defineFunctionProperties(
-            arrayOf("log"),
-            JsConsole::class.java,
-            ScriptableObject.DONTENUM
-        )
-        context.initSafeStandardObjects(jsConsole)
-        currentScope.put("console", currentScope, jsConsole)
-
-        context.evaluateString(
-            currentScope,
-            Js.initScript,
-            "maestro-runtime",
-            1,
-            null
-        )
-        currentScope.sealObject()
-
-        // We are entering a sub-scope so that no more declarations can be made
-        // on the root scope that is now sealed.
-        enterScope()
-    }
-
-    fun onLogMessage(callback: (String) -> Unit) {
-        onLogMessage = callback
-    }
-
-    fun enterScope() {
-        val subScope = JsScope(root = false)
-        subScope.parentScope = currentScope
-        currentScope = subScope
-    }
-
-    fun leaveScope() {
-        currentScope = currentScope.parentScope as JsScope
-    }
-
+interface JsEngine : AutoCloseable {
+    fun onLogMessage(callback: (String) -> Unit)
+    fun enterScope()
+    fun leaveScope()
+    fun putEnv(key: String, value: String)
+    fun setCopiedText(text: String?)
     fun evaluateScript(
         script: String,
         env: Map<String, String> = emptyMap(),
         sourceName: String = "inline-script",
         runInSubScope: Boolean = false,
-    ): Any? {
-        val scope = if (runInSubScope) {
-            // We create a new scope for each evaluation to prevent local variables
-            // from clashing with each other across multiple scripts.
-            // Only 'output' is shared across scopes.
-            JsScope(root = false)
-                .apply { parentScope = currentScope }
-        } else {
-            currentScope
-        }
-
-        if (env.isNotEmpty()) {
-            env.forEach { (key, value) ->
-                val wrappedValue = Context.javaToJS(value, scope)
-                ScriptableObject.putProperty(scope, key, wrappedValue)
-            }
-        }
-
-        return context.evaluateString(
-            scope,
-            script,
-            sourceName,
-            1,
-            null
-        )
-    }
-
+    ): Any?
 }

--- a/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
@@ -1,0 +1,118 @@
+package maestro.js
+
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import org.mozilla.javascript.Context
+import org.mozilla.javascript.ScriptableObject
+import java.util.concurrent.TimeUnit
+
+class RhinoJsEngine(
+    httpClient: OkHttpClient = OkHttpClient.Builder()
+        .readTimeout(5, TimeUnit.MINUTES)
+        .writeTimeout(5, TimeUnit.MINUTES)
+        .protocols(listOf(Protocol.HTTP_1_1))
+        .build(),
+) : JsEngine {
+
+    private val context = Context.enter()
+
+    private var currentScope = JsScope(root = true)
+    private var onLogMessage: (String) -> Unit = {}
+
+    init {
+        context.initSafeStandardObjects(currentScope)
+
+        val jsHttp = JsHttp(httpClient)
+        jsHttp.defineFunctionProperties(
+            arrayOf("request", "get", "post", "put", "delete"),
+            JsHttp::class.java,
+            ScriptableObject.DONTENUM
+        )
+        context.initSafeStandardObjects(jsHttp)
+        currentScope.put("http", currentScope, jsHttp)
+
+        val jsConsole = JsConsole(
+            onLogMessage = { onLogMessage(it) }
+        )
+        jsConsole.defineFunctionProperties(
+            arrayOf("log"),
+            JsConsole::class.java,
+            ScriptableObject.DONTENUM
+        )
+        context.initSafeStandardObjects(jsConsole)
+        currentScope.put("console", currentScope, jsConsole)
+
+        context.evaluateString(
+            currentScope,
+            Js.initScript,
+            "maestro-runtime",
+            1,
+            null
+        )
+        currentScope.sealObject()
+
+        // We are entering a sub-scope so that no more declarations can be made
+        // on the root scope that is now sealed.
+        enterScope()
+    }
+
+    override fun close() {
+        context.close()
+    }
+
+    override fun onLogMessage(callback: (String) -> Unit) {
+        onLogMessage = callback
+    }
+
+    override fun enterScope() {
+        val subScope = JsScope(root = false)
+        subScope.parentScope = currentScope
+        currentScope = subScope
+    }
+
+    override fun leaveScope() {
+        currentScope = currentScope.parentScope as JsScope
+    }
+
+    override fun setCopiedText(text: String?) {
+        evaluateScript("maestro.copiedText = '${Js.sanitizeJs(text ?: "")}'")
+    }
+
+    override fun putEnv(key: String, value: String) {
+        val cleanValue = Js.sanitizeJs(value)
+        evaluateScript("var $key = '$cleanValue'")
+    }
+
+    override fun evaluateScript(
+        script: String,
+        env: Map<String, String>,
+        sourceName: String,
+        runInSubScope: Boolean,
+    ): Any? {
+        val scope = if (runInSubScope) {
+            // We create a new scope for each evaluation to prevent local variables
+            // from clashing with each other across multiple scripts.
+            // Only 'output' is shared across scopes.
+            JsScope(root = false)
+                .apply { parentScope = currentScope }
+        } else {
+            currentScope
+        }
+
+        if (env.isNotEmpty()) {
+            env.forEach { (key, value) ->
+                val wrappedValue = Context.javaToJS(value, scope)
+                ScriptableObject.putProperty(scope, key, wrappedValue)
+            }
+        }
+
+        return context.evaluateString(
+            scope,
+            script,
+            sourceName,
+            1,
+            null
+        )
+    }
+
+}

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -1,0 +1,47 @@
+package maestro.test
+
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import maestro.js.GraalJsEngine
+import org.graalvm.polyglot.PolyglotException
+import org.graalvm.polyglot.Value
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GraalJsEngineTest : JsEngineTest() {
+
+    @BeforeEach
+    fun setUp() {
+        engine = GraalJsEngine()
+    }
+
+    @Test
+    fun `Allow redefinitions of variables`() {
+        engine.evaluateScript("const foo = null")
+        engine.evaluateScript("const foo = null")
+    }
+
+    @Test
+    fun `You can't share variables between scopes`() {
+        engine.evaluateScript("const foo = 'foo'")
+        val result = engine.evaluateScript("foo").toString()
+        assertThat(result).contains("undefined")
+    }
+
+    @Test
+    fun `Backslash and newline are supported`() {
+        engine.setCopiedText("\\\n")
+        engine.putEnv("FOO", "\\\n")
+
+        val result = engine.evaluateScript("maestro.copiedText + FOO").toString()
+
+        assertThat(result).isEqualTo("\\\n\\\n")
+    }
+
+    @Test
+    fun `parseInt returns an int representation`() {
+        val result = engine.evaluateScript("parseInt('1')").toString()
+        assertThat(result).isEqualTo("1")
+    }
+}

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2775,6 +2775,26 @@ class IntegrationTest {
         driver.assertEventCount(Event.Tap(Point(50, 50)), 2)
     }
 
+    @Test
+    fun `Case 102 - GraalJs config`() {
+        // given
+        val commands = readCommands("102_graaljs")
+        val driver = driver { }
+
+        // when
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // then
+        driver.assertEvents(
+            listOf(
+                Event.InputText("foo"),
+                Event.InputText("bar"),
+            )
+        )
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
@@ -1,0 +1,58 @@
+package maestro.test
+
+import com.google.common.truth.Truth.assertThat
+import maestro.js.RhinoJsEngine
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mozilla.javascript.RhinoException
+
+class RhinoJsEngineTest : JsEngineTest() {
+
+    @BeforeEach
+    fun setUp() {
+        engine = RhinoJsEngine()
+    }
+
+    @Test
+    fun `Redefinitions of variables are not allowed`() {
+        engine.evaluateScript("const foo = null")
+
+        assertThrows<RhinoException> {
+            engine.evaluateScript("const foo = null")
+        }
+    }
+
+    @Test
+    fun `You can access variables across scopes`() {
+        engine.evaluateScript("const foo = 'foo'")
+        assertThat(engine.evaluateScript("foo")).isEqualTo("foo")
+
+        engine.enterScope()
+        assertThat(engine.evaluateScript("foo")).isEqualTo("foo")
+    }
+
+    @Test
+    fun `Backslash and newline are not supported`() {
+        assertThrows<RhinoException> {
+            engine.setCopiedText("\\")
+        }
+
+        assertThrows<RhinoException> {
+            engine.putEnv("FOO", "\\")
+        }
+
+        engine.setCopiedText("\n")
+        engine.putEnv("FOO", "\n")
+
+        val result = engine.evaluateScript("maestro.copiedText + FOO").toString()
+
+        assertThat(result).isEqualTo("")
+    }
+
+    @Test
+    fun `parseInt returns a double representation`() {
+        val result = engine.evaluateScript("parseInt('1')").toString()
+        assertThat(result).isEqualTo("1.0")
+    }
+}

--- a/maestro-test/src/test/resources/102_graaljs.yaml
+++ b/maestro-test/src/test/resources/102_graaljs.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+jsEngine: graaljs
+---
+# Note: The ?? operator is an example of an ES2020 feature and is not supported by RhinoJS
+- inputText: ${null ?? 'foo'}
+- runFlow: 102_graaljs_subflow.yaml

--- a/maestro-test/src/test/resources/102_graaljs_subflow.yaml
+++ b/maestro-test/src/test/resources/102_graaljs_subflow.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+# Still uses graaljs in a subflow based on the top-level flow config
+- inputText: ${null ?? 'bar'}


### PR DESCRIPTION
# Proposed Changes

Enables opting in to use GraalJS instead of Rhino JS for javascript evaluation. GraalJS is fully ECMAScript 2022 compliant while Rhino JS only supports ES5.

This feature is experimental for now, but we intend to make GraalJS the default if all goes well.

### Enable GraalJS via Flow config

> **Note**
> This only has an effect if present at the top-level flow. It is ignored when included in any subflows.

```yaml
appId: com.example.app
jsEngine: graaljs
---
# Note: The ?? operator is an example of an ES2020 feature and is not supported by Rhino JS
- inputText: ${null ?? 'foo'}
```

### Enable GraalJS via environment variable

> **Warning**
> This env var will have no effect when running on Maestro Cloud. Use the Flow config above instead to opt into GraalJS on Maestro Cloud.

```shell
export MAESTRO_USE_GRAALJS=true
maestro test my-flow.yaml
```

# GraalJS behavior differences

There are some differences between the new `GraalJsEngine` and the current `RhinoJsEngine` implementation that are worth noting. All of the differences below and some others are documented and tested by the `GraalJsEngineTest` and `RhinoJsEngineTest` tests.

**tldr; The variable scoping with the GraalJS implementation is more consistent and understandable**

<table>
<tr><th>Rhino JS</th><th>GraalJS</th></tr>
<tr>
<td>
<li><b>Can not</b> reuse variable names across scripts within the same Flow</li>
<li><b>Can</b> reuse variable names if redeclaration lives in a subflow</li>
<li><b>Can</b> access variables declared earlier in the Flow in a separate script</li>
<li><code>output</code> variable is shared across all scripts</li>
</td>
<td>
<li>Variables are local to each script</li>
<li><code>output</code> variable is shared across all scripts</li>
</td>
</tr>
</table>

**Some examples**

<table>
<tr><th></th><th>Example</th><th>Rhino JS</th><th>GraalJS</th></tr>

<tr>
  <td><b>Redeclaring variables across scripts</b></td>
  <td>
  <pre>
appId: com.example
---
- evalScript: ${const foo = null}
- evalScript: ${const foo = null}
</pre>
  </td>
  <td>❌ Variable redeclarations throw an error</td>
  <td>✅ Variable names can be reused across scripts</td>
</tr>

<tr>
  <td><b>Accessing variables across scripts</b></td>
  <td>
  <pre>
appId: com.example
---
- evalScript: ${const name = 'joe'}
- assertTrue: ${name === 'joe'}
</pre>
  </td>
  <td>✅ Variables are accessible across scripts</td>
  <td>❌ Variables can't be accessed across scripts</td>
</tr>

<tr>
  <td><b>Special character handling</b></td>
  <td>
  <pre>
appId: com.example.app
env:
  FOO: \
---
- inputText: ${FOO}
</pre>
  </td>
  <td>❌ Single backslash causes an exception</td>
  <td>✅ Single backslash and all other special chars are handled correctly</td>
</tr>

</table>

# Testing

Ran integration tests with `MAESTRO_USE_GRAALJS=true`. 2 tests failed due to known differences between GraalJS and RhinoJS described above. All other tests passed.