### PR TITLE
Feature: add new studio CommandLine

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -35,6 +35,12 @@ class StudioCommand : Callable<Int> {
     )
     private var debugOutput: String? = null
 
+    @CommandLine.Option(
+        names = ["--auto-browser"],
+        description = ["Configures automatically start browser, default is true"]
+    )
+    private var autoBrowser: Boolean? = true
+
     override fun call(): Int {
         if (parent?.platform != null) {
             throw CliError("--platform option was deprecated. You can remove it to run your test.")
@@ -65,7 +71,7 @@ class StudioCommand : Callable<Int> {
 
     private fun tryOpenUrl(studioUrl: String) {
         try {
-            if (Desktop.isDesktopSupported()) {
+            if (Desktop.isDesktopSupported() && autoBrowser) {
                 Desktop.getDesktop().browse(URI(studioUrl))
             }
         } catch (ignore: Exception) {

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -88,6 +88,12 @@ class TestCommand : Callable<Int> {
     private var debugOutput: String? = null
 
     @Option(
+        names = ["--auto-browser"],
+        description = ["Configures automatically start browser, default is true"]
+    )
+    private var autoBrowser: Boolean? = true
+
+    @Option(
         names = ["--include-tags"],
         description = ["List of tags that will remove the Flows that does not have the provided tags"],
         split = ",",
@@ -151,6 +157,7 @@ class TestCommand : Callable<Int> {
                     device = device,
                     reporter = ReporterFactory.buildReporter(format, testSuiteName),
                     includeTags = includeTags,
+                    autoBrowser = autoBrowser,
                     excludeTags = excludeTags,
                 ).runTestSuite(
                     input = flowFile,


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0dc0e91</samp>

Add a `--no-browser` option to the `StudioCommand` to skip opening the browser when launching the Maestro Studio. Refactor the `tryOpenUrl` method in `maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt` to use this option.

Hello author, I have encountered a scene that I hope to integrate into vscode in the form of plug-ins, but when I start Maestro Studio, the browser will start and load the page uncontrollably, which I personally think may not be very friendly, I hope this place can give me free control.

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
