### PR TITLE
Use Server-Sent Events instead of custom long-polling in Maestro Studio

### DIFF
--- a/maestro-studio/server/src/main/java/maestro/studio/Models.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/Models.kt
@@ -48,6 +48,5 @@ data class ReplCommand(
 )
 
 data class Repl(
-    val version: Int,
     val commands: List<ReplCommand>,
 )

--- a/maestro-studio/web/package-lock.json
+++ b/maestro-studio/web/package-lock.json
@@ -37,7 +37,7 @@
         "react-icons": "^4.9.0",
         "react-router-dom": "^6.8.1",
         "react-scripts": "5.0.1",
-        "swr": "^2.0.0",
+        "swr": "^2.1.5",
         "tailwind-merge": "^1.13.2",
         "typescript": "^4.9.3",
         "web-vitals": "^2.1.4",
@@ -31477,14 +31477,12 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.0.tgz",
-      "integrity": "sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.1.tgz",
+      "integrity": "sha512-KJVA7dGtOBeZ+2sycEuzUfVIP5lZ/cd0xjevv85n2YG0x1uHJQicjAtahVZL6xG3+TjqhbBqimwYzVo3saeVXQ==",
       "dependencies": {
+        "client-only": "^0.0.1",
         "use-sync-external-store": "^1.2.0"
-      },
-      "engines": {
-        "pnpm": "7"
       },
       "peerDependencies": {
         "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
@@ -57579,10 +57577,11 @@
       }
     },
     "swr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.0.0.tgz",
-      "integrity": "sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.1.tgz",
+      "integrity": "sha512-KJVA7dGtOBeZ+2sycEuzUfVIP5lZ/cd0xjevv85n2YG0x1uHJQicjAtahVZL6xG3+TjqhbBqimwYzVo3saeVXQ==",
       "requires": {
+        "client-only": "^0.0.1",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/maestro-studio/web/package-lock.json
+++ b/maestro-studio/web/package-lock.json
@@ -59,7 +59,7 @@
         "@types/react-beautiful-dnd": "^13.1.4",
         "autoprefixer": "^10.4.13",
         "babel-plugin-named-exports-order": "^0.0.2",
-        "msw": "^0.49.2",
+        "msw": "^0.0.0-fetch.rc-16",
         "postcss": "^8.4.19",
         "prop-types": "^15.8.1",
         "storybook-addon-react-router-v6": "^0.2.1",
@@ -2102,6 +2102,33 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "node_modules/@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "dependencies": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/js-levenshtein": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
+      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
+      "dev": true,
+      "dependencies": {
+        "js-levenshtein": "^1.1.6"
+      }
+    },
+    "node_modules/@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "dependencies": {
+        "statuses": "^2.0.1"
+      }
+    },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -3799,35 +3826,29 @@
       "dev": true
     },
     "node_modules/@mswjs/cookies": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
-      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
+      "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
       "dev": true,
-      "dependencies": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.6.tgz",
-      "integrity": "sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.23.0.tgz",
+      "integrity": "sha512-JytvDa7pBbxXvCTXBYQs+0eE6MqxpqH/H4peRNY6zVAlvJ6d/hAWLHAef1D9lWN4zuIigN0VkakGOAUrX7FWLg==",
       "dev": true,
       "dependencies": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
+        "@open-draft/deferred-promise": "^2.1.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
         "headers-polyfill": "^3.1.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
+        "strict-event-emitter": "^0.5.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@mui/base": {
@@ -4170,10 +4191,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.1.0.tgz",
+      "integrity": "sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA==",
+      "dev": true
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
     "node_modules/@open-draft/until": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
-      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -12483,15 +12520,6 @@
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dev": true,
-      "dependencies": {
-        "@types/ms": "*"
-      }
-    },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -12669,12 +12697,6 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
-    "node_modules/@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
-    },
     "node_modules/@types/node": {
       "version": "16.18.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
@@ -12838,15 +12860,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/set-cookie-parser": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
-      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/sockjs": {
       "version": "0.3.33",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
@@ -12865,6 +12878,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-vVRgv7WXbhIZzILgr58b4Ki2uqpN/dlVCUBWCMkPbMDlV1CrQrgCl5hnIoUlMrgymGcTmdfVqbs1yWj/IRIRtQ==",
+      "dev": true
     },
     "node_modules/@types/tapable": {
       "version": "1.0.8",
@@ -13430,15 +13449,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
-      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -13448,13 +13458,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
-    },
-    "node_modules/@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "dev": true,
-      "optional": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -19567,6 +19570,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -20077,9 +20093,9 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "node_modules/graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "version": "16.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
+      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -21329,21 +21345,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -21399,9 +21400,9 @@
       }
     },
     "node_modules/is-node-process": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
