### PR TITLE
Show cancellation reason when available

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -438,6 +438,7 @@ data class UploadStatus(
         val name: String,
         val status: Status,
         val errors: List<String>,
+        val cancellationReason: CancellationReason? = null
     )
 
     enum class Status {
@@ -447,6 +448,13 @@ data class UploadStatus(
         ERROR,
         CANCELED,
         WARNING,
+    }
+
+    enum class CancellationReason {
+        BENCHMARK_DEPENDENCY_FAILED,
+        INFRA_ERROR,
+        OVERLAPPING_BENCHMARK,
+        TIMEOUT
     }
 }
 


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e79692a</samp>

This pull request adds support for cancellation reasons for test suite uploads and flows in the Maestro CLI. It modifies the `ApiClient`, `UploadStatus`, `FlowResult`, and `TestSuiteStatusView` classes to handle and display different reasons for cancelling a test suite.