### PR TITLE
[MOB-2209] Fail the flow if one of onStart / Complete hooks fails

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -582,16 +582,21 @@ class Orchestra(
         // filter out DefineVariablesCommand to not execute it twice
         val filteredCommands = commands.filter { it.asCommand() !is DefineVariablesCommand }
 
-        subflowConfig?.onFlowStart?.commands?.let {
-            executeSubflowCommands(it, config)
-        }
-
+        var flowSuccess = false
         try {
-            return executeSubflowCommands(filteredCommands, config)
-        } finally {
-            subflowConfig?.onFlowComplete?.commands?.let {
+            val onStartSuccess = subflowConfig?.onFlowStart?.commands?.let {
                 executeSubflowCommands(it, config)
+            } ?: true
+
+            if (onStartSuccess) {
+                flowSuccess = executeSubflowCommands(filteredCommands, config)
             }
+        } finally {
+            val onCompleteSuccess = subflowConfig?.onFlowComplete?.commands?.let {
+                executeSubflowCommands(it, config)
+            } ?: true
+
+            return onCompleteSuccess && flowSuccess
         }
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -103,6 +103,7 @@ class Orchestra(
         val filteredCommands = commands.filter { it.asCommand() !is DefineVariablesCommand }
 
         var flowSuccess = false
+        var exception: Throwable? = null
         try {
             val onStartSuccess = config?.onFlowStart?.commands?.let {
                 executeCommands(
@@ -123,7 +124,7 @@ class Orchestra(
                 }
             }
         } catch (e: Throwable) {
-            throw e
+            exception = e
         } finally {
             val onCompleteSuccess = config?.onFlowComplete?.commands?.let {
                 executeCommands(
@@ -132,6 +133,8 @@ class Orchestra(
                     shouldReinitJsEngine = false,
                 )
             } ?: true
+
+            exception?.let { throw it }
 
             return onCompleteSuccess && flowSuccess
         }
@@ -582,6 +585,7 @@ class Orchestra(
         // filter out DefineVariablesCommand to not execute it twice
         val filteredCommands = commands.filter { it.asCommand() !is DefineVariablesCommand }
 
+        var exception: Throwable? = null
         var flowSuccess = false
         try {
             val onStartSuccess = subflowConfig?.onFlowStart?.commands?.let {
@@ -591,10 +595,14 @@ class Orchestra(
             if (onStartSuccess) {
                 flowSuccess = executeSubflowCommands(filteredCommands, config)
             }
+        } catch (e: Throwable) {
+            exception = e
         } finally {
             val onCompleteSuccess = subflowConfig?.onFlowComplete?.commands?.let {
                 executeSubflowCommands(it, config)
             } ?: true
+
+            exception?.let { throw it }
 
             return onCompleteSuccess && flowSuccess
         }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -104,22 +104,23 @@ class Orchestra(
 
         var flowSuccess = false
         try {
-            config?.onFlowStart?.commands?.let {
-                if (!executeCommands(
-                        commands = it,
-                        config = config,
-                        shouldReinitJsEngine = false)) {
-                    return false
-                }
-            }
+            val onStartSuccess = config?.onFlowStart?.commands?.let {
+                executeCommands(
+                    commands = it,
+                    config = config,
+                    shouldReinitJsEngine = false,
+                )
+            } ?: true
 
-            flowSuccess = executeCommands(
-                commands = filteredCommands,
-                config = config,
-                shouldReinitJsEngine = false,
-            ).also {
-                // close existing screen recording, if left open.
-                screenRecording?.close()
+            if (onStartSuccess) {
+                flowSuccess = executeCommands(
+                    commands = filteredCommands,
+                    config = config,
+                    shouldReinitJsEngine = false,
+                ).also {
+                    // close existing screen recording, if left open.
+                    screenRecording?.close()
+                }
             }
         } catch (e: Throwable) {
             throw e

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2937,6 +2937,61 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 108 - fail the flow and skip commands in case of onStart hook failure`() {
+        // Given
+        val commands = readCommands("108_failed_start_hook")
+        val driver = driver {
+        }
+        val receivedLogs = mutableListOf<String>()
+
+        // When & Then
+        assertThrows<MaestroException.AssertionFailure> {
+            val result = Maestro(driver).use {
+                orchestra(
+                    it,
+                    onCommandMetadataUpdate = { _, metadata ->
+                        receivedLogs += metadata.logMessages
+                    }
+                ).runFlow(commands)
+            }
+
+            assertThat(result).isFalse()
+        }
+        assertThat(receivedLogs).containsExactly(
+            "on start",
+            "on complete",
+        ).inOrder()
+    }
+
+    @Test
+    fun `Case 109 - fail the flow and execute commands in case of onComplete hook failure`() {
+        // Given
+        val commands = readCommands("109_failed_complete_hook")
+        val driver = driver {
+        }
+        val receivedLogs = mutableListOf<String>()
+
+        // When & Then
+        assertThrows<MaestroException.AssertionFailure> {
+            val result = Maestro(driver).use {
+                orchestra(
+                    it,
+                    onCommandMetadataUpdate = { _, metadata ->
+                        receivedLogs += metadata.logMessages
+                    }
+                ).runFlow(commands)
+            }
+
+            assertThat(result).isFalse()
+        }
+        assertThat(receivedLogs).containsExactly(
+            "on start",
+            "main flow",
+            "on complete",
+        ).inOrder()
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/108_failed_start_hook.yaml
+++ b/maestro-test/src/test/resources/108_failed_start_hook.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+onFlowStart:
+  - evalScript: ${ console.log('on start'); }
+  - assertTrue: ${1-1}
+onFlowComplete:
+  - evalScript: ${ console.log('on complete'); }
+---
+- evalScript: ${ console.log('main flow'); }

--- a/maestro-test/src/test/resources/109_failed_complete_hook.yaml
+++ b/maestro-test/src/test/resources/109_failed_complete_hook.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+onFlowStart:
+  - evalScript: ${ console.log('on start'); }
+onFlowComplete:
+  - evalScript: ${ console.log('on complete'); }
+  - assertTrue: ${1-1}
+---
+- evalScript: ${ console.log('main flow'); }


### PR DESCRIPTION
## Proposed Changes

This PR implements failure handling in onStart / onComplete hooks. The behaviour will follow the logic in the following table:

| Test case                                              | JUnit behavior        | XCTest behavior      |
| ------------------------------------------------------ | --------------------- | -------------------- |
| when before function fails, does that fail the whole test? | test marked :red_circle: | test marked :red_circle: |
| when before function fails, does that skip the main body of the test execution? | test execution skipped | test execution skipped |
| when before function fails, does the after function still run? | after function is still called | after function is still called |
| when the after function fails, does the test fail?   | test marked :red_circle: | test marked :red_circle:   |

## Testing
- [x] local test
- [ ] staging test