### PR TITLE
Improve command speed for animation heavy screens

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -21,7 +21,7 @@ package maestro
 
 import okio.Sink
 import java.io.File
-import java.util.UUID
+import java.util.*
 
 interface Driver {
 
@@ -87,7 +87,7 @@ interface Driver {
 
     fun waitUntilScreenIsStatic(timeoutMs: Long): Boolean
 
-    fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?): ViewHierarchy?
+    fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int? = null): ViewHierarchy?
 
     fun capabilities(): List<Capability>
 

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -21,7 +21,7 @@ package maestro
 
 import okio.Sink
 import java.io.File
-import java.util.*
+import java.util.UUID
 
 interface Driver {
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -301,7 +301,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
                     if (tapRepeat.repeat > 1) Thread.sleep(delay) // do not wait for single taps
                 }
             } else driver.tap(Point(x, y))
-            val hierarchyAfterTap = waitForAppToSettle()
+            val hierarchyAfterTap = waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
 
             if (hierarchyAfterTap == null || hierarchyBeforeTap != hierarchyAfterTap) {
                 LOGGER.info("Something has changed in the UI judging by view hierarchy. Proceed.")

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -29,12 +29,10 @@ import maestro.utils.SocketUtils
 import okio.Sink
 import okio.buffer
 import okio.sink
-import okio.source
 import org.slf4j.LoggerFactory
 import java.awt.image.BufferedImage
 import java.io.File
-import java.nio.file.Path
-import java.util.UUID
+import java.util.*
 import kotlin.system.measureTimeMillis
 
 @Suppress("unused", "MemberVisibilityCanBePrivate")
@@ -169,19 +167,20 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         waitUntilVisible: Boolean = false,
         longPress: Boolean = false,
         appId: String? = null,
-        tapRepeat: TapRepeat? = null
+        tapRepeat: TapRepeat? = null,
+        waitToSettleTimeoutMs: Int? = null
     ) {
         LOGGER.info("Tapping on element: ${tapRepeat ?: ""} $element")
 
-        val hierarchyBeforeTap = waitForAppToSettle(initialHierarchy, appId) ?: initialHierarchy
+        val hierarchyBeforeTap = waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs) ?: initialHierarchy
 
         val center = (
-            hierarchyBeforeTap
-                .refreshElement(element.treeNode)
-                ?.also { LOGGER.info("Refreshed element") }
-                ?.toUiElementOrNull()
-                ?: element
-            ).bounds
+                hierarchyBeforeTap
+                    .refreshElement(element.treeNode)
+                    ?.also { LOGGER.info("Refreshed element") }
+                    ?.toUiElementOrNull()
+                    ?: element
+                ).bounds
             .center()
         performTap(
             x = center.x,
@@ -189,7 +188,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
             retryIfNoChange = retryIfNoChange,
             longPress = longPress,
             initialHierarchy = hierarchyBeforeTap,
-            tapRepeat = tapRepeat
+            tapRepeat = tapRepeat,
+            waitToSettleTimeoutMs = waitToSettleTimeoutMs
         )
 
         if (waitUntilVisible) {
@@ -219,7 +219,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         percentY: Int,
         retryIfNoChange: Boolean = true,
         longPress: Boolean = false,
-        tapRepeat: TapRepeat? = null
+        tapRepeat: TapRepeat? = null,
+        waitToSettleTimeoutMs: Int? = null
     ) {
         val x = cachedDeviceInfo.widthGrid * percentX / 100
         val y = cachedDeviceInfo.heightGrid * percentY / 100
@@ -228,7 +229,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
             y = y,
             retryIfNoChange = retryIfNoChange,
             longPress = longPress,
-            tapRepeat = tapRepeat
+            tapRepeat = tapRepeat,
+            waitToSettleTimeoutMs = waitToSettleTimeoutMs
         )
     }
 
@@ -238,13 +240,15 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         retryIfNoChange: Boolean = true,
         longPress: Boolean = false,
         tapRepeat: TapRepeat? = null,
