### PR TITLE
Fixes architecture detection

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
@@ -79,7 +79,7 @@ object EnvUtils {
         val isArm64 = runCommand("sysctl", "hw.optional.arm64")
         val isX86_64 = runCommand("sysctl", "hw.optional.x86_64")
         return when {
-            isArm64 -> MACOS_ARCHITECTURE.x86_64
+            isArm64 -> MACOS_ARCHITECTURE.ARM64
             isX86_64 -> MACOS_ARCHITECTURE.x86_64
             else -> MACOS_ARCHITECTURE.UNKNOWN
         }


### PR DESCRIPTION
## Issues Fixed
Previously we used `uname -m` to detect OS architecture but MacOS Rosetta was interfering. Replaced with `sysctl` which is more reliable.

More context on the issue https://github.com/JuliaLang/juliaup/pull/701/files