-      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true
     },
     "node_modules/is-number": {
@@ -25080,29 +25081,33 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/msw": {
-      "version": "0.49.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.49.2.tgz",
-      "integrity": "sha512-70/E10f+POE2UmMw16v8PnKatpZplpkUwVRLBqiIdimpgaC3le7y2yOq9JmOrL15jpwWM5wAcPTOj0f550LI3g==",
+      "version": "0.0.0-fetch.rc-16",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.0.0-fetch.rc-16.tgz",
+      "integrity": "sha512-tJP4a9FIEpiZuLxSNxRk9AnceqHhFosPCL/pjN5n1EgN6OfXONmYDRzjMqOo6EOEuiHPVOgofaL1FM89Z9NATQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.0.0",
+        "@mswjs/interceptors": "^0.23.0",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.0",
+        "formdata-node": "4.4.1",
+        "graphql": "^15.0.0 || ^16.7.0",
+        "headers-polyfill": "^3.1.2",
         "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^2.6.7",
-        "outvariant": "^1.3.0",
+        "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.2.6",
+        "strict-event-emitter": "^0.5.0",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -25110,14 +25115,14 @@
         "msw": "cli/index.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mswjs"
       },
       "peerDependencies": {
-        "typescript": ">= 4.4.x <= 4.9.x"
+        "typescript": ">= 4.4.x <= 5.1.x"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -25141,9 +25146,9 @@
       }
     },
     "node_modules/msw/node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -25187,15 +25192,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/msw/node_modules/cookie": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/msw/node_modules/has-flag": {
       "version": "4.0.0",
@@ -25375,6 +25371,25 @@
       },
       "engines": {
         "node": ">= 0.10.5"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -26059,9 +26074,9 @@
       }
     },
     "node_modules/outvariant": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.3.0.tgz",
-      "integrity": "sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
       "dev": true
     },
     "node_modules/p-all": {
@@ -30263,12 +30278,6 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
-    "node_modules/set-cookie-parser": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
-      "dev": true
-    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -31086,13 +31095,10 @@
       "dev": true
     },
     "node_modules/strict-event-emitter": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
-      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
-      "dev": true,
-      "dependencies": {
-        "events": "^3.3.0"
-      }
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.0.tgz",
+      "integrity": "sha512-sqnMpVJLSB3daNO6FcvsEk4Mq5IJeAwDeH80DP1S8+pgxrF6yZnE1+VeapesGled7nEcIkz1Ax87HzaIy+02kA==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -33188,31 +33194,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dev": true,
-      "dependencies": {
-        "util": "^0.12.3"
-      },
-      "optionalDependencies": {
-        "@zxing/text-encoding": "0.9.0"
-      }
-    },
-    "node_modules/web-encoding/node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
@@ -33221,6 +33202,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/web-vitals": {
@@ -35649,6 +35639,33 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
     },
+    "@bundled-es-modules/cookie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.0.tgz",
+      "integrity": "sha512-Or6YHg/kamKHpxULAdSqhGqnWFneIXu1NKvvfBBzKGwpVsYuFIQ5aBPHDnnoR3ghW1nvSkALd+EF9iMtY7Vjxw==",
+      "dev": true,
+      "requires": {
+        "cookie": "^0.5.0"
+      }
+    },
+    "@bundled-es-modules/js-levenshtein": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/js-levenshtein/-/js-levenshtein-2.0.1.tgz",
+      "integrity": "sha512-DERMS3yfbAljKsQc0U2wcqGKUWpdFjwqWuoMugEJlqBnKO180/n+4SR/J8MRDt1AN48X1ovgoD9KrdVXcaa3Rg==",
+      "dev": true,
+      "requires": {
+        "js-levenshtein": "^1.1.6"
+      }
+    },
+    "@bundled-es-modules/statuses": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/statuses/-/statuses-1.0.1.tgz",
+      "integrity": "sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==",
+      "dev": true,
+      "requires": {
+        "statuses": "^2.0.1"
+      }
+    },
     "@cnakazawa/watch": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
