### PR TITLE
WebDriver: Enable a rudimentary implementation of scrollUntilVisible for web

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -276,7 +276,8 @@ class WebDriver(val isStudio: Boolean) : Driver {
     }
 
     override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
-        TODO("Not yet implemented")
+        // Ignoring elementPoint to enable a rudimentary implementation of scrollUntilVisible for web
+        swipe(direction, durationMs)
     }
 
     fun swipe(start: Point, end: Point) {


### PR DESCRIPTION
## Proposed Changes

Currently `scrollUntilVisible` cannot be used on web because `swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long)` is not implemented.

This patch delegates to the already implemented `swipe(swipeDirection: SwipeDirection, durationMs: Long)` method, essentially ignoring `elementPoint` in the `WebDriver`. This allows us to rudimentarily use `scrollUntilVisible` on web.

So far we have been using a custom loop in our tests, like:

```yaml
- repeat:
    while:
      notVisible: ...
    commands:
      - scroll
- assertVisible: ...
```

But this has a big drawback: When the element is not visible then this test tries to scroll forever until killed. The implementation of `scrollUntilVisible` has a timeout and does not run into this problem.

## Testing

Test locally using Chrome 121 with simple test cases that scroll a website until an element at the bottom of the page is visible.

## Issues Fixed

Fixes #1051
