### PR TITLE
[iOS] Fix awaitLaunch and awaitShutdown logic

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
@@ -72,7 +72,7 @@ internal object DeviceCreateUtil {
             }
         }
 
-        if (existingDeviceId == null) PrintUtils.message("Created simulator with name $deviceName and UUID $deviceUUID)")
+        if (existingDeviceId == null) PrintUtils.message("Created simulator with name $deviceName and UUID $deviceUUID")
 
         return Device.AvailableForLaunch(
             modelId = deviceUUID,

--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -57,7 +57,7 @@ object LocalSimulatorUtils {
                     .devices
                     .values
                     .flatten()
-                    .find { it.udid == deviceId }
+                    .find { it.udid.equals(deviceId, ignoreCase = true) }
                     ?.state == "Booted"
             ) true else null
         } ?: throw SimctlError("Device $deviceId did not boot in time")
@@ -69,10 +69,10 @@ object LocalSimulatorUtils {
                     .devices
                     .values
                     .flatten()
-                    .find { it.udid == deviceId }
-                    ?.state != "Booted"
+                    .find { it.udid.equals(deviceId, ignoreCase = true) }
+                    ?.state == "Shutdown"
             ) true else null
-        } ?: throw SimctlError("Device $deviceId did not boot in time")
+        } ?: throw SimctlError("Device $deviceId did not shutdown in time")
     }
 
     private fun xcodePath(): String {


### PR DESCRIPTION
## Proposed Changes

This PR fixes awaitShutdown logic (which we use for `reboot` operation), considering that deviceId might be lowercase and state might be `Shutting Down`

## Testing
- [x] local test
