### PR TITLE
feat: create XCTestClient

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -164,6 +164,7 @@ object MaestroSessionManager {
                 },
                 device = selectedDevice.device,
             )
+
             selectedDevice.platform == Platform.ANDROID -> MaestroSession(
                 maestro = pickAndroidDevice(
                     selectedDevice.host,
@@ -172,6 +173,7 @@ object MaestroSessionManager {
                 ),
                 device = null,
             )
+
             selectedDevice.platform == Platform.IOS -> MaestroSession(
                 maestro = pickIOSDevice(
                     selectedDevice.host,
@@ -181,10 +183,12 @@ object MaestroSessionManager {
                 ),
                 device = null,
             )
+
             selectedDevice.platform == Platform.WEB -> MaestroSession(
                 maestro = pickWebDevice(isStudio),
                 device = null
             )
+
             else -> error("Unable to create Maestro session")
         }
     }
@@ -291,12 +295,11 @@ object MaestroSessionManager {
         val xcTestInstaller = LocalXCTestInstaller(
             logger = IOSDriverLogger(LocalXCTestInstaller::class.java),
             deviceId = deviceId,
-            port = defaultXcTestPort
+            host = defaultHost,
+            defaultPort = defaultXcTestPort
         )
 
         val xcTestDriverClient = XCTestDriverClient(
-            host = defaultHost,
-            port = defaultXcTestPort,
             installer = xcTestInstaller,
             logger = IOSDriverLogger(XCTestDriverClient::class.java),
         )
@@ -347,7 +350,6 @@ object MaestroSessionManager {
         fun close() {
             maestro.close()
         }
-
     }
 
     private class CustomSignalHandler() : SignalHandler {

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -20,7 +20,6 @@
 package maestro
 
 import com.github.romankh3.image.comparison.ImageComparison
-import com.google.protobuf.duration
 import maestro.Filters.asFilter
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.drivers.WebDriver

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestClient.kt
@@ -1,0 +1,17 @@
+package xcuitest
+
+import okhttp3.HttpUrl
+
+class XCTestClient(
+    val host: String,
+    val port: Int,
+) {
+
+    fun xctestAPIBuilder(pathSegment: String): HttpUrl.Builder {
+        return HttpUrl.Builder()
+            .scheme("http")
+            .host(host)
+            .addPathSegment(pathSegment)
+            .port(port)
+    }
+}

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -138,26 +138,25 @@ class LocalXCTestInstaller(
             .inputStream.source().buffer().readUtf8()
             .trim()
 
-        if (processOutput.contains(UI_TEST_RUNNER_APP_BUNDLE_ID)) {
-            logger.info("Not able to find port running - Uninstalling UI test runner")
-            uninstall()
-        }
-
-        logger.info("Not able to find ui test runner app, going to install now")
+        logger.info("[Start] Writing xctest run file")
         val tempDir = File(tempDir).apply { mkdir() }
         val xctestRunFile = File("$tempDir/maestro-driver-ios-config.xctestrun")
-
-        logger.info("[Start] Writing xctest run file")
         writeFileToDestination(XCTEST_RUN_PATH, xctestRunFile)
         logger.info("[Done] Writing xctest run file")
 
-        logger.info("[Start] Writing maestro-driver-iosUITests-Runner app")
-        extractZipToApp("maestro-driver-iosUITests-Runner", UI_TEST_RUNNER_PATH)
-        logger.info("[Done] Writing maestro-driver-iosUITests-Runner app")
+        if (processOutput.contains(UI_TEST_RUNNER_APP_BUNDLE_ID)) {
+            stop()
+        } else {
+            logger.info("Not able to find ui test runner app, going to install now")
 
-        logger.info("[Start] Writing maestro-driver-ios app")
-        extractZipToApp("maestro-driver-ios", UI_TEST_HOST_PATH)
-        logger.info("[Done] Writing maestro-driver-ios app")
+            logger.info("[Start] Writing maestro-driver-iosUITests-Runner app")
+            extractZipToApp("maestro-driver-iosUITests-Runner", UI_TEST_RUNNER_PATH)
+            logger.info("[Done] Writing maestro-driver-iosUITests-Runner app")
+
+            logger.info("[Start] Writing maestro-driver-ios app")
+            extractZipToApp("maestro-driver-ios", UI_TEST_HOST_PATH)
+            logger.info("[Done] Writing maestro-driver-ios app")
+        }
 
         logger.info("[Start] Running XcUITest with xcode build command")
         xcTestProcess = XCRunnerCLIUtils.runXcTestWithoutBuild(

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/XCTestInstaller.kt
@@ -1,8 +1,9 @@
 package xcuitest.installer
 
-interface XCTestInstaller: AutoCloseable {
+import xcuitest.XCTestClient
 
-    fun start(): Boolean
+interface XCTestInstaller: AutoCloseable {
+    fun start(): XCTestClient?
 
     fun uninstall()
 

--- a/maestro-utils/src/main/kotlin/SocketUtils.kt
+++ b/maestro-utils/src/main/kotlin/SocketUtils.kt
@@ -19,23 +19,23 @@
 
 package maestro.utils
 
-import java.io.IOException
 import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.NetworkInterface
-import java.net.Socket
+import java.net.ServerSocket
+import kotlin.random.Random
 
 object SocketUtils {
 
-    /**
-     * Checks whether the port can be connected to.
-     */
-    fun isPortOpen(host: String, port: Int): Boolean {
-        return try {
-            Socket(host, port).use { true }
-        } catch (ignored: IOException) {
-            false
+    fun nextFreePort(from: Int, to: Int): Int {
+        val mid = (to - from) / 2 + from
+        val range = Random.nextInt(from, mid)..Random.nextInt(mid, to)
+        range.forEach { port ->
+            try {
+                ServerSocket(port).use { return port }
+            } catch (ignore: Exception) {}
         }
+        throw IllegalStateException("Failed to retrieve an available port")
     }
 
     fun localIp(): String {


### PR DESCRIPTION
### Proposed Changes

This PR refactors the port number for `LocalXCTestInstaller` to allow a random port in case of not using a default port (22087). This PR still keeps the default port to avoid any compatibility issues.
`LocalXCTestInstaller` now returns the connection in terms of `XCTestClient`, to be used by the connection above. This keeps the connection contained and can be improved later on.

### Testing
✅ Manual tests on ios samples
✅ Integrated tests ran
