### PR TITLE
Fixes debug filename output when flow name contains "/"

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -46,7 +46,9 @@ object TestDebugReporter {
         // commands
         val commandMetadata = data.commands
         if (commandMetadata.isNotEmpty()) {
-            val file = File(path.absolutePathString(), "commands-(${flowName}).json")
+
+            val commandsFilename = "commands-(${flowName.replace("/", "_")}).json"
+            val file = File(path.absolutePathString(), commandsFilename)
             commandMetadata.map { CommandDebugWrapper(it.key, it.value) }.let {
                 mapper.writeValue(file, it)
             }


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61fc337</samp>

Fixed a bug in `TestDebugReporter` that caused report generation to fail when the flow name had slashes. Introduced a new variable `commandsFilename` to sanitize the flow name for the commands JSON file.

## Testing
Locally

## Issues Fixed
- Flow names that contained "/" would cause an error when trying to create a debug output file. Fixed by replacing "/" with "_"
