### PR TITLE
Extending retry to handle 404 in upload status call

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -36,7 +36,7 @@ class CloudInteractor(
     private val auth: Auth = Auth(client),
     private val waitTimeoutMs: Long = TimeUnit.MINUTES.toMillis(30),
     private val minPollIntervalMs: Long = TimeUnit.SECONDS.toMillis(10),
-    private val maxPollingRetries: Int = 3,
+    private val maxPollingRetries: Int = 5,
     private val failOnTimeout: Boolean = true,
 ) {
 
@@ -214,7 +214,7 @@ class CloudInteractor(
                     continue
                 }
 
-                if (e.statusCode == 500 || e.statusCode == 502) {
+                if (e.statusCode == 500 || e.statusCode == 502 || e.statusCode == 404) {
                     if (++retryCounter <= maxPollingRetries) {
                         // retry on 500
                         Thread.sleep(pollingInterval)


### PR DESCRIPTION
When the CLI calls Maestro Cloud backend to get the status of the upload it's not using the retry mechanism for 404 responses. I'm expanding the retry to also handle 404s