### PR TITLE
Studio: Fixed device overflow on window resize

### DIFF
--- a/maestro-studio/web/src/components/device-and-device-elements/DeviceWrapperAspectRatio.tsx
+++ b/maestro-studio/web/src/components/device-and-device-elements/DeviceWrapperAspectRatio.tsx
@@ -35,9 +35,9 @@ const DeviceWrapperAspectRatio = ({
   }, [aspectRatio]);
 
   return (
-    <div ref={containerRef} className="relative flex-grow">
+    <div ref={containerRef} className="relative flex-1">
       <div
-        className="h-full max-w-full mx-auto grid place-items-center"
+        className="h-full max-w-full absolute top-0 left-0 right-0 bottom-0 mx-auto grid place-items-center"
         style={{ width }}
         {...rest}
       >


### PR DESCRIPTION
**_Issue:_** The device's size expanded disproportionately when the window was resized.

**_Solution:_** Adjusted the styling by setting `flex-grow` to `flex-1` and positioning inner elements as `absolute`.