### PR TITLE
Include file name and line numbers in parsing error messages

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
@@ -4,15 +4,15 @@ import maestro.MaestroException
 import maestro.orchestra.error.InvalidFlowFile
 import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.NoInputException
-import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.error.UnicodeNotSupportedError
+import maestro.orchestra.error.ValidationError
 import org.mozilla.javascript.EcmaError
 
 object ErrorViewUtils {
 
     fun exceptionToMessage(e: Exception): String {
         return when (e) {
-            is SyntaxError -> "Could not parse Flow file:\n\n${e.message}"
+            is ValidationError -> e.message
             is NoInputException -> "No commands found in Flow file"
             is InvalidInitFlowFile -> "initFlow file is invalid: ${e.initFlowPath}"
             is InvalidFlowFile -> "Flow file is invalid: ${e.flowPath}"

--- a/maestro-orchestra/src/main/java/maestro/orchestra/error/SyntaxError.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/error/SyntaxError.kt
@@ -1,3 +1,3 @@
 package maestro.orchestra.error
 
-class SyntaxError(override val message: String) : RuntimeException()
+class SyntaxError(override val message: String) : ValidationError(message)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -29,14 +29,12 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule
 import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.absolutePathString
-import kotlin.io.path.inputStream
 import kotlin.io.path.isDirectory
 import kotlin.io.path.readText
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
-import maestro.orchestra.error.NoInputException
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.util.Env.withEnv
 
@@ -63,12 +61,10 @@ object YamlCommandReader {
         return config
     }
 
-    fun readWorkspaceConfig(configPath: Path): WorkspaceConfig = try {
-        mapParsingErrors(configPath) {
-            MAPPER.readValue(configPath.inputStream(), WorkspaceConfig::class.java)
-        }
-    } catch (ignored: NoInputException) {
-        WorkspaceConfig()
+    fun readWorkspaceConfig(configPath: Path): WorkspaceConfig = mapParsingErrors(configPath) {
+        val config = configPath.readText()
+        if (config.isBlank()) return@mapParsingErrors WorkspaceConfig()
+        MAPPER.readValue(config, WorkspaceConfig::class.java)
     }
 
     // Files to watch for changes. Includes any referenced files.

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -19,13 +19,19 @@
 
 package maestro.orchestra.yaml
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.core.type.TypeReference
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import java.nio.file.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.inputStream
+import kotlin.io.path.isDirectory
+import kotlin.io.path.readText
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
@@ -33,24 +39,17 @@ import maestro.orchestra.WorkspaceConfig
 import maestro.orchestra.error.NoInputException
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.util.Env.withEnv
-import java.nio.file.Path
-import java.nio.file.Paths
-import kotlin.io.path.absolute
-import kotlin.io.path.inputStream
-import kotlin.io.path.isDirectory
 
 object YamlCommandReader {
 
-    private val YAML = YAMLFactory().apply {
+    val MAPPER = ObjectMapper(YAMLFactory().apply {
         disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
-    }
-
-    val MAPPER = ObjectMapper(YAML).apply {
+    }).apply {
         registerModule(KotlinModule.Builder().build())
     }
 
     // If it exists, automatically resolves the initFlow file and inlines the commands into the config
-    fun readCommands(flowPath: Path): List<MaestroCommand> = mapParsingErrors {
+    fun readCommands(flowPath: Path): List<MaestroCommand> = mapParsingErrors(flowPath) {
         val (config, commands) = readConfigAndCommands(flowPath)
         val maestroCommands = commands
             .flatMap { it.toCommands(flowPath, config.appId) }
@@ -65,7 +64,7 @@ object YamlCommandReader {
     }
 
     fun readWorkspaceConfig(configPath: Path): WorkspaceConfig = try {
-        mapParsingErrors {
+        mapParsingErrors(configPath) {
             MAPPER.readValue(configPath.inputStream(), WorkspaceConfig::class.java)
         }
     } catch (ignored: NoInputException) {
@@ -73,7 +72,7 @@ object YamlCommandReader {
     }
 
     // Files to watch for changes. Includes any referenced files.
-    fun getWatchFiles(flowPath: Path): List<Path> = mapParsingErrors {
+    fun getWatchFiles(flowPath: Path): List<Path> = mapParsingErrors(flowPath) {
         val (config, commands) = readConfigAndCommands(flowPath)
         val configWatchFiles = config.getWatchFiles(flowPath)
         val commandWatchFiles = commands.flatMap { it.getWatchFiles(flowPath) }
@@ -91,48 +90,64 @@ object YamlCommandReader {
     }
 
     private fun readConfigAndCommands(flowPath: Path): Pair<YamlConfig, List<YamlFluentCommand>> {
-        val parser = YAML.createParser(flowPath.inputStream())
-        val nodes = parser.readValuesAs(JsonNode::class.java)
+        val flowContent = flowPath.readText()
+
+        // Check for sections
+        var parser = MAPPER.createParser(flowContent)
+
+        val sectionCount = parser.readValuesAs(JsonNode::class.java)
             .asSequence()
             .toList()
             .filter { !it.isNull }
-        if (nodes.size != 2) {
+            .size
+        if (sectionCount != 2) {
             throw SyntaxError(
-                "Flow files must contain a config section and a commands section. " +
-                    "Found ${nodes.size} section${if (nodes.size == 1) "" else "s"}: $flowPath"
+                """
+                    Flow files must contain a config section and a commands section separated by "---". For example:
+                    
+                    appId: com.example
+                    ---
+                    - launchApp
+                """.trimIndent()
             )
         }
-        val config: YamlConfig = MAPPER.convertValue(nodes[0], YamlConfig::class.java)
-        val commands = MAPPER.convertValue(
-            nodes[1],
+
+        // Parse sections
+        parser = MAPPER.createParser(flowContent)
+
+        val config: YamlConfig = parser.readValueAs(YamlConfig::class.java)
+        val commands = parser.readValueAs<List<YamlFluentCommand>>(
             object : TypeReference<List<YamlFluentCommand>>() {}
         )
         return config to commands
     }
 
-    private fun <T> mapParsingErrors(block: () -> T): T {
+    private fun <T> mapParsingErrors(path: Path, block: () -> T): T {
         try {
             return block()
-        } catch (e: JsonMappingException) {
-            val message = e.message ?: throw SyntaxError("Invalid syntax")
-
-            when {
-                message.contains("Unrecognized field") -> throw SyntaxError(message)
-                message.contains("Cannot construct instance") -> throw SyntaxError(message)
-                message.contains("Cannot deserialize") -> throw SyntaxError(message)
-                message.contains("No content to map") -> throw NoInputException
-                else -> throw SyntaxError(message)
-            }
-        } catch (e: IllegalArgumentException) {
-            val message = e.message ?: throw e
-
-            when {
-                message.contains("value failed for JSON property") -> throw SyntaxError(message)
-                message.contains("Unrecognized field") -> throw SyntaxError(message)
-                message.contains("Cannot construct instance") -> throw SyntaxError(message)
-                message.contains("Cannot deserialize") -> throw SyntaxError(message)
-                else -> throw e
-            }
+        } catch (e: Throwable) {
+            val message = getErrorMessage(path, e)
+            throw SyntaxError(message)
         }
+    }
+
+    private fun getErrorMessage(path: Path, e: Throwable): String {
+        val prefix = "Failed to parse file: ${path.absolutePathString()}"
+
+        val jsonException = getJsonProcessingException(e) ?: return "$prefix\n${e.message ?: e.toString()}"
+
+        val lineNumber = jsonException.location?.lineNr ?: -1
+        val originalMessage = jsonException.originalMessage
+
+        val header = if (lineNumber != -1) "$prefix:$lineNumber" else prefix
+
+        return "$header\n$originalMessage"
+    }
+
+    private fun getJsonProcessingException(e: Throwable): JsonProcessingException? {
+        if (e is JsonProcessingException) return e
+        val cause = e.cause
+        if (cause == null || cause == e) return null
+        return getJsonProcessingException(cause)
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -20,6 +20,9 @@
 package maestro.orchestra.yaml
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.core.JacksonException
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonProcessingException
 import maestro.KeyCode
 import maestro.Point
 import maestro.TapRepeat

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -1,26 +1,23 @@
 package maestro.orchestra.yaml
 
 import com.google.common.truth.Truth.assertThat
-import maestro.MaestroException
+import java.nio.file.FileSystems
+import java.nio.file.Paths
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.Command
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
-import maestro.orchestra.MaestroInitFlow
 import maestro.orchestra.MaestroOnFlowComplete
 import maestro.orchestra.MaestroOnFlowStart
 import maestro.orchestra.ScrollCommand
-import maestro.orchestra.error.InvalidInitFlowFile
 import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.yaml.junit.YamlCommandsExtension
 import maestro.orchestra.yaml.junit.YamlExceptionExtension
 import maestro.orchestra.yaml.junit.YamlFile
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import java.nio.file.FileSystems
-import java.nio.file.Paths
 
 @Suppress("JUnitMalformedDeclaration")
 @ExtendWith(YamlCommandsExtension::class, YamlExceptionExtension::class)
@@ -85,9 +82,9 @@ internal class YamlCommandReaderTest {
 
     @Test
     fun initFlow(
-        @YamlFile("007_initFlow.yaml") e: MaestroException.DeprecatedCommand,
+        @YamlFile("007_initFlow.yaml") e: SyntaxError,
     ) {
-        /* check if parsing the file results in the exception parameter type */
+        assertThat(e.message).containsMatch("initFlow command used at.*is deprecated")
     }
 
     @Test
@@ -127,9 +124,9 @@ internal class YamlCommandReaderTest {
 
     @Test
     fun initFlow_file(
-        @YamlFile("011_initFlow_file.yaml") e: MaestroException.DeprecatedCommand,
+        @YamlFile("011_initFlow_file.yaml") e: SyntaxError,
     ) {
-        /* check if parsing the file results in the exception parameter type */
+        assertThat(e.message).containsMatch("initFlow command used at.*is deprecated")
     }
 
     @Test
@@ -148,16 +145,16 @@ internal class YamlCommandReaderTest {
 
     @Test
     fun initFlow_invalidFile(
-        @YamlFile("013_initFlow_invalidFile.yaml") e: MaestroException.DeprecatedCommand,
+        @YamlFile("013_initFlow_invalidFile.yaml") e: SyntaxError,
     ) {
-        /* check if parsing the file results in the exception parameter type */
+        assertThat(e.message).containsMatch("initFlow command used at.*is deprecated")
     }
 
     @Test
     fun initFlow_recursive(
-        @YamlFile("014_initFlow_recursive.yaml") e: MaestroException.DeprecatedCommand,
+        @YamlFile("014_initFlow_recursive.yaml") e: SyntaxError,
     ) {
-        /* check if parsing the file results in the exception parameter type */
+        assertThat(e.message).containsMatch("initFlow command used at.*is deprecated")
     }
 
     @Test

--- a/maestro-orchestra/src/test/resources/workspaces/e006_single_flow_invalid_string_command/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e006_single_flow_invalid_string_command/error.txt
@@ -1,0 +1,2 @@
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e006_single_flow_invalid_string_command/workspace/Flow.yaml:3
+Cannot construct instance of `maestro.orchestra.yaml.YamlFluentCommand`, problem: Invalid command: "invalidCommand"

--- a/maestro-orchestra/src/test/resources/workspaces/e006_single_flow_invalid_string_command/singleFlow.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e006_single_flow_invalid_string_command/singleFlow.txt
@@ -1,0 +1,1 @@
+Flow.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e006_single_flow_invalid_string_command/workspace/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e006_single_flow_invalid_string_command/workspace/Flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- invalidCommand

--- a/maestro-orchestra/src/test/resources/workspaces/e007_single_flow_malformatted_command/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e007_single_flow_malformatted_command/error.txt
@@ -1,0 +1,2 @@
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e007_single_flow_malformatted_command/workspace/Flow.yaml:4
+Unrecognized field "invalidOption" (class maestro.orchestra.yaml.YamlLaunchApp), not marked as ignorable

--- a/maestro-orchestra/src/test/resources/workspaces/e007_single_flow_malformatted_command/singleFlow.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e007_single_flow_malformatted_command/singleFlow.txt
@@ -1,0 +1,1 @@
+Flow.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e007_single_flow_malformatted_command/workspace/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e007_single_flow_malformatted_command/workspace/Flow.yaml
@@ -1,0 +1,4 @@
+appId: com.example
+---
+- launchApp:
+    invalidOption: true

--- a/maestro-orchestra/src/test/resources/workspaces/e008_subflow_invalid_string_command/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e008_subflow_invalid_string_command/error.txt
@@ -1,0 +1,3 @@
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e008_subflow_invalid_string_command/workspace/Flow.yaml
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e008_subflow_invalid_string_command/workspace/./subflow/SubFlow.yaml:3
+Cannot construct instance of `maestro.orchestra.yaml.YamlFluentCommand`, problem: Invalid command: "invalidCommand"

--- a/maestro-orchestra/src/test/resources/workspaces/e008_subflow_invalid_string_command/workspace/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e008_subflow_invalid_string_command/workspace/Flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- runFlow: ./subflow/SubFlow.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e008_subflow_invalid_string_command/workspace/subflow/SubFlow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e008_subflow_invalid_string_command/workspace/subflow/SubFlow.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- invalidCommand

--- a/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/error.txt
@@ -1,0 +1,4 @@
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/Flow.yaml
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/./subflow/SubFlowA.yaml
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/./subflow/./SubFlowB.yaml:3
+Cannot construct instance of `maestro.orchestra.yaml.YamlFluentCommand`, problem: Invalid command: "invalidCommand"

--- a/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/Flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- runFlow: ./subflow/SubFlowA.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/subflow/SubFlowA.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/subflow/SubFlowA.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- runFlow: ./SubFlowB.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/subflow/SubFlowB.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e009_nested_subflow_invalid_string_command/workspace/subflow/SubFlowB.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- invalidCommand

--- a/maestro-orchestra/src/test/resources/workspaces/e010_missing_config_section/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e010_missing_config_section/error.txt
@@ -1,0 +1,6 @@
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e010_missing_config_section/workspace/Flow.yaml
+Flow files must contain a config section and a commands section separated by "---". For example:
+
+appId: com.example
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/e010_missing_config_section/workspace/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e010_missing_config_section/workspace/Flow.yaml
@@ -1,0 +1,1 @@
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/e011_missing_dashes/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e011_missing_dashes/error.txt
@@ -1,0 +1,2 @@
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e011_missing_dashes/workspace/Flow.yaml:3
+Cannot deserialize value of type `java.util.ArrayList<maestro.orchestra.yaml.YamlFluentCommand>` from String value (token `JsonToken.VALUE_STRING`)

--- a/maestro-orchestra/src/test/resources/workspaces/e011_missing_dashes/workspace/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e011_missing_dashes/workspace/Flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/e012_invalid_subflow_path/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e012_invalid_subflow_path/error.txt
@@ -1,0 +1,2 @@
+Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e012_invalid_subflow_path/workspace/Flow.yaml
+Flow file does not exist: file://{PROJECT_DIR}/src/test/resources/workspaces/e012_invalid_subflow_path/workspace/invalidpath.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/e012_invalid_subflow_path/workspace/Flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/e012_invalid_subflow_path/workspace/Flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example
+---
+- runFlow: invalidpath.yaml

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.assertThrows
 import java.awt.Color
 import java.io.File
 import java.nio.file.Paths
+import maestro.orchestra.error.SyntaxError
 
 class IntegrationTest {
 
@@ -604,7 +605,7 @@ class IntegrationTest {
 
     @Test
     fun `Case 023 - runFlow with initFlow`() {
-        assertThrows<MaestroException.DeprecatedCommand> {
+        assertThrows<SyntaxError> {
             val commands = readCommands("024_init_flow_init_state")
             val initFlow = YamlCommandReader.getConfig(commands)!!.initFlow!!
 
@@ -634,7 +635,7 @@ class IntegrationTest {
 
     @Test
     fun `Case 024 - runFlow with initState`() {
-        assertThrows<MaestroException.DeprecatedCommand> {
+        assertThrows<SyntaxError> {
             // Given
             val commands = readCommands("023_init_flow")
 


### PR DESCRIPTION
Example error message:

```
Failed to parse file: {PROJECT_DIR}/src/test/resources/workspaces/e006_single_flow_invalid_string_command/workspace/Flow.yaml:3
Cannot construct instance of `maestro.orchestra.yaml.YamlFluentCommand`, problem: Invalid command: "invalidCommand"
```