### PR TITLE
Remove screen record time limit for Android devices running on API levels >= 34

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -454,8 +454,9 @@ class AndroidDriver(
         val deviceScreenRecordingPath = "/sdcard/maestro-screenrecording.mp4"
 
         val future = CompletableFuture.runAsync({
+            val timeLimit = if (getDeviceApiLevel() >= 34) "--time-limit 0" else ""
             try {
-                shell("screenrecord --bit-rate '100000' $deviceScreenRecordingPath")
+                shell("screenrecord $timeLimit --bit-rate '100000' $deviceScreenRecordingPath")
             } catch (e: IOException) {
                 throw IOException(
                     "Failed to capture screen recording on the device. Note that some Android emulators do not support screen recording. " +


### PR DESCRIPTION
## Proposed Changes

Since API 34, screen recording duration limit has been extended [from 3 minutes to 30 minutes](https://issuetracker.google.com/issues/236721231). However, `--time-limit 0` needs to be passed to the adb `screenrecord` command (by default is 180).

## Testing

- Managed to record a flow of 7 minutes on a device running on API 34
- Running the same flow on API 33 produced the same output as before (recording stopped at 3 minutes)