### PR TITLE
[fix] set location permission is broken on iOS

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -460,6 +460,20 @@ object LocalSimulatorUtils {
                 )
             }
 
+            "unset" -> {
+                runCommand(
+                    listOf(
+                        "xcrun",
+                        "simctl",
+                        "privacy",
+                        deviceId,
+                        "reset",
+                        "location-always",
+                        bundleId
+                    )
+                )
+            }
+
             else -> throw IllegalArgumentException("wrong argument value '$value' was provided for 'location' permission")
         }
     }


### PR DESCRIPTION
## Proposed Changes

[AppleSimulatorUtils](https://github.com/wix/AppleSimulatorUtils) has some issues with setting permissions on iOS17 and newest Xcode 15 SDK. This PR migrates setting location permission logic (which was the main source of `Unable to clear state for app xxx.xxx` errors) to simctl.

## Testing
- [x] local test
- [x] staging test

## Issues Fixed
https://github.com/mobile-dev-inc/maestro/issues/1463
