### PR TITLE
[fix] Fix response headers mapping for GraalJS

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
@@ -96,8 +96,9 @@ class GraalJsHttp(
 
     private fun convertHeaders(headers: Headers): ProxyObject {
         val headersMap = headers.toMultimap().mapValues { (_, values) ->
-            ProxyArray.fromArray(*values.toTypedArray())
+            values.joinToString(",")
         }
         return ProxyObject.fromMap(headersMap)
     }
+
 }

--- a/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
@@ -1,9 +1,11 @@
 package maestro.js
 
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.graalvm.polyglot.HostAccess.Export
+import org.graalvm.polyglot.proxy.ProxyArray
 import org.graalvm.polyglot.proxy.ProxyObject
 
 class GraalJsHttp(
@@ -88,7 +90,14 @@ class GraalJsHttp(
             "ok" to response.isSuccessful,
             "status" to response.code,
             "body" to response.body?.string(),
-            "headers" to response.headers.toMultimap()
+            "headers" to convertHeaders(response.headers)
         ))
+    }
+
+    private fun convertHeaders(headers: Headers): ProxyObject {
+        val headersMap = headers.toMultimap().mapValues { (_, values) ->
+            ProxyArray.fromArray(*values.toTypedArray())
+        }
+        return ProxyObject.fromMap(headersMap)
     }
 }

--- a/maestro-client/src/main/java/maestro/js/JsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/JsHttp.kt
@@ -1,5 +1,6 @@
 package maestro.js
 
+import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -107,9 +108,16 @@ class JsHttp(
         resultBuilder["ok"] = response.isSuccessful
         resultBuilder["status"] = response.code
         resultBuilder["body"] = response.body?.string()
-        resultBuilder["headers"] = response.headers.toMultimap()
+        resultBuilder["headers"] = convertHeaders(response.headers)
 
         return resultBuilder.build()
+    }
+
+    private fun convertHeaders(headers: Headers): NativeObject {
+        val headersMap = headers.toMultimap().mapValues { (_, values) -> values.joinToString(",") }
+        val headersNativeObject = NativeObject()
+        headersMap.forEach { (key, value) -> headersNativeObject.put(key, headersNativeObject, value) }
+        return headersNativeObject
     }
 
     private class JsObjectBuilder {

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -43,45 +43,4 @@ class GraalJsEngineTest : JsEngineTest() {
         val result = engine.evaluateScript("parseInt('1')").toString()
         assertThat(result).isEqualTo("1")
     }
-
-    @Test
-    fun `HTTP - Make GET request and check response body and headers `(wiremockInfo: WireMockRuntimeInfo) {
-        // Given
-        val port = wiremockInfo.httpPort
-        val body =
-            """
-                {
-                    "message": "GET Endpoint"
-                }
-            """.trimIndent()
-
-        val testHeader = "testHeader"
-        val response = WireMock.aResponse().withStatus(200)
-            .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-            .withHeader(testHeader, "first")
-            .withHeader(testHeader, "second")
-            .withBody(body);
-
-        WireMock.stubFor(
-            WireMock.get("/json").willReturn(response)
-        )
-
-        val script = """
-            var response = http.get('http://localhost:$port/json');
-            
-            //check body
-            var message = json(response.body).message;
-            
-            // check headers
-            var contentType = response.headers['content-type'];
-            var testHeader = response.headers['testheader'];
-            String(message + String(" ") + contentType[0] + String(" ") + testHeader[0] + String(" ") + testHeader[1]);
-        """.trimIndent()
-
-        // When
-        val result = engine.evaluateScript(script)
-
-        // Then
-        assertThat(result.toString()).isEqualTo("GET Endpoint application/json first second")
-    }
 }

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -1,13 +1,12 @@
 package maestro.test
 
-import com.google.common.truth.Truth
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.google.common.net.HttpHeaders
 import com.google.common.truth.Truth.assertThat
 import maestro.js.GraalJsEngine
