### PR TITLE
fixed dark mode for element id

### DIFF
--- a/maestro-studio/web/src/components/device-and-device-elements/SelectedElementViewer.tsx
+++ b/maestro-studio/web/src/components/device-and-device-elements/SelectedElementViewer.tsx
@@ -115,7 +115,7 @@ const ElementHighInfo = ({
   }
 
   return (
-    <div className="bg-gray-100 pl-3 py-1 pr-1 rounded-lg mb-2 flex gap-3 items-start">
+    <div className="bg-gray-100 dark:bg-slate-800 pl-3 py-1 pr-1 rounded-lg mb-2 flex gap-3 items-start">
       <p className="text-sm py-1 min-w-[32px]">{label}:</p>
       <p
         className="text-sm font-semibold flex-grow py-1"


### PR DESCRIPTION
Fixed the Dark mode colors for recently added element id.
<img width="382" alt="Screenshot 2023-08-27 at 8 40 44 AM" src="https://github.com/mobile-dev-inc/maestro/assets/35415752/f799dc83-19b8-4891-be8a-12e8d286e356">
