### PR TITLE
Handles cases where we can't parse debug commands

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -1,6 +1,7 @@
 package maestro.cli.report
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import maestro.Driver
 import maestro.MaestroException
@@ -44,14 +45,17 @@ object TestDebugReporter {
     fun saveFlow(flowName: String, data: FlowDebugMetadata, path: Path) {
 
         // commands
-        val commandMetadata = data.commands
-        if (commandMetadata.isNotEmpty()) {
-
-            val commandsFilename = "commands-(${flowName.replace("/", "_")}).json"
-            val file = File(path.absolutePathString(), commandsFilename)
-            commandMetadata.map { CommandDebugWrapper(it.key, it.value) }.let {
-                mapper.writeValue(file, it)
+        try {
+            val commandMetadata = data.commands
+            if (commandMetadata.isNotEmpty()) {
+                val commandsFilename = "commands-(${flowName.replace("/", "_")}).json"
+                val file = File(path.absolutePathString(), commandsFilename)
+                commandMetadata.map { CommandDebugWrapper(it.key, it.value) }.let {
+                    mapper.writeValue(file, it)
+                }
             }
+        } catch (e: JsonMappingException) {
+            logger.error("Unable to parse commands", e)
         }
 
         // screenshots


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ea5463</samp>

Improved error handling for `TestDebugReporter` in `maestro-cli`. Added handling for `JsonMappingException` when saving commands metadata as JSON.

## Testing
Locally

## Issues Fixed
In some cases we're unable to serialize commands as debug output. Added a try/catch for such instances.