### PR TITLE
change test-report output directory

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -154,7 +154,7 @@ class TestCommand : Callable<Int> {
                     env = env,
                     reportOut = format.fileExtension
                         ?.let { extension ->
-                            (output ?: File("report$extension"))
+                            File(debugOutputPath.toFile(), "report$extension")
                                 .sink()
                                 .buffer()
                         },


### PR DESCRIPTION
## Proposed Changes
### what?
I propose these changes to move the test-result file output directory to `/Users/user/.maestro/tests/*/report.xml` instead of the root folder.

### why?
Since the generated files from test execution are stored at `/Users/user/.maestro/tests/*`, I think it'll be easier to find the test result if it's stored in the same location.

### result
<img width="982" alt="Screenshot 2024-05-15 at 13 13 17" src="https://github.com/mobile-dev-inc/maestro/assets/6134774/60e68e48-e4cf-4af4-9314-0da10af5d7c9">