### PR TITLE
[TV Remote] Add extra remote keys for TV

### DIFF
--- a/maestro-client/src/main/java/maestro/KeyCode.kt
+++ b/maestro-client/src/main/java/maestro/KeyCode.kt
@@ -26,7 +26,17 @@ enum class KeyCode(
     REMOTE_FAST_FORWARD("Remote Media Fast Forward"),
     ESCAPE("Escape"),
     POWER("Power"),
-    TAB("Tab");
+    TAB("Tab"),
+    REMOTE_SYSTEM_NAVIGATION_UP("Remote System Navigation Up"),
+    REMOTE_SYSTEM_NAVIGATION_DOWN("Remote System Navigation Down"),
+    REMOTE_BUTTON_A("Remote Button A"),
+    REMOTE_BUTTON_B("Remote Button B"),
+    REMOTE_MENU("Remote Menu"),
+    TV_INPUT("TV Input"),
+    TV_INPUT_HDMI_1("TV Input HDMI 1"),
+    TV_INPUT_HDMI_2("TV Input HDMI 2"),
+    TV_INPUT_HDMI_3("TV Input HDMI 3");
+
     companion object {
         fun getByName(name: String): KeyCode? {
             val lowercaseName = name.lowercase()

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -256,6 +256,15 @@ class AndroidDriver(
             KeyCode.POWER -> 26
             KeyCode.ESCAPE -> 111
             KeyCode.TAB -> 62
+            KeyCode.REMOTE_SYSTEM_NAVIGATION_UP -> 280
+            KeyCode.REMOTE_SYSTEM_NAVIGATION_DOWN -> 281
+            KeyCode.REMOTE_BUTTON_A -> 96
+            KeyCode.REMOTE_BUTTON_B -> 97
+            KeyCode.REMOTE_MENU -> 82
+            KeyCode.TV_INPUT -> 178
+            KeyCode.TV_INPUT_HDMI_1 -> 243
+            KeyCode.TV_INPUT_HDMI_2 -> 244
+            KeyCode.TV_INPUT_HDMI_3 -> 245
         }
 
         dadb.shell("input keyevent $intCode")

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -989,6 +989,15 @@ class IntegrationTest {
         driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_FAST_FORWARD))
         driver.assertHasEvent(Event.PressKey(KeyCode.POWER))
         driver.assertHasEvent(Event.PressKey(KeyCode.TAB))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_SYSTEM_NAVIGATION_UP))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_SYSTEM_NAVIGATION_DOWN))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_BUTTON_A))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_BUTTON_B))
+        driver.assertHasEvent(Event.PressKey(KeyCode.REMOTE_MENU))
+        driver.assertHasEvent(Event.PressKey(KeyCode.TV_INPUT))
+        driver.assertHasEvent(Event.PressKey(KeyCode.TV_INPUT_HDMI_1))
+        driver.assertHasEvent(Event.PressKey(KeyCode.TV_INPUT_HDMI_2))
+        driver.assertHasEvent(Event.PressKey(KeyCode.TV_INPUT_HDMI_3))
     }
 
     @Test

--- a/maestro-test/src/test/resources/034_press_key.yaml
+++ b/maestro-test/src/test/resources/034_press_key.yaml
@@ -20,4 +20,13 @@ appId: com.example.app
 - pressKey: Remote Media Fast Forward
 - pressKey: power
 - pressKey: Tab
+- pressKey: Remote System Navigation Up
+- pressKey: Remote System Navigation Down
+- pressKey: Remote Button A
+- pressKey: Remote Button B
+- pressKey: Remote Menu
+- pressKey: TV Input
+- pressKey: TV Input HDMI 1
+- pressKey: TV Input HDMI 2
+- pressKey: TV Input HDMI 3
 


### PR DESCRIPTION
## Proposed Changes

Added the following pressKeys for remote TV:

- Remote System Navigation Up
- Remote System Navigation Down
- Remote Button A
- Remote Button B
- Remote Menu
- TV Input
- TV Input HDMI 1
- TV Input HDMI 2
- TV Input HDMI 3


## Testing

![image](https://github.com/mobile-dev-inc/maestro/assets/12176091/46246ef4-775b-450b-9e35-a23ece36123a)

## Issues Fixed

Some remote keys weren't added to the codebase.