### PR TITLE
Fix cleaning up retries in iOS driver

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
@@ -122,8 +122,13 @@ object XCRunnerCLIUtils {
         return runningApps(deviceId)[bundleId]
     }
 
-    fun runXcTestWithoutBuild(deviceId: String, xcTestRunFilePath: String, port: Int): Process {
+    fun runXcTestWithoutBuild(deviceId: String, xcTestRunFilePath: String, port: Int, enableXCTestOutputFileLogging: Boolean = false): Process {
         val date = dateFormatter.format(LocalDateTime.now())
+        val outputFile = if (enableXCTestOutputFileLogging) {
+            File(logDirectory, "xctest_runner_$date.log")
+        } else {
+            null
+        }
         val logOutputDir = Files.createTempDirectory("maestro_xctestrunner_xcodebuild_output")
         return CommandLineUtils.runCommand(
             listOf(
@@ -137,7 +142,7 @@ object XCRunnerCLIUtils {
                 logOutputDir.absolutePathString()
             ),
             waitForCompletion = false,
-            outputFile = File(logDirectory, "xctest_runner_$date.log"),
+            outputFile = outputFile,
             params = mapOf("TEST_RUNNER_PORT" to port.toString())
         )
     }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -10,6 +10,7 @@ import okhttp3.Response
 import okio.buffer
 import okio.sink
 import okio.source
+import org.apache.commons.io.FileUtils
 import org.rauschig.jarchivelib.ArchiverFactory
 import util.XCRunnerCLIUtils
 import xcuitest.XCTestClient
@@ -175,7 +176,7 @@ class LocalXCTestInstaller(
         }
 
         logger.info("[Start] Cleaning up the ui test runner files")
-        File(tempDir).deleteRecursively()
+        FileUtils.cleanDirectory(File(tempDir))
         uninstall()
         logger.info("[Done] Cleaning up the ui test runner files")
     }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -22,7 +22,8 @@ class LocalXCTestInstaller(
     private val logger: Logger,
     private val deviceId: String,
     private val host: String = "[::1]",
-    defaultPort: Int? = null,
+    private val enableXCTestOutputFileLogging: Boolean = false,
+    defaultPort: Int? = null
 ) : XCTestInstaller {
     // Set this flag to allow using a test runner started from Xcode
     // When this flag is set, maestro will not install, run, stop or remove the xctest runner.
@@ -165,7 +166,8 @@ class LocalXCTestInstaller(
         xcTestProcess = XCRunnerCLIUtils.runXcTestWithoutBuild(
             deviceId,
             xctestRunFile.absolutePath,
-            port
+            port,
+            enableXCTestOutputFileLogging,
         )
         logger.info("[Done] Running XcUITest with xcode build command")
     }


### PR DESCRIPTION
## Proposed Changes

1. Properly release resources in case of retries
2. Clean directory instead of deleting the temp directory 
3. Add flag to enable/disable xctest logging

## Testing
<!--- Please describe how you tested your changes. -->

## Issues Fixed
