### PR TITLE
feat: support id selection for testID with react-native-web

### DIFF
--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -33,8 +33,8 @@
           bounds: getNodeBounds(node),
       }
 
-      if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor) {
-        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.title || node.htmlFor
+      if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
+        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.title || node.htmlFor || (node.attributes['data-testid'] ? node.attributes['data-testid'].value : undefined)
       }
 
       if (node.tagName.toLowerCase() === 'body') {

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -34,7 +34,7 @@
       }
 
       if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
-        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.title || node.htmlFor || (node.attributes['data-testid'] ? node.attributes['data-testid'].value : undefined)
+        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.title || node.htmlFor || node.attributes['data-testid']?.value
       }
 
       if (node.tagName.toLowerCase() === 'body') {


### PR DESCRIPTION
## Proposed Changes

`maestro-web.js` `traverse` uses "data-testid" as an additional fallback for "resource-id", because [that's what react-native-web uses](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/modules/createDOMProps/index.js#L813) for [testID](https://reactnative.dev/docs/view#testid).

## Testing
verified that the below Maestro script, which depends on an ID selector and works with React Native for iOS and Android, now works on web.

```
appId: "http://localhost:8090"
#appId: "com.trulysmall.expenses"
---
- launchApp:
    clearState: true
- tapOn: "Get Started"
- tapOn: "Email"
- inputText: "adam.hari+"
- "inputRandomNumber"
- inputText: "@kashoo.com"
- tapOn: "Full name"
- inputText: "Maestro E2E"
- tapOn: "Password.*"
- inputText: "test123456"
- "hideKeyboard"
- tapOn:
    id: "RegisterAccountScreenTermsCheckbox"
- tapOn: "Create An Account"
- tapOn: "Continue"
- tapOn: "Continue"
- assertVisible: "Get Started"
```

https://github.com/mobile-dev-inc/maestro/assets/16565387/876b5cf8-b4b8-4507-9d7b-27339c6ce251

## Issues Fixed
https://github.com/mobile-dev-inc/maestro/issues/1260