### PR TITLE
Add support for sequential execution API

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
@@ -22,7 +22,7 @@ data class WorkspaceConfig(
     )
 
     data class ExecutionOrder(
-        val continueOnFailure: Boolean = true,
+        val continueOnFailure: Boolean? = true,
         val flowsOrder: List<String> = emptyList()
     )
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
@@ -8,6 +8,7 @@ data class WorkspaceConfig(
     val includeTags: StringList? = null,
     val excludeTags: StringList? = null,
     val local: Local? = null,
+    val executionOrder: ExecutionOrder? = null
 ) {
 
     @JsonAnySetter
@@ -15,8 +16,14 @@ data class WorkspaceConfig(
         // Do nothing
     }
 
+    // deprecated in favour of ExecutionOrder
     data class Local(
         val deterministicOrder: Boolean? = null,
+    )
+
+    data class ExecutionOrder(
+        val continueOnFailure: Boolean = true,
+        val flowsOrder: List<String> = emptyList()
     )
 
     class StringList : ArrayList<String>() {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
@@ -16,7 +16,7 @@ data class WorkspaceConfig(
         // Do nothing
     }
 
-    // deprecated in favour of ExecutionOrder
+    @Deprecated("Use ExecutionOrder instead")
     data class Local(
         val deterministicOrder: Boolean? = null,
     )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -106,7 +106,7 @@ object WorkspaceExecutionPlanner {
         workspaceConfig: WorkspaceConfig)
     : List<Path>? {
         if (workspaceConfig.executionOrder?.flowsOrder?.isNotEmpty() == true) {
-            val flowsOrder = workspaceConfig.executionOrder?.flowsOrder!!
+            val flowsOrder = workspaceConfig.executionOrder?.flowsOrder!!.distinct()
 
             return flowsOrder.map { flowName ->
                 list.find {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -215,6 +215,24 @@ internal class WorkspaceExecutionPlannerTest {
         ).inOrder()
     }
 
+    @Test
+    internal fun `013 - Execution order is respected`() {
+        // When
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = path("/workspaces/013_execution_order"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+        )
+
+        // Then
+        assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/013_execution_order/flowB.yaml"),
+            path("/workspaces/013_execution_order/flowCWithCustomName.yaml"),
+            path("/workspaces/013_execution_order/flowD.yaml"),
+            path("/workspaces/013_execution_order/flowA.yaml"),
+        ).inOrder()
+    }
+
     private fun path(pathStr: String): Path {
         return Paths.get(WorkspaceExecutionPlannerTest::class.java.getResource(pathStr).toURI())
     }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -226,10 +226,15 @@ internal class WorkspaceExecutionPlannerTest {
 
         // Then
         assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/013_execution_order/flowA.yaml"),
+        )
+
+        // Then
+        assertThat(plan.sequence).isNotNull()
+        assertThat(plan.sequence!!.flows).containsExactly(
             path("/workspaces/013_execution_order/flowB.yaml"),
             path("/workspaces/013_execution_order/flowCWithCustomName.yaml"),
             path("/workspaces/013_execution_order/flowD.yaml"),
-            path("/workspaces/013_execution_order/flowA.yaml"),
         ).inOrder()
     }
 

--- a/maestro-orchestra/src/test/resources/workspaces/013_execution_order/config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/013_execution_order/config.yaml
@@ -1,0 +1,5 @@
+executionOrder:
+  flowsOrder:
+    - flowB
+    - flowC
+    - flowD

--- a/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowA.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowA.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowB.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowB.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowCWithCustomName.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowCWithCustomName.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+name: flowC
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowD.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/013_execution_order/flowD.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at abfcba9</samp>

This pull request adds a new feature to maestro-cli and maestro-orchestra to allow users to customize the execution order and failure handling of flows in a test suite. It also updates the models and the workspace execution planner to support the new feature. It deprecates the old class that handled deterministic order.

Some notes:
- Adds a deprecation warning when using `local.deterministicOrder`
- If `continueOnFailure` is set to `false` (default is `true`) and a Flow in the sequence fails, the following Flwos in the sequence will not be executed
    - Other Flows will be executed in normal fashion
- Executes the Flows defined in `executionOrder.flowsOrder` first before all the other Flows

## Testing
- [x] Tested locally
- [x] Unit tests

The following tests uses the following config for sequential execution:

```yaml
# config.yaml
executionOrder:
  flowsOrder:
    - ios-flow
    - ios-flow-3
    - ios-flow-2
```

with the following `.maestro` directory structure:
```
.maestro/
   config.yaml
   ios-advanced-flow.yaml
   ios-flow-2-custom-name.yaml
   ios-flow-3.yaml
   ios-flow.yaml
```

where `ios-flow-2-custom-name.yaml` has `name: ios-flow-2` configured in the config section, to showcase that this takes [custom names](https://maestro.mobile.dev/api-reference/configuration/flow-configuration) into consideration.

| Test case  | Output |
| ------------- | ------------- |
| Normal test suite  | <img width="444" alt="random_order" src="https://github.com/mobile-dev-inc/maestro/assets/6113675/7bb79e3d-6b82-4037-8e5c-59c827df6cb1">  |
| Deterministic ordering  | <img width="1181" alt="deterministic_order" src="https://github.com/mobile-dev-inc/maestro/assets/6113675/1a9480dd-836e-4c59-bed0-61235ddaa951"> |
| Sequential execution with failing Flow and default `continueOnFailure` (`true`)  | <img width="880" alt="sequence_continue_failure_true" src="https://github.com/mobile-dev-inc/maestro/assets/6113675/6c16faac-67ee-4a02-894d-40acda506076">  |
| Sequential execution with failing Flow and `continueOnFailure` set to `false`  | <img width="962" alt="sequence_continue_failure_false" src="https://github.com/mobile-dev-inc/maestro/assets/6113675/7fd18ded-6902-40fe-99e1-8c82a1763df4">  |
| Sequential execution all Flows passing  | <img width="875" alt="Screenshot 2023-06-13 at 13 28 18" src="https://github.com/mobile-dev-inc/maestro/assets/6113675/d37aae11-66fe-4169-966d-d52dcd97c7ac">  |
