### PR TITLE
feat: network failure simulation using a stub proxy

### DIFF
--- a/maestro-client/src/main/java/maestro/Proxy.kt
+++ b/maestro-client/src/main/java/maestro/Proxy.kt
@@ -1,0 +1,3 @@
+package maestro
+
+data class Proxy(val host: String, val port: Int)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -876,3 +876,15 @@ internal fun tapOnDescription(isLongPress: Boolean?, repeat: TapRepeat?): String
         }
     } else "Tap"
 }
+
+data class SimulateNetworkFailureCommand(
+    val state: Boolean,
+) : Command {
+    override fun description(): String {
+        return if (state) "Enable Network Failure" else "Disable Network Failure"
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+       return this
+    }
+}

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -62,6 +62,7 @@ data class MaestroCommand(
     val startRecordingCommand: StartRecordingCommand? = null,
     val stopRecordingCommand: StopRecordingCommand? = null,
     val addMediaCommand: AddMediaCommand? = null,
+    val simulateNetworkFailureCommand: SimulateNetworkFailureCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -98,7 +99,8 @@ data class MaestroCommand(
         travelCommand = command as? TravelCommand,
         startRecordingCommand = command as? StartRecordingCommand,
         stopRecordingCommand = command as? StopRecordingCommand,
-        addMediaCommand = command as? AddMediaCommand
+        addMediaCommand = command as? AddMediaCommand,
+        simulateNetworkFailureCommand = command as? SimulateNetworkFailureCommand,
     )
 
     fun asCommand(): Command? = when {
@@ -136,6 +138,7 @@ data class MaestroCommand(
         startRecordingCommand != null -> startRecordingCommand
         stopRecordingCommand != null -> stopRecordingCommand
         addMediaCommand != null -> addMediaCommand
+        simulateNetworkFailureCommand != null -> simulateNetworkFailureCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -277,6 +277,7 @@ class Orchestra(
             is StartRecordingCommand -> startRecordingCommand(command)
             is StopRecordingCommand -> stopRecordingCommand()
             is AddMediaCommand -> addMediaCommand(command.mediaPaths)
+            is SimulateNetworkFailureCommand -> maestro.simulateNetworkFailure(command.state)
             else -> true
         }.also { mutating ->
             if (mutating) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -74,6 +74,7 @@ data class YamlFluentCommand(
     val startRecording: YamlStartRecording? = null,
     val stopRecording: YamlStopRecording? = null,
     val addMedia: YamlAddMedia? = null,
+    val simulateNetworkFailure: YamlSimulateNetworkFailureCommand? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -210,6 +211,9 @@ data class YamlFluentCommand(
                 val delay = if (yamlDelay != null && yamlDelay >= 0) yamlDelay else TapOnElementCommand.DEFAULT_REPEAT_DELAY
                 val tapRepeat = TapRepeat(2, delay)
                 listOf(tapCommand(doubleTapOn, tapRepeat = tapRepeat))
+            }
+            simulateNetworkFailure != null -> {
+                listOf(MaestroCommand(SimulateNetworkFailureCommand(simulateNetworkFailure.state)))
             }
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSimulateNetworkFailureCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSimulateNetworkFailureCommand.kt
@@ -1,0 +1,15 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlSimulateNetworkFailureCommand(
+    val state: Boolean,
+) {
+    companion object {
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(state: Boolean): YamlSimulateNetworkFailureCommand {
+            return YamlSimulateNetworkFailureCommand(state)
+        }
+    }
+}

--- a/maestro-utils/src/main/kotlin/StubProxy.kt
+++ b/maestro-utils/src/main/kotlin/StubProxy.kt
@@ -1,0 +1,44 @@
+package maestro.utils
+
+import java.net.ServerSocket
+import kotlin.concurrent.thread
+
+/**
+ * "Proxy" which just closes a connection when received
+ */
+class StubProxy(private val serverPort: UInt) {
+
+    private var serverThread: Thread? = null
+    private var actualPort: UInt? = null
+
+    val port: UInt?
+        get() = actualPort
+
+    val isRunning: Boolean
+        get() = serverThread != null
+
+    fun start() {
+        if (serverThread != null) {
+            return
+        }
+
+        this.serverThread = thread(start = true, name = "StubProxy thread") {
+            val socket = ServerSocket(serverPort.toInt())
+            actualPort = socket.localPort.toUInt()
+            socket.use {
+                try {
+                    while (true) {
+                        val client = socket.accept()
+                        client.close()
+                        Thread.sleep(100)
+                    }
+                } catch (ignored: InterruptedException) { }
+            }
+        }
+    }
+
+    fun stop() {
+        this.serverThread?.interrupt()
+    }
+
+}


### PR DESCRIPTION
## Proposed Changes

This PR adds a new command `simulateNetworkFailure` which starts a stub proxy which closes all received connections to simulate a network failure.

## Testing

Ran this flow on an Android API 34 emulator.
```yaml
appId: org.wikipedia
---
- simulateNetworkFailure: true
- openLink: https://google.com/teapot
- assertVisible: "Webpage not available"
- back
- simulateNetworkFailure: false
- openLink: https://google.com/teapot
- assertNotVisible: "Webpage not available"
```

## Issues Fixed
