### PR TITLE
Improve scrollUntilVisible to center element

### DIFF
--- a/maestro-client/src/main/java/maestro/UiElement.kt
+++ b/maestro-client/src/main/java/maestro/UiElement.kt
@@ -58,23 +58,12 @@ data class UiElement(
             SwipeDirection.LEFT, SwipeDirection.RIGHT -> screenWidth / 5
         }
 
+        // return true when the element center is within the <direction> half of the screen bounds plus margin
         return when(direction) {
-            SwipeDirection.RIGHT -> {
-                // return true when the element center is within the right half of the screen bounds plus margin
-                elementCenterX > centerX - margin
-            }
-            SwipeDirection.LEFT -> {
-                // return true when the element center is within the left half of the screen bounds minus a margin
-                elementCenterX < centerX + margin
-            }
-            SwipeDirection.UP -> {
-                // return true when the element center is within the top half of the screen bounds minus a margin
-                elementCenterY < centerY + margin
-            }
-            SwipeDirection.DOWN -> {
-                // return true when the element center is within the bottom half of the screen bounds plus a margin
-                elementCenterY > centerY - margin
-            }
+            SwipeDirection.RIGHT -> elementCenterX > centerX - margin
+            SwipeDirection.LEFT -> elementCenterX < centerX + margin
+            SwipeDirection.UP -> elementCenterY < centerY + margin
+            SwipeDirection.DOWN -> elementCenterY > centerY - margin
         }
     }
 

--- a/maestro-client/src/main/java/maestro/UiElement.kt
+++ b/maestro-client/src/main/java/maestro/UiElement.kt
@@ -46,6 +46,38 @@ data class UiElement(
         return visibleArea.toDouble() / totalArea.toDouble()
     }
 
