### PR TITLE
Remove extra space at end of input from ansi colored text

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
@@ -33,7 +33,7 @@ class LogoutCommand : Callable<Int> {
 
         // TODO reuse
         private fun message(message: String) {
-            println(Ansi.ansi().render("@|cyan \n$message |@"))
+            println(Ansi.ansi().render("@|cyan \n$message|@"))
         }
 
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -135,7 +135,7 @@ class AnsiResultView(
     private fun Ansi.printLogMessages(indent: Int, commandState: CommandState) {
         renderLineStart(indent + 1)
         render("   ")   // Space that a status symbol would normally occupy
-        render("@|yellow Log messages: |@\n")
+        render("@|yellow Log messages:|@\n")
 
         commandState.logMessages.forEach {
             renderLineStart(indent + 2)

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -105,7 +105,7 @@ class AnsiResultView(
         render(
             commandState.command.description()
                 .replace("(?<!\\\\)\\\$\\{.*}".toRegex()) { match ->
-                    "@|cyan ${match.value} |@"
+                    "@|cyan ${match.value}|@"
                 }
         )
 

--- a/maestro-cli/src/main/java/maestro/cli/util/PrintUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/PrintUtils.kt
@@ -7,11 +7,11 @@ import kotlin.system.exitProcess
 object PrintUtils {
 
     fun message(message: String) {
-        println(Ansi.ansi().render("@|cyan \n$message |@"))
+        println(Ansi.ansi().render("@|cyan \n$message|@"))
     }
 
     fun prompt(message: String): String {
-        print(Ansi.ansi().render("\n@|yellow,bold $message\n> |@"))
+        print(Ansi.ansi().render("\n@|yellow,bold $message\n>|@"))
         try {
             return readln().trim()
         } catch (e: IOException) {


### PR DESCRIPTION
## Proposed Changes

Some ansi formatted strings insert an extra space at the end:
![Screenshot 2023-06-22 at 13 08 36](https://github.com/mobile-dev-inc/maestro/assets/915211/2ca0d971-0d78-4ce8-aa71-3143535b823d)

This PR removes all places where an extra space is inserted due to ansi formatting.

## Testing

Tested by running the samples locally
