### PR TITLE
Feature app binary id

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -227,7 +227,7 @@ class ApiClient(
         completedRetries: Int = 0,
         progressListener: (totalBytes: Long, bytesWritten: Long) -> Unit = { _, _ -> },
     ): UploadResponse {
-        if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter: <appFile> or <appBinaryId>")
+        if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter for option '--app-file' or '--app-binary-id'")
         if (appFile != null && !appFile.exists()) throw CliError("App file does not exist: ${appFile.absolutePathString()}")
         if (!workspaceZip.exists()) throw CliError("Workspace zip does not exist: ${workspaceZip.absolutePathString()}")
 

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -322,8 +322,9 @@ class ApiClient(
             val uploadId = analysisRequest["id"] as String
             val teamId = analysisRequest["teamId"] as String
             val appId = responseBody["targetId"] as String
+            val appBinaryIdResponse = responseBody["appBinaryId"] as? String
 
-            return UploadResponse(teamId, appId, uploadId)
+            return UploadResponse(teamId, appId, uploadId, appBinaryIdResponse)
         }
     }
 
@@ -381,6 +382,7 @@ data class UploadResponse(
     val teamId: String,
     val appId: String,
     val uploadId: String,
+    val appBinaryId: String?
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -227,7 +227,7 @@ class ApiClient(
         completedRetries: Int = 0,
         progressListener: (totalBytes: Long, bytesWritten: Long) -> Unit = { _, _ -> },
     ): UploadResponse {
-        if (appBinaryId == null && appFile == null) throw CliError("Please provide an appBinaryId or an app file")
+        if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter: <appFile> or <appBinaryId>")
         if (appFile != null && !appFile.exists()) throw CliError("App file does not exist: ${appFile.absolutePathString()}")
         if (!workspaceZip.exists()) throw CliError("Workspace zip does not exist: ${workspaceZip.absolutePathString()}")
 

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -208,7 +208,7 @@ class ApiClient(
 
     fun upload(
         authToken: String,
-        appFile: Path,
+        appFile: Path?,
         workspaceZip: Path,
         uploadName: String?,
         mappingFile: Path?,
@@ -220,13 +220,15 @@ class ApiClient(
         env: Map<String, String>? = null,
         androidApiLevel: Int?,
         iOSVersion: String? = null,
+        appBinaryId: String? = null,
         includeTags: List<String> = emptyList(),
         excludeTags: List<String> = emptyList(),
         maxRetryCount: Int = 3,
         completedRetries: Int = 0,
         progressListener: (totalBytes: Long, bytesWritten: Long) -> Unit = { _, _ -> },
     ): UploadResponse {
-        if (!appFile.exists()) throw CliError("App file does not exist: ${appFile.absolutePathString()}")
+        if (appBinaryId == null && appFile == null) throw CliError("Please provide an appBinaryId or an app file")
+        if (appFile != null && !appFile.exists()) throw CliError("App file does not exist: ${appFile.absolutePathString()}")
         if (!workspaceZip.exists()) throw CliError("Workspace zip does not exist: ${workspaceZip.absolutePathString()}")
 
         val requestPart = mutableMapOf<String, Any>()
@@ -242,14 +244,18 @@ class ApiClient(
         requestPart["agent"] = getAgent()
         androidApiLevel?.let { requestPart["androidApiLevel"] = it }
         iOSVersion?.let { requestPart["iOSVersion"] = it }
+        appBinaryId?.let { requestPart["appBinaryId"] = it }
         if (includeTags.isNotEmpty()) requestPart["includeTags"] = includeTags
         if (excludeTags.isNotEmpty()) requestPart["excludeTags"] = excludeTags
 
         val bodyBuilder = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
-            .addFormDataPart("app_binary", "app.zip", appFile.toFile().asRequestBody("application/zip".toMediaType()).observable(progressListener))
             .addFormDataPart("workspace", "workspace.zip", workspaceZip.toFile().asRequestBody("application/zip".toMediaType()))
             .addFormDataPart("request", JSON.writeValueAsString(requestPart))
+
+        if (appFile != null) {
+            bodyBuilder.addFormDataPart("app_binary", "app.zip", appFile.toFile().asRequestBody("application/zip".toMediaType()).observable(progressListener))
+        }
 
         if (mappingFile != null) {
             bodyBuilder.addFormDataPart("mapping", "mapping.txt", mappingFile.toFile().asRequestBody("text/plain".toMediaType()))
@@ -266,24 +272,25 @@ class ApiClient(
             Thread.sleep(BASE_RETRY_DELAY_MS + (2000 * completedRetries))
 
             return upload(
-                authToken,
-                appFile,
-                workspaceZip,
-                uploadName,
-                mappingFile,
-                repoOwner,
-                repoName,
-                branch,
-                commitSha,
-                pullRequestId,
-                env,
-                androidApiLevel,
-                iOSVersion,
-                includeTags,
-                excludeTags,
-                maxRetryCount,
-                completedRetries + 1,
-                progressListener,
+                authToken = authToken,
+                appFile = appFile,
+                workspaceZip = workspaceZip,
+                uploadName = uploadName,
+                mappingFile = mappingFile,
+                repoOwner = repoOwner,
+                repoName = repoName,
+                branch = branch,
+                commitSha = commitSha,
+                pullRequestId = pullRequestId,
+                env = env,
+                androidApiLevel = androidApiLevel,
+                iOSVersion = iOSVersion,
+                includeTags = includeTags,
+                excludeTags = excludeTags,
+                maxRetryCount = maxRetryCount,
+                completedRetries = completedRetries + 1,
+                progressListener = progressListener,
+                appBinaryId = appBinaryId
             )
         }
 

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -92,7 +92,7 @@ class CloudInteractor(
                 }
             }
 
-            val (teamId, appId, uploadId) = client.upload(
+            val (teamId, appId, uploadId, appBinaryIdResponse) = client.upload(
                 authToken =  authToken,
                 appFile = appFileToSend?.toPath(),
                 workspaceZip = workspaceZip,
@@ -116,11 +116,13 @@ class CloudInteractor(
 
             if (async) {
                 PrintUtils.message("✅ Upload successful! View the results of your upload below:")
+                if (appBinaryIdResponse != null) PrintUtils.message("App binary id: $appBinaryIdResponse")
                 PrintUtils.message(uploadUrl(uploadId, teamId, appId))
 
                 return 0
             } else {
                 PrintUtils.message("Visit the web console for more details about the upload: ${uploadUrl(uploadId, teamId, appId)}")
+                if (appBinaryIdResponse != null) PrintUtils.message("App binary id: $appBinaryIdResponse")
                 PrintUtils.message("Waiting for analyses to complete...")
                 println()
 

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -58,7 +58,7 @@ class CloudInteractor(
         reportOutput: File? = null,
         testSuiteName: String? = null
     ): Int {
-        if (appBinaryId == null && appFile == null) throw CliError("Please provide an appBinaryId or an app file")
+        if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter for option '--app-file' or '--app-binary-id'")
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
         if (mapping?.exists() == false) throw CliError("File does not exist: ${mapping.absolutePath}")
         if (async && reportFormat != ReportFormat.NOOP) throw CliError("Cannot use --format with --async")

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -37,7 +37,7 @@ class CloudInteractor(
 
     fun upload(
         flowFile: File,
-        appFile: File,
+        appFile: File?,
         async: Boolean,
         mapping: File? = null,
         apiKey: String? = null,
@@ -50,6 +50,7 @@ class CloudInteractor(
         env: Map<String, String> = emptyMap(),
         androidApiLevel: Int? = null,
         iOSVersion: String? = null,
+        appBinaryId: String? = null,
         failOnCancellation: Boolean = false,
         includeTags: List<String> = emptyList(),
         excludeTags: List<String> = emptyList(),
@@ -57,6 +58,7 @@ class CloudInteractor(
         reportOutput: File? = null,
         testSuiteName: String? = null
     ): Int {
+        if (appBinaryId == null && appFile == null) throw CliError("Please provide an appBinaryId or an app file")
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
         if (mapping?.exists() == false) throw CliError("File does not exist: ${mapping.absolutePath}")
         if (async && reportFormat != ReportFormat.NOOP) throw CliError("Cannot use --format with --async")
@@ -74,34 +76,39 @@ class CloudInteractor(
             println()
             val progressBar = ProgressBar(20)
 
-            val appFileToSend = if (appFile.isZip()) {
-                appFile
-            } else {
-                val archiver = ArchiverFactory.createArchiver(ArchiveFormat.ZIP)
+            // Binary id or Binary file
+            var appFileToSend: File? = null
+            if (appFile != null && appBinaryId == null) {
+                appFileToSend = if (appFile.isZip()) {
+                    appFile
+                } else {
+                    val archiver = ArchiverFactory.createArchiver(ArchiveFormat.ZIP)
 
-                // An awkward API of Archiver that has a different behaviour depending on
-                // whether we call a vararg method or a normal method. The *arrayOf() construct
-                // forces compiler to choose vararg method.
-                @Suppress("RemoveRedundantSpreadOperator")
-                archiver.create(appFile.name + ".zip", tmpDir.toFile(), *arrayOf(appFile.absoluteFile))
+                    // An awkward API of Archiver that has a different behaviour depending on
+                    // whether we call a vararg method or a normal method. The *arrayOf() construct
+                    // forces compiler to choose vararg method.
+                    @Suppress("RemoveRedundantSpreadOperator")
+                    archiver.create(appFile.name + ".zip", tmpDir.toFile(), *arrayOf(appFile.absoluteFile))
+                }
             }
 
             val (teamId, appId, uploadId) = client.upload(
-                authToken,
-                appFileToSend.toPath(),
-                workspaceZip,
-                uploadName,
-                mapping?.toPath(),
-                repoOwner,
-                repoName,
-                branch,
-                commitSha,
-                pullRequestId,
-                env,
-                androidApiLevel,
-                iOSVersion,
-                includeTags,
-                excludeTags,
+                authToken =  authToken,
+                appFile = appFileToSend?.toPath(),
+                workspaceZip = workspaceZip,
+                uploadName = uploadName,
+                mappingFile = mapping?.toPath(),
+                repoOwner = repoOwner,
+                repoName = repoName,
+                branch = branch,
+                commitSha = commitSha,
+                pullRequestId = pullRequestId,
+                env = env,
+                androidApiLevel = androidApiLevel,
+                iOSVersion = iOSVersion,
+                appBinaryId = appBinaryId,
+                includeTags = includeTags,
+                excludeTags = excludeTags,
             ) { totalBytes, bytesWritten ->
                 progressBar.set(bytesWritten.toFloat() / totalBytes.toFloat())
             }

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -44,10 +44,10 @@ class CloudCommand : Callable<Int> {
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
 
-    @CommandLine.Parameters(description = ["App binary to run your Flows against"])
-    private lateinit var appFile: File
+    @CommandLine.Parameters(index = "0..*", arity = "0..1", description = ["App binary to run your Flows against"])
+    private var appFile: File? = null
 
-    @CommandLine.Parameters(description = ["Flow file or directory"])
+    @CommandLine.Parameters(index = "0..*", description = ["Flow file or directory"])
     private lateinit var flowFile: File
 
     @Option(order = 0, names = ["--apiKey"], description = ["API key"])
@@ -126,6 +126,9 @@ class CloudCommand : Callable<Int> {
     @Option(order = 16, names = ["--ios-version"], description = ["iOS version to run your flow against"])
     private var iOSVersion: String? = null
 
+    @Option(order = 17, names = ["--appBinaryId"], description = ["The ID of the app binary previously uploaded to Maestro Cloud"])
+    private var appBinaryId: String? = null
+
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
 
@@ -158,6 +161,7 @@ class CloudCommand : Callable<Int> {
                 apiKey = apiKey,
                 androidApiLevel = androidApiLevel,
                 iOSVersion = iOSVersion,
+                appBinaryId = appBinaryId,
                 includeTags = includeTags,
                 excludeTags = excludeTags,
                 reportFormat = format,

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -54,8 +54,8 @@ class CloudCommand : Callable<Int> {
     @Option(names = ["--app-file"], description = ["App binary to run your Flows against"])
     private var appFile: File? = null
 
-    @Option(names = ["--workspace"], description = ["Flow file or workspace directory"])
-    private lateinit var flowFile: File
+    @Option(order = 1, names = ["--flows"], description = ["A Flow filepath or a folder filepath that contains Flows"])
+    private lateinit var flowsFile: File
 
     @Option(order = 0, names = ["--api-key", "--apiKey"], description = ["API key"])
     private var apiKey: String? = null
@@ -150,7 +150,7 @@ class CloudCommand : Callable<Int> {
             failOnTimeout = failOnCancellation,
         ).upload(
             async = async,
-            flowFile = flowFile,
+            flowFile = flowsFile,
             appFile = appFile,
             mapping = mapping,
             env = env.withInjectedShellEnvVars(),
@@ -178,7 +178,7 @@ class CloudCommand : Callable<Int> {
             PrintUtils.message("Evaluating workspace...")
             WorkspaceExecutionPlanner
                 .plan(
-                    input = flowFile.toPath().toAbsolutePath(),
+                    input = flowsFile.toPath().toAbsolutePath(),
                     includeTags = includeTags,
                     excludeTags = excludeTags,
                 )
@@ -195,27 +195,27 @@ class CloudCommand : Callable<Int> {
             when (files.size) {
                 2 -> {
                     appFile = files[0]
-                    flowFile = files[1]
+                    flowsFile = files[1]
                 }
                 1 -> {
-                    flowFile = files[0]
+                    flowsFile = files[0]
                 }
             }
         }
 
         val hasApp = appFile != null || appBinaryId != null
-        val hasWorkspace = this::flowFile.isInitialized
+        val hasWorkspace = this::flowsFile.isInitialized
 
         if (!hasApp && !hasWorkspace) {
-            throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameters: '--app-file', " +
-                "'--workspace'. " +
+            throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--flows"), "Missing required parameters: '--app-file', " +
+                "'--flows'. " +
                 "Example:" +
-                " maestro cloud --app-file <path> --workspace <path>")
+                " maestro cloud --app-file <path> --flows <path>")
         }
 
         if (!hasApp) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--app-file"), "Missing required parameter for option '--app-file' or " +
             "'--app-binary-id'")
-        if (!hasWorkspace) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameter for option '--workspace'")
+        if (!hasWorkspace) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--flows"), "Missing required parameter for option '--flows'")
 
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -51,7 +51,7 @@ class CloudCommand : Callable<Int> {
     @Option(names = ["--appFile"], description = ["App binary to run your Flows against"])
     private var appFile: File? = null
 
-    @Option(names = ["--flowFile"], description = ["Flow file or workspace directory"])
+    @Option(names = ["--workspace"], description = ["Flow file or workspace directory"])
     private lateinit var flowFile: File
 
     @Option(order = 0, names = ["--apiKey"], description = ["API key"])
@@ -200,7 +200,7 @@ class CloudCommand : Callable<Int> {
             }
         }
         if (appFile == null && appBinaryId == null) throw CliError("Missing required parameter for option '--appFile' or '--appBinaryId'")
-        if (!this::flowFile.isInitialized) throw CliError("Missing required parameter for option '--flowFile'")
+        if (!this::flowFile.isInitialized) throw CliError("Missing required parameter for option '--workspace'")
     }
 
 }

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -42,40 +42,43 @@ import java.util.concurrent.Callable
 )
 class CloudCommand : Callable<Int> {
 
+    @CommandLine.Spec
+    var spec: CommandLine.Model.CommandSpec? = null
+
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
 
     @CommandLine.Parameters(hidden = true, arity = "0..2", description = ["App file and/or Flow file i.e <appFile> <flowFile>"])
     private lateinit var files: List<File>
 
-    @Option(names = ["--appFile"], description = ["App binary to run your Flows against"])
+    @Option(names = ["--app-file"], description = ["App binary to run your Flows against"])
     private var appFile: File? = null
 
     @Option(names = ["--workspace"], description = ["Flow file or workspace directory"])
     private lateinit var flowFile: File
 
-    @Option(order = 0, names = ["--apiKey"], description = ["API key"])
+    @Option(order = 0, names = ["--api-key", "--apiKey"], description = ["API key"])
     private var apiKey: String? = null
 
-    @Option(order = 1, names = ["--apiUrl"], description = ["API base URL"])
+    @Option(order = 1, names = ["--api-url", "--apiUrl"], description = ["API base URL"])
     private var apiUrl: String = "https://api.mobile.dev"
 
     @Option(order = 2, names = ["--mapping"], description = ["dSYM file (iOS) or Proguard mapping file (Android)"])
     private var mapping: File? = null
 
-    @Option(order = 3, names = ["--repoOwner"], description = ["Repository owner (ie: GitHub organization or user slug)"])
+    @Option(order = 3, names = ["--repo-owner", "--repoOwner"], description = ["Repository owner (ie: GitHub organization or user slug)"])
     private var repoOwner: String? = null
 
-    @Option(order = 4, names = ["--repoName"], description = ["Repository name (ie: GitHub repo slug)"])
+    @Option(order = 4, names = ["--repo-name", "--repoName"], description = ["Repository name (ie: GitHub repo slug)"])
     private var repoName: String? = null
 
     @Option(order = 5, names = ["--branch"], description = ["The branch this upload originated from"])
     private var branch: String? = null
 
-    @Option(order = 6, names = ["--commitSha"], description = ["The commit SHA of this upload"])
+    @Option(order = 6, names = ["--commit-sha", "--commitSha"], description = ["The commit SHA of this upload"])
     private var commitSha: String? = null
 
-    @Option(order = 7, names = ["--pullRequestId"], description = ["The ID of the pull request this upload originated from"])
+    @Option(order = 7, names = ["--pull-request-id", "--pullRequestId"], description = ["The ID of the pull request this upload originated from"])
     private var pullRequestId: String? = null
 
     @Option(order = 8, names = ["-e", "--env"], description = ["Environment variables to inject into your Flows"])
@@ -130,7 +133,7 @@ class CloudCommand : Callable<Int> {
     @Option(order = 16, names = ["--ios-version"], description = ["iOS version to run your flow against"])
     private var iOSVersion: String? = null
 
-    @Option(order = 17, names = ["--appBinaryId"], description = ["The ID of the app binary previously uploaded to Maestro Cloud"])
+    @Option(order = 17, names = ["--app-binary-id", "--appBinaryId"], description = ["The ID of the app binary previously uploaded to Maestro Cloud"])
     private var appBinaryId: String? = null
 
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
@@ -199,8 +202,11 @@ class CloudCommand : Callable<Int> {
                 }
             }
         }
-        if (appFile == null && appBinaryId == null) throw CliError("Missing required parameter for option '--appFile' or '--appBinaryId'")
-        if (!this::flowFile.isInitialized) throw CliError("Missing required parameter for option '--workspace'")
+
+        if (appFile == null && appBinaryId == null) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--app-file"), "Missing required parameter for option '--app-file' or " +
+            "'--app-binary-id'")
+        if (!this::flowFile.isInitialized) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameter for option '--workspace'")
+
     }
 
 }

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -203,9 +203,16 @@ class CloudCommand : Callable<Int> {
             }
         }
 
-        if (appFile == null && appBinaryId == null) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--app-file"), "Missing required parameter for option '--app-file' or " +
+        val hasApp = appFile != null || appBinaryId != null
+        val hasWorkspace = this::flowFile.isInitialized
+
+        if (!hasApp && !hasWorkspace) {
+            throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameters: '<appFile>', '<workspace>'. Usage: maestro cloud <appFile> <workspace>")
+        }
+
+        if (!hasApp) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--app-file"), "Missing required parameter for option '--app-file' or " +
             "'--app-binary-id'")
-        if (!this::flowFile.isInitialized) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameter for option '--workspace'")
+        if (!hasWorkspace) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameter for option '--workspace'")
 
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -54,7 +54,7 @@ class CloudCommand : Callable<Int> {
     @Option(names = ["--app-file"], description = ["App binary to run your Flows against"])
     private var appFile: File? = null
 
-    @Option(order = 1, names = ["--flows"], description = ["A Flow filepath or a folder filepath that contains Flows"])
+    @Option(order = 1, names = ["--flows"], description = ["A Flow filepath or a folder path that contains Flows"])
     private lateinit var flowsFile: File
 
     @Option(order = 0, names = ["--api-key", "--apiKey"], description = ["API key"])

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -207,7 +207,10 @@ class CloudCommand : Callable<Int> {
         val hasWorkspace = this::flowFile.isInitialized
 
         if (!hasApp && !hasWorkspace) {
-            throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameters: '<appFile>', '<workspace>'. Usage: maestro cloud <appFile> <workspace>")
+            throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--workspace"), "Missing required parameters: '--app-file', " +
+                "'--workspace'. " +
+                "Example:" +
+                " maestro cloud --app-file <path> --workspace <path>")
         }
 
         if (!hasApp) throw CommandLine.MissingParameterException(spec!!.commandLine(), spec!!.findOption("--app-file"), "Missing required parameter for option '--app-file' or " +


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1dc91b1</samp>

This pull request adds the ability to upload app binaries to the cloud by their ID instead of a file path, and to get the app binary ID after the upload. It also refactors the `CloudCommand` class to simplify the command syntax and validation logic. The changes affect the `ApiClient`, `CloudInteractor`, and `CloudCommand` classes in the `maestro-cli` module.

## Changes

### Surface app binary
After uploading to Maestro Cloud, the app binary id will be returned in the CLI response

<img width="718" alt="Screenshot 2023-06-21 at 23 45 48" src="https://github.com/mobile-dev-inc/maestro/assets/2115575/b9189c53-2135-45b3-a0ba-84b8f44d98e7">

### --app-binary-id
You can now re-use a previous app binary by providing the appBinaryId. This will skip binary re-upload and improve iteration speed.

Example usage:
```bash
maestro cloud --api-key=123 --app-binary-id=1 workspace/
```

### Convenience params --app-file, --workspace
You can now specify appFile and workspace/flow via an argument.

Example usage:

(Workspace)

```bash
maestro cloud --api-key=123 --app-file=app.apk --workspace=workspace/
```

(Flow file)
```bash
maestro cloud --api-key=123 --app-file=app.apk --workspace=flow.yaml
```

### Backwards compatible
Old syntax is not affected

### Error output
In order to keep backwards compatibility and make the file optional I had to make a few changes in error output.

Previous
<img width="1155" alt="Screenshot 2023-06-22 at 16 54 00" src="https://github.com/mobile-dev-inc/maestro/assets/2115575/fc195850-14a4-4da6-92e6-7b28f3b720a5">

New
<img width="1173" alt="Screenshot 2023-06-22 at 16 53 22" src="https://github.com/mobile-dev-inc/maestro/assets/2115575/e631ea3c-c8fa-4e26-9a1f-3a14d331fd6a">

## Testing
- Manual testing locally
- Maestro Cloud Staging, with wikipedia app
