### PR TITLE
fix gradle task dependency issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,8 +8,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 detekt {

--- a/maestro-android/build.gradle
+++ b/maestro-android/build.gradle
@@ -75,49 +75,29 @@ android {
 }
 
 tasks.register("copyMaestroAndroid", Copy) {
+    dependsOn(packageDebug)
+
     def maestroAndroidApkPath = "outputs/apk/debug/maestro-android-debug.apk"
     def maestroAndroidApkDest = "../../maestro-client/src/main/resources"
-    def maestroAndroidApkDestPath = "../../maestro-client/src/main/resources/maestro-android-debug.apk"
 
     from layout.buildDirectory.dir(maestroAndroidApkPath)
     into layout.buildDirectory.file(maestroAndroidApkDest)
-
-    it.doLast {
-        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-            throw new GradleException("This build must be run with java 8")
-        }
-
-        if (!layout.buildDirectory.file(maestroAndroidApkDestPath).get().asFile.exists())
-            throw new GradleException("Error: Input source for copyMaestroAndroid doesn't exist")
-
-        new File("./maestro-client/src/main/resources/maestro-android-debug.apk")
-            .renameTo(new File("./maestro-client/src/main/resources/maestro-app.apk"))
-    }
+    rename "maestro-android-debug.apk", "maestro-app.apk"
 }
 
 tasks.register("copyMaestroServer", Copy) {
+    dependsOn(packageDebugAndroidTest)
     def maestroServerApkPath = "outputs/apk/androidTest/debug/maestro-android-debug-androidTest.apk"
     def maestroServerApkDest = "../../maestro-client/src/main/resources"
-    def maestroServerApkDestPath = "../../maestro-client/src/main/resources/maestro-android-debug-androidTest.apk"
 
     from layout.buildDirectory.dir(maestroServerApkPath)
     into layout.buildDirectory.file(maestroServerApkDest)
-
-    it.doLast {
-        if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-            throw new GradleException("This build must be run with java 8")
-        }
-        
-        if (!layout.buildDirectory.file(maestroServerApkDestPath).get().asFile.exists())
-            throw new GradleException("Error: Input source for copyMaestroServer doesn't exist")
-
-        new File("./maestro-client/src/main/resources/maestro-android-debug-androidTest.apk")
-            .renameTo(new File("./maestro-client/src/main/resources/maestro-server.apk"))
-    }
+    rename "maestro-android-debug-androidTest.apk", "maestro-server.apk"
 }
 
-tasks.named("assemble") { finalizedBy("copyMaestroAndroid") }
-tasks.named("assembleAndroidTest") { finalizedBy("copyMaestroServer") }
+tasks.named("assemble") {
+    finalizedBy("copyMaestroAndroid", "copyMaestroServer")
+}
 
 sourceSets {
     generated {

--- a/maestro-android/build.gradle
+++ b/maestro-android/build.gradle
@@ -74,6 +74,12 @@ android {
     }
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 tasks.register("copyMaestroAndroid", Copy) {
     dependsOn(packageDebug)
 

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -55,8 +55,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 tasks.create("createProperties") {

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -91,8 +91,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 plugins.withId("com.vanniktech.maven.publish") {

--- a/maestro-client/build.gradle
+++ b/maestro-client/build.gradle
@@ -104,3 +104,9 @@ plugins.withId("com.vanniktech.maven.publish") {
 test {
     useJUnitPlatform()
 }
+
+processResources {
+    def maestroAndroid = project(":maestro-android")
+    dependsOn(maestroAndroid.tasks.copyMaestroAndroid, maestroAndroid.tasks.copyMaestroServer)
+}
+

--- a/maestro-ios-driver/build.gradle
+++ b/maestro-ios-driver/build.gradle
@@ -23,8 +23,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 plugins.withId("com.vanniktech.maven.publish") {

--- a/maestro-ios/build.gradle
+++ b/maestro-ios/build.gradle
@@ -32,8 +32,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 plugins.withId("com.vanniktech.maven.publish") {

--- a/maestro-orchestra-models/build.gradle
+++ b/maestro-orchestra-models/build.gradle
@@ -11,8 +11,9 @@ plugins.withId("com.vanniktech.maven.publish") {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 dependencies {

--- a/maestro-orchestra/build.gradle
+++ b/maestro-orchestra/build.gradle
@@ -22,8 +22,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 plugins.withId("com.vanniktech.maven.publish") {

--- a/maestro-proto/build.gradle
+++ b/maestro-proto/build.gradle
@@ -5,8 +5,9 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 jar {

--- a/maestro-studio/server/build.gradle
+++ b/maestro-studio/server/build.gradle
@@ -27,8 +27,9 @@ tasks.processResources {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 dependencies {

--- a/maestro-studio/server/build.gradle
+++ b/maestro-studio/server/build.gradle
@@ -22,7 +22,7 @@ def copyWebFiles = tasks.register("copyWebFiles", Copy.class) {
     into(new File(projectDir, 'src/main/resources/web'))
 }
 
-tasks.compileJava {
+tasks.processResources {
     dependsOn(copyWebFiles)
 }
 

--- a/maestro-test/build.gradle
+++ b/maestro-test/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id "kotlin"
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 dependencies {
     implementation project(":maestro-orchestra")
     implementation project(':maestro-client')

--- a/maestro-utils/build.gradle
+++ b/maestro-utils/build.gradle
@@ -14,8 +14,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
 }
 
 plugins.withId("com.vanniktech.maven.publish") {


### PR DESCRIPTION
## Proposed Changes

This PR fixes some gradle task dependency issues experienced in #1527.
The maestro-{app,server}.apk files now also get correctly rebuilt when the source has been changed.

Without this PR these warnings get printed, which can lead to wrong results of the build:
```
> Task :maestro-client:processResources
Execution optimizations have been disabled for task ':maestro-client:processResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/marie/work/maestro/maestro-client/src/main/resources'. Reason: Task ':maestro-client:processResources' uses this output of task ':maestro-android:copyMaestroAndroid' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.

> Task :maestro-studio:server:processResources
Execution optimizations have been disabled for task ':maestro-studio:server:processResources' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/home/marie/work/maestro/maestro-studio/server/src/main/resources'. Reason: Task ':maestro-studio:server:processResources' uses this output of task ':maestro-studio:server:copyWebFiles' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```

## Testing
<!--- Please describe how you tested your changes. -->
I ran the android advanced flow sample using the `maestro` script in the project root, as well as running the build multiple times.

## Issues Fixed
None
