### PR TITLE
feat: Improve executionOrder planning

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/ExecutionOrderPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/ExecutionOrderPlanner.kt
@@ -1,0 +1,29 @@
+package maestro.orchestra.workspace
+
+import java.nio.file.Path
+
+object ExecutionOrderPlanner {
+
+    fun getFlowsToRunInSequence(
+        paths: Map<String, Path>,
+        flowOrder: List<String>,
+    ): List<Path> {
+        if (flowOrder.isEmpty()) return emptyList()
+
+        val orderSet = flowOrder.toSet()
+
+        val namesInOrder = paths.keys.filter { it in orderSet }
+        if (namesInOrder.isEmpty()) return emptyList()
+
+        val result = orderSet.takeWhile { it in namesInOrder }
+
+        return if (result.isEmpty()) {
+            error("Could not find flows needed for execution in order: ${(orderSet - namesInOrder.toSet()).joinToString()}")
+        } else if (flowOrder.slice(result.indices) == result) {
+            result.map { paths[it]!! }
+        } else {
+            emptyList()
+        }
+    }
+
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/ExecutionOrderPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/ExecutionOrderPlannerTest.kt
@@ -1,0 +1,90 @@
+package maestro.orchestra.workspace
+
+import com.google.common.truth.Truth.assertThat
+import maestro.orchestra.workspace.ExecutionOrderPlanner.getFlowsToRunInSequence
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalStateException
+import kotlin.io.path.Path
+
+internal class ExecutionOrderPlannerTest {
+
+    @Test
+    fun `if the paths are already in sequence it should return the sequence`() {
+        val paths = mapOf("flowA" to Path("flowA"), "flowB" to Path("flowB"))
+        val flowOrder = listOf("flowA", "flowB")
+        val expected = listOf(Path("flowA"), Path("flowB"))
+
+        val result = getFlowsToRunInSequence(paths, flowOrder)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `if the paths are not in sequence it should return in the correct sequence`() {
+        val paths = mapOf("flowA" to Path("flowA"), "flowB" to Path("flowB"))
+        val flowOrder = listOf("flowB", "flowA")
+        val expected = listOf(Path("flowB"), Path("flowA"))
+
+        val result = getFlowsToRunInSequence(paths, flowOrder)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `if there are more paths then the sequence it should return in only those in the sequence in the correct order`() {
+        val paths = mapOf("flowA" to Path("flowA"), "flowB" to Path("flowB"), "flowC" to Path("flowC"))
+        val flowOrder = listOf("flowC", "flowA")
+        val expected = listOf(Path("flowC"), Path("flowA"))
+
+        val result = getFlowsToRunInSequence(paths, flowOrder)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `if there are less paths then the sequence it should return in only those in the sequence in the correct order if the missing are after all the paths in the sequence`() {
+        val paths = mapOf("flowA" to Path("flowA"), "flowB" to Path("flowB"), "flowC" to Path("flowC"))
+        val flowOrder = listOf("flowC", "flowA", "flowD")
+        val expected = listOf(Path("flowC"), Path("flowA"))
+
+        val result = getFlowsToRunInSequence(paths, flowOrder)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `if there are less paths then the sequence it should return error if the missing are not after all present`() {
+        val pathsX = mapOf("flowA" to Path("flowA"), "flowB" to Path("flowB"), "flowC" to Path("flowC"))
+        val flowOrderX = listOf("flowG", "flowC", "flowD", "flowA")
+
+        val pathsY = mapOf("flowA" to Path("flowA"))
+        val flowOrderY = listOf("flowE", "flowC", "flowD", "flowA")
+
+        val exceptionX = assertThrows<IllegalStateException> {
+            getFlowsToRunInSequence(pathsX, flowOrderX)
+        }
+        val exceptionY = assertThrows<IllegalStateException> {
+            getFlowsToRunInSequence(pathsY, flowOrderY)
+        }
+        assertThat(exceptionX.message).isEqualTo("Could not find flows needed for execution in order: flowG, flowD")
+        assertThat(exceptionY.message).isEqualTo("Could not find flows needed for execution in order: flowE, flowC, flowD")
+    }
+
+    @Test
+    fun `if the sequence is empty it should return an empty list`() {
+        val paths = mapOf("flowA" to Path("flowA"), "flowB" to Path("flowB"), "flowC" to Path("flowC"))
+        val flowOrder = emptyList<String>()
+        val expected = emptyList<String>()
+
+        val result = getFlowsToRunInSequence(paths, flowOrder)
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `if no paths are present in the sequence it should return an empty list`() {
+        val paths = mapOf("flowA" to Path("flowA"), "flowB" to Path("flowB"), "flowC" to Path("flowC"))
+        val flowOrder = listOf("flowE", "flowD")
+        val expected = emptyList<String>()
+
+        val result = getFlowsToRunInSequence(paths, flowOrder)
+        assertThat(result).isEqualTo(expected)
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes

executionOrder right now is unnatural, and this PR proposes a better API/understanding for it. This PR also improves the error message to contain all missing flows, not only the first it encounters.

> This is not a breaking change, as working workspaces will be kept working.

### New behavior

Suppose you have 4 flows specified in the `executionOrder`:
A -> B -> C -> D (D depends on C, which depends on B, which depends on A)
However, if you decide to execute only the first 3 (A, B, C) the current behavior is to error out. This PR enables this execution since the missing flow is _AFTER_ the ones present, in other words, the ones being requested to execute does not have a dependency on the missing one (D).

Suppose you have 2 flows specified in the `executionOrder`:
A -> B
However, if you decide to execute the first and another one (A, C) the current behavior is to error out. This PR enables it.

Suppose you have 2 flows specified in the `executionOrder`:
A -> B
However, if you decide to execute none of the listed (C, D) the current behavior is to error out. This PR enables it.


### Behaviors kept

Suppose you have 4 flows specified in the `executionOrder`:
A -> B -> C -> D
However, if you decide to execute the last 2 (C, D) the current behavior is to error out. This PR keeps this behavior. Additionally, this PR improves the error message by saying that both A, B are missing, before it was only A.

## Testing

- [x] Given the complexity, I've tried to make a lot of unit tests.