### PR TITLE
bugfix: execute sequential Flows even if no other Flows are present

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -56,8 +56,8 @@ class TestSuiteInteractor(
                 )
             val flowFiles = plan.flowsToRun
 
-            if (flowFiles.isEmpty()) {
-                throw CliError("No flow returned from the tag filter used")
+            if (flowFiles.isEmpty() && plan.sequence?.flows?.isEmpty() == true) {
+                throw CliError("No flows returned from the tag filter used")
             }
 
             runTestSuite(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -39,7 +39,7 @@ object WorkspaceExecutionPlanner {
         val globalIncludeTags = workspaceConfig.includeTags?.toList() ?: emptyList()
         val globalExcludeTags = workspaceConfig.excludeTags?.toList() ?: emptyList()
 
-        // filter out all Flow files
+        // retrieve all Flow files
         val unsortedFlowFiles = Files.walk(input)
             .filter { path ->
                 matchers.any { matcher -> matcher.matches(path) }


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c33d06</samp>

This pull request fixes a bug in the `TestSuiteInteractor` class that caused an incorrect error message when running a plan with an empty sequence. It also clarifies a comment in the `WorkspaceExecutionPlanner` class that explained the logic for finding flow files.

## Testing
Tested locally.

Given the following workspace

```bash
config.yaml
1_ios-advanced-flow.yaml
2_ios-advanced-flow.yaml
3_ios-advanced-flow.yaml
4_ios-advanced-flow.yaml
```

```yaml
# config.yaml
includeTags:
  - advanced
excludeTags:
  - android
executionOrder:
  continueOnFailure: true
  flowsOrder:
    - 1_ios-advanced-flow
    - 2_ios-advanced-flow-2
    - 3_ios-advanced-flow-3
```

All Flows defined in `executionOrder.flowsOrder` contain the tag `advanced` and the Flow `4_ios-advanced-flow.yaml` only contains the tag `another-tag`.

**Before**
```bash
$ ./maestro test samples/
Running on iPhone 11 - iOS 15.5 - <udid>

No flow returned from the tag filter used
```

**After**
```bash
$ ./maestro test samples/
Running on iPhone 11 - iOS 15.5 - <udid>

Waiting for flows to complete...

[Passed] 1_ios-advanced-flow (2s)
[Passed] 2_ios-advanced-flow-2 (2s)
[Passed] 3_ios-advanced-flow-3 (2s)

3/3 Flows Passed in 6s
```

## Issues Fixed
#1186 