### PR TITLE
Add support for multipart form data file upload

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
@@ -1,11 +1,11 @@
 package maestro.js
 
+import maestro.utils.HttpUtils.toMultipartBody
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.graalvm.polyglot.HostAccess.Export
-import org.graalvm.polyglot.proxy.ProxyArray
 import org.graalvm.polyglot.proxy.ProxyObject
 
 class GraalJsHttp(
@@ -71,8 +71,13 @@ class GraalJsHttp(
             .url(url)
 
         val body = params?.get("body") as? String
+        val multipartForm = params?.get("multipartForm") as? Map<*, *>
 
-        requestBuilder.method(method, body?.toRequestBody())
+        if (multipartForm == null) {
+            requestBuilder.method(method, body?.toRequestBody())
+        } else {
+            requestBuilder.method(method, multipartForm.toMultipartBody())
+        }
 
         val headers: Map<*, *> = params?.get("headers") as? Map<*, *> ?: emptyMap<Any, Any>()
 

--- a/maestro-client/src/main/java/maestro/js/JsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/JsHttp.kt
@@ -1,5 +1,6 @@
 package maestro.js
 
+import maestro.utils.HttpUtils.toMultipartBody
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -79,8 +80,13 @@ class JsHttp(
                     it.toString()
                 }
             }
+        val multipartForm = params?.get("multipartForm") as? Map<*, *>
 
-        requestBuilder.method(method, body?.toRequestBody())
+        if (multipartForm == null) {
+            requestBuilder.method(method, body?.toRequestBody())
+        } else {
+            requestBuilder.method(method, multipartForm.toMultipartBody())
+        }
 
         params
             ?.get("headers")

--- a/maestro-client/src/main/java/maestro/utils/HttpUtils.kt
+++ b/maestro-client/src/main/java/maestro/utils/HttpUtils.kt
@@ -1,0 +1,30 @@
+package maestro.utils
+
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+
+object HttpUtils {
+
+    fun Map<*, *>.toMultipartBody(): MultipartBody {
+        return MultipartBody.Builder()
+            .setType(MultipartBody.FORM)
+            .addAllFormDataParts(this)
+            .build()
+    }
+
+    private fun <T : Map<*, *>> MultipartBody.Builder.addAllFormDataParts(multipartForm: T?): MultipartBody.Builder {
+        multipartForm?.forEach { (key, value) ->
+            val filePath = (value as? Map<*, *> ?: emptyMap<Any, Any>())["filePath"]
+            if (filePath != null) {
+                val file = File(filePath.toString())
+                val mediaType = (value as? Map<*, *> ?: emptyMap<Any, Any>())["mediaType"].toString()
+                this.addFormDataPart(key.toString(), file.name, file.asRequestBody(mediaType.toMediaTypeOrNull()))
+            } else {
+                this.addFormDataPart(key.toString(), value.toString())
+            }
+        }
+        return this
+    }
+}

--- a/maestro-client/src/test/java/maestro/utils/HttpUtilsTest.kt
+++ b/maestro-client/src/test/java/maestro/utils/HttpUtilsTest.kt
@@ -1,0 +1,63 @@
+package maestro.utils
+
+import com.google.common.truth.Truth.assertThat
+import maestro.utils.HttpUtils.toMultipartBody
+import okhttp3.MultipartBody
+import org.junit.jupiter.api.Test
+
+internal class HttpUtilsTest {
+
+    @Test
+    internal fun `toMultipartBody should successfully parse a map containing a filePath along with mediaType`() {
+        // Given
+        val map = mapOf(
+            "uploadType" to "import",
+            "data" to (listOf(
+                "filePath" to "testFilePath",
+                "mediaType" to "text/csv"
+            ))
+        )
+
+        // When
+        val multipartBody = map.toMultipartBody()
+
+        // Then
+        assertThat(multipartBody.size).isEqualTo(2)
+        assertThat(multipartBody.type).isEqualTo(MultipartBody.FORM)
+    }
+
+    @Test
+    internal fun `toMultipartBody should successfully parse a map containing a filePath without mediaType`() {
+        // Given
+        val map = mapOf(
+            "uploadType" to "import",
+            "data" to (listOf(
+                "filePath" to "testFilePath"
+            ))
+        )
+
+        // When
+        val multipartBody = map.toMultipartBody()
+
+        // Then
+        assertThat(multipartBody.size).isEqualTo(2)
+        assertThat(multipartBody.type).isEqualTo(MultipartBody.FORM)
+    }
+
+    @Test
+    internal fun `toMultipartBody should successfully parse a map without a filePath`() {
+        // Given
+        val map = mapOf(
+            "data1" to "test1",
+            "data2" to "test2",
+            "data3" to "test3",
+        )
+
+        // When
+        val multipartBody = map.toMultipartBody()
+
+        // Then
+        assertThat(multipartBody.size).isEqualTo(3)
+        assertThat(multipartBody.type).isEqualTo(MultipartBody.FORM)
+    }
+}


### PR DESCRIPTION
## Proposed Changes

This PR adds support for multipart form data file upload.

The feature can be used to prepare data on the backend before running e2e tests on mobile.

Usage is simple. Instead of a `body` object, we can define `multipartForm` with as many fields as we want. We can also upload multiple files in one request by using many objects with `filePath` properties. `filePath` is required for the files. `mediaType` is optional. If `multipartForm` is available in a request then `body` will be ignored.

PR with the updated docs can be found here: https://github.com/mobile-dev-inc/maestro-docs/pull/28

### Example script
``` js
function uploadFile() {
  const filePath = ``;
  const url = ``;

  const response = http.post(url, {
    multipartForm: {
      "uploadType": "test",
      "data": {
        "filePath": filePath,
        "mediaType": "text/csv"
      }
    },
    headers: {
      'Authorization': `Bearer ${token}`
    },
  });
}
```

## Testing
 - Integration + unit tests
 - Manual testing
