### PR TITLE
Clear state before running advanced example

### DIFF
--- a/samples/subflows/onboarding-ios.yaml
+++ b/samples/subflows/onboarding-ios.yaml
@@ -1,6 +1,7 @@
 appId: org.wikimedia.wikipedia
 ---
-- launchApp
+- launchApp:
+    clearState: true
 - swipe:
     direction: LEFT
     duration: 400


### PR DESCRIPTION
## Proposed Changes

Currently the advanced example flow on iOS will only successfully run once, because the Wikipedia app remembers the selected options.
By setting `clearState: true`, the app state is erased, and the advanced flow can be ran multiple times without failing in the setup.

## Testing

Tested locally
