### PR TITLE
Fix creating connections

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -157,9 +157,9 @@ class IOSDriver(
 
     fun viewHierarchy(): TreeNode {
         LOGGER.info("Requesting view hierarchy of the screen")
-        val hierarchyResult = iosDevice.viewHierarchy().get()
-        LOGGER.info("Depth of the screen is ${hierarchyResult?.depth ?: 0}")
-        if (hierarchyResult?.depth != null && hierarchyResult.depth > WARNING_MAX_DEPTH) {
+        val hierarchyResult = iosDevice.viewHierarchy().expect {  }
+        LOGGER.info("Depth of the screen is ${hierarchyResult.depth}")
+        if (hierarchyResult.depth > WARNING_MAX_DEPTH) {
             val message = "The view hierarchy has been calculated. The current depth of the hierarchy " +
                     "is ${hierarchyResult.depth}. This might affect the execution time of your test. " +
                     "If you are using React native, consider migrating to the new " +
@@ -169,7 +169,7 @@ class IOSDriver(
         } else {
             Insights.report(Insight("", Insight.Level.NONE))
         }
-        val hierarchy = hierarchyResult?.axElement ?: return TreeNode()
+        val hierarchy = hierarchyResult.axElement
         return mapViewHierarchy(hierarchy)
     }
 

--- a/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
+++ b/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
@@ -40,7 +40,7 @@ class XCTestDriverClientTest {
         assertThat(response.message).contains(
             "A timeout occurred while waiting for a response from the XCUITest server."
         )
-        mockXCTestInstaller.assertInstallationRetries(3)
+        mockXCTestInstaller.assertInstallationRetries(5)
         mockWebServer.shutdown()
     }
 
@@ -179,6 +179,6 @@ class XCTestDriverClientTest {
         assertThat(networkErrorModel.userFriendlyMessage).contains(
             "Unable to establish a connection to the XCUITest server."
         )
-        mockXCTestInstaller.assertInstallationRetries(3)
+        mockXCTestInstaller.assertInstallationRetries(5)
     }
 }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/api/NetworkErrorHandler.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/api/NetworkErrorHandler.kt
@@ -21,7 +21,7 @@ class NetworkErrorHandler(
     companion object {
         const val RETRY_RESPONSE_CODE = 503
         private const val NO_RETRY_RESPONSE_CODE = 502
-        private const val MAX_RETRY = 3
+        private const val MAX_RETRY = 5
         private val mapper = jacksonObjectMapper()
     }
 

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -56,7 +56,7 @@ class XCTestIOSDevice(
         val result = runCatching {
             val viewHierarchy = client.viewHierarchy(installedApps)
             DepthTracker.trackDepth(viewHierarchy.depth)
-            logger.info("Using new viewHierarchy call to get view hierarchy. Depth received: ${viewHierarchy.depth}")
+            logger.info("Depth received: ${viewHierarchy.depth}")
             viewHierarchy
         }
         return result


### PR DESCRIPTION
## Proposed Changes

1. Catching IOException in The `XCTestClient#ensureOpen` call which only caught connectException but driver is really going to be ready when it doesn't have any IOException on a call
2. Increase the retries to 5 instead, since I saw 4 is enough
3. Change call to expect instead of get() which gives null

## Testing
- [x] Local
- [ ] Staging

## Issues Fixed