@@ -36884,29 +36901,23 @@
       }
     },
     "@mswjs/cookies": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.2.2.tgz",
-      "integrity": "sha512-mlN83YSrcFgk7Dm1Mys40DLssI1KdJji2CMKN8eOlBqsTADYzj2+jWzsANsUTFbxDMWPD5e9bfA1RGqBpS3O1g==",
-      "dev": true,
-      "requires": {
-        "@types/set-cookie-parser": "^2.4.0",
-        "set-cookie-parser": "^2.4.6"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-1.0.0.tgz",
+      "integrity": "sha512-TdXoBdI+h/EDTsVLCX/34s4+9U0sWi92qFnIGUEikpMCSKLhBeujovyYVSoORNbYgsBH5ga7/tfxyWcEZAxiYA==",
+      "dev": true
     },
     "@mswjs/interceptors": {
-      "version": "0.17.6",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.17.6.tgz",
-      "integrity": "sha512-201pBIWehTURb6q8Gheu4Zhvd3Ox1U4BJq5KiOQsYzkWyfiOG4pwcz5hPZIEryztgrf8/sdwABpvY757xMmfrQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.23.0.tgz",
+      "integrity": "sha512-JytvDa7pBbxXvCTXBYQs+0eE6MqxpqH/H4peRNY6zVAlvJ6d/hAWLHAef1D9lWN4zuIigN0VkakGOAUrX7FWLg==",
       "dev": true,
       "requires": {
-        "@open-draft/until": "^1.0.3",
-        "@types/debug": "^4.1.7",
-        "@xmldom/xmldom": "^0.8.3",
-        "debug": "^4.3.3",
+        "@open-draft/deferred-promise": "^2.1.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
         "headers-polyfill": "^3.1.0",
         "outvariant": "^1.2.1",
-        "strict-event-emitter": "^0.2.4",
-        "web-encoding": "^1.1.5"
+        "strict-event-emitter": "^0.5.0"
       }
     },
     "@mui/base": {
@@ -37110,10 +37121,26 @@
         }
       }
     },
+    "@open-draft/deferred-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.1.0.tgz",
+      "integrity": "sha512-Rzd5JrXZX8zErHzgcGyngh4fmEbSHqTETdGj9rXtejlqMIgXFlyKBA7Jn1Xp0Ls0M0Y22+xHcWiEzbmdWl0BOA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
     "@open-draft/until": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
-      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
@@ -43269,15 +43296,6 @@
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==",
       "dev": true
     },
-    "@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
-      "dev": true,
-      "requires": {
-        "@types/ms": "*"
-      }
-    },
     "@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -43455,12 +43473,6 @@
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
       "dev": true
     },
-    "@types/ms": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
-    },
     "@types/node": {
       "version": "16.18.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.4.tgz",
@@ -43624,15 +43636,6 @@
         "@types/node": "*"
       }
     },
-    "@types/set-cookie-parser": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
-      "integrity": "sha512-fBZgytwhYAUkj/jC/FAV4RQ5EerRup1YQsXQCh8rZfiHkc4UahC192oH0smGwsXol3cL3A5oETuAHeQHmhXM4w==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/sockjs": {
       "version": "0.3.33",
       "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
@@ -43651,6 +43654,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "@types/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-vVRgv7WXbhIZzILgr58b4Ki2uqpN/dlVCUBWCMkPbMDlV1CrQrgCl5hnIoUlMrgymGcTmdfVqbs1yWj/IRIRtQ==",
+      "dev": true
     },
     "@types/tapable": {
       "version": "1.0.8",
@@ -44117,12 +44126,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "@xmldom/xmldom": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
-      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
-      "dev": true
-    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -44132,13 +44135,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
-    },
-    "@zxing/text-encoding": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
-      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
-      "dev": true,
-      "optional": true
     },
     "abab": {
       "version": "2.0.6",
@@ -48837,6 +48833,16 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "dev": true,
+      "requires": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -49230,9 +49236,9 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
     },
     "graphql": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
