### PR TITLE
feat: allow airplane mode control

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -96,4 +96,8 @@ interface Driver {
     fun setPermissions(appId: String, permissions: Map<String, String>)
 
     fun addMedia(mediaFiles: List<File>)
+
+    fun isAirplaneModeEnabled(): Boolean
+
+    fun setAirplaneMode(enabled: Boolean)
 }

--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -54,6 +54,8 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
     ) : MaestroException(message)
 
     class DeprecatedCommand(message: String) : MaestroException(message)
+
+    class NoRootAccess(message: String) : MaestroException(message)
 }
 
 sealed class MaestroDriverStartupException(override val message: String): RuntimeException() {

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -581,6 +581,14 @@ class Maestro(private val driver: Driver) : AutoCloseable {
         return driver.isUnicodeInputSupported()
     }
 
+    fun isAirplaneModeEnabled(): Boolean {
+        return driver.isAirplaneModeEnabled()
+    }
+
+    fun setAirplaneModeState(enabled: Boolean) {
+        driver.setAirplaneMode(enabled)
+    }
+
     companion object {
 
         private val LOGGER = LoggerFactory.getLogger(Maestro::class.java)

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -664,6 +664,50 @@ class AndroidDriver(
         LOGGER.info("[Done] Adding media files")
     }
 
+    override fun isAirplaneModeEnabled(): Boolean {
+        return when (val result = shell("cmd connectivity airplane-mode").trim()) {
+            "No shell command implementation.", "" -> {
+                LOGGER.debug("Falling back to old airplane mode read method")
+                when (val fallbackResult = shell("settings get global airplane_mode_on").trim()) {
+                    "0" -> false
+                    "1" -> true
+                    else -> throw IllegalStateException("Received invalid response from while trying to read airplane mode state: $fallbackResult")
+                }
+            }
+            "disabled" -> false
+            "enabled" -> true
+            else -> throw IllegalStateException("Received invalid response while trying to read airplane mode state: $result")
+        }
+    }
+
+    override fun setAirplaneMode(enabled: Boolean) {
+        // fallback to old way on API < 28
+        if (getDeviceApiLevel() < 28) {
+            val num = if (enabled) 1 else 0
+            shell("settings put global airplane_mode_on $num")
+            // We need to broadcast the change to really apply it
+            broadcastAirplaneMode(enabled)
+            return
+        }
+        val value = if (enabled) "enable" else "disable"
+        shell("cmd connectivity airplane-mode $value")
+    }
+
+    private fun broadcastAirplaneMode(enabled: Boolean) {
+        val command = "am broadcast -a android.intent.action.AIRPLANE_MODE --ez state $enabled"
+        try {
+            shell(command)
+        } catch (e: IOException) {
+            if (e.message?.contains("Security exception: Permission Denial:") == true) {
+                try {
+                    shell("su root $command")
+                } catch (e: IOException) {
+                    throw MaestroException.NoRootAccess("Failed to broadcast airplane mode change. Make sure to run an emulator with root access for API < 28")
+                }
+            }
+        }
+    }
+
     fun setDeviceLocale(country: String, language: String): Int {
         dadb.shell("pm grant dev.mobile.maestro android.permission.CHANGE_CONFIGURATION")
         val response = dadb.shell("am broadcast -a dev.mobile.maestro.locale -n dev.mobile.maestro/.receivers.LocaleSettingReceiver --es lang $language --es country $country")

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -440,6 +440,15 @@ class IOSDriver(
         LOGGER.info("[Done] Adding media files")
     }
 
+    override fun isAirplaneModeEnabled(): Boolean {
+        LOGGER.warn("Airplane mode is not available on iOS simulators")
+        return false
+    }
+
+    override fun setAirplaneMode(enabled: Boolean) {
+        LOGGER.warn("Airplane mode is not available on iOS simulators")
+    }
+
     private fun addMediaToDevice(mediaFile: File) {
         val namedSource = NamedSource(
             mediaFile.name,

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -377,6 +377,14 @@ class WebDriver(val isStudio: Boolean) : Driver {
         // noop for web
     }
 
+    override fun isAirplaneModeEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAirplaneMode(enabled: Boolean) {
+        TODO("Not yet implemented")
+    }
+
     companion object {
         private const val SCREENSHOT_DIFF_THRESHOLD = 0.005
     }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -889,6 +889,16 @@ data class SetAirplaneModeCommand(
     }
 }
 
+object ToggleAirplaneModeCommand : Command {
+    override fun description(): String {
+        return "Toggle airplane mode"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+}
+
 internal fun tapOnDescription(isLongPress: Boolean?, repeat: TapRepeat?): String {
     return if (isLongPress == true) "Long press"
     else if (repeat != null) {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -19,6 +19,7 @@
 
 package maestro.orchestra
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import maestro.KeyCode
 import maestro.Point
 import maestro.ScrollDirection
@@ -859,6 +860,28 @@ data class StopRecordingCommand(
 
     override fun description(): String {
         return label ?: "Stop recording"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+}
+
+enum class AirplaneValue {
+    @JsonProperty("enabled")
+    Enable,
+    @JsonProperty("disabled")
+    Disable,
+}
+
+data class SetAirplaneModeCommand(
+    val value: AirplaneValue,
+) : Command {
+    override fun description(): String {
+        return when (value) {
+            AirplaneValue.Enable -> "Enable airplane mode"
+            AirplaneValue.Disable -> "Disable airplane mode"
+        }
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -63,6 +63,7 @@ data class MaestroCommand(
     val stopRecordingCommand: StopRecordingCommand? = null,
     val addMediaCommand: AddMediaCommand? = null,
     val setAirplaneModeCommand: SetAirplaneModeCommand? = null,
+    val toggleAirplaneModeCommand: ToggleAirplaneModeCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -101,6 +102,7 @@ data class MaestroCommand(
         stopRecordingCommand = command as? StopRecordingCommand,
         addMediaCommand = command as? AddMediaCommand,
         setAirplaneModeCommand = command as? SetAirplaneModeCommand,
+        toggleAirplaneModeCommand = command as? ToggleAirplaneModeCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -139,6 +141,7 @@ data class MaestroCommand(
         stopRecordingCommand != null -> stopRecordingCommand
         addMediaCommand != null -> addMediaCommand
         setAirplaneModeCommand != null -> setAirplaneModeCommand
+        toggleAirplaneModeCommand != null -> toggleAirplaneModeCommand
         else -> null
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -62,6 +62,7 @@ data class MaestroCommand(
     val startRecordingCommand: StartRecordingCommand? = null,
     val stopRecordingCommand: StopRecordingCommand? = null,
     val addMediaCommand: AddMediaCommand? = null,
+    val setAirplaneModeCommand: SetAirplaneModeCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -98,7 +99,8 @@ data class MaestroCommand(
         travelCommand = command as? TravelCommand,
         startRecordingCommand = command as? StartRecordingCommand,
         stopRecordingCommand = command as? StopRecordingCommand,
-        addMediaCommand = command as? AddMediaCommand
+        addMediaCommand = command as? AddMediaCommand,
+        setAirplaneModeCommand = command as? SetAirplaneModeCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -136,6 +138,7 @@ data class MaestroCommand(
         startRecordingCommand != null -> startRecordingCommand
         stopRecordingCommand != null -> stopRecordingCommand
         addMediaCommand != null -> addMediaCommand
+        setAirplaneModeCommand != null -> setAirplaneModeCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -278,6 +278,7 @@ class Orchestra(
             is StopRecordingCommand -> stopRecordingCommand()
             is AddMediaCommand -> addMediaCommand(command.mediaPaths)
             is SetAirplaneModeCommand -> setAirplaneMode(command)
+            is ToggleAirplaneModeCommand -> toggleAirplaneMode()
             else -> true
         }.also { mutating ->
             if (mutating) {
@@ -292,6 +293,11 @@ class Orchestra(
             AirplaneValue.Disable -> maestro.setAirplaneModeState(false)
         }
 
+        return true
+    }
+
+    private fun toggleAirplaneMode(): Boolean {
+        maestro.setAirplaneModeState(!maestro.isAirplaneModeEnabled())
         return true
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -277,12 +277,22 @@ class Orchestra(
             is StartRecordingCommand -> startRecordingCommand(command)
             is StopRecordingCommand -> stopRecordingCommand()
             is AddMediaCommand -> addMediaCommand(command.mediaPaths)
+            is SetAirplaneModeCommand -> setAirplaneMode(command)
             else -> true
         }.also { mutating ->
             if (mutating) {
                 timeMsOfLastInteraction = System.currentTimeMillis()
             }
         }
+    }
+
+    private fun setAirplaneMode(command: SetAirplaneModeCommand): Boolean {
+        when (command.value) {
+            AirplaneValue.Enable -> maestro.setAirplaneModeState(true)
+            AirplaneValue.Disable -> maestro.setAirplaneModeState(false)
+        }
+
+        return true
     }
 
     private fun travelCommand(command: TravelCommand): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -74,6 +74,7 @@ data class YamlFluentCommand(
     val startRecording: YamlStartRecording? = null,
     val stopRecording: YamlStopRecording? = null,
     val addMedia: YamlAddMedia? = null,
+    val setAirplaneMode: YamlSetAirplaneMode? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -211,6 +212,7 @@ data class YamlFluentCommand(
                 val tapRepeat = TapRepeat(2, delay)
                 listOf(tapCommand(doubleTapOn, tapRepeat = tapRepeat))
             }
+            setAirplaneMode != null -> listOf(MaestroCommand(SetAirplaneModeCommand(setAirplaneMode.value)))
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -75,6 +75,7 @@ data class YamlFluentCommand(
     val stopRecording: YamlStopRecording? = null,
     val addMedia: YamlAddMedia? = null,
     val setAirplaneMode: YamlSetAirplaneMode? = null,
+    val toggleAirplaneMode: YamlToggleAirplaneMode? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -213,6 +214,7 @@ data class YamlFluentCommand(
                 listOf(tapCommand(doubleTapOn, tapRepeat = tapRepeat))
             }
             setAirplaneMode != null -> listOf(MaestroCommand(SetAirplaneModeCommand(setAirplaneMode.value)))
+            toggleAirplaneMode != null -> listOf(MaestroCommand(ToggleAirplaneModeCommand))
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }
     }
@@ -667,6 +669,10 @@ data class YamlFluentCommand(
 
                 "stopRecording" -> YamlFluentCommand(
                     stopRecording = YamlStopRecording()
+                )
+
+                "toggleAirplaneMode" -> YamlFluentCommand(
+                    toggleAirplaneMode = YamlToggleAirplaneMode()
                 )
 
                 else -> throw SyntaxError("Invalid command: \"$stringCommand\"")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSetAirplaneMode.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSetAirplaneMode.kt
@@ -1,0 +1,16 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import maestro.orchestra.AirplaneValue
+
+data class YamlSetAirplaneMode(
+    val value: AirplaneValue,
+) {
+    companion object {
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(value: AirplaneValue): YamlSetAirplaneMode {
+            return YamlSetAirplaneMode(value)
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlToggleAirplaneMode.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlToggleAirplaneMode.kt
@@ -1,0 +1,3 @@
+package maestro.orchestra.yaml
+
+class YamlToggleAirplaneMode

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -43,6 +43,8 @@ class FakeDriver : Driver {
 
     private var currentText: String = ""
 
+    private var airplaneMode: Boolean = false
+
     override fun name(): String {
         return "Fake Device"
     }
@@ -376,6 +378,14 @@ class FakeDriver : Driver {
         ensureOpen()
 
         mediaFiles.forEach { _ -> events.add(Event.AddMedia) }
+    }
+
+    override fun isAirplaneModeEnabled(): Boolean {
+        return this.airplaneMode
+    }
+
+    override fun setAirplaneMode(enabled: Boolean) {
+        this.airplaneMode = enabled
     }
 
     sealed class Event {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3108,6 +3108,16 @@ class IntegrationTest {
 
     }
 
+    @Test
+    fun `Case 115 - airplane mode`()  {
+        val commands = readCommands("115_airplane_mode")
+        val driver = driver { }
+
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/115_airplane_mode.yaml
+++ b/maestro-test/src/test/resources/115_airplane_mode.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- setAirplaneMode: enabled
+- setAirplaneMode: disabled
+- toggleAirplaneMode


### PR DESCRIPTION
## Proposed Changes

add a new command for controlling the airplane mode of android devices.

## Testing

ran the following flow on android 27 and 28 emulators:
```yaml
appId: org.wikipedia
---
- launchApp
- setAirplaneMode: disable
- setAirplaneMode: enable
```