### PR TITLE
Update selenium-java and remove webdrivermanager to support Chrome 116+ (#1393)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,13 +39,12 @@ kotlinResult = "1.1.14"
 ktor = "2.2.2"
 mozillaRhino = "1.7.14"
 picocli = "4.5.2"
-selenium = "4.7.2"
+selenium = "4.11.0"
 slf4j = "1.7.36"
 squareOkhttp = "4.10.0"
 squareOkio = "3.2.0"
 squareRetrofit = "2.9.0"
 squareMockWebServer = "4.11.0"
-webdrivermanager = "5.3.1"
 wiremock = "2.35.0"
 logback="1.2.3"
 
@@ -111,7 +110,6 @@ square-okio = { module = "com.squareup.okio:okio", version.ref = "squareOkio" }
 square-mock-server = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "squareMockWebServer" }
 square-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "squareRetrofit" }
 square-retrofit-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "squareRetrofit" }
-webdrivermanager = { module = "io.github.bonigarcia:webdrivermanager", version.ref = "webdrivermanager" }
 wiremock-jre8 = { module = "com.github.tomakehurst:wiremock-jre8", version.ref = "wiremock" }
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -77,9 +77,6 @@ dependencies {
     implementation(libs.google.findbugs)
     implementation(libs.axml)
     implementation(libs.selenium)
-    implementation((libs.webdrivermanager)) {
-        exclude group: 'org.slf4j', module: 'slf4j-api'
-    }
     api(libs.slf4j)
     api(libs.logback) {
         exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -1,6 +1,5 @@
 package maestro.drivers
 
-import io.github.bonigarcia.wdm.WebDriverManager
 import maestro.Capability
 import maestro.DeviceInfo
 import maestro.Driver
@@ -16,16 +15,15 @@ import maestro.ViewHierarchy
 import maestro.utils.ScreenshotUtils
 import okio.Sink
 import okio.buffer
-import org.apache.commons.io.output.NullOutputStream
 import org.openqa.selenium.By
 import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.Keys
 import org.openqa.selenium.OutputType
 import org.openqa.selenium.TakesScreenshot
 import org.openqa.selenium.chrome.ChromeDriver
-import org.openqa.selenium.chrome.ChromeDriverLogLevel
 import org.openqa.selenium.chrome.ChromeDriverService
 import org.openqa.selenium.chrome.ChromeOptions
+import org.openqa.selenium.chromium.ChromiumDriverLogLevel
 import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.interactions.PointerInput
 import org.openqa.selenium.remote.RemoteWebDriver
@@ -60,20 +58,16 @@ class WebDriver(val isStudio: Boolean) : Driver {
         Logger.getLogger("org.openqa.selenium").level = Level.OFF;
         Logger.getLogger("org.openqa.selenium.devtools.CdpVersionFinder").level = Level.OFF;
 
-        WebDriverManager
-            .chromedriver()
-            .setup()
-
-        val driverService = ChromeDriverService.Builder().build()
-        driverService.sendOutputTo(NullOutputStream.NULL_OUTPUT_STREAM)
+        val driverService = ChromeDriverService.Builder()
+            .withLogLevel(ChromiumDriverLogLevel.OFF)
+            .build()
 
         seleniumDriver = ChromeDriver(
             driverService,
             ChromeOptions().apply {
-                logLevel = ChromeDriverLogLevel.OFF
                 addArguments("--remote-allow-origins=*")
                 if (isStudio) {
-                    setHeadless(true)
+                    addArguments("--headless=new")
                     addArguments("--window-size=1024,768")
                 }
             }


### PR DESCRIPTION
This PR updates `selenium-java` to `4.11.0` and removes `webdrivermanager` (which is no longer needed) to support Chrome 116.0+.

## Testing

Tested locally on Mac with Chrome 116.0.5845.110 installed.