### PR TITLE
Log error message in case of 500 errors during upload

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -328,10 +328,12 @@ class ApiClient(
 
         response.use {
             if (!response.isSuccessful) {
+                val errorMessage = response.body?.string().takeIf { it?.isNotEmpty() == true } ?: "Unknown"
+
                 if (response.code >= 500) {
-                    return retry("Upload failed with status code ${response.code}")
+                    return retry("Upload failed with status code ${response.code}: $errorMessage")
                 } else {
-                    throw CliError("Upload request failed (${response.code}): ${response.body?.string()}")
+                    throw CliError("Upload request failed (${response.code}): $errorMessage")
                 }
             }
 


### PR DESCRIPTION
## Proposed Changes

Currently we're seeing this message in case of 500 errors:

`Upload failed with status code 500, retrying...`

This PR implements logging the error message itself as well