### PR TITLE
reinit js engine only when needed (fixes variable scope resolution fo…

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -99,11 +99,19 @@ class Orchestra(
         onFlowStart(commands)
 
         config?.onFlowStart?.commands?.let {
-            executeCommands(it, config)
+            executeCommands(
+                commands = it,
+                config = config,
+                shouldReinitJsEngine = false,
+            )
         }
 
         try {
-            val flowSuccess = executeCommands(commands, config).also {
+            val flowSuccess = executeCommands(
+                commands = commands,
+                config = config,
+                shouldReinitJsEngine = false,
+            ).also {
                 // close existing screen recording, if left open.
                 screenRecording?.close()
             }
@@ -113,7 +121,11 @@ class Orchestra(
             throw e
         } finally {
             config?.onFlowComplete?.commands?.let {
-                executeCommands(it, config)
+                executeCommands(
+                    commands = it,
+                    config = config,
+                    shouldReinitJsEngine = false,
+                )
             }
         }
     }
@@ -148,9 +160,12 @@ class Orchestra(
 
     fun executeCommands(
         commands: List<MaestroCommand>,
-        config: MaestroConfig? = null
+        config: MaestroConfig? = null,
+        shouldReinitJsEngine: Boolean = true,
     ): Boolean {
-        initJsEngine(config)
+        if (shouldReinitJsEngine) {
+            initJsEngine(config)
+        }
 
         commands
             .forEachIndexed { index, command ->

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2853,6 +2853,59 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 105 - execute onFlowStart and onFlowComplete when js output is set`() {
+        // Given
+        val commands = readCommands("105_on_flow_start_complete_when_js_output_set")
+
+        val driver = driver {
+        }
+        val receivedLogs = mutableListOf<String>()
+
+        // when
+        Maestro(driver).use {
+            orchestra(
+                it,
+                onCommandMetadataUpdate = { _, metadata ->
+                    receivedLogs += metadata.logMessages
+                }
+            ).runFlow(commands)
+        }
+
+        // Then
+        assertThat(receivedLogs).containsExactly(
+            "setup",
+            "teardown",
+        ).inOrder()
+    }
+
+    @Test
+    fun `Case 106 - execute onFlowStart and onFlowComplete when js output is set with subflows`() {
+// Given
+        val commands = readCommands("106_on_flow_start_complete_when_js_output_set_subflows")
+
+        val driver = driver {
+        }
+        val receivedLogs = mutableListOf<String>()
+
+        // when
+        Maestro(driver).use {
+            orchestra(
+                it,
+                onCommandMetadataUpdate = { _, metadata ->
+                    receivedLogs += metadata.logMessages
+                }
+            ).runFlow(commands)
+        }
+
+        // Then
+        assertThat(receivedLogs).containsExactly(
+            "subflow",
+            "setup subflow",
+            "teardown subflow",
+        ).inOrder()
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/105_on_flow_start_complete_when_js_output_set.yaml
+++ b/maestro-test/src/test/resources/105_on_flow_start_complete_when_js_output_set.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+onFlowStart:
+  - runScript: "105_setup.js"
+onFlowComplete:
+  - runScript: "105_teardown.js"
+  - evalScript: ${ console.log(output.teardown_result); }
+---
+- evalScript: ${ console.log(output.setup_result); }

--- a/maestro-test/src/test/resources/105_setup.js
+++ b/maestro-test/src/test/resources/105_setup.js
@@ -1,0 +1,1 @@
+output.setup_result = 'setup';

--- a/maestro-test/src/test/resources/105_teardown.js
+++ b/maestro-test/src/test/resources/105_teardown.js
@@ -1,0 +1,1 @@
+output.teardown_result = 'teardown';

--- a/maestro-test/src/test/resources/106_on_flow_start_complete_when_js_output_set_subflows.yaml
+++ b/maestro-test/src/test/resources/106_on_flow_start_complete_when_js_output_set_subflows.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- runFlow: "106_subflow.yaml"
+- evalScript: ${ console.log(output.setup_subflow_result); }
+- evalScript: ${ console.log(output.teardown_subflow_result); }

--- a/maestro-test/src/test/resources/106_setup.js
+++ b/maestro-test/src/test/resources/106_setup.js
@@ -1,0 +1,1 @@
+output.setup_subflow_result = 'setup subflow';

--- a/maestro-test/src/test/resources/106_subflow.yaml
+++ b/maestro-test/src/test/resources/106_subflow.yaml
@@ -1,0 +1,7 @@
+appId: com.example.app
+onFlowStart:
+  - runScript: "106_setup.js"
+onFlowComplete:
+  - runScript: "106_teardown.js"
+---
+- evalScript: ${ console.log('subflow'); }

--- a/maestro-test/src/test/resources/106_teardown.js
+++ b/maestro-test/src/test/resources/106_teardown.js
@@ -1,0 +1,1 @@
+output.teardown_subflow_result = 'teardown subflow';


### PR DESCRIPTION
## Proposed Changes

Currently when the flow is setup like this:

```
appId: some.id
onFlowStart:
  - runScript: "setup.js"
---
- evalScript: ${ console.log(output.result); }
```

setup.js
```
output.result = 'Hello World'
```

`output.result` will not be resolved correctly for `evalScript` and all following maestro main flow commands, this is because we reinitialize JS engine on every `Orchestra.executeCommands` call, this PR makes this initialization logic configurable

## Testing
- [x] tested locally
- [x] tested on staging
