### PR TITLE
Allow Java classes to be accessible within JavaScript with GraalJS

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -3,6 +3,7 @@ package maestro.js
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.PolyglotAccess
 import org.graalvm.polyglot.Source
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyObject
@@ -76,13 +77,16 @@ class GraalJsEngine(
                 reset()
             }
         }
-
+        val options = hashMapOf<String, String>();
+        options["js.strict"] = "true";
         val context = Context.newBuilder("js")
-            .option("js.strict", "true")
+            .allowAllAccess(true)
+            .allowIO(true)
+            .allowHostClassLookup { c -> c.matches(Regex(".*")) }
             .logHandler(NULL_HANDLER)
             .out(outputStream)
+            .options(options)
             .build()
-
         openContexts.add(context)
 
         envBinding.forEach { (key, value) -> context.getBindings("js").putMember(key, value) }

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -44,4 +44,13 @@ class GraalJsEngineTest : JsEngineTest() {
         val result = engine.evaluateScript("parseInt('1')").toString()
         assertThat(result).isEqualTo("1")
     }
+
+    @Test
+    fun `Java type correctly imports Java class`() {
+        val result = engine.evaluateScript("""
+            const pi = Java.type('java.lang.Math').PI;
+            parseFloat(pi);
+        """).toString();
+        assertThat(result).isEqualTo(kotlin.math.PI.toString());
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Hi Maestro team, I appreciate your work on maestro framework, really impressing tool and very easy to use. Just want to try to contribute to it as much as I can. To be said, I'm not experienced developer at any point, just really needed some workaround to be able to test biometrics, so I'm proposing this solution: allow Java classes to be accessible within JavaScript code to be able to interact with shell/cmd.

## Testing
1 unit test added, would appreciate help on test flows

## Issues Fixed
No issues fixed