### PR TITLE
fix: add secondary constructor to initialize a default XCTestClient

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory
 import sun.misc.Signal
 import sun.misc.SignalHandler
 import util.XCRunnerCLIUtils
+import xcuitest.XCTestClient
 import xcuitest.XCTestDriverClient
 import xcuitest.installer.LocalXCTestInstaller
 import java.util.UUID
@@ -302,6 +303,7 @@ object MaestroSessionManager {
         val xcTestDriverClient = XCTestDriverClient(
             installer = xcTestInstaller,
             logger = IOSDriverLogger(XCTestDriverClient::class.java),
+            client = XCTestClient(defaultHost, defaultXcTestPort)
         )
 
         val xcTestDevice = XCTestIOSDevice(

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -27,6 +27,9 @@ class XCTestDriverClient(
     private val logger: Logger,
 ) {
     private lateinit var client: XCTestClient
+    constructor(installer: XCTestInstaller, logger: Logger, client: XCTestClient): this(installer, logger) {
+        this.client = client
+    }
 
     private var isShuttingDown = false
 


### PR DESCRIPTION
## Proposed Changes

This new constructor adds the possibility to initialize a default XCTestClient, this is useful if the client is already opened with another execution of Maestro.

## Testing
✅ Tested locally running both maestro studio and test at the same time
