### PR TITLE
chilfOf Selector added

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -448,7 +448,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return if (element == null) {
             null
         } else {
-            return FindElementResult(element, viewHierarchy)
+            return FindElementResult(element, ViewHierarchy(element.treeNode))
         }
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -436,6 +436,22 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         }
     }
 
+    fun findElementFromViewHierarchyWithTimeout(
+        timeoutMs: Long,
+        filter: ElementFilter,
+        viewHierarchy: ViewHierarchy
+    ): FindElementResult? {
+        val element = MaestroTimer.withTimeout(timeoutMs) {
+            filter(viewHierarchy.aggregate()).firstOrNull()
+        }?.toUiElementOrNull()
+
+        return if (element == null) {
+            null
+        } else {
+            return FindElementResult(element, viewHierarchy)
+        }
+    }
+
     fun allElementsMatching(filter: ElementFilter): List<TreeNode> {
         return filter(viewHierarchy().aggregate())
     }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -39,6 +39,7 @@ data class ElementSelector(
     val selected: Boolean? = null,
     val checked: Boolean? = null,
     val focused: Boolean? = null,
+    val childOf: ElementSelector? = null
 ) {
 
     data class SizeSelector(
@@ -58,6 +59,7 @@ data class ElementSelector(
             containsChild = containsChild?.evaluateScripts(jsEngine),
             containsDescendants = containsDescendants?.map { it.evaluateScripts(jsEngine) },
             index = index?.evaluateScripts(jsEngine),
+            childOf = childOf?.evaluateScripts(jsEngine)
         )
     }
 
@@ -114,6 +116,10 @@ data class ElementSelector(
 
         index?.let {
             descriptions.add("Index: ${it.toDoubleOrNull()?.toInt() ?: it}")
+        }
+
+        childOf?.let {
+            descriptions.add("Child Of: ${it.description()}")
         }
 
         val combined = descriptions.joinToString(", ")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -856,7 +856,7 @@ class Orchestra(
             filterFunc,
             parentViewHierarchy)?.hierarchy?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
-            maestro.viewHierarchy().root,
+            parentViewHierarchy.root,
         )
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -47,5 +47,6 @@ data class YamlElementSelector(
     val checked: Boolean? = null,
     val focused: Boolean? = null,
     val repeat: Int? = null,
-    val delay: Int? = null
+    val delay: Int? = null,
+    val childOf: YamlElementSelectorUnion? = null
 ) : YamlElementSelectorUnion

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -506,6 +506,7 @@ data class YamlFluentCommand(
             checked = selector.checked,
             focused = selector.focused,
             optional = selector.optional ?: false,
+            childOf = selector.childOf?.let { toElementSelector(it) }
         )
     }
 


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0070d6</samp>

This pull request adds the `childOf` feature to the `ElementSelector` class and its YAML representation, which allows finding elements that are nested inside other elements. It also refactors the project structure and adds a new function to the `Maestro` class that uses the `childOf` feature to find an element from a view hierarchy.
Added support of `childOf`  selector which takes a `element node` as value. If we want to search a selector that is child of some view we can use this selector
`childOf: Element`

```
tapOn:
   text: "buy now"
    childOf:
        - id: "buy-now-button"


```

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
