### PR TITLE
Adds iOS 17 to start-device 

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/DeviceConfig.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/DeviceConfig.kt
@@ -3,10 +3,11 @@ package maestro.cli.util
 internal object DeviceConfigIos {
 
     val device: String = "iPhone-11"
-    val versions = listOf(15, 16)
+    val versions = listOf(15, 16, 17)
     val runtimes = mapOf(
         15 to "iOS-15-5",
-        16 to "iOS-16-2"
+        16 to "iOS-16-2",
+        17 to "iOS-17-0"
     )
 
     val defaultVersion = 15


### PR DESCRIPTION
## Proposed Changes

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 45765a0</samp>

Added iOS 17 support to `DeviceConfig` class in `maestro-cli`. This enables testing on the newest iOS devices with the maestro command-line tool.

## Testing
Local
