### PR TITLE
Add command-line switch to omit folders from debug output

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -88,6 +88,12 @@ class TestCommand : Callable<Int> {
     private var debugOutput: String? = null
 
     @Option(
+        names = ["--flatten-debug-output"],
+        description = ["Don't create subfolders or timestamps for each run. Useful for CI."]
+    )
+    private var flattenDebugOutput: Boolean = false
+
+    @Option(
         names = ["--include-tags"],
         description = ["List of tags that will remove the Flows that does not have the provided tags"],
         split = ",",
@@ -130,7 +136,7 @@ class TestCommand : Callable<Int> {
 
         env = env.withInjectedShellEnvVars()
 
-        TestDebugReporter.install(debugOutputPathAsString = debugOutput)
+        TestDebugReporter.install(debugOutputPathAsString = debugOutput, flattenDebugOutput = flattenDebugOutput)
         val debugOutputPath = TestDebugReporter.getDebugOutputPath()
         
         return MaestroSessionManager.newSession(parent?.host, parent?.port, deviceId) { session ->

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -33,6 +33,7 @@ object TestDebugReporter {
 
     private var debugOutputPath: Path? = null
     private var debugOutputPathAsString: String? = null
+    private var flattenDebugOutput: Boolean = false
 
     init {
 
@@ -114,8 +115,9 @@ object TestDebugReporter {
         logger.info("---------------------")
     }
 
-    fun install(debugOutputPathAsString: String?) {
+    fun install(debugOutputPathAsString: String?, flattenDebugOutput: Boolean = false) {
         this.debugOutputPathAsString = debugOutputPathAsString
+        this.flattenDebugOutput = flattenDebugOutput
         val path = getDebugOutputPath()
         LogConfig.configure(path.absolutePathString() + "/maestro.log")
         logSystemInfo()
@@ -125,10 +127,11 @@ object TestDebugReporter {
     fun getDebugOutputPath(): Path {
         if (debugOutputPath != null) return debugOutputPath as Path
 
-        val dateFormat = "yyyy-MM-dd_HHmmss"
-        val dateFormatter = DateTimeFormatter.ofPattern(dateFormat)
-        val folderName = dateFormatter.format(LocalDateTime.now())
-        val debugOutput = Paths.get(debugOutputPathAsString ?: System.getProperty("user.home"), ".maestro", "tests", folderName)
+        val preamble = if(flattenDebugOutput) arrayOf("") else arrayOf(".maestro", "tests")
+        val foldername = if(flattenDebugOutput) "" else DateTimeFormatter.ofPattern("yyyy-MM-dd_HHmmss").format(LocalDateTime.now())
+        val debugRootPath = if(debugOutputPathAsString != null) debugOutputPathAsString!! else System.getProperty("user.home")
+        val debugOutput = Paths.get(debugRootPath, *preamble, foldername)
+        
         if (!debugOutput.exists()) {
             Files.createDirectories(debugOutput)
         }


### PR DESCRIPTION
Fixes #1427 

Adding a `--flatten-debug-output` switch that will remove the datetime folder, as well as `/.maestro/tests/` from the path, leaving the debug output exactly where the user defined.

## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 972f615</samp>

Added a new option `--flatten-debug-output` to the `test` command in `maestro-cli` to simplify the test output folder structure for CI environments. Updated the `TestDebugReporter` class to handle this option and generate the output path accordingly.

## Testing

No params:
```
 ⇒ ./maestro test ~/maestro/scratch.yaml 
Running on iPhone 14 Pro - iOS 16.4 - 1FCE17AC-A5FF-496C-9EDB-7C66E9D0FBE3
                                                                                
 ║                                                                              
 ║  > Flow                                                                      
 ║                                                                              
 ║    ❌  1 is the same as 2                                                     
 ║                                                                              
                                                                                
Assertion is false: false is true

==== Debug output (logs & screenshots) ====

/Users/danc/.maestro/tests/2023-09-13_174225
```

Just the debug option:
```
 ⇒ ./maestro test --debug-output /tmp/maestro ~/maestro/scratch.yaml                    
Running on iPhone 14 Pro - iOS 16.4 - 1FCE17AC-A5FF-496C-9EDB-7C66E9D0FBE3
                                                                                
 ║                                                                              
 ║  > Flow                                                                      
 ║                                                                              
 ║    ❌  1 is the same as 2                                                     
 ║                                                                              
                                                                                
Assertion is false: false is true

==== Debug output (logs & screenshots) ====

/tmp/maestro/.maestro/tests/2023-09-13_174126
```

With the new option:
```
 ⇒ ./maestro test --debug-output /tmp/maestro --flatten-debug-output  ~/maestro/scratch.yaml
Running on iPhone 14 Pro - iOS 16.4 - 1FCE17AC-A5FF-496C-9EDB-7C66E9D0FBE3
                                                                                
 ║                                                                              
 ║  > Flow                                                                      
 ║                                                                              
 ║    ❌  1 is the same as 2                                                     
 ║                                                                              
                                                                                
Assertion is false: false is true

==== Debug output (logs & screenshots) ====

/tmp/maestro
```

## Issues Fixed

#1427 