### PR TITLE
Add support for deviceLocale param in `maestro cloud`

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -244,6 +244,7 @@ class ApiClient(
         maxRetryCount: Int = 3,
         completedRetries: Int = 0,
         disableNotifications: Boolean,
+        deviceLocale: String? = null,
         progressListener: (totalBytes: Long, bytesWritten: Long) -> Unit = { _, _ -> },
     ): UploadResponse {
         if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter for option '--app-file' or '--app-binary-id'")
@@ -264,6 +265,7 @@ class ApiClient(
         androidApiLevel?.let { requestPart["androidApiLevel"] = it }
         iOSVersion?.let { requestPart["iOSVersion"] = it }
         appBinaryId?.let { requestPart["appBinaryId"] = it }
+        deviceLocale?.let { requestPart["deviceLocale"] = it }
         if (includeTags.isNotEmpty()) requestPart["includeTags"] = includeTags
         if (excludeTags.isNotEmpty()) requestPart["excludeTags"] = excludeTags
         if (disableNotifications) requestPart["disableNotifications"] = true
@@ -312,6 +314,7 @@ class ApiClient(
                 progressListener = progressListener,
                 appBinaryId = appBinaryId,
                 disableNotifications = disableNotifications,
+                deviceLocale = deviceLocale,
             )
         }
 
@@ -352,7 +355,8 @@ class ApiClient(
                 DeviceInfo(
                     platform = it["platform"] as String,
                     displayInfo = it["displayInfo"] as String,
-                    isDefaultOsVersion = it["isDefaultOsVersion"] as Boolean
+                    isDefaultOsVersion = it["isDefaultOsVersion"] as Boolean,
+                    deviceLocale = responseBody["deviceLocale"] as String
                 )
             }
 
@@ -423,7 +427,8 @@ data class UploadResponse(
 data class DeviceInfo(
     val platform: String,
     val displayInfo: String,
-    val isDefaultOsVersion: Boolean
+    val isDefaultOsVersion: Boolean,
+    val deviceLocale: String,
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -63,6 +63,7 @@ class CloudInteractor(
         reportOutput: File? = null,
         testSuiteName: String? = null,
         disableNotifications: Boolean = false,
+        deviceLocale: String? = null,
     ): Int {
         if (appBinaryId == null && appFile == null) throw CliError("Missing required parameter for option '--app-file' or '--app-binary-id'")
         if (!flowFile.exists()) throw CliError("File does not exist: ${flowFile.absolutePath}")
@@ -116,6 +117,7 @@ class CloudInteractor(
                 includeTags = includeTags,
                 excludeTags = excludeTags,
                 disableNotifications = disableNotifications,
+                deviceLocale = deviceLocale,
             ) { totalBytes, bytesWritten ->
                 progressBar.set(bytesWritten.toFloat() / totalBytes.toFloat())
             }

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -136,6 +136,9 @@ class CloudCommand : Callable<Int> {
     @Option(order = 17, names = ["--app-binary-id", "--appBinaryId"], description = ["The ID of the app binary previously uploaded to Maestro Cloud"])
     private var appBinaryId: String? = null
 
+    @Option(order = 18, names = ["--device-locale"], description = ["Locale that will be set to a device, ISO-639-1 code and uppercase ISO-3166-1 code i.e. \"de_DE\" for Germany"])
+    private var deviceLocale: String? = null
+
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
 
@@ -181,6 +184,7 @@ class CloudCommand : Callable<Int> {
             failOnCancellation = failOnCancellation,
             testSuiteName = testSuiteName,
             disableNotifications = disableNotifications,
+            deviceLocale = deviceLocale,
         )
     }
 


### PR DESCRIPTION
## Proposed Changes

This PR adds a new parameter to `maestro cloud` command to be able to set device locale for device to execute a flow on.

Example usage:

`maestro cloud --device-locale de_DE <app_binary_path> <flows_path>`

## Testing

- [x] staging test
