### PR TITLE
fix: use correct port for LocalXCTestInstaller

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.TimeUnit
 
 class XCTestDriverClient(
     private val host: String = "localhost",
-    private val port: Int = 22087,
+    private val port: Int,
     private val installer: XCTestInstaller,
     private val logger: Logger,
 ) {


### PR DESCRIPTION
## Proposed Changes

This PR fixes the usage of port when running `subTreeOfRunnerApp` to ensure that XCUiTestServer is running. 
It also fixes the temporary directory used to install XCUiTestServer

## Testing
- Manual testing done (`./maestro test samples/ios-advanced-flow.yaml`)
- Ran integration test
