### PR TITLE
Make simulator reboot logic more robust

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceService.kt
@@ -15,7 +15,7 @@ import util.LocalSimulatorUtils
 import util.LocalSimulatorUtils.SimctlError
 import util.SimctlList
 import java.io.File
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -35,7 +35,7 @@ object DeviceService {
                         LocalSimulatorUtils.reboot(device.modelId)
                     }
                     LocalSimulatorUtils.launchSimulator(device.modelId)
-                    LocalSimulatorUtils.awaitLaunch(device.modelId, 60000)
+                    LocalSimulatorUtils.awaitLaunch(device.modelId)
                 } catch (e: SimctlError) {
                     logger.error("Failed to launch simulator", e)
                     throw CliError(e.message)
@@ -197,7 +197,7 @@ object DeviceService {
     private fun device(
         runtimeNameByIdentifier: Map<String, String>,
         runtime: Map.Entry<String, List<SimctlList.Device>>,
-        device: SimctlList.Device
+        device: SimctlList.Device,
     ): Device {
         val runtimeName = runtimeNameByIdentifier[runtime.key] ?: "Unknown runtime"
         val description = "${device.name} - $runtimeName - ${device.udid}"
@@ -258,7 +258,6 @@ object DeviceService {
         }
     }
 
-
     /**
      * Creates an iOS simulator
      *
@@ -295,7 +294,6 @@ object DeviceService {
             } catch (ignore: IllegalArgumentException) {
                 throw IllegalStateException("Unable to create device. No UUID was generated")
             }
-
         }
     }
 
@@ -314,7 +312,7 @@ object DeviceService {
         systemImage: String,
         tag: String,
         abi: String,
-        force: Boolean = false
+        force: Boolean = false,
     ): String {
         val avd = requireAvdManagerBinary()
         val command = mutableListOf(
@@ -374,7 +372,6 @@ object DeviceService {
         }.getOrNull() ?: emptyList()
     }
 
-
     /**
      * @return true is Android system image is already installed
      */
@@ -394,7 +391,6 @@ object DeviceService {
 
                 return output.contains(image)
             }
-
         } catch (e: Exception) {
             logger.error("Unable to detect if SDK package is installed", e)
         }
@@ -423,7 +419,6 @@ object DeviceService {
 
                 return output.contains(image)
             }
-
         } catch (e: Exception) {
             logger.error("Unable to install if SDK package is installed", e)
         }

--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -3,22 +3,17 @@ package util
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import maestro.utils.MaestroTimer
-import org.apache.commons.io.FileUtils
 import org.rauschig.jarchivelib.ArchiveFormat
 import org.rauschig.jarchivelib.ArchiverFactory
 import util.CommandLineUtils.runCommand
 import java.io.File
 import java.io.InputStream
 import java.lang.ProcessBuilder.Redirect.PIPE
-import java.nio.file.*
-import java.nio.file.attribute.BasicFileAttributes
-import kotlin.io.path.absolutePathString
 import kotlin.io.path.createTempDirectory
-import kotlin.io.path.name
 
 object LocalSimulatorUtils {
 
-    data class SimctlError(override val message: String): Throwable(message)
+    data class SimctlError(override val message: String) : Throwable(message)
 
     private val homedir = System.getProperty("user.home")
 
@@ -51,20 +46,13 @@ object LocalSimulatorUtils {
         return jacksonObjectMapper().readValue(json)
     }
 
-    fun awaitLaunch(deviceId: String, timeout: Long= 30000) {
-        MaestroTimer.withTimeout(timeout) {
-            if (list()
-                    .devices
-                    .values
-                    .flatten()
-                    .find { it.udid.equals(deviceId, ignoreCase = true) }
-                    ?.state == "Booted"
-            ) true else null
-        } ?: throw SimctlError("Device $deviceId did not boot in time")
+    fun awaitLaunch(deviceId: String) {
+        val command = listOf("xcrun", "simctl", "bootstatus", deviceId)
+        runCommand(command, waitForCompletion = true)
     }
 
-    fun awaitShutdown(deviceId: String) {
-        MaestroTimer.withTimeout(30000) {
+    fun awaitShutdown(deviceId: String, timeoutMs: Long = 60000) {
+        MaestroTimer.withTimeout(timeoutMs) {
             if (list()
                     .devices
                     .values
@@ -89,9 +77,25 @@ object LocalSimulatorUtils {
                 "simctl",
                 "boot",
                 deviceId
-            )
+            ),
+            waitForCompletion = true
         )
+        awaitLaunch(deviceId)
     }
+
+    fun shutdownSimulator(deviceId: String) {
+        runCommand(
+            listOf(
+                "xcrun",
+                "simctl",
+                "shutdown",
+                deviceId
+            ),
+            waitForCompletion = true
+        )
+        awaitShutdown(deviceId)
+    }
+
     fun launchSimulator(deviceId: String) {
         val simulatorPath = "${xcodePath()}/Applications/Simulator.app"
         var exceptionToThrow: Exception? = null
@@ -122,27 +126,8 @@ object LocalSimulatorUtils {
     fun reboot(
         deviceId: String,
     ) {
-        runCommand(
-            listOf(
-                "xcrun",
-                "simctl",
-                "shutdown",
-                deviceId
-            ),
-            waitForCompletion = true
-        )
-        awaitShutdown(deviceId)
-
-        runCommand(
-            listOf(
-                "xcrun",
-                "simctl",
-                "boot",
-                deviceId
-            ),
-            waitForCompletion = true
-        )
-        awaitLaunch(deviceId)
+        shutdownSimulator(deviceId)
+        bootSimulator(deviceId)
     }
 
     fun addTrustedCertificate(
@@ -219,7 +204,6 @@ object LocalSimulatorUtils {
 
         return String(process.inputStream.readBytes()).trimEnd()
     }
-
 
     fun launch(
         deviceId: String,
@@ -367,7 +351,7 @@ object LocalSimulatorUtils {
                         permissionsArgument
                     )
                 )
-            } catch(e: Exception) {
+            } catch (e: Exception) {
                 runCommand(
                     listOf(
                         "applesimutils",
@@ -525,7 +509,7 @@ object LocalSimulatorUtils {
 
     data class ScreenRecording(
         val process: Process,
-        val file: File
+        val file: File,
     )
 
     fun startScreenRecording(deviceId: String): ScreenRecording {


### PR DESCRIPTION
## Proposed Changes

This PR makes awaitLaunch more robust - no timeout needed anymore, bootstatus is better in this case, since it waits until Springboard is fully launched, while just tracking the Booted state from `simctl list` doesn't

## Testing
- [x] tested locally