+    fun isElementNearScreenCenter(direction: SwipeDirection, screenWidth: Int, screenHeight: Int): Boolean {
+        val centerX = screenWidth / 2
+        val centerY = screenHeight / 2
+
+        val elementCenterX = bounds.x + (bounds.width / 2)
+        val elementCenterY = bounds.y + (bounds.height / 2)
+
+        val margin = when(direction) {
+            SwipeDirection.DOWN, SwipeDirection.UP -> screenHeight / 5
+            SwipeDirection.LEFT, SwipeDirection.RIGHT -> screenWidth / 5
+        }
+
+        return when(direction) {
+            SwipeDirection.RIGHT -> {
+                // return true when the element center is within the right half of the screen bounds plus margin
+                elementCenterX > centerX - margin
+            }
+            SwipeDirection.LEFT -> {
+                // return true when the element center is within the left half of the screen bounds minus a margin
+                elementCenterX < centerX + margin
+            }
+            SwipeDirection.UP -> {
+                // return true when the element center is within the top half of the screen bounds minus a margin
+                elementCenterY < centerY + margin
+            }
+            SwipeDirection.DOWN -> {
+                // return true when the element center is within the bottom half of the screen bounds plus a margin
+                elementCenterY > centerY - margin
+            }
+        }
+    }
+
     fun isWithinViewPortBounds(info: DeviceInfo, paddingHorizontal: Float = 0f, paddingVertical: Float = 0f): Boolean {
         val paddingX = (info.widthGrid * paddingHorizontal).toInt()
         val paddingY = (info.heightGrid * paddingVertical).toInt()

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -94,7 +94,8 @@ data class ScrollUntilVisibleCommand(
     val direction: ScrollDirection,
     val scrollDuration: Long,
     val visibilityPercentage: Int,
-    val timeout: Long = DEFAULT_TIMEOUT_IN_MILLIS
+    val timeout: Long = DEFAULT_TIMEOUT_IN_MILLIS,
+    val centerElement: Boolean
 ) : Command {
 
     val visibilityPercentageNormalized = (visibilityPercentage / 100).toDouble()
@@ -113,6 +114,7 @@ data class ScrollUntilVisibleCommand(
         const val DEFAULT_TIMEOUT_IN_MILLIS = 20 * 1000L
         const val DEFAULT_SCROLL_DURATION = 40
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
+        const val DEFAULT_CENTER_ELEMENT = false
     }
 }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -398,7 +398,6 @@ class Orchestra(
 
                 if (command.centerElement && visibility > 0.1 && retryCenterCount <= maxRetryCenterCount) {
                     if (element.isElementNearScreenCenter(direction, deviceInfo.widthGrid, deviceInfo.heightGrid)) {
-                        println("Element is near center")
                         return true
                     }
                     retryCenterCount++

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -388,16 +388,15 @@ class Orchestra(
         val direction = command.direction.toSwipeDirection()
         val deviceInfo = maestro.deviceInfo()
 
-        val shouldCenterElement = true
         var retryCenterCount = 0
-        var maxRetryCenterCount = 4
+        val maxRetryCenterCount = 4 // for when the list is no longer scrollable (last element) but the element is visible
 
         do {
             try {
                 val element = findElement(command.selector, 500).element
                 val visibility = element.getVisiblePercentage(deviceInfo.widthGrid, deviceInfo.heightGrid)
 
-                if (shouldCenterElement && visibility > 0.1 && retryCenterCount <= maxRetryCenterCount) {
+                if (command.centerElement && visibility > 0.1 && retryCenterCount <= maxRetryCenterCount) {
                     if (element.isElementNearScreenCenter(direction, deviceInfo.widthGrid, deviceInfo.heightGrid)) {
                         println("Element is near center")
                         return true

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -529,7 +529,8 @@ data class YamlFluentCommand(
                 direction = yaml.direction,
                 timeout = timeout,
                 scrollDuration = yaml.speedToDuration(),
-                visibilityPercentage = visibility
+                visibilityPercentage = visibility,
+                centerElement = yaml.centerElement
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -10,7 +10,8 @@ data class YamlScrollUntilVisible(
     val element: YamlElementSelectorUnion,
     val timeout: Long = ScrollUntilVisibleCommand.DEFAULT_TIMEOUT_IN_MILLIS,
     val speed: Int = ScrollUntilVisibleCommand.DEFAULT_SCROLL_DURATION,
-    val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE
+    val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE,
+    val centerElement: Boolean = ScrollUntilVisibleCommand.DEFAULT_CENTER_ELEMENT
 ) {
     fun speedToDuration(): Long {
         return (1000 * (100 - speed).toDouble() / 100).toLong() + 1

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2995,6 +2995,33 @@ class IntegrationTest {
         driver.assertEvents(listOf(Event.AddMedia, Event.AddMedia, Event.AddMedia))
     }
 
+    @Test
+    fun `Case 112 - Scroll until view is visible - with element center`() {
+        // Given
+        val commands = readCommands("112_scroll_until_visible_center")
+        val info = driver { }.deviceInfo()
+
+        val elementBounds = Bounds(0, 0 + info.heightGrid, 100, 100 + info.heightGrid)
+        val driver = driver {
+            element {
+                text = "Test"
+                bounds = elementBounds
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            assertThat(orchestra(it).runFlow(commands)).isTrue()
+        }
+
+        // Then
+        driver.assertEvents(
+            listOf(
+                Event.SwipeElementWithDirection(Point(270, 480), SwipeDirection.UP, 1),
+            )
+        )
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/112_scroll_until_visible_center.yaml
+++ b/maestro-test/src/test/resources/112_scroll_until_visible_center.yaml
@@ -1,0 +1,10 @@
+appId: com.example.app
+---
+- scrollUntilVisible:
+    centerElement: true
+    element:
+      text: "Test"
+    speed: 100
+    visibilityPercentage: 100
+    direction: DOWN
+    timeout: 10


### PR DESCRIPTION
## Proposed Changes
This change will attempt to center (on screen) the element we scroll to.
- If the element is the last element on the list, we will attempt to center a few times and then exit with success (if the element is indeed visible)
- This is an opt-in feature

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef41ce2</samp>

This pull request adds a new feature to the `maestro` framework that allows scrolling until an element is centered on the screen. It modifies the `ScrollUntilVisibleCommand` class, the `Orchestra` class, the `UiElement` class, and the YAML parsing and command execution logic to support the new feature. It also adds a new test case and a YAML file to verify the functionality.

## Testing
- Locally
- Test case

**PS: This is a non breaking change. It's opt-in**

## Issues Fixed
- Sometimes elements would not fully show but it would be considered as visible
- Different UI Frameworks return inconsistent element bounds. Centering on screen should make this command more reliable.

Usage:

```yaml
- scrollUntilVisible:
    centerElement: true
    element:
      text: "Item 6"
```

**Before**

https://github.com/mobile-dev-inc/maestro/assets/2115575/f9d65a3b-dd53-478b-b4cb-4a769b182b67

**After**

https://github.com/mobile-dev-inc/maestro/assets/2115575/593c27ef-ad85-4f2b-84cc-a82b5ddc2eea



