### PR TITLE
Adds multiple tap option in tapOn (double tap)

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -20,6 +20,7 @@
 package maestro
 
 import com.github.romankh3.image.comparison.ImageComparison
+import com.google.protobuf.duration
 import maestro.Filters.asFilter
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.drivers.WebDriver
@@ -33,6 +34,7 @@ import org.slf4j.LoggerFactory
 import java.awt.image.BufferedImage
 import java.io.File
 import java.util.UUID
+import kotlin.system.measureTimeMillis
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 class Maestro(private val driver: Driver) : AutoCloseable {
@@ -294,8 +296,12 @@ class Maestro(private val driver: Driver) : AutoCloseable {
                 driver.longPress(Point(x, y))
             } else if (tapRepeat != null) {
                 for (i in 0 until tapRepeat.repeat) {
-                    driver.tap(Point(x, y))
-                    if (tapRepeat.repeat > 1) Thread.sleep(tapRepeat.delay) // do not wait for single taps
+
+                    // subtract execution duration from tap delay
+                    val duration = measureTimeMillis { driver.tap(Point(x, y)) }
+                    val delay = if (duration >= tapRepeat.delay) 0 else tapRepeat.delay - duration
+
+                    if (tapRepeat.repeat > 1) Thread.sleep(delay) // do not wait for single taps
                 }
             } else driver.tap(Point(x, y))
             val hierarchyAfterTap = waitForAppToSettle()
@@ -326,8 +332,12 @@ class Maestro(private val driver: Driver) : AutoCloseable {
                 driver.longPress(Point(x, y))
             } else if (tapRepeat != null) {
                 for (i in 0 until tapRepeat.repeat) {
-                    driver.tap(Point(x, y))
-                    if (tapRepeat.repeat > 1) Thread.sleep(tapRepeat.delay) // do not wait for single taps
+
+                    // subtract execution duration from tap delay
+                    val duration = measureTimeMillis { driver.tap(Point(x, y)) }
+                    val delay = if (duration >= tapRepeat.delay) 0 else tapRepeat.delay - duration
+
+                    if (tapRepeat.repeat > 1) Thread.sleep(delay) // do not wait for single taps
                 }
             } else {
                 driver.tap(Point(x, y))

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -180,7 +180,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         appId: String? = null,
         tapRepeat: TapRepeat? = null
     ) {
-        LOGGER.info("Tapping on element: $element")
+        LOGGER.info("Tapping on element: ${tapRepeat ?: ""} $element")
 
         val hierarchyBeforeTap = waitForAppToSettle(initialHierarchy, appId) ?: initialHierarchy
 

--- a/maestro-client/src/main/java/maestro/TapRepeat.kt
+++ b/maestro-client/src/main/java/maestro/TapRepeat.kt
@@ -1,0 +1,6 @@
+package maestro
+
+data class TapRepeat(
+    val repeat: Int,
+    val delay: Long // millis
+)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -809,7 +809,7 @@ internal fun tapOnDescription(isLongPress: Boolean?, repeat: TapRepeat?): String
     else if (repeat != null) {
         when (repeat.repeat) {
             1 -> "Tap"
-            2 -> "Tap twice"
+            2 -> "Double tap"
             else -> "Tap x${repeat.repeat}"
         }
     } else "Tap"

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -23,6 +23,7 @@ import maestro.KeyCode
 import maestro.Point
 import maestro.ScrollDirection
 import maestro.SwipeDirection
+import maestro.TapRepeat
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
 import maestro.orchestra.util.InputRandomTextHelper
@@ -220,16 +221,21 @@ data class TapOnElementCommand(
     val retryIfNoChange: Boolean? = null,
     val waitUntilVisible: Boolean? = null,
     val longPress: Boolean? = null,
+    val repeat: TapRepeat? = null
 ) : Command {
 
     override fun description(): String {
-        return "${tapOrLong(longPress)} on ${selector.description()}"
+        return "${tapOnDescription(longPress, repeat)} on ${selector.description()}"
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): TapOnElementCommand {
         return copy(
             selector = selector.evaluateScripts(jsEngine),
         )
+    }
+
+    companion object {
+        const val DEFAULT_REPEAT_DELAY = 100L
     }
 }
 
@@ -240,10 +246,11 @@ data class TapOnPointCommand(
     val retryIfNoChange: Boolean? = null,
     val waitUntilVisible: Boolean? = null,
     val longPress: Boolean? = null,
+    val repeat: TapRepeat? = null
 ) : Command {
 
     override fun description(): String {
-        return "${tapOrLong(longPress)} on point ($x, $y)"
+        return "${tapOnDescription(longPress, repeat)} on point ($x, $y)"
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): TapOnPointCommand {
@@ -255,10 +262,11 @@ data class TapOnPointV2Command(
     val point: String,
     val retryIfNoChange: Boolean? = null,
     val longPress: Boolean? = null,
+    val repeat: TapRepeat? = null
 ) : Command {
 
     override fun description(): String {
-        return "${tapOrLong(longPress)} on point ($point)"
+        return "${tapOnDescription(longPress, repeat)} on point ($point)"
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): TapOnPointV2Command {
@@ -771,6 +779,7 @@ data class AssertOutgoingRequestsCommand(
     }
 }
 
+
 data class StartRecordingCommand(val path: String) : Command {
 
     override fun description(): String {
@@ -795,4 +804,13 @@ class StopRecordingCommand : Command {
     }
 }
 
-internal fun tapOrLong(isLongPress: Boolean?): String = if (isLongPress == true) "Long press" else "Tap"
+internal fun tapOnDescription(isLongPress: Boolean?, repeat: TapRepeat?): String {
+    return if (isLongPress == true) "Long press"
+    else if (repeat != null) {
+        when (repeat.repeat) {
+            1 -> "Tap"
+            2 -> "Tap twice"
+            else -> "Tap x${repeat.repeat}"
+        }
+    } else "Tap"
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -675,7 +675,8 @@ class Orchestra(
                 retryIfNoChange,
                 waitUntilVisible,
                 command.longPress ?: false,
-                config?.appId
+                config?.appId,
+                tapRepeat = command.repeat
             )
 
             true
@@ -697,6 +698,7 @@ class Orchestra(
             command.y,
             retryIfNoChange,
             command.longPress ?: false,
+            tapRepeat = command.repeat
         )
 
         return true
@@ -721,7 +723,8 @@ class Orchestra(
                 percentX = percentX,
                 percentY = percentY,
                 retryIfNoChange = command.retryIfNoChange ?: true,
-                longPress = command.longPress ?: false
+                longPress = command.longPress ?: false,
+                tapRepeat = command.repeat
             )
         } else {
             val (x, y) = point.split(",")
@@ -733,7 +736,8 @@ class Orchestra(
                 x = x,
                 y = y,
                 retryIfNoChange = command.retryIfNoChange ?: true,
-                longPress = command.longPress ?: false
+                longPress = command.longPress ?: false,
+                tapRepeat = command.repeat
             )
         }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -46,4 +46,6 @@ data class YamlElementSelector(
     val selected: Boolean? = null,
     val checked: Boolean? = null,
     val focused: Boolean? = null,
+    val repeat: Int? = null,
+    val delay: Int? = null
 ) : YamlElementSelectorUnion

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -22,6 +22,7 @@ package maestro.orchestra.yaml
 import com.fasterxml.jackson.annotation.JsonCreator
 import maestro.KeyCode
 import maestro.Point
+import maestro.TapRepeat
 import maestro.orchestra.AssertConditionCommand
 import maestro.orchestra.AssertOutgoingRequestsCommand
 import maestro.orchestra.BackPressCommand
@@ -391,12 +392,20 @@ data class YamlFluentCommand(
         val waitUntilVisible = (tapOn as? YamlElementSelector)?.waitUntilVisible ?: false
         val point = (tapOn as? YamlElementSelector)?.point
 
+        val delay = (tapOn as? YamlElementSelector)?.delay?.toLong()
+        val repeat = (tapOn as? YamlElementSelector)?.repeat?.let {
+            val count = if (it <= 0) 1 else it
+            val d = if (delay != null && delay >= 0) delay else TapOnElementCommand.DEFAULT_REPEAT_DELAY
+            TapRepeat(count, d)
+        }
+
         return if (point != null) {
             MaestroCommand(
                 TapOnPointV2Command(
                     point = point,
                     retryIfNoChange = retryIfNoChange,
                     longPress = longPress,
+                    repeat = repeat
                 )
             )
         } else {
@@ -406,6 +415,7 @@ data class YamlFluentCommand(
                     retryIfNoChange = retryIfNoChange,
                     waitUntilVisible = waitUntilVisible,
                     longPress = longPress,
+                    repeat = repeat
                 )
             )
         }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2729,6 +2729,52 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 100 - tapOn multiple times`() {
+        // Given
+        val commands = readCommands("100_tapOn_multiple_times")
+
+        val driver = driver {
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+
+        // Then
+        // No test failure
+        driver.assertEventCount(Event.Tap(Point(50, 50)), 3)
+    }
+
+    @Test
+    fun `Case 101 - doubleTapOn`() {
+        // Given
+        val commands = readCommands("101_doubleTapOn")
+
+        val driver = driver {
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+
+        // Then
+        // No test failure
+        driver.assertEventCount(Event.Tap(Point(50, 50)), 2)
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/100_tapOn_multiple_times.yaml
+++ b/maestro-test/src/test/resources/100_tapOn_multiple_times.yaml
@@ -1,0 +1,7 @@
+appId: com.other.app
+---
+- tapOn:
+    text: Button
+    repeat: 3
+    delay: 1
+    retryTapIfNoChange: false

--- a/maestro-test/src/test/resources/101_doubleTapOn.yaml
+++ b/maestro-test/src/test/resources/101_doubleTapOn.yaml
@@ -1,0 +1,5 @@
+appId: com.other.app
+---
+- doubleTapOn:
+    text: Button
+    retryTapIfNoChange: false


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbd1a2c</samp>

This pull request adds a new feature to the `Maestro` and `Orchestra` modules that allows the user to repeat and delay the tap action on elements, points, and relative points on the screen. The feature is implemented by introducing a new data class `TapRepeat` and adding a `tapRepeat` parameter to the relevant functions and data classes. The feature is also supported in the YAML commands, by adding `repeat` and `delay` properties to the element selectors. The purpose of this feature is to enhance the functionality and flexibility of the `Maestro` and `Orchestra` modules.

Introduces multi tap
```yaml
appId: com.other.app
---
- tapOn:
    text: Button
    repeat: 3
```

Possible to customise delay
```yaml
appId: com.other.app
---
- tapOn:
    text: Button
    repeat: 10
    delay: 500
```

For convenience, a wrapper command was added for double tap
```yaml
appId: com.other.app
---
- doubleTapOn:
    text: Button
```

## Testing
- Integration test
- iOS: double tap on Apple Maps
- Android: double tap on Google Maps
