### PR TITLE
setup / teardown hooks

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/CommandState.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/CommandState.kt
@@ -24,6 +24,8 @@ import maestro.orchestra.MaestroCommand
 data class CommandState(
     val status: CommandStatus,
     val command: MaestroCommand,
+    val subOnStartCommands: List<CommandState>?,
+    val subOnCompleteCommands: List<CommandState>?,
     val numberOfRuns: Int? = null,
     val subCommands: List<CommandState>? = null,
     val logMessages: List<String> = emptyList(),

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -50,6 +50,7 @@ object MaestroCommandRunner {
         debug: FlowDebugMetadata
     ): Result {
         val initFlow = YamlCommandReader.getConfig(commands)?.initFlow
+        val onFlowComplete = YamlCommandReader.getConfig(commands)?.onFlowComplete
 
         val commandStatuses = IdentityHashMap<MaestroCommand, CommandStatus>()
         val commandMetadata = IdentityHashMap<MaestroCommand, Orchestra.CommandMetadata>()
@@ -89,6 +90,11 @@ object MaestroCommandRunner {
                     device = device,
                     initCommands = toCommandStates(
                         initFlow?.commands ?: emptyList(),
+                        commandStatuses,
+                        commandMetadata
+                    ),
+                    onFlowCompleteCommands = toCommandStates(
+                        onFlowComplete?.commands ?: emptyList(),
                         commandStatuses,
                         commandMetadata
                     ),
@@ -177,6 +183,11 @@ object MaestroCommandRunner {
         }
 
         val flowSuccess = orchestra.runFlow(commands, cachedState)
+
+        if (onFlowComplete != null) {
+            orchestra.runFlow(onFlowComplete.commands)
+        }
+
         return Result(flowSuccess = flowSuccess, cachedAppState = cachedState)
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -190,15 +190,7 @@ object MaestroCommandRunner {
             cachedAppState
         }
 
-        if (onFlowStart != null) {
-            orchestra.runFlow(onFlowStart.commands)
-        }
-
         val flowSuccess = orchestra.runFlow(commands, cachedState)
-
-        if (onFlowComplete != null) {
-            orchestra.runFlow(onFlowComplete.commands)
-        }
 
         return Result(flowSuccess = flowSuccess, cachedAppState = cachedState)
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -19,6 +19,7 @@
 
 package maestro.cli.runner
 
+import io.ktor.client.utils.EmptyContent.status
 import maestro.Maestro
 import maestro.MaestroException
 import maestro.cli.device.Device
@@ -30,6 +31,7 @@ import maestro.cli.runner.resultview.UiState
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.CompositeCommand
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
 import maestro.orchestra.Orchestra
 import maestro.orchestra.OrchestraAppState
 import maestro.orchestra.yaml.YamlCommandReader
@@ -198,7 +200,7 @@ object MaestroCommandRunner {
     private fun toCommandStates(
         commands: List<MaestroCommand>,
         commandStatuses: MutableMap<MaestroCommand, CommandStatus>,
-        commandMetadata: IdentityHashMap<MaestroCommand, Orchestra.CommandMetadata>
+        commandMetadata: IdentityHashMap<MaestroCommand, Orchestra.CommandMetadata>,
     ): List<CommandState> {
         return commands
             // Don't render configuration commands
@@ -206,6 +208,14 @@ object MaestroCommandRunner {
             .mapIndexed { _, command ->
                 CommandState(
                     command = commandMetadata[command]?.evaluatedCommand ?: command,
+                    subOnStartCommands = (command.asCommand() as? CompositeCommand)
+                        ?.config()
+                        ?.onFlowStart
+                        ?.let { toCommandStates(it.commands, commandStatuses, commandMetadata) },
+                    subOnCompleteCommands = (command.asCommand() as? CompositeCommand)
+                        ?.config()
+                        ?.onFlowComplete
+                        ?.let { toCommandStates(it.commands, commandStatuses, commandMetadata) },
                     status = commandStatuses[command] ?: CommandStatus.PENDING,
                     numberOfRuns = commandMetadata[command]?.numberOfRuns,
                     subCommands = (command.asCommand() as? CompositeCommand)

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -74,6 +74,12 @@ class AnsiResultView(
         render(" ║\n")
         renderCommands(state.commands)
         render(" ║\n")
+        if (state.onFlowCompleteCommands.isNotEmpty()) {
+            render(" ║\n")
+            render(" ║  > On Flow Complete\n")
+            render(" ║\n")
+            renderCommands(state.onFlowCompleteCommands)
+        }
         renderPrompt()
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -134,12 +134,32 @@ class AnsiResultView(
             printLogMessages(indent, commandState)
         }
 
-        val expandSubCommands = commandState.status in setOf(CommandStatus.RUNNING, CommandStatus.FAILED) &&
+        val subCommandsHasNotPending =
             (commandState.subCommands?.any { subCommand -> subCommand.status != CommandStatus.PENDING } ?: false)
+        val onStartHasNotPending =
+            (commandState.subOnStartCommands?.any { subCommand -> subCommand.status != CommandStatus.PENDING } ?: false)
+        val onCompleteHasNotPending =
+            (commandState.subOnCompleteCommands?.any { subCommand -> subCommand.status != CommandStatus.PENDING } ?: false)
+        val expandSubCommands = commandState.status in setOf(CommandStatus.RUNNING, CommandStatus.FAILED) &&
+                (subCommandsHasNotPending || onStartHasNotPending || onCompleteHasNotPending)
 
         if (expandSubCommands) {
+            commandState.subOnStartCommands?.let {
+                render(" ║\n")
+                render(" ║  > On Flow Start\n")
+                render(" ║\n")
+                renderCommands(it)
+            }
+
             commandState.subCommands?.let { subCommands ->
                 renderCommands(subCommands, indent + 1)
+            }
+
+            commandState.subOnCompleteCommands?.let {
+                render(" ║\n")
+                render(" ║  > On Flow Complete\n")
+                render(" ║\n")
+                renderCommands(it)
             }
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -69,6 +69,12 @@ class AnsiResultView(
             render(" ║\n")
             renderCommands(state.initCommands)
         }
+        if (state.onFlowStartCommands.isNotEmpty()) {
+            render(" ║\n")
+            render(" ║  > On Flow Start\n")
+            render(" ║\n")
+            renderCommands(state.onFlowStartCommands)
+        }
         render(" ║\n")
         render(" ║  > Flow\n")
         render(" ║\n")

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
@@ -50,17 +50,15 @@ class PlainTextResultView: ResultView {
                 println("  > Init Flow")
             }
 
-
             renderCommandsPlainText(state.initCommands)
         }
 
-        if (state.onFlowCompleteCommands.isNotEmpty()) {
+        if (state.onFlowStartCommands.isNotEmpty()) {
             if (shouldPrintStep()) {
-                println("  > On Flow Complete")
+                println("  > On Flow Start")
             }
 
-
-            renderCommandsPlainText(state.onFlowCompleteCommands)
+            renderCommandsPlainText(state.onFlowStartCommands)
         }
 
         if (shouldPrintStep()) {
@@ -68,6 +66,14 @@ class PlainTextResultView: ResultView {
         }
 
         renderCommandsPlainText(state.commands)
+
+        if (state.onFlowCompleteCommands.isNotEmpty()) {
+            if (shouldPrintStep()) {
+                println("  > On Flow Complete")
+            }
+
+            renderCommandsPlainText(state.onFlowCompleteCommands)
+        }
     }
 
     private fun renderCommandsPlainText(commands: List<CommandState>, indent: Int = 0) {

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
@@ -54,6 +54,15 @@ class PlainTextResultView: ResultView {
             renderCommandsPlainText(state.initCommands)
         }
 
+        if (state.onFlowCompleteCommands.isNotEmpty()) {
+            if (shouldPrintStep()) {
+                println("  > On Flow Complete")
+            }
+
+
+            renderCommandsPlainText(state.onFlowCompleteCommands)
+        }
+
         if (shouldPrintStep()) {
             println(" > Flow")
         }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
@@ -92,7 +92,21 @@ class PlainTextResultView: ResultView {
                 println("  ".repeat(indent) + "${c?.description()}...")
             }
 
+            if (command.subOnStartCommands != null) {
+                if (shouldPrintStep()) {
+                    println("  > On Flow Start")
+                }
+                renderCommandsPlainText(command.subOnStartCommands, indent = indent + 1)
+            }
+
             renderCommandsPlainText(command.subCommands, indent = indent + 1)
+
+            if (command.subOnCompleteCommands != null) {
+                if (shouldPrintStep()) {
+                    println("  > On Flow Complete")
+                }
+                renderCommandsPlainText(command.subOnCompleteCommands, indent = indent + 1)
+            }
 
             if (shouldPrintStep()) {
                 println("  ".repeat(indent) + "${c?.description()}... " + status(command.status))

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/UiState.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/UiState.kt
@@ -10,6 +10,7 @@ sealed class UiState {
     data class Running(
         val device: Device? = null,
         val initCommands: List<CommandState> = emptyList(),
+        val onFlowCompleteCommands: List<CommandState> = emptyList(),
         val commands: List<CommandState>,
     ) : UiState()
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/UiState.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/UiState.kt
@@ -10,6 +10,7 @@ sealed class UiState {
     data class Running(
         val device: Device? = null,
         val initCommands: List<CommandState> = emptyList(),
+        val onFlowStartCommands: List<CommandState> = emptyList(),
         val onFlowCompleteCommands: List<CommandState> = emptyList(),
         val commands: List<CommandState>,
     ) : UiState()

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -41,7 +41,7 @@ sealed interface Command {
 sealed interface CompositeCommand : Command {
 
     fun subCommands(): List<MaestroCommand>
-
+    fun config(): MaestroConfig?
 }
 
 data class SwipeCommand(
@@ -570,6 +570,10 @@ data class RunFlowCommand(
         return commands
     }
 
+    override fun config(): MaestroConfig? {
+        return config
+    }
+
     override fun description(): String {
         val runDescription = if (sourceDescription != null) {
             "Run $sourceDescription"
@@ -615,6 +619,10 @@ data class RepeatCommand(
 
     override fun subCommands(): List<MaestroCommand> {
         return commands
+    }
+
+    override fun config(): MaestroConfig? {
+        return null
     }
 
     override fun description(): String {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -563,6 +563,7 @@ data class RunFlowCommand(
     val commands: List<MaestroCommand>,
     val condition: Condition? = null,
     val sourceDescription: String? = null,
+    val config: MaestroConfig?,
 ) : CompositeCommand {
 
     override fun subCommands(): List<MaestroCommand> {
@@ -586,6 +587,7 @@ data class RunFlowCommand(
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
             condition = condition?.evaluateScripts(jsEngine),
+            config = config?.evaluateScripts(jsEngine),
         )
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -11,6 +11,7 @@ data class MaestroConfig(
     val tags: List<String>? = emptyList(),
     val initFlow: MaestroInitFlow? = null,
     val ext: Map<String, Any?> = emptyMap(),
+    val onFlowStart: MaestroOnFlowStart?,
     val onFlowComplete: MaestroOnFlowComplete?,
 ) {
 
@@ -20,6 +21,7 @@ data class MaestroConfig(
             name = name?.evaluateScripts(jsEngine),
             initFlow = initFlow?.evaluateScripts(jsEngine),
             onFlowComplete = onFlowComplete?.evaluateScripts(jsEngine),
+            onFlowStart = onFlowStart?.evaluateScripts(jsEngine),
         )
     }
 
@@ -40,6 +42,12 @@ data class MaestroInitFlow(
 
 data class MaestroOnFlowComplete(val commands: List<MaestroCommand>) {
     fun evaluateScripts(jsEngine: JsEngine): MaestroOnFlowComplete {
+        return this
+    }
+}
+
+data class MaestroOnFlowStart(val commands: List<MaestroCommand>) {
+    fun evaluateScripts(jsEngine: JsEngine): MaestroOnFlowStart {
         return this
     }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -11,6 +11,7 @@ data class MaestroConfig(
     val tags: List<String>? = emptyList(),
     val initFlow: MaestroInitFlow? = null,
     val ext: Map<String, Any?> = emptyMap(),
+    val onFlowComplete: MaestroOnFlowComplete?,
 ) {
 
     fun evaluateScripts(jsEngine: JsEngine): MaestroConfig {
@@ -18,6 +19,7 @@ data class MaestroConfig(
             appId = appId?.evaluateScripts(jsEngine),
             name = name?.evaluateScripts(jsEngine),
             initFlow = initFlow?.evaluateScripts(jsEngine),
+            onFlowComplete = onFlowComplete?.evaluateScripts(jsEngine),
         )
     }
 
@@ -34,4 +36,10 @@ data class MaestroInitFlow(
         )
     }
 
+}
+
+data class MaestroOnFlowComplete(val commands: List<MaestroCommand>) {
+    fun evaluateScripts(jsEngine: JsEngine): MaestroOnFlowComplete {
+        return this
+    }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -11,8 +11,8 @@ data class MaestroConfig(
     val tags: List<String>? = emptyList(),
     val initFlow: MaestroInitFlow? = null,
     val ext: Map<String, Any?> = emptyMap(),
-    val onFlowStart: MaestroOnFlowStart?,
-    val onFlowComplete: MaestroOnFlowComplete?,
+    val onFlowStart: MaestroOnFlowStart? = null,
+    val onFlowComplete: MaestroOnFlowComplete? = null,
 ) {
 
     fun evaluateScripts(jsEngine: JsEngine): MaestroConfig {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -97,10 +97,21 @@ class Orchestra(
         }
 
         onFlowStart(commands)
-        return executeCommands(commands, config).also {
+
+        config?.onFlowStart?.commands?.let {
+            executeCommands(it)
+        }
+
+        val flowSuccess = executeCommands(commands, config).also {
             // close existing screen recording, if left open.
             screenRecording?.close()
         }
+
+        config?.onFlowComplete?.commands?.let {
+            executeCommands(it)
+        }
+
+        return flowSuccess
     }
 
     /**

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -102,16 +102,20 @@ class Orchestra(
             executeCommands(it)
         }
 
-        val flowSuccess = executeCommands(commands, config).also {
-            // close existing screen recording, if left open.
-            screenRecording?.close()
-        }
+        try {
+            val flowSuccess = executeCommands(commands, config).also {
+                // close existing screen recording, if left open.
+                screenRecording?.close()
+            }
 
-        config?.onFlowComplete?.commands?.let {
-            executeCommands(it)
+            return flowSuccess
+        } catch (e: Throwable) {
+            throw e
+        } finally {
+            config?.onFlowComplete?.commands?.let {
+                executeCommands(it)
+            }
         }
-
-        return flowSuccess
     }
 
     /**

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -6,6 +6,7 @@ import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroInitFlow
+import maestro.orchestra.MaestroOnFlowComplete
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
@@ -16,6 +17,7 @@ data class YamlConfig(
     val initFlow: YamlInitFlowUnion?,
     val tags: List<String>? = emptyList(),
     val env: Map<String, String> = emptyMap(),
+    val onFlowComplete: YamlOnFlowComplete?,
 ) {
 
     private val ext = mutableMapOf<String, Any?>()
@@ -31,7 +33,8 @@ data class YamlConfig(
             name = name,
             tags = tags,
             initFlow = initFlow(flowPath),
-            ext = ext.toMap()
+            ext = ext.toMap(),
+            onFlowComplete = onFlowComplete(flowPath)
         )
         return MaestroCommand(ApplyConfigurationCommand(config))
     }
@@ -56,6 +59,12 @@ data class YamlConfig(
             appId = appId,
             commands = initCommands,
         )
+    }
+
+    private fun onFlowComplete(flowPath: Path): MaestroOnFlowComplete? {
+        if (onFlowComplete == null) return null
+
+        return MaestroOnFlowComplete(onFlowComplete.commands.flatMap { it.toCommands(flowPath, appId) })
     }
 
     companion object {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -7,6 +7,7 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroInitFlow
 import maestro.orchestra.MaestroOnFlowComplete
+import maestro.orchestra.MaestroOnFlowStart
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
@@ -17,6 +18,7 @@ data class YamlConfig(
     val initFlow: YamlInitFlowUnion?,
     val tags: List<String>? = emptyList(),
     val env: Map<String, String> = emptyMap(),
+    val onFlowStart: YamlOnFlowStart?,
     val onFlowComplete: YamlOnFlowComplete?,
 ) {
 
@@ -34,6 +36,7 @@ data class YamlConfig(
             tags = tags,
             initFlow = initFlow(flowPath),
             ext = ext.toMap(),
+            onFlowStart = onFlowStart(flowPath),
             onFlowComplete = onFlowComplete(flowPath)
         )
         return MaestroCommand(ApplyConfigurationCommand(config))
@@ -65,6 +68,12 @@ data class YamlConfig(
         if (onFlowComplete == null) return null
 
         return MaestroOnFlowComplete(onFlowComplete.commands.flatMap { it.toCommands(flowPath, appId) })
+    }
+
+    private fun onFlowStart(flowPath: Path): MaestroOnFlowStart? {
+        if (onFlowStart == null) return null
+
+        return MaestroOnFlowStart(onFlowStart.commands.flatMap { it.toCommands(flowPath, appId) })
     }
 
     companion object {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -38,6 +38,7 @@ import maestro.orchestra.InputRandomType
 import maestro.orchestra.InputTextCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
 import maestro.orchestra.OpenLinkCommand
 import maestro.orchestra.PasteTextCommand
 import maestro.orchestra.PressKeyCommand
@@ -240,11 +241,16 @@ data class YamlFluentCommand(
             }
             ?: runFlow(flowPath, runFlow)
 
+        val config = runFlow.file?.let {
+            readConfig(flowPath, runFlow.file)
+        }
+
         return MaestroCommand(
             RunFlowCommand(
                 commands = commands,
                 condition = runFlow.`when`?.toCondition(),
                 sourceDescription = runFlow.file,
+                config
             )
         )
     }
@@ -314,6 +320,11 @@ data class YamlFluentCommand(
         val runFlowPath = resolvePath(flowPath, command.file)
         return YamlCommandReader.readCommands(runFlowPath)
             .withEnv(command.env)
+    }
+
+    private fun readConfig(flowPath: Path, commandFile: String): MaestroConfig? {
+        val runFlowPath = resolvePath(flowPath, commandFile)
+        return YamlCommandReader.readConfig(runFlowPath).toCommand(flowPath).applyConfigurationCommand?.config
     }
 
     private fun resolvePath(flowPath: Path, requestedPath: String): Path {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOnFlowComplete.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOnFlowComplete.kt
@@ -1,0 +1,13 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlOnFlowComplete(val commands: List<YamlFluentCommand>) {
+    companion object {
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(commands: List<YamlFluentCommand>) = YamlOnFlowComplete(
+            commands = commands
+        )
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOnFlowStart.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOnFlowStart.kt
@@ -1,0 +1,13 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlOnFlowStart(val commands: List<YamlFluentCommand>) {
+    companion object {
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(commands: List<YamlFluentCommand>) = YamlOnFlowStart(
+            commands = commands
+        )
+    }
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -8,6 +8,8 @@ import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroInitFlow
+import maestro.orchestra.MaestroOnFlowComplete
+import maestro.orchestra.MaestroOnFlowStart
 import maestro.orchestra.ScrollCommand
 import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.SyntaxError
@@ -301,6 +303,32 @@ internal class YamlCommandReaderTest {
         @YamlFile("021_launchApp_syntaxError.yaml") e: SyntaxError,
     ) {
         assertThat(e.message).contains("Cannot deserialize value of type")
+    }
+
+    @Test
+    fun onFlowStartCompleteHooks(
+        @YamlFile("022_on_flow_start_complete.yaml") commands: List<Command>,
+    ) {
+        assertThat(commands).containsExactly(
+            ApplyConfigurationCommand(
+                config = MaestroConfig(
+                    appId = "com.example.app",
+                    onFlowStart = MaestroOnFlowStart(
+                        commands = commands(
+                            BackPressCommand()
+                        )
+                    ),
+                    onFlowComplete = MaestroOnFlowComplete(
+                        commands = commands(
+                            ScrollCommand()
+                        )
+                    )
+                )
+            ),
+            LaunchAppCommand(
+                appId = "com.example.app"
+            )
+        )
     }
 
     private fun commands(vararg commands: Command): List<MaestroCommand> =

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/022_on_flow_start_complete.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/022_on_flow_start_complete.yaml
@@ -1,0 +1,7 @@
+appId: com.example.app
+onFlowStart:
+  - back
+onFlowComplete:
+  - scroll
+---
+- launchApp

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -11,7 +11,10 @@ import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroInitFlow
+import maestro.orchestra.MaestroOnFlowComplete
+import maestro.orchestra.MaestroOnFlowStart
 import maestro.orchestra.Orchestra
+import maestro.orchestra.RunScriptCommand
 import maestro.orchestra.error.UnicodeNotSupportedError
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.yaml.YamlCommandReader
@@ -2793,6 +2796,48 @@ class IntegrationTest {
                 Event.InputText("bar"),
             )
         )
+    }
+
+    @Test
+    fun `Case 103 - execute onFlowStart and onFlowComplete hooks`() {
+        val commands = readCommands("103_on_flow_start_complete_hooks")
+
+        val driver = driver {
+        }
+
+        val receivedLogs = mutableListOf<String>()
+
+        for (command in commands) {
+            val maestroCommand = command.asCommand()
+            if (maestroCommand is ApplyConfigurationCommand) {
+                Maestro(driver).use {
+                    val onFlowStart = maestroCommand.config.onFlowStart
+                    val onFlowComplete = maestroCommand.config.onFlowComplete
+                    if (onFlowStart != null) {
+                        orchestra(
+                            it,
+                            onCommandMetadataUpdate = { _, metadata ->
+                                receivedLogs += metadata.logMessages
+                            }
+                        ).runFlow(onFlowStart.commands)
+                    }
+                    if (onFlowComplete != null) {
+                        orchestra(
+                            it,
+                            onCommandMetadataUpdate = { _, metadata ->
+                                receivedLogs += metadata.logMessages
+                            }
+                        ).runFlow(onFlowComplete.commands)
+                    }
+                }
+            }
+        }
+
+        // Then
+        assertThat(receivedLogs).containsExactly(
+            "setup",
+            "teardown",
+        ).inOrder()
     }
 
     private fun orchestra(

--- a/maestro-test/src/test/resources/103_on_flow_start_complete_hooks.yaml
+++ b/maestro-test/src/test/resources/103_on_flow_start_complete_hooks.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+onFlowStart:
+  - runScript: "103_setup.js"
+onFlowComplete:
+  - runScript: "103_teardown.js"
+---
+- tapOn:
+    point: 100,200

--- a/maestro-test/src/test/resources/103_setup.js
+++ b/maestro-test/src/test/resources/103_setup.js
@@ -1,0 +1,1 @@
+console.log('setup');

--- a/maestro-test/src/test/resources/103_teardown.js
+++ b/maestro-test/src/test/resources/103_teardown.js
@@ -1,0 +1,1 @@
+console.log('teardown');

--- a/maestro-test/src/test/resources/104_on_flow_start_complete_hooks_flow_failed.yaml
+++ b/maestro-test/src/test/resources/104_on_flow_start_complete_hooks_flow_failed.yaml
@@ -1,10 +1,8 @@
 appId: com.example.app
 onFlowStart:
-  - runScript: "103_setup.js"
   - inputText: "test1"
 onFlowComplete:
-  - runScript: "103_teardown.js"
   - inputText: "test2"
 ---
-- tapOn:
-    point: 100,200
+- assertVisible:
+    id: "element_id"


### PR DESCRIPTION
## Proposed Changes

This PR implements two hooks that can be executed before and after each maestro flow, i.e. to execute some setup / teardown actions.

Example of how the API will look like:

```
# myFlow.yaml
appId: myId
onFlowStart:
          - runFlow: setup.yaml
	  - runScript: setup.js
	  - <any other command>
onFlowComplete:
	  - runFlow: teardown.yaml
	  - runScript: teardown.js
	  - <any other command>
---
- launchApp
```

## Testing
- [x] tested with successful case (both `onFlowStart` and `onFlowComplete` executed)
- [x] tested that `onFlowComplete` is executed if main flow fails
- [x] tested with multiple commands under `onFlowStart` and `onFlowComplete`

successful case:

https://github.com/mobile-dev-inc/maestro/assets/961175/49aa1ed7-2c75-4658-8c18-f00081be556c

failed case:


https://github.com/mobile-dev-inc/maestro/assets/961175/fd58cb97-9efb-4f46-b356-973bb0008ffb

