### PR TITLE
Log xctest xcodebuild output to system temp dir

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import maestro.utils.MaestroTimer
 import net.harawata.appdirs.AppDirsFactory
 import java.io.File
+import java.nio.file.Files
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
+import kotlin.io.path.absolutePathString
 
 object XCRunnerCLIUtils {
 
@@ -128,6 +130,7 @@ object XCRunnerCLIUtils {
 
     fun runXcTestWithoutBuild(deviceId: String, xcTestRunFilePath: String, port: Int): Process {
         val date = dateFormatter.format(LocalDateTime.now())
+        val logOutputDir = Files.createTempDirectory("maestro_xctestrunner_xcodebuild_output")
         return CommandLineUtils.runCommand(
             listOf(
                 "xcodebuild",
@@ -136,6 +139,8 @@ object XCRunnerCLIUtils {
                 xcTestRunFilePath,
                 "-destination",
                 "id=$deviceId",
+                "-derivedDataPath",
+                logOutputDir.absolutePathString()
             ),
             waitForCompletion = false,
             outputFile = File(logDirectory, "xctest_runner_$date.log"),


### PR DESCRIPTION
## Proposed Changes

Save xcodebuild Log output from the xctest-runner into the OS level temporary directory.
By default, xcodebuild saves the xctest-runner Log output to DerivedData, where it will accumulate.
With this change, the Log output will be saved to the OS level temporary directory, which will be cleaned up by the OS when needed.

## Testing

Tested locally

## Issues Fixed

#1166 