### PR TITLE
Move device locale validation logic to maestro-client

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -3,13 +3,18 @@ package maestro.cli.command
 import maestro.cli.CliError
 import maestro.cli.device.DeviceCreateUtil
 import maestro.cli.device.DeviceService
-import maestro.cli.device.LocaleConstants
 import maestro.cli.device.Platform
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.util.DeviceConfigAndroid
 import maestro.cli.util.DeviceConfigIos
 import maestro.cli.util.EnvUtils
 import maestro.cli.util.PrintUtils
+import maestro.utils.LocaleUtils
+import maestro.utils.LocaleValidationAndroidCountryException
+import maestro.utils.LocaleValidationAndroidLanguageException
+import maestro.utils.LocaleValidationIosException
+import maestro.utils.LocaleValidationNotSupportedPlatformException
+import maestro.utils.LocaleValidationWrongLocaleFormatException
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
@@ -71,76 +76,45 @@ class StartDeviceCommand : Callable<Int> {
         }
         val o = osVersion.toIntOrNull()
 
-        val (deviceLanguage, deviceCountry) = validateLocaleParams(p)
+        val maestroPlatform = when(p) {
+            Platform.ANDROID -> maestro.Platform.ANDROID
+            Platform.IOS -> maestro.Platform.IOS
+            Platform.WEB -> maestro.Platform.WEB
+        }
 
