### PR TITLE
Fix iOS url arguments

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/IOSLaunchArguments.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/IOSLaunchArguments.kt
@@ -17,12 +17,6 @@ object IOSLaunchArguments {
                 }
             }
         }
-        val iOSLaunchArguments = mutableListOf<String>()
-        iOSLaunchArgumentsMap.toList().map { "${it.first}:${it.second}" }
-            .forEach {
-                iOSLaunchArguments += it.split(":")
-            }
-
-        return iOSLaunchArguments
+        return iOSLaunchArgumentsMap.toList().flatMap { listOf(it.first, it.second.toString()) }
     }
 }

--- a/maestro-ios-driver/src/test/kotlin/IOSLaunchArgumentsTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/IOSLaunchArgumentsTest.kt
@@ -48,4 +48,20 @@ class IOSLaunchArgumentsTest {
             listOf("isCartScreen", "false", "-cartValue", "3", "-cartColor", "Orange")
         )
     }
+
+    @Test
+    fun `url arguments are passed correctly`() {
+        // given
+        val launchArguments = mapOf<String, Any>(
+            "-url" to "http://example.com"
+        )
+
+        // when
+        val iOSLaunchArguments = launchArguments.toIOSLaunchArguments()
+
+        // then
+        assertThat(iOSLaunchArguments).isEqualTo(
+            listOf("-url", "http://example.com")
+        )
+    }
 }


### PR DESCRIPTION
## Proposed Changes

- Any string argument containing a column that's passed on iOS gets truncated
- This is especially annoying if you want to pass urls as a launch argument
- This PR fixes this bug

Sample flow with issue: 

```
- launchApp:
    arguments: 
       -url: http://example.com
```

In the AppDelegate: 

```
UserDefaults.standard.string(key: "url") // Value is 'http' instead of 'http://example.com'
```

It works fine on Android

## Testing

- I introduced a failing test and fixed it