-      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
+      "version": "16.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
+      "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
       "dev": true
     },
     "gzip-size": {
@@ -50146,15 +50152,6 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="
     },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -50191,9 +50188,9 @@
       "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
     },
     "is-node-process": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.0.1.tgz",
-      "integrity": "sha512-5IcdXuf++TTNt3oGl9EBdkvndXA8gmc4bz/Y+mdEpWh3Mcn/+kOw6hI7LD5CocqJWMzeb0I0ClndRVNdEPuJXQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true
     },
     "is-number": {
@@ -52926,28 +52923,32 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msw": {
-      "version": "0.49.2",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-0.49.2.tgz",
-      "integrity": "sha512-70/E10f+POE2UmMw16v8PnKatpZplpkUwVRLBqiIdimpgaC3le7y2yOq9JmOrL15jpwWM5wAcPTOj0f550LI3g==",
+      "version": "0.0.0-fetch.rc-16",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.0.0-fetch.rc-16.tgz",
+      "integrity": "sha512-tJP4a9FIEpiZuLxSNxRk9AnceqHhFosPCL/pjN5n1EgN6OfXONmYDRzjMqOo6EOEuiHPVOgofaL1FM89Z9NATQ==",
       "dev": true,
       "requires": {
-        "@mswjs/cookies": "^0.2.2",
-        "@mswjs/interceptors": "^0.17.5",
-        "@open-draft/until": "^1.0.3",
+        "@bundled-es-modules/cookie": "^2.0.0",
+        "@bundled-es-modules/js-levenshtein": "^2.0.1",
+        "@bundled-es-modules/statuses": "^1.0.1",
+        "@mswjs/cookies": "^1.0.0",
+        "@mswjs/interceptors": "^0.23.0",
+        "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.4.1",
         "@types/js-levenshtein": "^1.1.1",
-        "chalk": "4.1.1",
+        "@types/statuses": "^2.0.1",
+        "chalk": "^4.1.2",
         "chokidar": "^3.4.2",
-        "cookie": "^0.4.2",
-        "graphql": "^15.0.0 || ^16.0.0",
-        "headers-polyfill": "^3.1.0",
+        "formdata-node": "4.4.1",
+        "graphql": "^15.0.0 || ^16.7.0",
+        "headers-polyfill": "^3.1.2",
         "inquirer": "^8.2.0",
-        "is-node-process": "^1.0.1",
+        "is-node-process": "^1.2.0",
         "js-levenshtein": "^1.1.6",
         "node-fetch": "^2.6.7",
-        "outvariant": "^1.3.0",
+        "outvariant": "^1.4.0",
         "path-to-regexp": "^6.2.0",
-        "strict-event-emitter": "^0.2.6",
+        "strict-event-emitter": "^0.5.0",
         "type-fest": "^2.19.0",
         "yargs": "^17.3.1"
       },
@@ -52962,9 +52963,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -52995,12 +52996,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "cookie": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-          "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
           "dev": true
         },
         "has-flag": {
@@ -53148,6 +53143,12 @@
       "requires": {
         "minimatch": "^3.0.2"
       }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "dev": true
     },
     "node-fetch": {
       "version": "2.6.7",
@@ -53679,9 +53680,9 @@
       "dev": true
     },
     "outvariant": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.3.0.tgz",
