### PR TITLE
Fix performance issues with maestro studio device refresh

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -74,7 +74,7 @@ object MaestroCommandRunner {
             val result = kotlin.runCatching {
                 val out = File.createTempFile("screenshot-${System.currentTimeMillis()}", ".png")
                     .also { it.deleteOnExit() } // save to another dir before exiting
-                maestro.takeScreenshot(out)
+                maestro.takeScreenshot(out, false)
                 debugScreenshots.add(
                     ScreenshotDebugMetadata(
                         screenshot = out,

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -179,7 +179,7 @@ class TestSuiteInteractor(
             val result = kotlin.runCatching {
                 val out = File.createTempFile("screenshot-${System.currentTimeMillis()}", ".png")
                     .also { it.deleteOnExit() } // save to another dir before exiting
-                maestro.takeScreenshot(out)
+                maestro.takeScreenshot(out, false)
                 debugScreenshots.add(
                     ScreenshotDebugMetadata(
                         screenshot = out,

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -462,7 +462,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         driver.close()
     }
 
-    fun takeScreenshot(outFile: File) {
+    fun takeScreenshot(outFile: File, compressed: Boolean) {
         LOGGER.info("Taking screenshot: $outFile")
 
         val absoluteOutFile = outFile.absoluteFile
@@ -472,7 +472,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
                 .sink()
                 .buffer()
                 .use {
-                    ScreenshotUtils.takeScreenshot(it, false, driver)
+                    ScreenshotUtils.takeScreenshot(it, compressed, driver)
                 }
         } else {
             throw MaestroException.DestinationIsNotWritable(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -623,7 +623,7 @@ class Orchestra(
             ?.let { File(it, pathStr) }
             ?: File(pathStr)
 
-        maestro.takeScreenshot(file)
+        maestro.takeScreenshot(file, false)
 
         return false
     }

--- a/maestro-studio/server/src/main/java/maestro/studio/DeviceScreenService.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/DeviceScreenService.kt
@@ -148,7 +148,7 @@ object DeviceScreenService {
         val screenshotFile = SCREENSHOT_DIR.resolve(name).toFile()
         screenshotFile.deleteOnExit()
         try {
-            maestro.takeScreenshot(screenshotFile)
+            maestro.takeScreenshot(screenshotFile, true)
         } catch (ignore: Exception) {
             // ignore intermittent screenshot errors
         }

--- a/maestro-studio/web/src/pages/InteractPage.tsx
+++ b/maestro-studio/web/src/pages/InteractPage.tsx
@@ -49,6 +49,7 @@ const InteractPage = () => {
         try {
           const deviceScreen = await API.getDeviceScreen();
           setDeviceScreen(deviceScreen);
+          await wait(250);
         } catch (e) {
           console.error(e);
           await wait(1000);

--- a/maestro-studio/web/src/pages/InteractPage.tsx
+++ b/maestro-studio/web/src/pages/InteractPage.tsx
@@ -49,7 +49,6 @@ const InteractPage = () => {
         try {
           const deviceScreen = await API.getDeviceScreen();
           setDeviceScreen(deviceScreen);
-          await wait(250);
         } catch (e) {
           console.error(e);
           await wait(1000);


### PR DESCRIPTION
## Proposed Changes

This PR:
- adds compression for maestro studio screen refresh device screenshots to improve refresh performance

## Testing
- [x] tested locally

## Issues Fixed
Some of the problems related to the issues mentioned [here](https://github.com/mobile-dev-inc/maestro/issues/805) might be resolved
