### PR TITLE
Add primary support for snapshot testing

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -476,6 +476,22 @@ data class TakeScreenshotCommand(
     }
 }
 
+data class AssertSnapshotCommand(
+    val path: String,
+    val threshold: String? = null,
+) : Command {
+
+    override fun description(): String {
+        return "Assert that current screen matches $path"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): AssertSnapshotCommand {
+        return copy(
+            path = path.evaluateScripts(jsEngine)
+        )
+    }
+}
+
 data class StopAppCommand(
     val appId: String,
 ) : Command {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -61,6 +61,7 @@ data class MaestroCommand(
     val travelCommand: TravelCommand? = null,
     val startRecordingCommand: StartRecordingCommand? = null,
     val stopRecordingCommand: StopRecordingCommand? = null,
+    val assertSnapshotCommand: AssertSnapshotCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -97,6 +98,7 @@ data class MaestroCommand(
         travelCommand = command as? TravelCommand,
         startRecordingCommand = command as? StartRecordingCommand,
         stopRecordingCommand = command as? StopRecordingCommand,
+        assertSnapshotCommand = command as? AssertSnapshotCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -133,6 +135,7 @@ data class MaestroCommand(
         travelCommand != null -> travelCommand
         startRecordingCommand != null -> startRecordingCommand
         stopRecordingCommand != null -> stopRecordingCommand
+        assertSnapshotCommand != null -> assertSnapshotCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertSnapshot.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertSnapshot.kt
@@ -1,0 +1,40 @@
+/*
+ *
+ *  Copyright (c) 2022 mobile.dev inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlAssertSnapshot(
+    val path: String,
+    val threshold: String? = null,
+) {
+
+    companion object {
+
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(path: String): YamlAssertSnapshot {
+            return YamlAssertSnapshot(
+                path = path,
+                threshold = null,
+            )
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -24,6 +24,7 @@ import maestro.KeyCode
 import maestro.Point
 import maestro.TapRepeat
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.AssertSnapshotCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
 import maestro.orchestra.Condition
@@ -99,6 +100,7 @@ data class YamlFluentCommand(
     val travel: YamlTravelCommand? = null,
     val startRecording: YamlStartRecording? = null,
     val stopRecording: YamlStopRecording? = null,
+    val assertSnapshot: YamlAssertSnapshot? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -217,6 +219,7 @@ data class YamlFluentCommand(
                 val tapRepeat = TapRepeat(2, delay)
                 listOf(tapCommand(doubleTapOn, tapRepeat = tapRepeat))
             }
+            assertSnapshot != null -> listOf(assertSnapshot(assertSnapshot))
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }
     }
@@ -374,6 +377,15 @@ data class YamlFluentCommand(
                 stopApp = command.stopApp,
                 permissions = command.permissions,
                 launchArguments = command.arguments,
+            )
+        )
+    }
+
+    private fun assertSnapshot(command: YamlAssertSnapshot): MaestroCommand {
+        return MaestroCommand(
+            AssertSnapshotCommand(
+                path = command.path,
+                threshold = command.threshold,
             )
         )
     }


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99cbba9</samp>

This pull request adds a new feature to the maestro-orchestra module that allows users to compare screenshots with reference images using a new command type, `AssertSnapshotCommand`. It also adds support for this command type in the `MaestroCommand` sealed class, the `Orchestra` class, and the YAML syntax. It modifies the `maestro-orchestra-models` and `maestro-orchestra` modules to handle and execute this new command type.

The proposed YAML syntax and the comparison algorithm (right now its a simple pixel by pixel comparison) are open to suggestions. I haven't written tests, as the API or the implementation is not finalized yet.

You pass in a screenshot file path that you want the current screen to be compared against. You can also specify a threshold value, for example 98% meaning the images should have the same pixel across 98% of the image and only a 2% variation is allowed. This property is optional and if not declared, will be assumed to be a perfect match.

I'm new to Kotlin, so feel free to point out any silly mistakes I might have made.

## Testing
Manually tested changes with different combinations of yaml

```yaml
appId: com.apple.Preferences
---
- launchApp
- assertVisible: "Screen Time"
- assertVisible: "General"
- assertSnapshot:
    path: "test.png"
    threshold: "98%" 
```

```yaml
appId: com.apple.Preferences
---
- launchApp
- assertVisible: "Screen Time"
- assertVisible: "General"
- assertSnapshot:
    path: "test.png"
```

```yaml
appId: com.apple.Preferences
---
- launchApp
- assertVisible: "Screen Time"
- assertVisible: "General"
- assertSnapshot: "test.png"
```

## Issues Fixed

Added primary support for snapshot testing
