### PR TITLE
fix shebang in maestro script

### DIFF
--- a/maestro
+++ b/maestro
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
## Proposed Changes
This PR fixes the shebang in the maestro script to work on systems where `/bin/bash` doesn't exist (e.g. NixOS).
Instead it now uses `/usr/bin/env` to lookup a bash binary in PATH.
