### PR TITLE
Added KillApp option for launchApp command

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -41,6 +41,8 @@ interface Driver {
 
     fun stopApp(appId: String)
 
+    fun killApp(appId: String)
+
     fun clearAppState(appId: String)
 
     fun clearKeychain()

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -63,12 +63,14 @@ class Maestro(private val driver: Driver) : AutoCloseable {
     fun launchApp(
         appId: String,
         launchArguments: Map<String, Any> = emptyMap(),
-        stopIfRunning: Boolean = true
+        stopIfRunning: Boolean = true,
+        killIfRunning: Boolean = false,
     ) {
         LOGGER.info("Launching app $appId")
 
-        if (stopIfRunning) {
-            driver.stopApp(appId)
+        when {
+            killIfRunning -> driver.killApp(appId)
+            stopIfRunning -> driver.stopApp(appId)
         }
         driver.launchApp(appId, launchArguments, sessionId = sessionId)
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -206,6 +206,10 @@ class AndroidDriver(
         shell("am force-stop $appId")
     }
 
+    override fun killApp(appId: String) {
+        shell("am kill $appId")
+    }
+
     override fun clearAppState(appId: String) {
         if (!isPackageInstalled(appId)) {
             return

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -100,6 +100,10 @@ class IOSDriver(
         iosDevice.stop(appId)
     }
 
+    override fun killApp(appId: String) {
+        /* no-op */
+    }
+
     override fun clearAppState(appId: String) {
         iosDevice.clearAppState(appId)
     }

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -161,6 +161,10 @@ class WebDriver(val isStudio: Boolean) : Driver {
         driver.close()
     }
 
+    override fun killApp(appId: String) {
+        /* no-op */
+    }
+
     override fun contentDescriptor(excludeKeyboardElements: Boolean): TreeNode {
         ensureOpen()
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -385,6 +385,7 @@ data class LaunchAppCommand(
     val clearState: Boolean? = null,
     val clearKeychain: Boolean? = null,
     val stopApp: Boolean? = null,
+    val killApp: Boolean? = null,
     var permissions: Map<String, String>? = null,
     val launchArguments: Map<String, Any>? = null,
     val label: String? = null,
@@ -405,8 +406,9 @@ data class LaunchAppCommand(
             result += " and clear keychain"
         }
 
-        if (stopApp == false) {
-            result += " without stopping app"
+        when {
+            killApp == true -> result += " by killing app"
+            stopApp == false -> result += " without stopping app"
         }
 
         if (launchArguments != null) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -700,7 +700,8 @@ class Orchestra(
             maestro.launchApp(
                 appId = command.appId,
                 launchArguments = command.launchArguments ?: emptyMap(),
-                stopIfRunning = command.stopApp ?: true
+                stopIfRunning = command.stopApp ?: true,
+                killIfRunning = command.killApp ?: false,
             )
         } catch (e: Exception) {
             throw MaestroException.UnableToLaunchApp("Unable to launch app ${command.appId}: ${e.message}")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -392,6 +392,7 @@ data class YamlFluentCommand(
                 clearState = command.clearState,
                 clearKeychain = command.clearKeychain,
                 stopApp = command.stopApp,
+                killApp = command.killApp,
                 permissions = command.permissions,
                 launchArguments = command.arguments,
                 label = command.label,
@@ -604,6 +605,7 @@ data class YamlFluentCommand(
                         clearState = null,
                         clearKeychain = null,
                         stopApp = null,
+                        killApp = null,
                         permissions = null,
                         arguments = null,
                     )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlLaunchApp.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlLaunchApp.kt
@@ -26,6 +26,7 @@ data class YamlLaunchApp(
     val clearState: Boolean?,
     val clearKeychain: Boolean?,
     val stopApp: Boolean?,
+    val killApp: Boolean?,
     val permissions: Map<String, String>?,
     val arguments: Map<String, Any>?,
     val label: String? = null
@@ -41,6 +42,7 @@ data class YamlLaunchApp(
                 clearState = null,
                 clearKeychain = null,
                 stopApp = null,
+                killApp = null,
                 permissions = null,
                 arguments = null,
             )

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -608,6 +608,21 @@ internal class YamlCommandReaderTest {
         )
     }
 
+    @Test
+    fun launchApp_withKillApp(
+        @YamlFile("025_launchApp_withKillApp.yaml") commands: List<Command>
+    ) {
+        assertThat(commands).containsExactly(
+            ApplyConfigurationCommand(MaestroConfig(
+                appId = "com.example.app",
+            )),
+            LaunchAppCommand(
+                appId = "com.example.app",
+                killApp = true,
+            ),
+        )
+    }
+
     private fun commands(vararg commands: Command): List<MaestroCommand> =
         commands.map(::MaestroCommand).toList()
 }

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/025_launchApp_withKillApp.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/025_launchApp_withKillApp.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- launchApp:
+    killApp: true

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -24,7 +24,6 @@ import com.google.common.truth.Truth.assertThat
 import maestro.*
 import maestro.utils.ScreenshotUtils
 import okio.Sink
-import okio.Source
 import okio.buffer
 import java.awt.image.BufferedImage
 import java.io.File
@@ -100,6 +99,12 @@ class FakeDriver : Driver {
         ensureOpen()
 
         events.add(Event.StopApp(appId))
+    }
+
+    override fun killApp(appId: String) {
+        ensureOpen()
+
+        events.add(Event.KillApp(appId))
     }
 
     override fun clearAppState(appId: String) {
@@ -418,7 +423,12 @@ class FakeDriver : Driver {
         ) : Event(), UserInteraction
 
         data class StopApp(
-            val appId: String
+            val appId: String,
+        ) : Event()
+
+        data class KillApp(
+            val appId: String,
+            val kill: Boolean = false,
         ) : Event()
 
         data class ClearState(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3108,6 +3108,26 @@ class IntegrationTest {
 
     }
 
+    @Test
+    fun `Case 115 - Launch app with kill app`() {
+        // Given
+        val commands = readCommands("115_launch_app_with_kill_app")
+
+        val driver = driver {
+        }
+        driver.addInstalledApp("com.example.app")
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertHasEvent(Event.KillApp("com.example.app"))
+        driver.assertHasEvent(Event.LaunchApp("com.example.app"))
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/115_launch_app_with_kill_app.yaml
+++ b/maestro-test/src/test/resources/115_launch_app_with_kill_app.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- launchApp:
+    killApp: true


### PR DESCRIPTION
## Proposed Changes

This PR allows to test a screen against what is called a [System-initiated Process Death](https://galex.dev/posts/how-to-detect-process-death-issues/) which is something very specific to the Android platform, but gives a very strong proposal value to Maestro for Android developers :+1: 

To trigger that properly, we need the `launchApp` command to call
```bash
adb shell am kill <package name>
```
Instead of 
```bash
adb shell am force-stop <package name>
```
I suggest doing so by adding a `killApp` parameter to the `LaunchApp` command that takes precedence to `stopApp`:

```yaml
appId: com.example.app
---
- launchApp:
    killApp: true
```

## Testing
- Added an unit test for reading a new `killApp` parameter on the `LaunchApp` command.
- Added an integration test
- Tested against a real [use case in a demo project](https://github.com/galex/process-death-demo-project/blob/main/maestro/process-death-flow.yaml)


Let me know what you think or if something missing! :blush: 
Thank you :pray: 


