### PR TITLE
[fix] xcuitest.XCTestDriverClient$XCTestDriverUnreachable issues

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -48,6 +48,7 @@ import kotlin.system.exitProcess
 
 object MaestroSessionManager {
     private const val defaultHost = "localhost"
+    private const val defaultXctestHost = "[::1]"
     private const val defaultIdbPort = 10882
     private const val defaultXcTestPort = 22087
 
@@ -276,14 +277,14 @@ object MaestroSessionManager {
         val xcTestInstaller = LocalXCTestInstaller(
             logger = IOSDriverLogger(LocalXCTestInstaller::class.java),
             deviceId = deviceId,
-            host = defaultHost,
+            host = defaultXctestHost,
             defaultPort = defaultXcTestPort
         )
 
         val xcTestDriverClient = XCTestDriverClient(
             installer = xcTestInstaller,
             logger = IOSDriverLogger(XCTestDriverClient::class.java),
-            client = XCTestClient(defaultHost, defaultXcTestPort)
+            client = XCTestClient(defaultXctestHost, defaultXcTestPort)
         )
 
         val xcTestDevice = XCTestIOSDevice(

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 class LocalXCTestInstaller(
     private val logger: Logger,
     private val deviceId: String,
-    private val host: String = "localhost",
+    private val host: String = "[::1]",
     defaultPort: Int? = null,
 ) : XCTestInstaller {
     // Set this flag to allow using a test runner started from Xcode
@@ -111,7 +111,7 @@ class LocalXCTestInstaller(
         fun xctestAPIBuilder(pathSegment: String): HttpUrl.Builder {
             return HttpUrl.Builder()
                 .scheme("http")
-                .host("localhost")
+                .host("[::1]")
                 .addPathSegment(pathSegment)
                 .port(port)
         }


### PR DESCRIPTION
## Proposed Changes

[FlyingFox](https://github.com/swhitty/FlyingFox) (the library that we use for XCTest HTTP server) implements loopback address using Darwin POSIX address:

```
Darwin.sockaddr_in6(
            sin6_len: UInt8(MemoryLayout<sockaddr_in6>.stride),
            sin6_family: sa_family_t(AF_INET6),
            sin6_port: port.bigEndian,
            sin6_flowinfo: 0,
            sin6_addr: in6addr_loopback,
            sin6_scope_id: 0
)
```

Server is listening on IPv6 all the time and is able to resolve IPv4 connections correctly if `::1 localhost` is present inside `etc/hosts`, however fails if it doesn't.

[SwiftNIO](https://github.com/apple/swift-nio) has its own [convenience method](https://swiftinit.org/docs/swift-nio/niocore/socketaddress.makeaddressresolvinghost(_:port:)) for this case. We could consider in the future to migrate to [SwiftNIO](https://github.com/apple/swift-nio) based server for this and many other reasons.

For now the best solution would be to send requests to IPv6 host directly instead of using localhost as a host.

## Testing
- [x] local test
- [x] cloud test 

## Issues Fixed
https://github.com/mobile-dev-inc/maestro/issues/1299
https://github.com/mobile-dev-inc/maestro/issues/1257
