### PR TITLE
Test port number for android

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - spike/kshitij/test-build-with-logs
 
 jobs:
   publish:

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -195,6 +195,7 @@ object MaestroSessionManager {
     }
 
     private fun isAndroid(host: String?, port: Int?): Boolean {
+        println("Port number is :$port")
         return try {
             val dadb = if (port != null) {
                 Dadb.create(host ?: defaultHost, port)


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58e447b</samp>

Added a debug statement to `maestro-cli` to print the port number of the `maestro-server` endpoint. This helps diagnose the connection issue between the two components.

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
