### PR TITLE
Update iOS sample flow to handle Wikipedia auth modal

### DIFF
--- a/samples/ios-advanced-flow.yaml
+++ b/samples/ios-advanced-flow.yaml
@@ -15,6 +15,8 @@ tags:
 - tapOn: Search Wikipedia
 - runScript: scripts/getSearchQuery.js
 - inputText: ${output.result}
+- assertNotVisible: Search Wikipedia
 - eraseText
+- assertVisible: Search Wikipedia
 - inputText: qwerty
 - assertVisible: ${output.result}

--- a/samples/ios-advanced-flow.yaml
+++ b/samples/ios-advanced-flow.yaml
@@ -3,7 +3,18 @@ tags:
   - advanced
 ---
 - runFlow: subflows/onboarding-ios.yaml
+
+# Dismiss the auth modal if visible
+- runFlow:
+    when:
+      visible: "You have been logged out"
+    commands:
+      - tapOn:
+          text: "Continue without logging in"
+
 - tapOn: Search Wikipedia
 - runScript: scripts/getSearchQuery.js
 - inputText: ${output.result}
+- eraseText
+- inputText: qwerty
 - assertVisible: ${output.result}

--- a/samples/subflows/onboarding-ios.yaml
+++ b/samples/subflows/onboarding-ios.yaml
@@ -1,14 +1,11 @@
 appId: org.wikimedia.wikipedia
 ---
-- launchApp:
-    clearState: true
-- swipe:
-    direction: LEFT
-    duration: 400
-- swipe:
-    direction: LEFT
-    duration: 400
-- swipe:
-    direction: LEFT
-    duration: 400
+- launchApp
+- repeat:
+    times: 3
+    commands:
+      - swipe:
+          direction: LEFT
+          duration: 400
+      - waitForAnimationToEnd
 - tapOn: Get started


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 544bcd3</samp>

This pull request updates two sample YAML files for iOS testing: `samples/ios-advanced-flow.yaml` and `samples/subflows/onboarding-ios.yaml`. It adds a conditional subflow to handle the auth modal, demonstrates the inputText and eraseText commands, and simplifies the onboarding subflow by using a repeat loop and a waitForAnimationToEnd command.

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