+        waitToSettleTimeoutMs: Int? = null
     ) {
         performTap(
             x = x,
             y = y,
             retryIfNoChange = retryIfNoChange,
             longPress = longPress,
-            tapRepeat = tapRepeat
+            tapRepeat = tapRepeat,
+            waitToSettleTimeoutMs = waitToSettleTimeoutMs
         )
     }
 
@@ -258,14 +262,15 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         retryIfNoChange: Boolean = true,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
-        tapRepeat: TapRepeat? = null
+        tapRepeat: TapRepeat? = null,
+        waitToSettleTimeoutMs: Int? = null
     ) {
         val capabilities = driver.capabilities()
 
         if (Capability.FAST_HIERARCHY in capabilities) {
-            hierarchyBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat)
+            hierarchyBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs)
         } else {
-            screenshotBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat)
+            screenshotBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs)
         }
     }
 
@@ -275,7 +280,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         retryIfNoChange: Boolean = true,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
-        tapRepeat: TapRepeat? = null
+        tapRepeat: TapRepeat? = null,
+        waitToSettleTimeoutMs: Int? = null
     ) {
         LOGGER.info("Tapping at ($x, $y) using screenshot based logic for wait")
 
@@ -310,7 +316,8 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         retryIfNoChange: Boolean = true,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
-        tapRepeat: TapRepeat? = null
+        tapRepeat: TapRepeat? = null,
+        waitToSettleTimeoutMs: Int? = null
     ) {
         LOGGER.info("Tapping at ($x, $y) using hierarchy based logic for wait")
 
@@ -333,7 +340,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
             } else {
                 driver.tap(Point(x, y))
             }
-            val hierarchyAfterTap = waitForAppToSettle()
+            val hierarchyAfterTap = waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
 
             if (hierarchyBeforeTap != hierarchyAfterTap) {
                 LOGGER.info("Something have changed in the UI judging by view hierarchy. Proceed.")
@@ -442,8 +449,12 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return filter(viewHierarchy().aggregate())
     }
 
-    fun waitForAppToSettle(initialHierarchy: ViewHierarchy? = null, appId: String? = null): ViewHierarchy? {
-        return driver.waitForAppToSettle(initialHierarchy, appId)
+    fun waitForAppToSettle(
+        initialHierarchy: ViewHierarchy? = null,
+        appId: String? = null,
+        waitToSettleTimeoutMs: Int? = null
+    ): ViewHierarchy? {
+        return driver.waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs)
     }
 
     fun inputText(text: String) {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -519,24 +519,24 @@ class AndroidDriver(
         return false
     }
 
-    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?): ViewHierarchy? {
+    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int?): ViewHierarchy? {
         return if (appId != null) {
-            waitForWindowToSettle(appId, initialHierarchy)
+            waitForWindowToSettle(appId, initialHierarchy, timeoutMs)
         } else {
-            ScreenshotUtils.waitForAppToSettle(initialHierarchy, this)
+            ScreenshotUtils.waitForAppToSettle(initialHierarchy, this, timeoutMs)
         }
     }
 