-        DeviceCreateUtil.getOrCreateDevice(p, o, deviceLanguage, deviceCountry, forceCreate).let {
-            PrintUtils.message(if (p == Platform.IOS) "Launching simulator..." else "Launching emulator...")
-            DeviceService.startDevice(it)
+        val locale = deviceLocale ?: "en_US"
+
+        try {
+            val (deviceLanguage, deviceCountry) = LocaleUtils.parseLocaleParams(locale, maestroPlatform)
+
+            DeviceCreateUtil.getOrCreateDevice(p, o, deviceLanguage, deviceCountry, forceCreate).let {
+                PrintUtils.message(if (p == Platform.IOS) "Launching simulator..." else "Launching emulator...")
+                DeviceService.startDevice(it)
+            }
+        } catch (e: LocaleValidationIosException) {
+            val locales = LocaleUtils.IOS_SUPPORTED_LOCALES.joinToString("\n")
+            throw CliError("$deviceLocale locale is currently not supported by Maestro, please check that it is a valid ISO-639-1 + ISO-3166-1 code. Here is a full list of supported locales:\n" +
+                    "\n" +
+                    locales
+            )
+        } catch (e: LocaleValidationAndroidLanguageException) {
+            val languages = LocaleUtils.ANDROID_SUPPORTED_LANGUAGES.joinToString("\n")
+            throw CliError("${e.language} language is currently not supported by Maestro, please check that it is a valid ISO-639-1 code. Here is a full list of supported languages:\n" +
+                    "\n" +
+                    languages
+            )
+        } catch (e: LocaleValidationAndroidCountryException) {
+            val countries = LocaleUtils.ANDROID_SUPPORTED_COUNTRIES.joinToString("\n")
+            throw CliError("${e.country} country is currently not supported by Maestro, please check that it is a valid ISO-3166-1 code. Here is a full list of supported countries:\n" +
+                    "\n" +
+                    countries
+            )
+        } catch(e: LocaleValidationWrongLocaleFormatException) {
+            throw CliError("Wrong device locale format was provided $deviceLocale. A combination of lowercase ISO-639-1 code and uppercase ISO-3166-1 code should be used, i.e. \"de_DE\" for Germany. More info can be found here https://maestro.mobile.dev/")
+        } catch (e: LocaleValidationNotSupportedPlatformException) {
+            throw CliError("The feature to set a device locale is not supported by the platform ${p.description}")
         }
 
         return 0
-    }
-
-    private fun validateLocaleParams(platform: Platform): Pair<String, String> {
-        deviceLocale?.let {
-            var parts = it.split("_")
-
-            if (parts.size == 2) {
-                val language = parts[0]
-                val country = parts[1]
-
-                validateLocale(language, country, it, platform)
-
-                return Pair(language, country)
-            } else {
-                parts = it.split("-")
-
-                if (parts.size == 2) {
-                    val language = parts[0]
-                    val country = parts[1]
-
-                    validateLocale(language, country, it, platform)
-
-                    return Pair(language, country)
-                }
-
-                throw CliError("Wrong device locale format was provided $it. A combination of lowercase ISO-639-1 code and uppercase ISO-3166-1 code should be used, i.e. \"de_DE\" for Germany. More info can be found here https://maestro.mobile.dev/")
-            }
-        }
-
-        // use en_US locale as a default
-        return Pair("en", "US")
-    }
-
-    private fun validateLocale(language: String, country: String, fullLocale: String, platform: Platform) {
-        when (platform) {
-            Platform.IOS -> {
-                if (LocaleConstants.findIOSLocale(language, country) == null) {
-                    val locales = LocaleConstants.IOS_SUPPORTED_LOCALES.joinToString("\n")
-                    throw CliError("$fullLocale locale is currently not supported by Maestro, please check that it is a valid ISO-639-1 + ISO-3166-1 code. Here is a full list of supported locales:\n" +
-                            "\n" +
-                            locales
-                    )
-                }
-            }
-            Platform.ANDROID -> {
-                if (!LocaleConstants.ANDROID_SUPPORTED_LANGUAGES.map { it.first }.contains(language)) {
-                    val languages = LocaleConstants.ANDROID_SUPPORTED_LANGUAGES.joinToString("\n")
-                    throw CliError("$language language is currently not supported by Maestro, please check that it is a valid ISO-639-1 code. Here is a full list of supported languages:\n" +
-                            "\n" +
-                            languages
-                    )
-                }
-
-                if (!LocaleConstants.ANDROID_SUPPORTED_COUNTRIES.map { it.first }.contains(country)) {
-                    val countries = LocaleConstants.ANDROID_SUPPORTED_COUNTRIES.joinToString("\n")
-                    throw CliError("$country country is currently not supported by Maestro, please check that it is a valid ISO-3166-1 code. Here is a full list of supported countries:\n" +
-                            "\n" +
-                            countries
-                    )
-                }
-            }
-            else -> return
-        }
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -6,6 +6,7 @@ import maestro.cli.util.AndroidEnvUtils
 import maestro.cli.util.AvdDevice
 import maestro.cli.util.PrintUtils
 import maestro.drivers.AndroidDriver
+import maestro.utils.LocaleUtils
 import maestro.utils.MaestroTimer
 import okio.buffer
 import okio.source
@@ -28,7 +29,7 @@ object DeviceService {
                     if (device.language != null && device.country != null) {
                         PrintUtils.message("Setting the device locale to ${device.language}_${device.country}...")
                         LocalSimulatorUtils.setDeviceLanguage(device.modelId, device.language)
-                        LocaleConstants.findIOSLocale(device.language, device.country)?.let {
+                        LocaleUtils.findIOSLocale(device.language, device.country)?.let {
                             LocalSimulatorUtils.setDeviceLocale(device.modelId, it)
                         }
                         LocalSimulatorUtils.reboot(device.modelId)

--- a/maestro-client/src/main/java/maestro/utils/LocaleUtils.kt
+++ b/maestro-client/src/main/java/maestro/utils/LocaleUtils.kt
@@ -106,11 +106,11 @@ object LocaleUtils {
 
     val IOS_SUPPORTED_LOCALES = listOf(
         "en_AU" to "Australia",
-        "nl_BE" to "Belgium",
-        "fr_BE" to "Belgium",
+        "nl_BE" to "Belgium (Dutch)",
+        "fr_BE" to "Belgium (French)",
         "ms_BN" to "Brunei Darussalam",
-        "en_CA" to "Canada",
-        "fr_CA" to "Canada",
+        "en_CA" to "Canada (English)",
+        "fr_CA" to "Canada (French)",
         "cs_CZ" to "Czech Republic",
         "fi_FI" to "Finland",
         "de_DE" to "Germany",
@@ -139,18 +139,20 @@ object LocaleUtils {
         "tr_TR" to "Turkey",
         "en_GB" to "UK",
         "uk_UA" to "Ukraine",
-        "es_US" to "US",
-        "en_US" to "USA",
+        "es_US" to "USA (Spanish)",
+        "en_US" to "USA (English)",
         "vi_VN" to "Vietnam",
         "pt-BR" to "Brazil",
         "zh-Hans" to "China (Simplified)",
         "zh-Hant" to "China (Traditional)",
         "zh-HK" to "Hong Kong",
-        "en-IN" to "India",
+        "en-IN" to "India (English)",
         "en-IE" to "Ireland",
         "es-419" to "Latin America",
         "es-MX" to "Mexico",
-        "en-ZA" to "South Africa"
+        "en-ZA" to "South Africa",
+        "es_ES" to "Spain",
+        "fr_FR" to "France",
     )
 
     fun findIOSLocale(language: String, country: String): String? {
@@ -158,6 +160,7 @@ object LocaleUtils {
 
         for (pair in IOS_SUPPORTED_LOCALES) {
             if (searchedPair.matches(pair.first)) {
+                println("found locale ${pair.first}")
                 return pair.first
             }
         }

--- a/maestro-client/src/main/java/maestro/utils/LocaleUtils.kt
+++ b/maestro-client/src/main/java/maestro/utils/LocaleUtils.kt
@@ -2,11 +2,13 @@ package maestro.utils
 
 import maestro.Platform
 
-class LocaleValidationIosException : Exception("Failed to validate iOS device locale")
-class LocaleValidationAndroidLanguageException(val language: String) : Exception("Failed to validate Android device language")
-class LocaleValidationAndroidCountryException(val country: String) : Exception("Failed to validate Android device country")
-class LocaleValidationNotSupportedPlatformException : Exception("Failed to validate device locale - not supported platform provided")
-class LocaleValidationWrongLocaleFormatException : Exception("Failed to validate device locale - wrong locale format is used")
+open class LocaleValidationException(message: String): Exception(message)
+
+class LocaleValidationIosException : LocaleValidationException("Failed to validate iOS device locale")
+class LocaleValidationAndroidLanguageException(val language: String) : LocaleValidationException("Failed to validate Android device language")
+class LocaleValidationAndroidCountryException(val country: String) : LocaleValidationException("Failed to validate Android device country")
+class LocaleValidationNotSupportedPlatformException : LocaleValidationException("Failed to validate device locale - not supported platform provided")
+class LocaleValidationWrongLocaleFormatException : LocaleValidationException("Failed to validate device locale - wrong locale format is used")
 
 object LocaleUtils {
     val ANDROID_SUPPORTED_LANGUAGES = listOf(

--- a/maestro-client/src/test/java/maestro/utils/LocaleUtilsTest.kt
+++ b/maestro-client/src/test/java/maestro/utils/LocaleUtilsTest.kt
@@ -1,0 +1,54 @@
+package maestro.utils
+
+import maestro.Platform
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import com.google.common.truth.Truth.assertThat
+
+internal class LocaleUtilsTest {
+    @Test
+    internal fun `parseLocaleParams when invalid locale is received throws WrongLocaleFormat exception`() {
+        assertThrows<LocaleValidationWrongLocaleFormatException> {
+            LocaleUtils.parseLocaleParams("someInvalidLocale", Platform.ANDROID)
+        }
+    }
+
+    @Test
+    internal fun `parseLocaleParams when not supported platform is received throws NotSupportedPlatform exception`() {
+        assertThrows<LocaleValidationNotSupportedPlatformException> {
+            LocaleUtils.parseLocaleParams("de_DE", Platform.WEB)
+        }
+    }
+
+    @Test
+    internal fun `parseLocaleParams when not supported locale is received and platform is iOS throws ValidationIos exception`() {
+        assertThrows<LocaleValidationIosException> {
+            LocaleUtils.parseLocaleParams("de_IN", Platform.IOS)
+        }
+    }
+
+    @Test
+    internal fun `parseLocaleParams when not supported locale language is received and platform is Android throws ValidationAndroidLanguage exception`() {
+        assertThrows<LocaleValidationAndroidLanguageException> {
+            LocaleUtils.parseLocaleParams("ee_IN", Platform.ANDROID)
+        }
+    }
+
+    @Test
+    internal fun `parseLocaleParams when not supported locale country is received and platform is Android throws ValidationAndroidLanguage exception`() {
+        assertThrows<LocaleValidationAndroidCountryException> {
+            LocaleUtils.parseLocaleParams("hi_EE", Platform.ANDROID)
+        }
+    }
+
+    @Test
+    internal fun `parseLocaleParams when supported locale is received returns correct language and country codes`() {
+        val (language1, country1) = LocaleUtils.parseLocaleParams("de_DE", Platform.ANDROID)
+        val (language2, country2) = LocaleUtils.parseLocaleParams("es_ES", Platform.IOS)
+
+        assertThat(language1).isEqualTo("de")
+        assertThat(country1).isEqualTo("DE")
+        assertThat(language2).isEqualTo("es")
+        assertThat(country2).isEqualTo("ES")
+    }
+}


### PR DESCRIPTION
## Proposed Changes

This PR moves logic related to device locale validation to the `maestro-client` module to be able to reuse in in Maestro Cloud

## Testing
- [x] local test