-      "integrity": "sha512-yeWM9k6UPfG/nzxdaPlJkB2p08hCg4xP6Lx99F+vP8YF7xyZVfTmJjrrNalkmzudD4WFvNLVudQikqUmF8zhVQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.0.tgz",
+      "integrity": "sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==",
       "dev": true
     },
     "p-all": {
@@ -56597,12 +56598,6 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
-    "set-cookie-parser": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.5.1.tgz",
-      "integrity": "sha512-1jeBGaKNGdEq4FgIrORu/N570dwoPYio8lSoYLWmX7sQ//0JY08Xh9o5pBcgmHQ/MbsYp/aZnOe1s1lIsbLprQ==",
-      "dev": true
-    },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -57279,13 +57274,10 @@
       "dev": true
     },
     "strict-event-emitter": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.2.8.tgz",
-      "integrity": "sha512-KDf/ujU8Zud3YaLtMCcTI4xkZlZVIYxTLr+XIULexP+77EEVWixeXroLUXQXiVtH4XH2W7jr/3PT1v3zBuvc3A==",
-      "dev": true,
-      "requires": {
-        "events": "^3.3.0"
-      }
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.0.tgz",
+      "integrity": "sha512-sqnMpVJLSB3daNO6FcvsEk4Mq5IJeAwDeH80DP1S8+pgxrF6yZnE1+VeapesGled7nEcIkz1Ax87HzaIy+02kA==",
+      "dev": true
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -58899,35 +58891,16 @@
         "defaults": "^1.0.3"
       }
     },
-    "web-encoding": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
-      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
-      "dev": true,
-      "requires": {
-        "@zxing/text-encoding": "0.9.0",
-        "util": "^0.12.3"
-      },
-      "dependencies": {
-        "util": {
-          "version": "0.12.5",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "is-arguments": "^1.0.4",
-            "is-generator-function": "^1.0.7",
-            "is-typed-array": "^1.1.3",
-            "which-typed-array": "^1.1.2"
-          }
-        }
-      }
-    },
     "web-namespaces": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz",
       "integrity": "sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==",
