### PR TITLE
fix: adds new crash case

### DIFF
--- a/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
+++ b/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
@@ -213,7 +213,8 @@ class XCTestDriverClientTest {
             return arrayOf(
                 "Application com.app.id is not running",
                 "Lost connection to the application (pid 19985).",
-                "Error getting main window kAXErrorCannotComplete"
+                "Error getting main window kAXErrorCannotComplete",
+                "Error getting main window Unknown kAXError value -25218"
             )
         }
     }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -291,6 +291,12 @@ class XCTestDriverClient(
                     "Request for $pathString failed, due to app crash with message ${error.errorMessage}"
                 )
             }
+            error.errorMessage.contains("Error getting main window.*".toRegex()) -> {
+                logger.error("Request for $pathString failed, because of app crash, body: $responseBodyAsString")
+                throw XCUITestServerError.AppCrash(
+                    "Request for $pathString failed, due to app crash with message ${error.errorMessage}"
+                )
+            }
             else -> {
                 logger.error("Request for $pathString failed, because of unknown reason, body: $responseBodyAsString")
                 throw XCUITestServerError.UnknownFailure(


### PR DESCRIPTION
## Proposed Changes

Adding a new crash case found during tests.

The message "Error getting main window Unknown kAXError value -25218" also means that app is crashed or force stopped. 