-import org.graalvm.polyglot.PolyglotException
-import org.graalvm.polyglot.Value
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 class GraalJsEngineTest : JsEngineTest() {
 
@@ -43,5 +42,46 @@ class GraalJsEngineTest : JsEngineTest() {
     fun `parseInt returns an int representation`() {
         val result = engine.evaluateScript("parseInt('1')").toString()
         assertThat(result).isEqualTo("1")
+    }
+
+    @Test
+    fun `HTTP - Make GET request and check response body and headers `(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        val body =
+            """
+                {
+                    "message": "GET Endpoint"
+                }
+            """.trimIndent()
+
+        val testHeader = "testHeader"
+        val response = WireMock.aResponse().withStatus(200)
+            .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            .withHeader(testHeader, "first")
+            .withHeader(testHeader, "second")
+            .withBody(body);
+
+        WireMock.stubFor(
+            WireMock.get("/json").willReturn(response)
+        )
+
+        val script = """
+            var response = http.get('http://localhost:$port/json');
+            
+            //check body
+            var message = json(response.body).message;
+            
+            // check headers
+            var contentType = response.headers['content-type'];
+            var testHeader = response.headers['testheader'];
+            String(message + String(" ") + contentType[0] + String(" ") + testHeader[0] + String(" ") + testHeader[1]);
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then
+        assertThat(result.toString()).isEqualTo("GET Endpoint application/json first second")
     }
 }

--- a/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
@@ -1,5 +1,6 @@
 package maestro.test
 
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
@@ -8,6 +9,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
 import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import com.google.common.net.HttpHeaders
 import com.google.common.truth.Truth.assertThat
 import maestro.js.JsEngine
 import org.junit.jupiter.api.Test
@@ -164,5 +166,46 @@ abstract class JsEngineTest {
 
         result = engine.evaluateScript("FOO").toString()
         assertThat(result).isEqualTo("foo")
+    }
+
+    @Test
+    fun `HTTP - Make GET request and check response body and headers `(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        val body =
+            """
+                {
+                    "message": "GET Endpoint"
+                }
+            """.trimIndent()
+
+        val testHeader = "testHeader"
+        val response = WireMock.aResponse().withStatus(200)
+            .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
+            .withHeader(testHeader, "first")
+            .withHeader(testHeader, "second")
+            .withBody(body);
+
+        WireMock.stubFor(
+            WireMock.get("/json").willReturn(response)
+        )
+
+        val script = """
+            var response = http.get('http://localhost:$port/json');
+            
+            //check body
+            var message = json(response.body).message;
+            
+            // check headers
+            var contentType = response.headers['content-type'];
+            var testHeader = response.headers['testheader'];
+            String(message + String(" ") + contentType + String(" ") + testHeader);
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then
+        assertThat(result.toString()).isEqualTo("GET Endpoint application/json first,second")
     }
 }

--- a/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
@@ -11,8 +11,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest
 import com.google.common.truth.Truth.assertThat
 import maestro.js.JsEngine
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import org.mozilla.javascript.RhinoException
 
 @WireMockTest
 abstract class JsEngineTest {

--- a/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
@@ -58,46 +58,4 @@ class RhinoJsEngineTest : JsEngineTest() {
         val result = engine.evaluateScript("parseInt('1')").toString()
         assertThat(result).isEqualTo("1.0")
     }
-
-    @Test
-    fun `HTTP - Make GET request and check response body and headers `(wiremockInfo: WireMockRuntimeInfo) {
-        // Given
-        val port = wiremockInfo.httpPort
-        val body =
-            """
-                {
-                    "message": "GET Endpoint"
-                }
-            """.trimIndent()
-
-        val testHeader = "testHeader"
-        val response = WireMock.aResponse().withStatus(200)
-            .withHeader(HttpHeaders.CONTENT_TYPE, "application/json")
-            .withHeader(testHeader, "first")
-            .withHeader(testHeader, "second")
-            .withBody(body);
-
-        WireMock.stubFor(
-            WireMock.get("/json").willReturn(response)
-        )
-
-        val script = """
-            var response = http.get('http://localhost:$port/json');
-            
-            //check body
-            var message = json(response.body).message;
-            
-            
-            // check headers
-            var contentType = response.headers.get("content-type");
-            var testHeader = response.headers.get("testHeader");
-            String(message + String(" ") + contentType.get(0)) + String(" ") + String(testHeader.get(0)) + String(" ") + String(testHeader.get(1));
-        """.trimIndent()
-
-        // When
-        val result = engine.evaluateScript(script)
-
-        // Then
-        assertThat(result.toString()).isEqualTo("GET Endpoint application/json first second")
-    }
 }


### PR DESCRIPTION
## Proposed Changes

The ProxyObject.fromMap() method requires a ProxyObject, and we're giving it a Kotlin Map for the headers field. So when we're trying to access headers in GraalJS they are empty.

We should convert the headers to a Map object that GraalJS can work with. Since headers are multi-value, we will convert them to a Map where each key has a string with comma-separated values.

This PR also fixes the headers API, to be unified for GraalJS and RhinoJS, where value is a string (comma separated values in case of multiple values):

```
headers = Object(
  "key1": "1,2"
)
```

and i.e. content-type can be parsed like that:

```
var contentType = response.headers['content-type'];
```

cc @jlwillo 

## Testing
- [x] local test
- [x] staging test