### PR TITLE
Error message improvements

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -19,29 +19,16 @@
 
 package maestro.cli
 
-import maestro.cli.command.BugReportCommand
-import maestro.cli.command.CloudCommand
-import maestro.cli.command.DownloadSamplesCommand
-import maestro.cli.command.LoginCommand
-import maestro.cli.command.LogoutCommand
-import maestro.cli.command.PrintHierarchyCommand
-import maestro.cli.command.QueryCommand
-import maestro.cli.command.RecordCommand
-import maestro.cli.command.StudioCommand
-import maestro.cli.command.TestCommand
-import maestro.cli.command.UploadCommand
+import maestro.cli.command.*
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.update.Updates
 import maestro.cli.util.ErrorReporter
 import maestro.cli.view.box
 import maestro.debuglog.DebugLogStore
-import maestro.debuglog.LogConfig
-import org.slf4j.LoggerFactory
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
-import java.util.Properties
-import kotlin.io.path.absolutePathString
+import java.util.*
 import kotlin.system.exitProcess
 
 @Command(
@@ -94,9 +81,6 @@ fun main(args: Array<String>) {
     // https://stackoverflow.com/a/17544259
     System.setProperty("apple.awt.UIElement", "true")
 
-    // logs & debug output
-    val logger = LoggerFactory.getLogger(App::class.java)
-
     Dependencies.install()
     Updates.fetchUpdatesAsync()
 
@@ -113,7 +97,6 @@ fun main(args: Array<String>) {
                 ex.stackTraceToString()
             }
 
-            logger.error(message)
             println()
             cmd.err.println(
                 cmd.colorScheme.errorText(message)

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -19,7 +19,19 @@
 
 package maestro.cli
 
-import maestro.cli.command.*
+import java.util.Properties
+import kotlin.system.exitProcess
+import maestro.cli.command.BugReportCommand
+import maestro.cli.command.CloudCommand
+import maestro.cli.command.DownloadSamplesCommand
+import maestro.cli.command.LoginCommand
+import maestro.cli.command.LogoutCommand
+import maestro.cli.command.PrintHierarchyCommand
+import maestro.cli.command.QueryCommand
+import maestro.cli.command.RecordCommand
+import maestro.cli.command.StudioCommand
+import maestro.cli.command.TestCommand
+import maestro.cli.command.UploadCommand
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.update.Updates
 import maestro.cli.util.ErrorReporter
@@ -28,8 +40,6 @@ import maestro.debuglog.DebugLogStore
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
-import java.util.*
-import kotlin.system.exitProcess
 
 @Command(
     name = "maestro",

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -30,7 +30,6 @@ import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import picocli.CommandLine
 import picocli.CommandLine.Option
 import java.io.File
-import java.nio.file.Files
 import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 
@@ -186,16 +185,11 @@ class CloudCommand : Callable<Int> {
     }
 
     private fun validateWorkSpace() {
-        val flowPath = flowsFile.toPath().toAbsolutePath()
-        if (Files.notExists(flowPath)) {
-            throw CliError("Flow file path $flowsFile does not exist")
-        }
-
         try {
             PrintUtils.message("Evaluating workspace...")
             WorkspaceExecutionPlanner
                 .plan(
-                    input = flowPath,
+                    input = flowsFile.toPath().toAbsolutePath(),
                     includeTags = includeTags,
                     excludeTags = excludeTags,
                 )

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -31,9 +31,9 @@ import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.runner.resultview.PlainTextResultView
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.util.PrintUtils
-import maestro.debuglog.DebugLogStore
-import maestro.debuglog.LogConfig
+import maestro.orchestra.error.ValidationError
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
+import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.yaml.YamlCommandReader
 import okio.buffer
 import okio.sink
@@ -114,15 +114,14 @@ class TestCommand : Callable<Int> {
     }
 
     override fun call(): Int {
-        if (!flowFile.exists()) {
-            throw CommandLine.ParameterException(
-                commandSpec.commandLine(),
-                "File not found: $flowFile"
-            )
-        }
-
         if (parent?.platform != null) {
             throw CliError("--platform option was deprecated. You can remove it to run your test.")
+        }
+
+        val executionPlan = try {
+            WorkspaceExecutionPlanner.plan(flowFile.toPath().toAbsolutePath(), includeTags, excludeTags)
+        } catch (e: ValidationError) {
+            throw CliError(e.message)
         }
 
         val deviceId =
@@ -150,10 +149,8 @@ class TestCommand : Callable<Int> {
                     maestro = maestro,
                     device = device,
                     reporter = ReporterFactory.buildReporter(format, testSuiteName),
-                    includeTags = includeTags,
-                    excludeTags = excludeTags,
                 ).runTestSuite(
-                    input = flowFile,
+                    executionPlan = executionPlan,
                     env = env,
                     reportOut = format.fileExtension
                         ?.let { extension ->

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -6,17 +6,11 @@ import maestro.cli.CliError
 import maestro.cli.device.Device
 import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
-import maestro.cli.report.CommandDebugMetadata
-import maestro.cli.report.FlowDebugMetadata
-import maestro.cli.report.ScreenshotDebugMetadata
-import maestro.cli.report.TestDebugReporter
-import maestro.cli.report.TestSuiteReporter
+import maestro.cli.report.*
 import maestro.cli.util.PrintUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
-import maestro.debuglog.DebugLogStore
-import maestro.debuglog.LogConfig
 import maestro.orchestra.Orchestra
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
@@ -24,7 +18,6 @@ import maestro.orchestra.yaml.YamlCommandReader
 import okio.Sink
 import org.slf4j.LoggerFactory
 import java.io.File
-import kotlin.io.path.absolutePathString
 import kotlin.math.roundToLong
 import kotlin.system.measureTimeMillis
 import kotlin.time.Duration.Companion.seconds
@@ -33,53 +26,20 @@ class TestSuiteInteractor(
     private val maestro: Maestro,
     private val device: Device? = null,
     private val reporter: TestSuiteReporter,
-    private val includeTags: List<String> = emptyList(),
-    private val excludeTags: List<String> = emptyList(),
 ) {
 
     private val logger = LoggerFactory.getLogger(TestSuiteInteractor::class.java)
 
     fun runTestSuite(
-        input: File,
-        reportOut: Sink?,
-        env: Map<String, String>,
-        debugOutput: String?
-    ): TestExecutionSummary {
-        return if (input.isFile) {
-            runTestSuite(
-                WorkspaceExecutionPlanner.ExecutionPlan(flowsToRun = listOf(input.toPath())),
-                reportOut,
-                env,
-                debugOutput
-            )
-        } else {
-            val plan = WorkspaceExecutionPlanner
-                .plan(
-                    input = input.toPath().toAbsolutePath(),
-                    includeTags = includeTags,
-                    excludeTags = excludeTags,
-                )
-            val flowFiles = plan.flowsToRun
-
-            if (flowFiles.isEmpty() && plan.sequence?.flows?.isEmpty() == true) {
-                throw CliError("No flows returned from the tag filter used")
-            }
-
-            runTestSuite(
-                plan,
-                reportOut,
-                env,
-                debugOutput
-            )
-        }
-    }
-
-    private fun runTestSuite(
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan,
         reportOut: Sink?,
         env: Map<String, String>,
         debugOutput: String?
     ): TestExecutionSummary {
+        if (executionPlan.flowsToRun.isEmpty() && executionPlan.sequence?.flows?.isEmpty() == true) {
+            throw CliError("No flows returned from the tag filter used")
+        }
+
         val flowResults = mutableListOf<TestExecutionSummary.FlowResult>()
 
         PrintUtils.message("Waiting for flows to complete...")

--- a/maestro-orchestra/build.gradle
+++ b/maestro-orchestra/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     api(libs.jackson.dataformat.yaml)
 
     testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junit.jupiter.params)
     testRuntimeOnly(libs.junit.jupiter.engine)
 
     testImplementation(libs.google.truth)
@@ -33,4 +34,5 @@ plugins.withId("com.vanniktech.maven.publish") {
 
 test {
     useJUnitPlatform()
+    environment("PROJECT_DIR", projectDir.absolutePath)
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/error/ValidationError.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/error/ValidationError.kt
@@ -1,0 +1,3 @@
+package maestro.orchestra.error
+
+open class ValidationError(override val message: String) : RuntimeException()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -1,15 +1,13 @@
 package maestro.orchestra.workspace
 
+import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
+import maestro.orchestra.error.ValidationError
 import maestro.orchestra.yaml.YamlCommandReader
 import java.nio.file.Files
 import java.nio.file.Path
-import kotlin.io.path.exists
-import kotlin.io.path.isRegularFile
-import kotlin.io.path.name
-import kotlin.io.path.nameWithoutExtension
-import kotlin.io.path.pathString
+import kotlin.io.path.*
 import kotlin.streams.toList
 
 object WorkspaceExecutionPlanner {
@@ -19,11 +17,29 @@ object WorkspaceExecutionPlanner {
         includeTags: List<String>,
         excludeTags: List<String>,
     ): ExecutionPlan {
+        if (input.notExists()) {
+            throw ValidationError("""
+                Flow path does not exist: ${input.absolutePathString()}
+            """.trimIndent())
+        }
+
         if (input.isRegularFile()) {
+            validateFlowFile(input)
             return ExecutionPlan(
                 flowsToRun = listOf(input),
             )
         }
+
+        // retrieve all Flow files
+
+        val unfilteredFlowFiles = Files.walk(input).filter(this::isFlowFile).toList()
+        if (unfilteredFlowFiles.isEmpty()) {
+            throw ValidationError("""
+                Flow directory does not contain any Flow files: ${input.absolutePathString()}
+            """.trimIndent())
+        }
+
+        // Filter flows based on flows config
 
         val workspaceConfig = findConfigFile(input)
             ?.let { YamlCommandReader.readWorkspaceConfig(it) }
@@ -36,40 +52,47 @@ object WorkspaceExecutionPlanner {
                 input.fileSystem.getPathMatcher("glob:${input.pathString}/$it")
             }
 
-        val globalIncludeTags = workspaceConfig.includeTags?.toList() ?: emptyList()
-        val globalExcludeTags = workspaceConfig.excludeTags?.toList() ?: emptyList()
-
-        // retrieve all Flow files
-        val unsortedFlowFiles = Files.walk(input)
+        val unsortedFlowFiles = unfilteredFlowFiles
             .filter { path ->
                 matchers.any { matcher -> matcher.matches(path) }
             }
             .toList()
-            .filter { it.nameWithoutExtension != "config" }
-            .filter {
-                it.isRegularFile()
-                    && (
-                    it.name.endsWith(".yaml")
-                        || it.name.endsWith(".yml")
-                    )
-            }
 
-        // retrieve config for each Flow file
+        if (unsortedFlowFiles.isEmpty()) {
+            if ("*" == globs.singleOrNull()) {
+                throw ValidationError("""
+                    Top-level directory does not contain any Flows: ${input.absolutePathString()}
+                    To configure Maestro to run Flows in subdirectories, check out the following resources:
+                      * https://maestro.mobile.dev/cli/test-suites-and-reports#inclusion-patterns
+                      * https://blog.mobile.dev/maestro-best-practices-structuring-your-test-suite-54ec390c5c82
+                """.trimIndent())
+            } else {
+                throw ValidationError("Flow inclusion pattern(s) did not match any Flow files:\n${toYamlListString(globs)}")
+            }
+        }
+
+        // Filter flows based on tags
+
         val configPerFlowFile = unsortedFlowFiles.associateWith {
-            val commands = YamlCommandReader.readCommands(it)
+            val commands = validateFlowFile(it)
             YamlCommandReader.getConfig(commands)
         }
 
-        // filter out all Flows not matching tags if present
+        val allIncludeTags = includeTags + (workspaceConfig.includeTags?.toList() ?: emptyList())
+        val allExcludeTags = excludeTags + (workspaceConfig.excludeTags?.toList() ?: emptyList())
         val allFlows = unsortedFlowFiles.filter {
             val config = configPerFlowFile[it]
             val tags = config?.tags ?: emptyList()
 
-            (includeTags.isEmpty() || tags.any(includeTags::contains))
-                && (globalIncludeTags.isEmpty() || tags.any(globalIncludeTags::contains))
-                && (excludeTags.isEmpty() || !tags.any(excludeTags::contains))
-                && (globalExcludeTags.isEmpty() || !tags.any(globalExcludeTags::contains))
+            (allIncludeTags.isEmpty() || tags.any(allIncludeTags::contains))
+                && (allExcludeTags.isEmpty() || !tags.any(allExcludeTags::contains))
         }
+
+        if (allFlows.isEmpty()) {
+            throw ValidationError("Include / Exclude tags did not match any Flows:\n\nInclude Tags:\n${toYamlListString(allIncludeTags)}\n\nExclude Tags:\n${toYamlListString(allExcludeTags)}")
+        }
+
+        // Handle sequential execution
 
         val flowsToRunInSequence = getFlowsToRunInSequence(allFlows, configPerFlowFile, workspaceConfig) ?: emptyList()
         var normalFlows = allFlows - flowsToRunInSequence.toSet()
@@ -87,6 +110,10 @@ object WorkspaceExecutionPlanner {
                 workspaceConfig.executionOrder?.continueOnFailure
             )
         )
+    }
+
+    private fun validateFlowFile(topLevelFlowPath: Path): List<MaestroCommand> {
+        return YamlCommandReader.readCommands(topLevelFlowPath)
     }
 
     private fun findConfigFile(input: Path): Path? {
@@ -119,6 +146,18 @@ object WorkspaceExecutionPlanner {
         return null
     }
 
+    private fun isFlowFile(path: Path): Boolean {
+        if (!path.isRegularFile()) return false // Not a file
+        val extension = path.extension
+        if (extension != "yaml" && extension != "yml") return false // Not YAML
+        if (path.nameWithoutExtension == "config") return false // Config file
+        return true
+    }
+
+    private fun toYamlListString(strings: List<String>): String {
+        return strings.joinToString("\n") { "- $it" }
+    }
+
     data class FlowSequence(
         val flows: List<Path>,
         val continueOnFailure: Boolean? = true
@@ -128,5 +167,4 @@ object WorkspaceExecutionPlanner {
         val flowsToRun: List<Path>,
         val sequence: FlowSequence? = null
     )
-
 }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerErrorsTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerErrorsTest.kt
@@ -1,0 +1,88 @@
+package maestro.orchestra.workspace
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import maestro.orchestra.error.ValidationError
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.*
+
+/**
+ * How to add a new error test case:
+ *
+ * 1. Create a new workspace directory eg. resources/workspaces/e###_test_case_name
+ * 2. Run ./gradlew :maestro-orchestra:test --tests "maestro.orchestra.workspace.WorkspaceExecutionPlannerErrorsTest"
+ * 3. Error message output will be saved to resources/workspaces/e###_test_case_name/error.actual.txt
+ * 4. Move error.actual.txt to error.txt and commit the file
+ * 5. Rerun and ensure this passes: ./gradlew :maestro-orchestra:test --tests "maestro.orchestra.workspace.WorkspaceExecutionPlannerErrorsTest"
+ *
+ *
+ * Test case files:
+ *
+ *   workspace/: The workspace directory passed into WorkspaceExecutionPlanner.plan()
+ *   error.txt: The expected error message for the test case
+ *   error.actual.txt: The actual error message generated when running the test case (ignored by VCS)
+ *   includeTags.txt: Include tags (one per line) to be passed into WorkspaceExecutionPlanner.plan()
+ *   excludeTags.txt: Exclude tags (one per line) to be passed into WorkspaceExecutionPlanner.plan()
+ *   singleFlow.txt: Indicates that the test should pass the path to the specified flow file instead of the workspace/ directory
+ *
+ *
+ * Note about the "{PROJECT_DIR}" string in error.txt files:
+ *
+ *   This test fixture replaces any reference to the current project directory with "{PROJECT_DIR}" so that error
+ *   messages referencing absolute paths can still be tested on different development machines.
+ */
+internal class WorkspaceExecutionPlannerErrorsTest {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideTestCases")
+    fun test(testCaseName: String, path: Path) {
+        val workspacePath = path.resolve("workspace")
+        val singleFlowFilePath = path.resolve("singleFlow.txt").takeIf { it.isRegularFile() }?.readText()
+        val expectedErrorPath = path.resolve("error.txt")
+        val expectedError = expectedErrorPath.takeIf { it.isRegularFile() }?.readText()
+        val includeTags = path.resolve("includeTags.txt").takeIf { it.isRegularFile() }?.readLines() ?: emptyList()
+        val excludeTags = path.resolve("excludeTags.txt").takeIf { it.isRegularFile() }?.readLines() ?: emptyList()
+        try {
+            val inputPath = singleFlowFilePath?.let { workspacePath.resolve(it) } ?: workspacePath
+            WorkspaceExecutionPlanner.plan(inputPath, includeTags, excludeTags)
+            assertWithMessage("No exception was not thrown. Ensure this test case triggers a ValidationError.").fail()
+        } catch (e: Exception) {
+            if (e !is ValidationError) {
+                e.printStackTrace()
+                return assertWithMessage("An exception was thrown but it was not a ValidationError. Ensure this test case triggers a ValidationError. Found: ${e::class.java.name}").fail()
+            }
+
+            val actualError = e.message.replace(PROJECT_DIR, "{PROJECT_DIR}")
+            val actualErrorPath = path.resolve("error.actual.txt")
+
+            actualErrorPath.writeText(actualError)
+
+            if (expectedError == null) {
+                assertWithMessage("Error message written to $actualErrorPath\nIf the error message looks good, copy the file above to error.txt and rerun this test").fail()
+            } else if (expectedError != actualError) {
+                System.err.println("Expected and actual error messages differ. If actual error message is preferred, move error.actual.txt to error.txt and rerun this test")
+                System.err.println("Expected error message path: $expectedErrorPath")
+                System.err.println("Actual error message path: $actualErrorPath")
+                assertThat(actualError).isEqualTo(expectedError)
+            }
+        }
+    }
+
+    companion object {
+
+        private val PROJECT_DIR = System.getenv("PROJECT_DIR")?.let { Paths.get(it).absolutePathString().trimEnd('/') } ?: throw RuntimeException("Enable to determine project directory")
+
+        @JvmStatic
+        private fun provideTestCases(): List<Arguments> {
+            return Paths.get(PROJECT_DIR)
+                .resolve("src/test/resources/workspaces")
+                .listDirectoryEntries()
+                .filter { it.isDirectory() && it.name.startsWith("e") }
+                .map { Arguments.of(it.name, it) }
+        }
+    }
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -171,13 +171,15 @@ internal class WorkspaceExecutionPlannerTest {
         // When
         val plan = WorkspaceExecutionPlanner.plan(
             input = path("/workspaces/010_global_include_tags"),
-            includeTags = listOf("featureA"),
+            includeTags = listOf("featureB"),
             excludeTags = listOf(),
         )
 
         // Then
         assertThat(plan.flowsToRun).containsExactly(
             path("/workspaces/010_global_include_tags/flowA.yaml"),
+            path("/workspaces/010_global_include_tags/flowA_subflow.yaml"),
+            path("/workspaces/010_global_include_tags/flowB.yaml"),
         )
     }
 

--- a/maestro-orchestra/src/test/resources/workspaces/.gitignore
+++ b/maestro-orchestra/src/test/resources/workspaces/.gitignore
@@ -1,0 +1,1 @@
+error.actual.txt

--- a/maestro-orchestra/src/test/resources/workspaces/010_global_include_tags/config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/010_global_include_tags/config.yaml
@@ -1,2 +1,2 @@
 includeTags:
-  - included
+  - featureA

--- a/maestro-orchestra/src/test/resources/workspaces/e000_flow_path_does_not_exist/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e000_flow_path_does_not_exist/error.txt
@@ -1,0 +1,1 @@
+Flow path does not exist: {PROJECT_DIR}/src/test/resources/workspaces/e000_flow_path_does_not_exist/workspace

--- a/maestro-orchestra/src/test/resources/workspaces/e001_directory_does_not_contain_flow_files/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e001_directory_does_not_contain_flow_files/error.txt
@@ -1,0 +1,1 @@
+Flow directory does not contain any Flow files: {PROJECT_DIR}/src/test/resources/workspaces/e001_directory_does_not_contain_flow_files/workspace

--- a/maestro-orchestra/src/test/resources/workspaces/e002_top_level_directory_does_not_contain_flow_files/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e002_top_level_directory_does_not_contain_flow_files/error.txt
@@ -1,0 +1,4 @@
+Top-level directory does not contain any Flows: {PROJECT_DIR}/src/test/resources/workspaces/e002_top_level_directory_does_not_contain_flow_files/workspace
+To configure Maestro to run Flows in subdirectories, check out the following resources:
+  * https://maestro.mobile.dev/cli/test-suites-and-reports#inclusion-patterns
+  * https://blog.mobile.dev/maestro-best-practices-structuring-your-test-suite-54ec390c5c82

--- a/maestro-orchestra/src/test/resources/workspaces/e002_top_level_directory_does_not_contain_flow_files/workspace/subdir/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e002_top_level_directory_does_not_contain_flow_files/workspace/subdir/Flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/e003_flow_inclusion_pattern_does_not_match_any_flow_files/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e003_flow_inclusion_pattern_does_not_match_any_flow_files/error.txt
@@ -1,0 +1,3 @@
+Flow inclusion pattern(s) did not match any Flow files:
+- FlowA.yaml
+- FlowB.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e003_flow_inclusion_pattern_does_not_match_any_flow_files/workspace/FlowC.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e003_flow_inclusion_pattern_does_not_match_any_flow_files/workspace/FlowC.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/e003_flow_inclusion_pattern_does_not_match_any_flow_files/workspace/config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e003_flow_inclusion_pattern_does_not_match_any_flow_files/workspace/config.yaml
@@ -1,0 +1,3 @@
+flows:
+  - FlowA.yaml
+  - FlowB.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/error.txt
@@ -1,0 +1,9 @@
+Include / Exclude tags did not match any Flows:
+
+Include Tags:
+- parameterInclude
+- configInclude
+
+Exclude Tags:
+- parameterExclude
+- configExclude

--- a/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/excludeTags.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/excludeTags.txt
@@ -1,0 +1,1 @@
+parameterExclude

--- a/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/includeTags.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/includeTags.txt
@@ -1,0 +1,1 @@
+parameterInclude

--- a/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/workspace/ConfigExclude.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/workspace/ConfigExclude.yaml
@@ -1,0 +1,6 @@
+tags:
+  - configInclude
+  - configExclude
+appId: com.example
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/workspace/ParameterExclude.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/workspace/ParameterExclude.yaml
@@ -1,0 +1,6 @@
+tags:
+  - parameterInclude
+  - parameterExclude
+appId: com.example
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/workspace/config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e004_tags_config_does_not_match_any_flow_files/workspace/config.yaml
@@ -1,0 +1,4 @@
+includeTags:
+  - configInclude
+excludeTags:
+  - configExclude

--- a/maestro-orchestra/src/test/resources/workspaces/e005_single_flow_does_not_exist/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e005_single_flow_does_not_exist/error.txt
@@ -1,0 +1,1 @@
+Flow path does not exist: {PROJECT_DIR}/src/test/resources/workspaces/e005_single_flow_does_not_exist/workspace/Flow.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e005_single_flow_does_not_exist/singleFlow.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e005_single_flow_does_not_exist/singleFlow.txt
@@ -1,0 +1,1 @@
+Flow.yaml


### PR DESCRIPTION
### Overview

* Proper error messages for empty workspaces
* Surface workspace validation errors before trying to connect to device when running `maestro test`
* Lay test fixture groundwork for future error improvements

### Behavior Change

This PR also changes the behavior when includeTags are specified in both config.yaml and as a command line option. Previously, in order for a flow to be included, it would need to match one of the config.yaml includeTags AND one of the command line includeTags. Even though this might be useful for some specific scenarios, this behavior is confusing and hard to explain. Now, in order for a flow to be included, it needs to match only one includeTag regardless of where the includeTag was specified.

### Error Messages

#### Flow path doesn't exist

```
Flow path does not exist: {PROJECT_DIR}/src/test/resources/workspaces/e000_flow_path_does_not_exist/workspace
```

#### Flow directory doesn't contain any Flow files (recursively)

```
Flow directory does not contain any Flow files: {PROJECT_DIR}/src/test/resources/workspaces/e001_directory_does_not_contain_flow_files/workspace
```

#### Top-level flow directory doesn't contain any files (but subdirectories do)

```
Top-level directory does not contain any Flows: {PROJECT_DIR}/src/test/resources/workspaces/e002_top_level_directory_does_not_contain_flow_files/workspace
To configure Maestro to run Flows in subdirectories, check out the following resources:
  * https://maestro.mobile.dev/cli/test-suites-and-reports#inclusion-patterns
  * https://blog.mobile.dev/maestro-best-practices-structuring-your-test-suite-54ec390c5c82
```

#### Inclusion patterns (ie: flows config in config.yaml) don't match any Flows

```
Flow inclusion pattern(s) did not match any Flow files:
- FlowA.yaml
- FlowB.yaml
```

#### Include tags / exclude tags don't match any Flow files:

```
Include / Exclude tags did not match any Flows:

Include Tags:
- parameterInclude
- configInclude

Exclude Tags:
- parameterExclude
- configExclude
```