### PR TITLE
fix: raise a invalid url exception when open link url is not valid

### DIFF
--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -33,6 +33,8 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
 
     class DriverTimeout(message: String): MaestroException(message)
 
+    class InvalidURL(message: String): MaestroException(message)
+
     open class AssertionFailure(
         message: String,
         val hierarchyRoot: TreeNode,

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory
 import util.XCRunnerCLIUtils
 import java.io.File
 import java.util.UUID
-import java.util.concurrent.TimeoutException
 import kotlin.collections.set
 
 class IOSDriver(
@@ -382,7 +381,7 @@ class IOSDriver(
 
     override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
         val sanitizedLink = link.toSanitizedIOSLink()
-        iosDevice.openLink(sanitizedLink).expect {}
+        runDeviceCall { iosDevice.openLink(sanitizedLink) }
     }
 
     override fun setLocation(latitude: Double, longitude: Double) {
@@ -483,6 +482,8 @@ class IOSDriver(
             call()
         } catch (appCrashException: IOSDeviceErrors.AppCrash) {
             throw MaestroException.AppCrash(appCrashException.errorMessage)
+        } catch (invalidURLException: IOSDeviceErrors.InvalidURL) {
+            throw MaestroException.InvalidURL(invalidURLException.errorMessage)
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -30,6 +30,7 @@ import maestro.MaestroDriverStartupException.*
 import maestro.UiElement.Companion.toUiElement
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.utils.*
+import maestro.utils.StringUtils.toSanitizedIOSLink
 import okio.Sink
 import okio.source
 import org.slf4j.LoggerFactory
@@ -380,7 +381,8 @@ class IOSDriver(
     }
 
     override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
-        iosDevice.openLink(link).expect {}
+        val sanitizedLink = link.toSanitizedIOSLink()
+        iosDevice.openLink(sanitizedLink).expect {}
     }
 
     override fun setLocation(latitude: Double, longitude: Double) {

--- a/maestro-client/src/main/java/maestro/utils/StringUtils.kt
+++ b/maestro-client/src/main/java/maestro/utils/StringUtils.kt
@@ -12,4 +12,7 @@ object StringUtils {
         }
     }
 
+    fun String.toSanitizedIOSLink(): String {
+        return this.replace("?", "\\?")
+    }
 }

--- a/maestro-client/src/test/java/maestro/IOSLinkSanitizerTest.kt
+++ b/maestro-client/src/test/java/maestro/IOSLinkSanitizerTest.kt
@@ -1,0 +1,34 @@
+package maestro
+
+import com.google.common.truth.Truth.assertThat
+import maestro.utils.StringUtils.toSanitizedIOSLink
+import org.junit.jupiter.api.Test
+
+class IOSLinkSanitizerTest {
+
+    @Test
+    fun `sanitize the question mark if present in the link`() {
+        // given
+        val link = "testapp://testpage?testparam={TEST:\"test\"}"
+
+        // when
+        val sanitizedLink = link.toSanitizedIOSLink()
+
+        // then
+        assertThat(sanitizedLink).isEqualTo(
+            "testapp://testpage\\?testparam={TEST:\"test\"}"
+        )
+    }
+
+    @Test
+    fun `sanitize the normal links without side effect`() {
+        // given
+        val link = "https://google.com"
+
+        // when
+        val sanitizedLink = link.toSanitizedIOSLink()
+
+        // then
+        assertThat(sanitizedLink).isEqualTo(link)
+    }
+}

--- a/maestro-ios-driver/src/main/kotlin/util/CommandLineUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/CommandLineUtils.kt
@@ -24,7 +24,7 @@ object CommandLineUtils {
         } else {
             ProcessBuilder(*parts.toTypedArray())
                 .redirectOutput(nullFile)
-                .redirectError(nullFile)
+                .redirectError(ProcessBuilder.Redirect.PIPE)
         }
 
         processBuilder.environment().putAll(params)

--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import maestro.utils.MaestroTimer
 import org.rauschig.jarchivelib.ArchiveFormat
+import maestro.utils.network.SimctlError.InvalidURL
+import maestro.utils.network.SimctlError.UnknownFailure
 import org.rauschig.jarchivelib.ArchiverFactory
 import util.CommandLineUtils.runCommand
 import java.io.File
@@ -258,15 +260,24 @@ object LocalSimulatorUtils {
     }
 
     fun openURL(deviceId: String, url: String) {
-        runCommand(
-            listOf(
-                "xcrun",
-                "simctl",
-                "openurl",
-                deviceId,
-                url,
+        try {
+            runCommand(
+                listOf(
+                    "xcrun",
+                    "simctl",
+                    "openurl",
+                    deviceId,
+                    url,
+                )
             )
-        )
+        } catch (illegalStateException: IllegalStateException) {
+            val message = illegalStateException.message ?: ""
+            if (message.contains("Invalid URL")) {
+                throw InvalidURL(message)
+            } else {
+                throw UnknownFailure(message)
+            }
+        }
     }
 
     fun uninstall(deviceId: String, bundleId: String) {

--- a/maestro-ios/src/main/java/ios/IOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/IOSDevice.kt
@@ -105,7 +105,7 @@ interface IOSDevice : AutoCloseable {
      *
      * @param link - link to open
      */
-    fun openLink(link: String): Result<Unit, Throwable>
+    fun openLink(link: String)
 
     /**
      * Takes a screenshot and writes it into output sink

--- a/maestro-ios/src/main/java/ios/IOSDeviceErrors.kt
+++ b/maestro-ios/src/main/java/ios/IOSDeviceErrors.kt
@@ -2,4 +2,5 @@ package ios
 
 sealed class IOSDeviceErrors : Throwable() {
     data class AppCrash(val errorMessage: String): IOSDeviceErrors()
+    data class InvalidURL(val errorMessage: String): IOSDeviceErrors()
 }

--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -110,8 +110,8 @@ class LocalIOSDevice(
         return simctlIOSDevice.stop(id)
     }
 
-    override fun openLink(link: String): Result<Unit, Throwable> {
-        return simctlIOSDevice.openLink(link)
+    override fun openLink(link: String) {
+        simctlIOSDevice.openLink(link)
     }
 
     override fun takeScreenshot(out: Sink, compressed: Boolean) {

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -151,7 +151,7 @@ class XCTestIOSDevice(
         error("Not supported")
     }
 
-    override fun openLink(link: String): Result<Unit, Throwable> {
+    override fun openLink(link: String) {
         error("Not supported")
     }
 

--- a/maestro-utils/src/main/kotlin/network/Errors.kt
+++ b/maestro-utils/src/main/kotlin/network/Errors.kt
@@ -1,7 +1,6 @@
 package maestro.utils.network
 
 class InputFieldNotFound : Throwable("Unable to find focused input field")
-class UnknownFailure(errorResponse: String) : Throwable(errorResponse)
 
 sealed class XCUITestServerResult<out T> {
     data class Success<T>(val data: T): XCUITestServerResult<T>()
@@ -13,4 +12,9 @@ sealed class XCUITestServerError: Throwable() {
     data class NetworkError(val errorResponse: String): XCUITestServerError()
     data class AppCrash(val errorResponse: String): XCUITestServerError()
     data class BadRequest(val errorResponse: String, val clientMessage: String): XCUITestServerError()
+}
+
+sealed class SimctlError: Throwable() {
+    data class InvalidURL(val errorMessage: String): SimctlError()
+    data class UnknownFailure(val errorResponse: String) : SimctlError()
 }


### PR DESCRIPTION
## Proposed Changes

1. Escape `?` 
2. Raise invalid URL exception exception to avoid throwing illegal state exceptions

## Testing
- [ ] Local
- [ ] Staging

## Issues Fixed
