### PR TITLE
fix: throws different exception instead of `TimeoutException` for driver startup

### DIFF
--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -36,10 +36,6 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
         val hierarchyRoot: TreeNode,
     ) : MaestroException(message)
 
-    open class OutgoingRequestAssertionFailure(
-        message: String,
-    ) : MaestroException(message)
-
     class ElementNotFound(
         message: String,
         hierarchyRoot: TreeNode,
@@ -56,4 +52,10 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
     ) : MaestroException(message)
 
     class DeprecatedCommand(message: String) : MaestroException(message)
+}
+
+sealed class MaestroDriverStartupException(override val message: String): RuntimeException() {
+    class AndroidDriverTimeoutException(message: String): MaestroDriverStartupException(message)
+    class AndroidInstrumentationSetupFailure(message: String): MaestroDriverStartupException(message)
+    class IOSDriverTimeoutException(message: String): MaestroDriverStartupException(message)
 }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -26,6 +26,7 @@ import dadb.AdbShellStream
 import dadb.Dadb
 import io.grpc.ManagedChannelBuilder
 import maestro.*
+import maestro.MaestroDriverStartupException.*
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.android.AndroidAppFiles
 import maestro.android.AndroidLaunchArguments.toAndroidLaunchArguments
@@ -96,7 +97,7 @@ class AndroidDriver(
             instrumentationSession?.close()
             Thread.sleep(100)
         }
-        throw TimeoutException("Maestro instrumentation could not be initialized")
+        throw AndroidInstrumentationSetupFailure("Maestro instrumentation could not be initialized")
     }
 
     private fun allocateForwarder() {
@@ -123,7 +124,7 @@ class AndroidDriver(
             Thread.sleep(100)
         }
 
-        throw TimeoutException("Maestro Android driver did not start up in time")
+        throw AndroidDriverTimeoutException("Maestro Android driver did not start up in time")
     }
 
     override fun close() {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -26,6 +26,7 @@ import hierarchy.AXElement
 import ios.IOSDevice
 import ios.IOSDeviceErrors
 import maestro.*
+import maestro.MaestroDriverStartupException.*
 import maestro.UiElement.Companion.toUiElement
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.utils.*
@@ -472,7 +473,7 @@ class IOSDriver(
             Thread.sleep(100)
         }
 
-        throw TimeoutException("Maestro iOS driver did not start up in time")
+        throw IOSDriverTimeoutException("Maestro iOS driver did not start up in time")
     }
 
     private fun <T> runDeviceCall(call: () -> T): T {


### PR DESCRIPTION
## Proposed Changes

Throws custom exception instead of timeout exception since that can lead to misclassification of exceptions

## Testing
- [x] Local
- [x] Staging

## Issues Fixed
