### PR TITLE
chore: add stacktrace and message to response

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -233,7 +233,7 @@ class XCTestDriverClient(
             } else {
                 val message = "Failed request for XCTest server"
                 val responseBody = """
-                    { "message" : "$message" }
+                    { "exceptionMessage": "${connectException.localizedMessage}, "stackTrace": "${connectException.stackTraceToString()} }
                 """.trimIndent().toResponseBody("application/json; charset=utf-8".toMediaType())
 
                 Response.Builder()


### PR DESCRIPTION
## Proposed Changes

This PR adds the exception message and the stacktrace to the Fake Ok response when receiving an error from XCTest Server.
This should facilitate debug.