### PR TITLE
feat: add a more generic retry interceptor to XCTestDriverClient

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -47,7 +47,7 @@ class XCTestDriverClient(
     private val okHttpClient = OkHttpClient.Builder()
         .connectTimeout(10, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)
-        .addRetryOnErrorInterceptor()
+        .addRetryInterceptor()
         .addReturnOkOnShutdownInterceptor()
         .build()
 
@@ -197,16 +197,25 @@ class XCTestDriverClient(
         return okHttpClient.newCall(requestBuilder.build()).execute()
     }
 
-    private fun OkHttpClient.Builder.addRetryOnErrorInterceptor() = addInterceptor(Interceptor {
-        val request = it.request()
-        try {
-            it.proceed(request)
-        } catch (connectException: IOException) {
-            installer.start()?.let { newClient ->
-                client = newClient
-                it.proceed(request)
-            } ?: throw XCTestDriverUnreachable("Failed to reach out XCUITest Server in RetryOnError")
+    private fun OkHttpClient.Builder.addRetryInterceptor() = addInterceptor(Interceptor { chain ->
+        var exception: IOException? = null
+        repeat(3) {
+            try {
+                val response = chain.proceed(chain.request())
+                if (response.isSuccessful) {
+                    return@Interceptor response
+                }
+            } catch (e: IOException) {
+                installer.start()?.let {
+                    client = it
+                }
+                exception = e
+            }
+            Thread.sleep(200L)
         }
+
+        exception?.let { throw it }
+            ?: throw XCTestDriverUnreachable("Failed to reach out XCUITest Server after 3 attempts")
     })
 
     private fun OkHttpClient.Builder.addReturnOkOnShutdownInterceptor() = addNetworkInterceptor(Interceptor {


### PR DESCRIPTION
## Proposed Changes

This PR adds a more generic retry interceptor, trying more aggressively to retry if XCTestServer fails to respond.

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