+      "dev": true
+    },
+    "web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
       "dev": true
     },
     "web-vitals": {

--- a/maestro-studio/web/package.json
+++ b/maestro-studio/web/package.json
@@ -32,7 +32,7 @@
     "react-icons": "^4.9.0",
     "react-router-dom": "^6.8.1",
     "react-scripts": "5.0.1",
-    "swr": "^2.0.0",
+    "swr": "^2.1.5",
     "tailwind-merge": "^1.13.2",
     "typescript": "^4.9.3",
     "web-vitals": "^2.1.4",

--- a/maestro-studio/web/package.json
+++ b/maestro-studio/web/package.json
@@ -90,7 +90,7 @@
     "@types/react-beautiful-dnd": "^13.1.4",
     "autoprefixer": "^10.4.13",
     "babel-plugin-named-exports-order": "^0.0.2",
-    "msw": "^0.49.2",
+    "msw": "^0.0.0-fetch.rc-16",
     "postcss": "^8.4.19",
     "prop-types": "^15.8.1",
     "storybook-addon-react-router-v6": "^0.2.1",

--- a/maestro-studio/web/src/api/api.ts
+++ b/maestro-studio/web/src/api/api.ts
@@ -61,21 +61,15 @@ const useRepl = (): ReplResponse => {
   return { repl, error };
 };
 
+const useDeviceScreen = (): { deviceScreen?: DeviceScreen, error?: any } => {
+  const { data: deviceScreen, error } = useSse<DeviceScreen>('/api/device-screen/sse')
+  return { deviceScreen, error };
+};
+
 const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 export const API = {
-  useDeviceScreen: (
-    config?: SWRConfiguration<DeviceScreen>
-  ): SWRResponse<DeviceScreen> => {
-    return useSWR(
-      "/api/device-screen",
-      (url) => makeRequest("GET", url),
-      config
-    );
-  },
-  getDeviceScreen: async (): Promise<DeviceScreen> => {
-    return makeRequest("GET", `/api/device-screen`);
-  },
+  useDeviceScreen,
   useBannerMessage: (
     config?: SWRConfiguration<BannerMessage>
   ): SWRResponse<BannerMessage> => {

--- a/maestro-studio/web/src/api/mocks.ts
+++ b/maestro-studio/web/src/api/mocks.ts
@@ -1,7 +1,8 @@
-import { ResponseComposition, rest, RestContext, setupWorker } from "msw";
+import { delay, http } from "msw";
 import { DeviceScreen, MockEvent, ReplCommand } from "../helpers/models";
 import { sampleElements } from "../helpers/sampleElements";
 import { wait } from "./api";
+import { setupWorker } from 'msw/browser';
 
 export const mockDeviceScreen: DeviceScreen = {
   screenshot: "/sample-screenshot.png",
@@ -14,14 +15,11 @@ let nextId = 0;
 let version = 0;
 let commands: ReplCommand[] = [];
 
-const replResponse = (res: ResponseComposition, ctx: RestContext) => {
-  return res(
-    ctx.status(200),
-    ctx.json({
-      version,
-      commands,
-    })
-  );
+const replResponse = () => {
+  return new Response(JSON.stringify({
+    version,
+    commands,
+  }));
 };
 
 const runCommands = async (ids: string[]) => {
@@ -58,37 +56,37 @@ const createCommand = (yaml: string) => {
 };
 
 const handlers = [
-  rest.get("/api/repl/watch", async (req, res, ctx) => {
-    const currentVersionParam = req.url.searchParams.get("currentVersion");
-    if (currentVersionParam === null) return res(ctx.status(400));
+  http.get("/api/repl/sse", async ({ request }) => {
+    const currentVersionParam = new URL(request.url).searchParams.get("currentVersion");
+    if (currentVersionParam === null) return new Response(null, { status: 400 })
     const requestVersion = parseInt(currentVersionParam);
     while (requestVersion >= version) {
       await wait(200);
     }
-    return replResponse(res, ctx);
+    return replResponse();
   }),
-  rest.post("/api/repl/command", async (req, res, ctx) => {
-    const { yaml, ids }: { yaml?: string; ids?: string[] } = await req.json();
+  http.post<any, any>("/api/repl/command", async ({ request }) => {
+    const { yaml, ids }: { yaml?: string; ids?: string[] } = await request.json();
     if (yaml) {
       if (yaml.includes("error")) {
-        return res(ctx.status(400), ctx.text("Invalid command"));
+        return new Response("Invalid command", { status: 400 })
       }
       createCommand(yaml);
     } else if (ids) {
       runCommands(ids);
     } else {
-      return res(ctx.status(400));
+      return new Response(null, { status: 400 })
     }
-    return replResponse(res, ctx);
+    return replResponse();
   }),
-  rest.delete("/api/repl/command", async (req, res, ctx) => {
-    const { ids }: { ids: string[] } = await req.json();
+  http.delete<any, any>("/api/repl/command", async ({ request }) => {
+    const { ids }: { ids: string[] } = await request.json();
     commands = commands.filter((c) => !ids.includes(c.id));
     version++;
-    return replResponse(res, ctx);
+    return replResponse();
   }),
-  rest.post("/api/repl/command/reorder", async (req, res, ctx) => {
-    const { ids }: { ids: string[] } = await req.json();
+  http.post<any, any>("/api/repl/command/reorder", async ({ request }) => {
+    const { ids }: { ids: string[] } = await request.json();
     const newCommands: ReplCommand[] = [];
     ids.forEach((id) => {
       const command = commands.find((c) => c.id === id);
@@ -102,26 +100,24 @@ const handlers = [
     await wait(30);
     commands = newCommands;
     version++;
-    return replResponse(res, ctx);
+    return replResponse();
   }),
-  rest.get("/api/device-screen", (req, res, ctx) => {
-    return res(ctx.delay(500), ctx.status(200), ctx.json(mockDeviceScreen));
+  http.get("/api/device-screen", async () => {
+    await delay(500)
+    return new Response(JSON.stringify(mockDeviceScreen))
   }),
-  rest.post("/api/repl/command/format", async (req, res, ctx) => {
-    const { ids }: { ids: string[] } = await req.json();
+  http.post<any, any>("/api/repl/command/format", async ({ request }) => {
+    const { ids }: { ids: string[] } = await request.json();
     const contentString = commands
       .filter((c) => ids.includes(c.id))
       .map((c) => (c.yaml.endsWith("\n") ? c.yaml : `${c.yaml}\n`))
       .join("");
-    return res(
-      ctx.status(200),
-      ctx.json({
-        config: "appId: com.example.app",
-        commands: contentString,
-      })
-    );
+    return new Response(JSON.stringify({
+      config: "appId: com.example.app",
+      commands: contentString,
+    }))
   }),
-  rest.get("/api/mock-server/data", (req, res, ctx) => {
+  http.get("/api/mock-server/data", async () => {
     const projectId = "1803cbd0-7258-4878-a16c-1ef0022d2f4a";
     const sessions = [
       "9c4e5640-eaa8-4c81-94b4-efa96192dfd5",
@@ -167,23 +163,18 @@ const handlers = [
       events.push(event);
     }
 
-    return res(
-      ctx.delay(500),
-      ctx.status(200),
-      ctx.json({
-        projectId,
-        events,
-      })
-    );
+    await delay(500)
+
+    return new Response(JSON.stringify({
+      projectId,
+      events,
+    }))
   }),
-  rest.get("/api/banner-message", (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({
-        level: 'warning',
-        message: 'Retrieving the hierarchy is taking longer than usual. This might be due to a deep hierarchy in the current view. Please wait a bit more to complete the operation.',
-      })
-    )
+  http.get("/api/banner-message", () => {
+    return new Response(JSON.stringify({
+      level: 'warning',
+      message: 'Retrieving the hierarchy is taking longer than usual. This might be due to a deep hierarchy in the current view. Please wait a bit more to complete the operation.',
+    }))
   })
 ];
 

--- a/maestro-studio/web/src/helpers/models.ts
+++ b/maestro-studio/web/src/helpers/models.ts
@@ -38,7 +38,6 @@ export type ReplCommand = {
 }
 
 export type Repl = {
-  version: number
   commands: ReplCommand[]
 }
 

--- a/maestro-studio/web/src/pages/InteractPage.tsx
+++ b/maestro-studio/web/src/pages/InteractPage.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import clsx from "clsx";
 
 import InteractableDevice from "../components/device-and-device-elements/InteractableDevice";
 import ReplView from "../components/commands/ReplView";
-import { DeviceScreen, UIElement } from "../helpers/models";
-import { API, wait } from "../api/api";
+import { UIElement } from "../helpers/models";
+import { API } from "../api/api";
 import ActionModal from "../components/device-and-device-elements/ActionModal";
 import { CommandExample } from "../helpers/commandExample";
 import ElementsPanel from "../components/device-and-device-elements/ElementsPanel";
@@ -13,7 +13,7 @@ import DeviceWrapperAspectRatio from "../components/device-and-device-elements/D
 
 const InteractPage = () => {
   const [showElementsPanel, setShowElementsPanel] = useState<boolean>(false);
-  const [deviceScreen, setDeviceScreen] = useState<DeviceScreen>();
+  const { deviceScreen } = API.useDeviceScreen();
   const [input, setInput] = useState("");
   const [footerHint, setFooterHint] = useState<string | null>();
   const [hoveredElement, setHoveredElement] = useState<UIElement | null>(null);
@@ -41,24 +41,6 @@ const InteractPage = () => {
     API.repl.runCommand(example.content);
     setInspectedElementId(null);
   };
-
-  useEffect(() => {
-    let running = true;
-    (async () => {
-      while (running) {
-        try {
-          const deviceScreen = await API.getDeviceScreen();
-          setDeviceScreen(deviceScreen);
-        } catch (e) {
-          console.error(e);
-          await wait(1000);
-        }
-      }
-    })();
-    return () => {
-      running = false;
-    };
-  }, [setDeviceScreen]);
 
   if (!deviceScreen) return null;
 


### PR DESCRIPTION
## Impact
* Maestro Studio can now run in multiple tabs simultaneously
* Improves Maestro Studio performance

## Background
* Custom long-polling was causing simultaneous API calls to hang (mostly in Chrome)
* Switching to Server-Sent Events instead
* In order to mock SSEs we need to upgrade MSW to the fetch release candidate version. Context: https://github.com/mswjs/msw/blob/feat/standard-api/MIGRATING.md#support-readablestream-mocked-responses
