### PR TITLE
Add support for disabling notifications configured in config.yaml

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -242,6 +242,7 @@ class ApiClient(
         excludeTags: List<String> = emptyList(),
         maxRetryCount: Int = 3,
         completedRetries: Int = 0,
+        disableNotifications: Boolean,
         progressListener: (totalBytes: Long, bytesWritten: Long) -> Unit = { _, _ -> },
     ): UploadResponse {
         if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter for option '--app-file' or '--app-binary-id'")
@@ -264,6 +265,7 @@ class ApiClient(
         appBinaryId?.let { requestPart["appBinaryId"] = it }
         if (includeTags.isNotEmpty()) requestPart["includeTags"] = includeTags
         if (excludeTags.isNotEmpty()) requestPart["excludeTags"] = excludeTags
+        if (disableNotifications) requestPart["disableNotifications"] = true
 
         val bodyBuilder = MultipartBody.Builder()
             .setType(MultipartBody.FORM)
@@ -307,7 +309,8 @@ class ApiClient(
                 maxRetryCount = maxRetryCount,
                 completedRetries = completedRetries + 1,
                 progressListener = progressListener,
-                appBinaryId = appBinaryId
+                appBinaryId = appBinaryId,
+                disableNotifications = disableNotifications,
             )
         }
 

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -56,7 +56,8 @@ class CloudInteractor(
         excludeTags: List<String> = emptyList(),
         reportFormat: ReportFormat = ReportFormat.NOOP,
         reportOutput: File? = null,
-        testSuiteName: String? = null
+        testSuiteName: String? = null,
+        disableNotifications: Boolean = false,
     ): Int {
         if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter for option '--app-file' or '--app-binary-id'")
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
@@ -109,6 +110,7 @@ class CloudInteractor(
                 appBinaryId = appBinaryId,
                 includeTags = includeTags,
                 excludeTags = excludeTags,
+                disableNotifications = disableNotifications,
             ) { totalBytes, bytesWritten ->
                 progressBar.set(bytesWritten.toFloat() / totalBytes.toFloat())
             }

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -99,8 +99,7 @@ class CloudCommand : Callable<Int> {
         names = ["--include-tags"],
         description = ["List of tags that will remove the Flows that does not have the provided tags"],
         split = ",",
-
-        )
+    )
     private var includeTags: List<String> = emptyList()
 
     @Option(
@@ -140,6 +139,9 @@ class CloudCommand : Callable<Int> {
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
 
+    @Option(names = ["--disable-notifications"], description = ["Do not send the notifications configured in config.yaml"])
+    private var disableNotifications = false
+
     override fun call(): Int {
 
         validateFiles()
@@ -170,7 +172,8 @@ class CloudCommand : Callable<Int> {
             reportFormat = format,
             reportOutput = output,
             failOnCancellation = failOnCancellation,
-            testSuiteName = testSuiteName
+            testSuiteName = testSuiteName,
+            disableNotifications = disableNotifications,
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -139,7 +139,7 @@ class CloudCommand : Callable<Int> {
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
 
-    @Option(names = ["--disable-notifications"], description = ["Do not send the notifications configured in config.yaml"])
+    @Option(hidden = true, names = ["--disable-notifications"], description = ["Do not send the notifications configured in config.yaml"])
     private var disableNotifications = false
 
     override fun call(): Int {


### PR DESCRIPTION
## Proposed Changes

When notifications are configured in workspace/config.yaml they will trigger on the result of the flow runs. Which is not always desired.
This PR allows to specify `--disable-notifications` on `maestro cloud`, which will request notifications of that upload to not be send.

## Testing

Tested locally.
