### PR TITLE
🚀 [VIS-4480] Get maestro working on android api level 24 and above and build and deploy to github releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build Maestro for Dojo
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '1.8'
+          distribution: 'adopt'
+
+      - name: Assemble APKs
+        run: ./gradlew :maestro-android:assembleAndroidTest :maestro-android:assemble
+
+      - name: Install maestro-cli
+        run: ./gradlew :maestro-cli:installDist -q
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload maestro-cli asset to GitHub release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./maestro-cli/build/install/maestro/bin/maestro
+          asset_name: maestro
+          asset_content_type: application/octet-stream

--- a/maestro-android/build.gradle
+++ b/maestro-android/build.gradle
@@ -38,7 +38,7 @@ android {
 
     defaultConfig {
         applicationId "dev.mobile.maestro"
-        minSdk 21
+        minSdk 24
         targetSdk 31
         versionCode 1
         versionName "1.0"
@@ -91,7 +91,7 @@ tasks.register("copyMaestroAndroid", Copy) {
             throw new GradleException("Error: Input source for copyMaestroAndroid doesn't exist")
 
         new File("./maestro-client/src/main/resources/maestro-android-debug.apk")
-            .renameTo(new File("./maestro-client/src/main/resources/maestro-app.apk"))
+                .renameTo(new File("./maestro-client/src/main/resources/maestro-app.apk"))
     }
 }
 
@@ -107,12 +107,12 @@ tasks.register("copyMaestroServer", Copy) {
         if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
             throw new GradleException("This build must be run with java 8")
         }
-        
+
         if (!layout.buildDirectory.file(maestroServerApkDestPath).get().asFile.exists())
             throw new GradleException("Error: Input source for copyMaestroServer doesn't exist")
 
         new File("./maestro-client/src/main/resources/maestro-android-debug-androidTest.apk")
-            .renameTo(new File("./maestro-client/src/main/resources/maestro-server.apk"))
+                .renameTo(new File("./maestro-client/src/main/resources/maestro-server.apk"))
     }
 }
 
@@ -143,9 +143,6 @@ dependencies {
     implementation(libs.ktor.server.cio)
     implementation(libs.ktor.server.content.negotiation)
     implementation(libs.ktor.serial.gson)
-
-    implementation('org.apache.commons:commons-lang3:3.13.0')
-    implementation('org.lsposed.hiddenapibypass:hiddenapibypass:4.3')
 
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/maestro-android/src/androidTest/java/dev/mobile/maestro/AccessibilityNodeInfoExt.kt
+++ b/maestro-android/src/androidTest/java/dev/mobile/maestro/AccessibilityNodeInfoExt.kt
@@ -1,0 +1,23 @@
+package dev.mobile.maestro
+
+import android.os.Build
+import android.view.accessibility.AccessibilityNodeInfo
+
+object AccessibilityNodeInfoExt {
+
+    /**
+     * Retrieves the hint text associated with this [android.view.accessibility.AccessibilityNodeInfo].
+     *
+     * If the device API level is below 26 (Oreo), this function provides a fallback
+     * by returning an empty CharSequence instead.
+     *
+     * @return [CharSequence] representing the hint text or its fallback.
+     */
+    fun AccessibilityNodeInfo.getHintOrFallback(): CharSequence {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            this.hintText
+        } else {
+            ""
+        }
+    }
+}

--- a/maestro-android/src/androidTest/java/dev/mobile/maestro/ViewHierarchy.kt
+++ b/maestro-android/src/androidTest/java/dev/mobile/maestro/ViewHierarchy.kt
@@ -15,6 +15,7 @@ import android.widget.ListView
 import android.widget.TableLayout
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import dev.mobile.maestro.AccessibilityNodeInfoExt.getHintOrFallback
 import org.xmlpull.v1.XmlSerializer
 import java.io.IOException
 import java.io.OutputStream
@@ -120,7 +121,7 @@ object ViewHierarchy {
             serializer.attribute("", "NAF", java.lang.Boolean.toString(true))
         }
         serializer.attribute("", "index", Integer.toString(index))
-        serializer.attribute("", "hintText", safeCharSeqToString(node.hintText))
+        serializer.attribute("", "hintText", safeCharSeqToString(node.getHintOrFallback()))
         serializer.attribute("", "text", safeCharSeqToString(node.text))
         serializer.attribute("", "resource-id", safeCharSeqToString(node.viewIdResourceName))
         serializer.attribute("", "class", safeCharSeqToString(node.className))
@@ -193,8 +194,8 @@ object ViewHierarchy {
      */
     private fun nafCheck(node: AccessibilityNodeInfo): Boolean {
         val isNaf = (node.isClickable && node.isEnabled
-            && safeCharSeqToString(node.contentDescription).isEmpty()
-            && safeCharSeqToString(node.text).isEmpty())
+                && safeCharSeqToString(node.contentDescription).isEmpty()
+                && safeCharSeqToString(node.text).isEmpty())
         return if (!isNaf) true else childNafCheck(node)
 
         // check children since sometimes the containing element is clickable

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -87,7 +87,7 @@ interface Driver {
 
     fun waitUntilScreenIsStatic(timeoutMs: Long): Boolean
 
-    fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int? = null): ViewHierarchy?
+    fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?): ViewHierarchy?
 
     fun capabilities(): List<Capability>
 


### PR DESCRIPTION
VIS-4480

# Problem
We want to use Maestro as a black-box test framework that we can use with device farm in CI. Official Maestro does not support API 25 and below.

# Solution
I have made a PR in the Open Source repo here -> https://github.com/mobile-dev-inc/maestro/pull/1527. It is actually going to be merged soon apparently but until then, I have forked the repo here and made the same fix to support older Android versions and also build and deploy the maestro-cli binary to our own GitHub releases so that Bitrise workflows can later grab the maestro-cli tool and use it for testing against real devices in CI

## Screenshots / videos
N/A

# Prevention
N/A

#  Manual QA testing notes
Areas affected that need attention from QA:
N/A

# Checklist
I have:
- [X] considered documenting breaking changes for public module APIs in RELEASE_NOTES.md
- [X] considered testing UI changes on A80
- [X] tested all important logic with unit tests, except mentioned above
- [X] done a self-review and believe the PR follows our best practices