### PR TITLE
conform to XDG base dir spec on linux

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -26,6 +26,7 @@ import maestro.cli.update.Updates
 import maestro.cli.util.ErrorReporter
 import maestro.cli.view.box
 import maestro.debuglog.DebugLogStore
+import maestro.utils.MaestroDirectory
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.Option
@@ -82,6 +83,8 @@ fun main(args: Array<String>) {
     // Disable icon in Mac dock
     // https://stackoverflow.com/a/17544259
     System.setProperty("apple.awt.UIElement", "true")
+
+    MaestroDirectory.migrate()
 
     Dependencies.install()
     Updates.fetchUpdatesAsync()

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -10,20 +10,21 @@ import maestro.cli.runner.CommandStatus
 import maestro.debuglog.DebugLogStore
 import maestro.debuglog.LogConfig
 import maestro.orchestra.MaestroCommand
+import maestro.utils.MaestroDirectory
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.Paths
 import java.nio.file.attribute.FileTime
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
-import java.util.IdentityHashMap
-import java.util.Properties
+import java.util.*
+import kotlin.io.path.Path
 import kotlin.io.path.absolutePathString
+import kotlin.io.path.div
 import kotlin.io.path.exists
 
 object TestDebugReporter {
@@ -128,7 +129,8 @@ object TestDebugReporter {
         val dateFormat = "yyyy-MM-dd_HHmmss"
         val dateFormatter = DateTimeFormatter.ofPattern(dateFormat)
         val folderName = dateFormatter.format(LocalDateTime.now())
-        val debugOutput = Paths.get(debugOutputPathAsString ?: System.getProperty("user.home"), ".maestro", "tests", folderName)
+        val debugOutput =
+            (debugOutputPathAsString?.let(::Path) ?: MaestroDirectory.getMaestroDirectory()) / "tests" / folderName
         if (!debugOutput.exists()) {
             Files.createDirectories(debugOutput)
         }

--- a/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
@@ -2,21 +2,18 @@ package maestro.cli.session
 
 import maestro.cli.db.KeyValueStore
 import maestro.cli.device.Platform
-import java.nio.file.Paths
+import maestro.utils.MaestroDirectory
 import java.util.concurrent.TimeUnit
+import kotlin.io.path.createDirectories
+import kotlin.io.path.div
 
 object SessionStore {
 
     private val keyValueStore by lazy {
         KeyValueStore(
-            Paths
-                .get(
-                    System.getProperty("user.home"),
-                    ".maestro",
-                    "sessions"
-                )
-                .toFile()
-                .also { it.parentFile.mkdirs() }
+            (MaestroDirectory.getMaestroDirectory() / "sessions").apply {
+                parent.createDirectories()
+            }.toFile()
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
+++ b/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
@@ -4,16 +4,12 @@ import maestro.cli.api.ApiClient
 import maestro.cli.api.CliVersion
 import maestro.cli.util.CiUtils
 import maestro.cli.view.red
-import java.nio.file.Paths
-import java.util.Properties
-import java.util.UUID
+import maestro.utils.MaestroDirectory
+import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import kotlin.io.path.createDirectories
-import kotlin.io.path.exists
-import kotlin.io.path.readText
-import kotlin.io.path.writeText
+import kotlin.io.path.*
 
 object Updates {
 
@@ -37,7 +33,7 @@ object Updates {
     private var future: CompletableFuture<CliVersion?>? = null
 
     init {
-        val uuidPath = Paths.get(System.getProperty("user.home"), ".maestro", "uuid")
+        val uuidPath = MaestroDirectory.getMaestroDirectory() / "uuid"
         FRESH_INSTALL = if (uuidPath.exists()) {
             false
         } else {

--- a/maestro-cli/src/main/java/maestro/cli/util/Unpacker.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/Unpacker.kt
@@ -1,12 +1,13 @@
 package maestro.cli.util
 
+import maestro.utils.MaestroDirectory
 import org.apache.commons.codec.digest.DigestUtils
 import java.io.File
 import java.net.URL
 import java.nio.file.FileSystems
 import java.nio.file.Files
-import java.nio.file.Paths
 import java.nio.file.attribute.PosixFilePermission
+import kotlin.io.path.div
 
 /**
  * Unpacks files from jar resources.
@@ -33,13 +34,7 @@ object Unpacker {
     }
 
     fun binaryDependency(name: String): File {
-        return Paths
-            .get(
-                System.getProperty("user.home"),
-                ".maestro",
-                "deps",
-                name
-            )
+        return (MaestroDirectory.getMaestroDirectory() / "deps" / name)
             .toAbsolutePath()
             .toFile()
             .also { file ->

--- a/maestro-utils/build.gradle
+++ b/maestro-utils/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 dependencies {
     api(libs.square.okio)
+    implementation(libs.slf4j)
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/maestro-utils/src/main/kotlin/MaestroDirectory.kt
+++ b/maestro-utils/src/main/kotlin/MaestroDirectory.kt
@@ -1,0 +1,65 @@
+package maestro.utils
+
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.*
+
+object MaestroDirectory {
+    private val oldPath = Paths.get(System.getProperty("user.home"), ".maestro")
+    private val LOGGER = LoggerFactory.getLogger(MaestroDirectory::class.java)
+
+    fun getMaestroDirectory(): Path {
+        val dir = getMigratedDirectory()
+        // Check if we didn't migrate yet
+        if (oldPath.exists()) {
+            return oldPath
+        }
+        return dir
+    }
+
+    private fun getMigratedDirectory(): Path {
+        val osName = System.getProperty("os.name")
+
+        val newDir = when {
+            osName.startsWith("Linux") -> getLinuxDirectory()
+            else -> oldPath
+        }
+        return newDir
+    }
+
+    fun migrate() {
+        try {
+            val dir = getMigratedDirectory()
+            if (dir != oldPath && oldPath.exists()) {
+                LOGGER.warn("We detected that you use the old maestro directory ($oldPath).")
+                val migrate = if (System.getenv("CI") != null) {
+                    LOGGER.warn("We seem to run in a CI environment, not migrating.")
+                    false
+                } else {
+                    print("Do you want to automatically migrate to the new directory ($dir)? [y/N]: ")
+                    val response = readln()
+                    when (response) {
+                        "Y", "y" -> true
+                        else -> false
+                    }
+                }
+
+                if (migrate) {
+                    oldPath.toFile().copyRecursively(dir.toFile(), true)
+                    oldPath.toFile().deleteRecursively()
+                    LOGGER.info("Successfully migrated data from $oldPath to $dir")
+                }
+            }
+        } catch (e: IOException) {
+            LOGGER.error("Failed to migrate old data", e)
+        }
+    }
+
+    private fun getLinuxDirectory(): Path {
+        val xdgDataHome =
+            System.getenv("XDG_DATA_HOME")?.let(::Path) ?: (Path(System.getenv("HOME")) / ".local" / "share")
+        return xdgDataHome / "maestro"
+    }
+}


### PR DESCRIPTION
## Proposed Changes
Conform to the [XDG base dir spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) on linux to not spam the users home directory.
This change is backwards compatible and still uses the old directory if it exists.
It also asks the user on startup if they want to migrate to the new directory.

## Testing
Ran tests and the advanced flow on an Android AVD.
