### PR TITLE
Fix "Protocol family unavailable" on rerun after failure

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -92,8 +92,12 @@ class LocalXCTestInstaller(
     }
 
     override fun isChannelAlive(): Boolean {
-        return XCRunnerCLIUtils.isAppAlive(UI_TEST_RUNNER_APP_BUNDLE_ID, deviceId) &&
-            xcTestDriverStatusCheck().use { it.isSuccessful }
+        return try {
+            XCRunnerCLIUtils.isAppAlive(UI_TEST_RUNNER_APP_BUNDLE_ID, deviceId) &&
+                xcTestDriverStatusCheck().use { it.isSuccessful }
+        } catch (ignore: IOException) {
+            false
+        }
     }
 
     private fun ensureOpen(): Boolean {


### PR DESCRIPTION
## Proposed Changes

I think `xcTestDriverStatusCheck` may return a response object with an error response or throw. In `isChannelAlive`, where we care about _whether_ channel is alive we should treat an exception as an `isChannelAlive = false`.

## Testing

I verified this is valid Kotlin code and looks similar to `ensureOpen`.

## Issues Fixed

I've run into the "Protocol family unavailable" after a CI-run test job fails to connect to XCUITest server. I believe the `xcTestDriverStatusCheck` should be wrapped with `try-catch`, as it is in `ensureOpen()`.