### PR TITLE
Feature: Add headers onto http response.

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
@@ -88,6 +88,7 @@ class GraalJsHttp(
             "ok" to response.isSuccessful,
             "status" to response.code,
             "body" to response.body?.string(),
+            "headers" to response.headers.toMultimap()
         ))
     }
 }

--- a/maestro-client/src/main/java/maestro/js/JsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/JsHttp.kt
@@ -107,6 +107,7 @@ class JsHttp(
         resultBuilder["ok"] = response.isSuccessful
         resultBuilder["status"] = response.code
         resultBuilder["body"] = response.body?.string()
+        resultBuilder["headers"] = response.headers.toMultimap()
 
         return resultBuilder.build()
     }

--- a/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
@@ -1,5 +1,8 @@
 package maestro.test
 
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.google.common.net.HttpHeaders
 import com.google.common.truth.Truth.assertThat
 import maestro.js.RhinoJsEngine
 import org.junit.jupiter.api.BeforeEach
@@ -54,5 +57,47 @@ class RhinoJsEngineTest : JsEngineTest() {
     fun `parseInt returns a double representation`() {
         val result = engine.evaluateScript("parseInt('1')").toString()
         assertThat(result).isEqualTo("1.0")
+    }
+
+    @Test
+    fun `HTTP - Make GET request and check response body and headers `(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        val body =
+            """
+                {
+                    "message": "GET Endpoint"
+                }
+            """.trimIndent()
+
+        val testHeader = "testHeader"
+        val response = WireMock.aResponse().withStatus(200)
+            .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            .withHeader(testHeader, "first")
+            .withHeader(testHeader, "second")
+            .withBody(body);
+
+        WireMock.stubFor(
+            WireMock.get("/json").willReturn(response)
+        )
+
+        val script = """
+            var response = http.get('http://localhost:$port/json');
+            
+            //check body
+            var message = json(response.body).message;
+            
+            
+            // check headers
+            var contentType = response.headers.get("content-type");
+            var testHeader = response.headers.get("testHeader");
+            String(message + String(" ") + contentType.get(0)) + String(" ") + String(testHeader.get(0)) + String(" ") + String(testHeader.get(1));
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then
+        assertThat(result.toString()).isEqualTo("GET Endpoint application/json first second")
     }
 }


### PR DESCRIPTION
## Proposed Changes

Hello Maestro team, this is my first PR to an open source repo so please let me know if I've missed anything 🙂

As it stands right now, [the response from an http request in maestro](https://maestro.mobile.dev/advanced/javascript/make-http-s-requests#response-object) only returns fields:
- `ok`
- `status`
- `body`

However there are use cases where the `headers` returned on a response are also needed.

This PR simply adds a `headers` property onto the response object.
Thankfully this is easy given that the okHttpClient under the hood exposes a way for us 🎉 

This now means in our JS scripts we can call something like:

**Script**
```
const response = http.get("https://google.com");
console.log(response.headers);
```

**Output (i.e the headers)** 
```
{
    alt-svc=[h3=":443"; ma=2592000,h3-29=":443"; ma=2592000],
    cache-control=[private, max-age=0],
    content-security-policy-report-only=[object-src 'none';base-uri 'self';script-src 'nonce-QTQrMThjMPBu5bXPTwTBuw' 'strict-dynamic' 'report-sample' 'unsafe-eval' 'unsafe-inline' https: http:;report-uri https://csp.withgoogle.com/csp/gws/other-hp],
    content-type=[text/html; charset=ISO-8859-1],
    date=[Fri, 14 Jul 2023 12:30:22 GMT],
    expires=[-1], p3p=[CP="This is not a P3P policy! See g.co/p3phelp for more info."],
    server=[gws],
    set-cookie=[SOCS=CAAaBgiAoMKlBg; expires=Mon, 12-Aug-2024 12:30:22 GMT; path=/; domain=.google.com; Secure; SameSite=lax, AEC=Ad49MVHLRDm9QnY_9SIssRmo5IIk9Sw-FrE7VXB6rQcwBUiwrz5wGGiF2mc; expires=Wed, 10-Jan-2024 12:30:22 GMT; path=/; domain=.google.com; Secure; HttpOnly; SameSite=lax, __Secure-ENID=13.SE=bqLVDeIx1u4PZYKmvK1ZuMZU8Kt-3wEZR75Tu6kQaWbLS5BTPk-KWnhJGy987ESwGMW_Wa0JVHFTl66cmPwHU3ezWUjuCSSc26ZoeaD44uF6MyPQwpDan59XkkBniUWglc2yl6gzDX2SHttKUeskne5tqvem8U5gyxZH_595FCY; expires=Tue, 13-Aug-2024 04:48:40 GMT; path=/; domain=.google.com; Secure; HttpOnly; SameSite=lax, CONSENT=PENDING+642; expires=Sun, 13-Jul-2025 12:30:22 GMT; path=/; domain=.google.com; Secure],
    transfer-encoding=[chunked],
    x-frame-options=[SAMEORIGIN],
    x-xss-protection=[0]
}
```
 -----

Also if this change goes in we'll need to update the docs on the website [here](https://maestro.mobile.dev/advanced/javascript/make-http-s-requests#response-object):

![Screenshot 2023-07-14 at 14 02 49](https://github.com/mobile-dev-inc/maestro/assets/40520415/68ac30e5-eb2f-4be1-aa88-833342c9ec01)

I'm happy to do this, but I'm not sure where to make the changes.

Thanks for taking a look at my PR 😁

## Testing

I've done the following:

- manual testing (via ./maestro) and got the headers output as shown above...
- Added a unit test for the rhinoJSEngine.

I wasn't sure how to write a unit test that works in both rhinoJS/GraalJs engines simultaneously, so for now I've only added a unit test in **RhinoJsEngineTest** only.

Happy to add one if someone can help out 🙏🏾 

## Issues Fixed

No issues fixed, this is a new feature!
