### PR TITLE
Add config to disable automatic HTTP redirects

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -24,6 +24,8 @@ class GraalJsEngine(
         .readTimeout(5, TimeUnit.MINUTES)
         .writeTimeout(5, TimeUnit.MINUTES)
         .protocols(listOf(Protocol.HTTP_1_1))
+        .followRedirects(System.getenv("MAESTRO_FOLLOW_REDIRECTS")?.equals("true")?: true)
+        .followSslRedirects(System.getenv("MAESTRO_FOLLOW_REDIRECTS")?.equals("true")?: true)
         .build(),
 ) : JsEngine {
 

--- a/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
@@ -11,6 +11,8 @@ class RhinoJsEngine(
         .readTimeout(5, TimeUnit.MINUTES)
         .writeTimeout(5, TimeUnit.MINUTES)
         .protocols(listOf(Protocol.HTTP_1_1))
+        .followRedirects(System.getenv("MAESTRO_FOLLOW_REDIRECTS")?.equals("true")?: true)
+        .followSslRedirects(System.getenv("MAESTRO_FOLLOW_REDIRECTS")?.equals("true")?: true)
         .build(),
 ) : JsEngine {
 


### PR DESCRIPTION
## Context

Hi! In my company we have some HTTP flows with requests that respond with 30X. We need to get some data from those responses, but Maestro's HTTP client follows HTTP redirects automatically and we cannot access that response's data.

## Proposed Changes

This PR **enables configuring** whether the HTTP client should **follow redirects automatically** with an environment variable (`MAESTRO_FOLLOW_REDIRECTS`).

- Setting the environment variable to "false" will disable redirects.
- Setting the environment variable to "true" or leaving it unsetted will **default to follow redirects** as before.

If you think this needed for the main project I'll update the PR to include some tests and I'll open another PR to update the documentation in [maestro-docs](https://github.com/mobile-dev-inc/maestro-docs) 🙂 

## Testing

I tested this locally with an internal API, but if you give me the heads-up I'll add a test to these files too:

- kotlin/maestro/test/RhinoJsEngineTest.kt
- kotlin/maestro/test/GraalJsEngineTest.kt

## Issues Fixed

N/A (should I create one with what I explained in the context?)