### PR TITLE
Add support for MAESTRO_DRIVER_STARTUP_TIMEOUT to the iOS driver

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -81,7 +81,7 @@ class IOSDriver(
     }
 
     override fun open() {
-        iosDevice.open()
+        awaitLaunch()
     }
 
     override fun close() {
@@ -559,10 +559,31 @@ class IOSDriver(
         return (percent * widthPoints).toInt()
     }
 
+    private fun awaitLaunch() {
+        val startTime = System.currentTimeMillis()
+
+        while (System.currentTimeMillis() - startTime < getStartupTimeout()) {
+            runCatching {
+                iosDevice.open()
+                return
+            }
+            Thread.sleep(100)
+        }
+
+        throw TimeoutException("Maestro iOS driver did not start up in time")
+    }
+
+    private fun getStartupTimeout(): Long = runCatching {
+        System.getenv(MAESTRO_DRIVER_STARTUP_TIMEOUT).toLong()
+    }.getOrDefault(SERVER_LAUNCH_TIMEOUT_MS)
+
     companion object {
         const val NAME = "iOS Simulator"
 
         private val LOGGER = LoggerFactory.getLogger(IOSDevice::class.java)
+
+        private const val SERVER_LAUNCH_TIMEOUT_MS = 15000L
+        private const val MAESTRO_DRIVER_STARTUP_TIMEOUT = "MAESTRO_DRIVER_STARTUP_TIMEOUT"
 
         private const val ELEMENT_TYPE_CHECKBOX = 12
         private const val ELEMENT_TYPE_SWITCH = 40

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -55,6 +55,7 @@ import java.nio.file.Files
 import java.util.UUID
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.collections.set
 
 class IOSDriver(


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b22935f</samp>

Added a new method and constants to `IOSDriver` to improve the reliability of launching iosDevices. This method uses a retry and timeout logic to handle possible delays or failures.

I've never done any Kotlin development and I'm not sure how the Maestro executable is built, so this isn't as DRY as I would like. However, since I don't know how to run and test this, I didn't want to introduce more likelihood of me slipping up. I'd like to dive in more and verify it myself, but I don't have that much time and I'm hoping this would be trivial for whoever looks at this.

## Testing

As I said about not being ramped up on Kotlin and this project, I haven't verified it. However, I believe these changes will work. If not, there's probably only very minimal changes needed.

## Issues Fixed

The documentation mentions that [`MAESTRO_DRIVER_STARTUP_TIMEOUT`](https://maestro.mobile.dev/advanced/configuring-maestro-driver-timeout) can be used to modify the timeout for starting the driver. However, it's Android-only right now. This PR adds support for the iOS driver.

Note: I'm not sure where the docs can be modified, but if this is merged, that page of documentation should be modified to remove the "Android" header since it won't be Android-only anymore.
