### PR TITLE
childOf selector

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -457,7 +457,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return if (element == null) {
             null
         } else {
-            return FindElementResult(element, viewHierarchy)
+            return FindElementResult(element, ViewHierarchy(element.treeNode))
         }
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -401,7 +401,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun findElementByRegexp(regex: Regex, timeoutMs: Long): UiElement {
         LOGGER.info("Looking for element by regex: ${regex.pattern} (timeout $timeoutMs)")
 
-        return findElementWithTimeout(timeoutMs, Filters.textMatches(regex), null)?.element
+        return findElementWithTimeout(timeoutMs, Filters.textMatches(regex))?.element
             ?: throw MaestroException.ElementNotFound(
                 "No element that matches regex: $regex",
                 viewHierarchy().root
@@ -415,7 +415,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun findElementByIdRegex(regex: Regex, timeoutMs: Long): UiElement {
         LOGGER.info("Looking for element by id regex: ${regex.pattern} (timeout $timeoutMs)")
 
-        return findElementWithTimeout(timeoutMs, Filters.idMatches(regex), null)?.element
+        return findElementWithTimeout(timeoutMs, Filters.idMatches(regex))?.element
             ?: throw MaestroException.ElementNotFound(
                 "No element has id that matches regex $regex",
                 viewHierarchy().root
@@ -427,15 +427,14 @@ class Maestro(private val driver: Driver) : AutoCloseable {
 
         return findElementWithTimeout(
             timeoutMs,
-            Filters.sizeMatches(width, height, tolerance).asFilter(),
-            null
+            Filters.sizeMatches(width, height, tolerance).asFilter()
         )?.element
     }
 
     fun findElementWithTimeout(
         timeoutMs: Long,
         filter: ElementFilter,
-        viewHierarchy: ViewHierarchy?
+        viewHierarchy: ViewHierarchy? = null
     ): FindElementResult? {
         var hierarchy = viewHierarchy ?: ViewHierarchy(TreeNode())
         val element = MaestroTimer.withTimeout(timeoutMs) {

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -401,7 +401,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun findElementByRegexp(regex: Regex, timeoutMs: Long): UiElement {
         LOGGER.info("Looking for element by regex: ${regex.pattern} (timeout $timeoutMs)")
 
-        return findElementWithTimeout(timeoutMs, Filters.textMatches(regex))?.element
+        return findElementWithTimeout(timeoutMs, Filters.textMatches(regex), null)?.element
             ?: throw MaestroException.ElementNotFound(
                 "No element that matches regex: $regex",
                 viewHierarchy().root
@@ -415,7 +415,7 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun findElementByIdRegex(regex: Regex, timeoutMs: Long): UiElement {
         LOGGER.info("Looking for element by id regex: ${regex.pattern} (timeout $timeoutMs)")
 
-        return findElementWithTimeout(timeoutMs, Filters.idMatches(regex))?.element
+        return findElementWithTimeout(timeoutMs, Filters.idMatches(regex), null)?.element
             ?: throw MaestroException.ElementNotFound(
                 "No element has id that matches regex $regex",
                 viewHierarchy().root
@@ -425,39 +425,31 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun findElementBySize(width: Int?, height: Int?, tolerance: Int?, timeoutMs: Long): UiElement? {
         LOGGER.info("Looking for element by size: $width x $height (tolerance $tolerance) (timeout $timeoutMs)")
 
-        return findElementWithTimeout(timeoutMs, Filters.sizeMatches(width, height, tolerance).asFilter())?.element
+        return findElementWithTimeout(
+            timeoutMs,
+            Filters.sizeMatches(width, height, tolerance).asFilter(),
+            null
+        )?.element
     }
 
     fun findElementWithTimeout(
         timeoutMs: Long,
         filter: ElementFilter,
+        viewHierarchy: ViewHierarchy?
     ): FindElementResult? {
-        var hierarchy = ViewHierarchy(TreeNode())
+        var hierarchy = viewHierarchy ?: ViewHierarchy(TreeNode())
         val element = MaestroTimer.withTimeout(timeoutMs) {
-            hierarchy = viewHierarchy()
+            hierarchy = viewHierarchy ?: viewHierarchy()
             filter(hierarchy.aggregate()).firstOrNull()
         }?.toUiElementOrNull()
 
         return if (element == null) {
             null
         } else {
+            if (viewHierarchy != null) {
+                hierarchy = ViewHierarchy(element.treeNode)
+            }
             return FindElementResult(element, hierarchy)
-        }
-    }
-
-    fun findElementFromViewHierarchyWithTimeout(
-        timeoutMs: Long,
-        filter: ElementFilter,
-        viewHierarchy: ViewHierarchy
-    ): FindElementResult? {
-        val element = MaestroTimer.withTimeout(timeoutMs) {
-            filter(viewHierarchy.aggregate()).firstOrNull()
-        }?.toUiElementOrNull()
-
-        return if (element == null) {
-            null
-        } else {
-            return FindElementResult(element, ViewHierarchy(element.treeNode))
         }
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -445,6 +445,22 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         }
     }
 
+    fun findElementFromViewHierarchyWithTimeout(
+        timeoutMs: Long,
+        filter: ElementFilter,
+        viewHierarchy: ViewHierarchy
+    ): FindElementResult? {
+        val element = MaestroTimer.withTimeout(timeoutMs) {
+            filter(viewHierarchy.aggregate()).firstOrNull()
+        }?.toUiElementOrNull()
+
+        return if (element == null) {
+            null
+        } else {
+            return FindElementResult(element, viewHierarchy)
+        }
+    }
+
     fun allElementsMatching(filter: ElementFilter): List<TreeNode> {
         return filter(viewHierarchy().aggregate())
     }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -119,7 +119,7 @@ data class ElementSelector(
         }
 
         childOf?.let {
-            descriptions.add("Child Of: ${it.description()}")
+            descriptions.add("Child of: ${it.description()}")
         }
 
         val combined = descriptions.joinToString(", ")

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -39,6 +39,7 @@ data class ElementSelector(
     val selected: Boolean? = null,
     val checked: Boolean? = null,
     val focused: Boolean? = null,
+    val childOf: ElementSelector? = null
 ) {
 
     data class SizeSelector(
@@ -58,6 +59,7 @@ data class ElementSelector(
             containsChild = containsChild?.evaluateScripts(jsEngine),
             containsDescendants = containsDescendants?.map { it.evaluateScripts(jsEngine) },
             index = index?.evaluateScripts(jsEngine),
+            childOf = childOf?.evaluateScripts(jsEngine)
         )
     }
 
@@ -114,6 +116,10 @@ data class ElementSelector(
 
         index?.let {
             descriptions.add("Index: ${it.toDoubleOrNull()?.toInt() ?: it}")
+        }
+
+        childOf?.let {
+            descriptions.add("Child Of: ${it.description()}")
         }
 
         val combined = descriptions.joinToString(", ")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -855,15 +855,14 @@ class Orchestra(
                 parentViewHierarchy
             ) ?: throw MaestroException.ElementNotFound(
                 "Element not found: $description",
-                maestro.viewHierarchy().root,
+                parentViewHierarchy.root,
             )
         }
 
 
         return maestro.findElementWithTimeout(
             timeoutMs = timeout,
-            filter = filterFunc,
-            null
+            filter = filterFunc
         ) ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             maestro.viewHierarchy().root,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -840,16 +840,49 @@ class Orchestra(
                     lookupTimeoutMs
                 }
             )
-
         val (description, filterFunc) = buildFilter(
             selector,
             deviceInfo(),
         )
+        if(selector.childOf != null){
+            val parentViewHierarchy = findElementViewHierarchy(
+                selector.childOf,
+                timeout
+            )
+            return maestro.findElementFromViewHierarchyWithTimeout(
+                timeout,
+                filterFunc,
+                parentViewHierarchy)?:throw MaestroException.ElementNotFound(
+                "Element not found: $description",
+                maestro.viewHierarchy().root,
+            )
+        }
+
 
         return maestro.findElementWithTimeout(
             timeoutMs = timeout,
             filter = filterFunc,
         ) ?: throw MaestroException.ElementNotFound(
+            "Element not found: $description",
+            maestro.viewHierarchy().root,
+        )
+    }
+
+    private fun findElementViewHierarchy(
+        selector: ElementSelector?,
+        timeout: Long
+    ):ViewHierarchy {
+        if(selector == null ){
+            return maestro.viewHierarchy()
+        }
+        val parentViewHierarchy = findElementViewHierarchy(selector.childOf,timeout);
+        val (description, filterFunc) = buildFilter(
+            selector,
+            deviceInfo(),
+        )
+        return maestro.findElementFromViewHierarchyWithTimeout(timeout,
+            filterFunc,
+            parentViewHierarchy)?.hierarchy?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             maestro.viewHierarchy().root,
         )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -844,15 +844,16 @@ class Orchestra(
             selector,
             deviceInfo(),
         )
-        if(selector.childOf != null){
+        if (selector.childOf != null) {
             val parentViewHierarchy = findElementViewHierarchy(
                 selector.childOf,
                 timeout
             )
-            return maestro.findElementFromViewHierarchyWithTimeout(
+            return maestro.findElementWithTimeout(
                 timeout,
                 filterFunc,
-                parentViewHierarchy)?:throw MaestroException.ElementNotFound(
+                parentViewHierarchy
+            ) ?: throw MaestroException.ElementNotFound(
                 "Element not found: $description",
                 maestro.viewHierarchy().root,
             )
@@ -871,18 +872,20 @@ class Orchestra(
     private fun findElementViewHierarchy(
         selector: ElementSelector?,
         timeout: Long
-    ):ViewHierarchy {
-        if(selector == null ){
+    ): ViewHierarchy {
+        if (selector == null) {
             return maestro.viewHierarchy()
         }
-        val parentViewHierarchy = findElementViewHierarchy(selector.childOf,timeout);
+        val parentViewHierarchy = findElementViewHierarchy(selector.childOf, timeout);
         val (description, filterFunc) = buildFilter(
             selector,
             deviceInfo(),
         )
-        return maestro.findElementFromViewHierarchyWithTimeout(timeout,
+        return maestro.findElementWithTimeout(
+            timeout,
             filterFunc,
-            parentViewHierarchy)?.hierarchy?: throw MaestroException.ElementNotFound(
+            parentViewHierarchy
+        )?.hierarchy ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             parentViewHierarchy.root,
         )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -884,7 +884,7 @@ class Orchestra(
             filterFunc,
             parentViewHierarchy)?.hierarchy?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
-            maestro.viewHierarchy().root,
+            parentViewHierarchy.root,
         )
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -863,6 +863,7 @@ class Orchestra(
         return maestro.findElementWithTimeout(
             timeoutMs = timeout,
             filter = filterFunc,
+            null
         ) ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             maestro.viewHierarchy().root,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -48,5 +48,6 @@ data class YamlElementSelector(
     val focused: Boolean? = null,
     val repeat: Int? = null,
     val delay: Int? = null,
-    val waitToSettleTimeoutMs: Int? = null
+    val waitToSettleTimeoutMs: Int? = null,
+    val childOf: YamlElementSelectorUnion? = null
 ) : YamlElementSelectorUnion

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -510,6 +510,7 @@ data class YamlFluentCommand(
             checked = selector.checked,
             focused = selector.focused,
             optional = selector.optional ?: false,
+            childOf = selector.childOf?.let { toElementSelector(it) }
         )
     }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3051,6 +3051,54 @@ class IntegrationTest {
         driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 1)
     }
 
+    @Test
+    fun `Case 114 - child of selector`() {
+        // Given
+        val commands = readCommands("114_child_of_selector")
+
+        val driver = driver {
+            element {
+                id = "id1"
+                bounds = Bounds(0, 0, 200, 600)
+
+                element {
+                    bounds = Bounds(0, 0, 200, 200)
+                    text = "parent_id_1"
+                    element {
+                        text = "child_id"
+                        bounds = Bounds(0, 0, 100, 200)
+                    }
+                }
+                element {
+                    bounds = Bounds(0, 200, 200, 400)
+                    text = "parent_id_2"
+                    element {
+                        text = "child_id"
+                        bounds = Bounds(0, 200, 100, 400)
+                    }
+                }
+                element {
+                    bounds = Bounds(0, 400, 200, 600)
+                    text = "parent_id_3"
+                    element {
+                        text = "child_id_1"
+                        bounds = Bounds(0, 400, 100, 600)
+                    }
+                }
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failures
+        driver.assertNoInteraction()
+
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/114_child_of_selector.yaml
+++ b/maestro-test/src/test/resources/114_child_of_selector.yaml
@@ -1,0 +1,10 @@
+appId: com.example.app
+---
+- assertVisible:
+    text: "child_id"
+    childOf:
+      text: "parent_id_1"
+- assertNotVisible:
+    text: "child_id"
+    childOf:
+      text: "parent__id_3"

--- a/maestro-test/src/test/resources/114_child_of_selector.yaml
+++ b/maestro-test/src/test/resources/114_child_of_selector.yaml
@@ -7,4 +7,4 @@ appId: com.example.app
 - assertNotVisible:
     text: "child_id"
     childOf:
-      text: "parent__id_3"
+      text: "parent_id_3"


### PR DESCRIPTION
## Proposed Changes
When we are reusing a component/ui inside different different UI. Then to correctly identify which component to select we are adding this `childOf` selector

eg we have a button element and its id is `proceed`. Now this button is used by two UI component in the same page. Now we have two view components id: add_to_cart and buy_now but the inner button have same id `proceed`. So if placement of  these two UI element is dynamic it becomes very difficult to correctly select which one represents add_to_cart and which represents buy_now to tap.

`childOf` selector into rescue. `childOf` selector tells maestro to select id or text which is child of provided selector.

eg if we want to tap on buy now button we can easily write.
```
tapOn:
   text: "proceed"
    childOf:
        - id: "buy-now"
```


this will first search for Element with id  "buy-now" then inside it's child tree it will try to find  element with id "proceed"

View
![image](https://github.com/mobile-dev-inc/maestro/assets/15627173/7b90d2eb-f9ba-44d0-ad23-8aec7fb968c0)

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