-    private fun waitForWindowToSettle(appId: String, initialHierarchy: ViewHierarchy?): ViewHierarchy {
+    private fun waitForWindowToSettle(appId: String, initialHierarchy: ViewHierarchy?, timeoutMs: Int? = null): ViewHierarchy {
         val endTime = System.currentTimeMillis() + WINDOW_UPDATE_TIMEOUT_MS
-
+        var hierarchy: ViewHierarchy? = null
         do {
             if (blockingStub.isWindowUpdating(checkWindowUpdatingRequest { this.appId = appId }).isWindowUpdating) {
-                ScreenshotUtils.waitForAppToSettle(initialHierarchy, this)
+                 hierarchy = ScreenshotUtils.waitForAppToSettle(initialHierarchy, this, timeoutMs)
             }
         } while (System.currentTimeMillis() < endTime)
 
-        return ScreenshotUtils.waitForAppToSettle(initialHierarchy, this)
+        return hierarchy ?: ScreenshotUtils.waitForAppToSettle(initialHierarchy, this)
     }
 
     override fun waitUntilScreenIsStatic(timeoutMs: Long): Boolean {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -416,7 +416,7 @@ class IOSDriver(
         LOGGER.info("Waiting for animation to end with timeout $SCREEN_SETTLE_TIMEOUT_MS")
         val didFinishOnTime = waitUntilScreenIsStatic(SCREEN_SETTLE_TIMEOUT_MS)
 
-        return if (didFinishOnTime) null else ScreenshotUtils.waitForAppToSettle(initialHierarchy, this)
+        return if (didFinishOnTime) null else ScreenshotUtils.waitForAppToSettle(initialHierarchy, this, timeoutMs)
     }
 
     override fun capabilities(): List<Capability> {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -412,7 +412,7 @@ class IOSDriver(
         }
     }
 
-    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?): ViewHierarchy? {
+    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int?): ViewHierarchy? {
         LOGGER.info("Waiting for animation to end with timeout $SCREEN_SETTLE_TIMEOUT_MS")
         val didFinishOnTime = waitUntilScreenIsStatic(SCREEN_SETTLE_TIMEOUT_MS)
 

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -351,7 +351,7 @@ class WebDriver(val isStudio: Boolean) : Driver {
         return true
     }
 
-    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?): ViewHierarchy? {
+    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int?): ViewHierarchy? {
         return ScreenshotUtils.waitForAppToSettle(initialHierarchy, this)
     }
 

--- a/maestro-client/src/main/java/maestro/utils/ScreenshotUtils.kt
+++ b/maestro-client/src/main/java/maestro/utils/ScreenshotUtils.kt
@@ -35,19 +35,39 @@ class ScreenshotUtils {
             null
         }
 
-        fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, driver: Driver): ViewHierarchy {
-            var latestHierarchy = initialHierarchy ?: viewHierarchy(driver)
-            repeat(10) {
-                val hierarchyAfter = viewHierarchy(driver)
-                if (latestHierarchy == hierarchyAfter) {
-                    val isLoading = latestHierarchy.root.attributes.getOrDefault("is-loading", "false").toBoolean()
-                    if (!isLoading) {
-                        return hierarchyAfter
+        fun waitForAppToSettle(
+            initialHierarchy: ViewHierarchy?,
+            driver: Driver,
+            timeoutMs: Int? = null
+        ): ViewHierarchy {
+            var latestHierarchy: ViewHierarchy
+            if (timeoutMs != null) {
+                val endTime = System.currentTimeMillis() + timeoutMs
+                latestHierarchy = initialHierarchy ?: viewHierarchy(driver)
+                do {
+                    val hierarchyAfter = viewHierarchy(driver)
+                    if (latestHierarchy == hierarchyAfter) {
+                        val isLoading = latestHierarchy.root.attributes.getOrDefault("is-loading", "false").toBoolean()
+                        if (!isLoading) {
+                            return hierarchyAfter
+                        }
                     }
-                }
-                latestHierarchy = hierarchyAfter
+                    latestHierarchy = hierarchyAfter
+                } while (System.currentTimeMillis() < endTime)
+            } else {
+                latestHierarchy = initialHierarchy ?: viewHierarchy(driver)
+                repeat(10) {
+                    val hierarchyAfter = viewHierarchy(driver)
+                    if (latestHierarchy == hierarchyAfter) {
+                        val isLoading = latestHierarchy.root.attributes.getOrDefault("is-loading", "false").toBoolean()
+                        if (!isLoading) {
+                            return hierarchyAfter
+                        }
+                    }
+                    latestHierarchy = hierarchyAfter
 
-                MaestroTimer.sleep(MaestroTimer.Reason.WAIT_TO_SETTLE, 200)
+                    MaestroTimer.sleep(MaestroTimer.Reason.WAIT_TO_SETTLE, 200)
+                }
             }
 
             return latestHierarchy

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -240,6 +240,7 @@ data class TapOnElementCommand(
 
     companion object {
         const val DEFAULT_REPEAT_DELAY = 100L
+        const val MAX_TIMEOUT_WAIT_TO_SETTLE_MS = 30000
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -224,7 +224,8 @@ data class TapOnElementCommand(
     val retryIfNoChange: Boolean? = null,
     val waitUntilVisible: Boolean? = null,
     val longPress: Boolean? = null,
-    val repeat: TapRepeat? = null
+    val repeat: TapRepeat? = null,
+    val waitToSettleTimeoutMs: Int? = null
 ) : Command {
 
     override fun description(): String {
@@ -265,7 +266,8 @@ data class TapOnPointV2Command(
     val point: String,
     val retryIfNoChange: Boolean? = null,
     val longPress: Boolean? = null,
-    val repeat: TapRepeat? = null
+    val repeat: TapRepeat? = null,
+    val waitToSettleTimeoutMs: Int? = null
 ) : Command {
 
     override fun description(): String {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -222,7 +222,8 @@ class Orchestra(
         if (this::jsEngine.isInitialized) {
             jsEngine.close()
         }
-        val shouldUseGraalJs = config?.ext?.get("jsEngine") == "graaljs" || System.getenv("MAESTRO_USE_GRAALJS") == "true"
+        val shouldUseGraalJs =
+            config?.ext?.get("jsEngine") == "graaljs" || System.getenv("MAESTRO_USE_GRAALJS") == "true"
         jsEngine = if (shouldUseGraalJs) {
             httpClient?.let { GraalJsEngine(it) } ?: GraalJsEngine()
         } else {
@@ -317,7 +318,7 @@ class Orchestra(
 
     private fun isOptional(condition: Condition): Boolean {
         return condition.visible?.optional == true
-            || condition.notVisible?.optional == true
+                || condition.notVisible?.optional == true
     }
 
     private fun evalScriptCommand(command: EvalScriptCommand): Boolean {
@@ -389,7 +390,8 @@ class Orchestra(
         val deviceInfo = maestro.deviceInfo()
 
         var retryCenterCount = 0
-        val maxRetryCenterCount = 4 // for when the list is no longer scrollable (last element) but the element is visible
+        val maxRetryCenterCount =
+            4 // for when the list is no longer scrollable (last element) but the element is visible
 
         do {
             try {
@@ -401,8 +403,7 @@ class Orchestra(
                         return true
                     }
                     retryCenterCount++
-                }
-                else if (visibility >= command.visibilityPercentageNormalized) {
+                } else if (visibility >= command.visibilityPercentageNormalized) {
                     return true
                 }
             } catch (ignored: MaestroException.ElementNotFound) {
@@ -410,7 +411,10 @@ class Orchestra(
             maestro.swipeFromCenter(direction, durationMs = command.scrollDuration)
         } while (System.currentTimeMillis() < endTime)
 
-        throw MaestroException.ElementNotFound("No visible element found: ${command.selector.description()}", maestro.viewHierarchy().root)
+        throw MaestroException.ElementNotFound(
+            "No visible element found: ${command.selector.description()}",
+            maestro.viewHierarchy().root
+        )
     }
 
     private fun hideKeyboardCommand(): Boolean {
@@ -598,7 +602,11 @@ class Orchestra(
         }
     }
 
-    private fun runSubFlow(commands: List<MaestroCommand>, config: MaestroConfig?, subflowConfig: MaestroConfig?): Boolean {
+    private fun runSubFlow(
+        commands: List<MaestroCommand>,
+        config: MaestroConfig?,
+        subflowConfig: MaestroConfig?
+    ): Boolean {
         executeDefineVariablesCommands(commands, config)
         // filter out DefineVariablesCommand to not execute it twice
         val filteredCommands = commands.filter { it.asCommand() !is DefineVariablesCommand }
@@ -738,7 +746,7 @@ class Orchestra(
         command: TapOnElementCommand,
         retryIfNoChange: Boolean,
         waitUntilVisible: Boolean,
-        config: MaestroConfig?,
+        config: MaestroConfig?
     ): Boolean {
         return try {
             val result = findElement(command.selector)
@@ -749,7 +757,8 @@ class Orchestra(
                 waitUntilVisible,
                 command.longPress ?: false,
                 config?.appId,
-                tapRepeat = command.repeat
+                tapRepeat = command.repeat,
+                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
             )
 
             true
@@ -764,7 +773,7 @@ class Orchestra(
 
     private fun tapOnPoint(
         command: TapOnPointCommand,
-        retryIfNoChange: Boolean,
+        retryIfNoChange: Boolean
     ): Boolean {
         maestro.tap(
             command.x,
@@ -797,7 +806,8 @@ class Orchestra(
                 percentY = percentY,
                 retryIfNoChange = command.retryIfNoChange ?: true,
                 longPress = command.longPress ?: false,
-                tapRepeat = command.repeat
+                tapRepeat = command.repeat,
+                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
             )
         } else {
             val (x, y) = point.split(",")
@@ -810,7 +820,8 @@ class Orchestra(
                 y = y,
                 retryIfNoChange = command.retryIfNoChange ?: true,
                 longPress = command.longPress ?: false,
-                tapRepeat = command.repeat
+                tapRepeat = command.repeat,
+                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
             )
         }
 
@@ -914,7 +925,12 @@ class Orchestra(
             ?.let { descendantSelectors ->
                 val descendantDescriptions = descendantSelectors.joinToString("; ") { it.description() }
                 descriptions += "Contains descendants: $descendantDescriptions"
-                filters += Filters.containsDescendants(descendantSelectors.map { buildFilter(it, deviceInfo).filterFunc })
+                filters += Filters.containsDescendants(descendantSelectors.map {
+                    buildFilter(
+                        it,
+                        deviceInfo
+                    ).filterFunc
+                })
             }
 
         selector.traits
@@ -1004,7 +1020,12 @@ class Orchestra(
             }
 
             direction != null -> maestro.swipe(swipeDirection = direction, duration = command.duration)
-            start != null && end != null -> maestro.swipe(startPoint = start, endPoint = end, duration = command.duration)
+            start != null && end != null -> maestro.swipe(
+                startPoint = start,
+                endPoint = end,
+                duration = command.duration
+            )
+
             else -> error("Illegal arguments for swiping")
         }
         return true

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -47,5 +47,6 @@ data class YamlElementSelector(
     val checked: Boolean? = null,
     val focused: Boolean? = null,
     val repeat: Int? = null,
-    val delay: Int? = null
+    val delay: Int? = null,
+    val waitToSettleTimeoutMs: Int? = null
 ) : YamlElementSelectorUnion

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -391,7 +391,10 @@ data class YamlFluentCommand(
             TapRepeat(count, d)
         }
 
-        val waitToSettleTimeoutMs = (tapOn as? YamlElementSelector)?.waitToSettleTimeoutMs
+        val waitToSettleTimeoutMs = (tapOn as? YamlElementSelector)?.waitToSettleTimeoutMs?.let {
+            if (it > TapOnElementCommand.MAX_TIMEOUT_WAIT_TO_SETTLE_MS) TapOnElementCommand.MAX_TIMEOUT_WAIT_TO_SETTLE_MS
+            else it
+        }
 
         return if (point != null) {
             MaestroCommand(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -391,13 +391,16 @@ data class YamlFluentCommand(
             TapRepeat(count, d)
         }
 
+        val waitToSettleTimeoutMs = (tapOn as? YamlElementSelector)?.waitToSettleTimeoutMs
+
         return if (point != null) {
             MaestroCommand(
                 TapOnPointV2Command(
                     point = point,
                     retryIfNoChange = retryIfNoChange,
                     longPress = longPress,
-                    repeat = repeat
+                    repeat = repeat,
+                    waitToSettleTimeoutMs = waitToSettleTimeoutMs
                 )
             )
         } else {
@@ -407,7 +410,8 @@ data class YamlFluentCommand(
                     retryIfNoChange = retryIfNoChange,
                     waitUntilVisible = waitUntilVisible,
                     longPress = longPress,
-                    repeat = repeat
+                    repeat = repeat,
+                    waitToSettleTimeoutMs = waitToSettleTimeoutMs
                 )
             )
         }

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -343,8 +343,8 @@ class FakeDriver : Driver {
         }
     }
 
-    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?): ViewHierarchy? {
-        return ScreenshotUtils.waitForAppToSettle(initialHierarchy, this)
+    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int?): ViewHierarchy? {
+        return ScreenshotUtils.waitForAppToSettle(initialHierarchy, this, timeoutMs)
     }
 
     override fun waitUntilScreenIsStatic(timeoutMs: Long): Boolean {

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeLayoutElement.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeLayoutElement.kt
@@ -35,6 +35,7 @@ data class FakeLayoutElement(
     var color: Color = Color.BLACK,
     var onClick: (FakeLayoutElement) -> Unit = {},
     val children: MutableList<FakeLayoutElement> = mutableListOf(),
+    var mutatingText: (() -> String)? = null
 ) {
 
     fun toTreeNode(): TreeNode {
@@ -44,7 +45,9 @@ data class FakeLayoutElement(
             attributes += "bounds" to "${it.left},${it.top},${it.right},${it.bottom}"
         }
 
-        text?.let {
+        val textNode = if (mutatingText != null) mutatingText!!() else text
+
+        textNode?.let {
             attributes += "text" to it
         }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3045,11 +3045,9 @@ class IntegrationTest {
             }
         }
 
-        println("Time elapsed: ${elapsedTime}ms")
-
         // Then
         // No test failure
-        assertThat(elapsedTime).isAtMost(1200)
+        assertThat(elapsedTime).isAtMost(1000)
         driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 1)
     }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3023,6 +3023,28 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 113 - Tap on element - with app settle timeout`() {
+        // Given
+        val commands = readCommands("113_tap_on_element_settle_timeout")
+
+        val driver = driver {
+            element {
+                text = "Primary button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 2)
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/113_tap_on_element_settle_timeout.yaml
+++ b/maestro-test/src/test/resources/113_tap_on_element_settle_timeout.yaml
@@ -1,5 +1,5 @@
 appId: com.example.app
 ---
 - tapOn:
-    text: ".*button.*"
-    waitToSettleTimeoutMs: 500
+    text: "The time is.*"
+    waitToSettleTimeoutMs: 100

--- a/maestro-test/src/test/resources/113_tap_on_element_settle_timeout.yaml
+++ b/maestro-test/src/test/resources/113_tap_on_element_settle_timeout.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- tapOn:
+    text: ".*button.*"
+    waitToSettleTimeoutMs: 500


### PR DESCRIPTION
## Proposed Changes
This PR introduces a `waitForAppToSettle` timeout for tapOn commands that will limit the time we wait for app to settle before proceeding to the next command.

## Issues Fixed
Flows run on animation heavy apps or apps that have moving elements as part of their UI took longer than expected to complete. This addition will allow such flows to limit the waiting time.

Notes:
- This is a best effort timeout. There are future plans to refactor and improve Driver speed / logic.
- This is an opt-in feature and will not break previous behaviour

Usage
```yaml
appId: com.example.app
---
- launchApp
- tapOn:
    text: "Button"
    waitToSettleTimeoutMs: 1500
```

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f0f32e</samp>

This pull request adds a new feature to the maestro framework that allows customizing the timeout for waiting for the app to settle after tapping an element or a point on the screen. This feature can improve the reliability and performance of the maestro orchestration and testing. The feature is implemented by adding a `waitToSettleTimeoutMs` parameter to the `Driver`, `Maestro`, `Commands`, and `YamlFluentCommand` classes, and modifying the `waitForAppToSettle` functions in the `AndroidDriver`, `IOSDriver`, `WebDriver`, `ScreenshotUtils`, and `FakeDriver` classes. The feature is also tested by adding a new test case `Case 113 - Tap on element - with app settle timeout` in the `IntegrationTest` class and the `113_tap_on_element_settle_timeout.yaml` file.

## Testing
- Local
- Cloud
- Unit


