### PR TITLE
Add 'maestro.platform' for javascript to determine platform

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -25,6 +25,7 @@ class GraalJsEngine(
         .writeTimeout(5, TimeUnit.MINUTES)
         .protocols(listOf(Protocol.HTTP_1_1))
         .build(),
+    platform: String = "unknown",
 ) : JsEngine {
 
     private val openContexts = HashSet<Context>()
@@ -35,6 +36,8 @@ class GraalJsEngine(
     private val envBinding = HashMap<String, String>()
 
     private var onLogMessage: (String) -> Unit = {}
+
+    private var platform = platform
 
     override fun close() {
         openContexts.forEach { it.close() }
@@ -90,6 +93,8 @@ class GraalJsEngine(
         context.getBindings("js").putMember("http", httpBinding)
         context.getBindings("js").putMember("output", ProxyObject.fromMap(outputBinding))
         context.getBindings("js").putMember("maestro", ProxyObject.fromMap(maestroBinding))
+
+        maestroBinding["platform"] = platform
 
         context.eval(
             "js", """

--- a/maestro-client/src/main/java/maestro/js/Js.kt
+++ b/maestro-client/src/main/java/maestro/js/Js.kt
@@ -16,9 +16,14 @@ object Js {
         
         const output = {}
         const maestro = {
-            copiedText: ''
+            copiedText: '',
+            platform: 'unknown'
         }
     """.trimIndent()
+
+    fun initScriptWithPlatform(platform: String): String {
+        return initScript.replace("platform: 'unknown'", "platform: '$platform'")
+    }
 
     fun sanitizeJs(text: String): String {
         return text

--- a/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
@@ -12,6 +12,7 @@ class RhinoJsEngine(
         .writeTimeout(5, TimeUnit.MINUTES)
         .protocols(listOf(Protocol.HTTP_1_1))
         .build(),
+    platform: String = "unknown",
 ) : JsEngine {
 
     private val context = Context.enter()
@@ -44,7 +45,7 @@ class RhinoJsEngine(
 
         context.evaluateString(
             currentScope,
-            Js.initScript,
+            Js.initScriptWithPlatform(platform),
             "maestro-runtime",
             1,
             null

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -224,10 +224,11 @@ class Orchestra(
         }
         val shouldUseGraalJs =
             config?.ext?.get("jsEngine") == "graaljs" || System.getenv("MAESTRO_USE_GRAALJS") == "true"
+        val platform = maestro.deviceInfo().platform.toString().lowercase()
         jsEngine = if (shouldUseGraalJs) {
-            httpClient?.let { GraalJsEngine(it) } ?: GraalJsEngine()
+            httpClient?.let { GraalJsEngine(it, platform) } ?: GraalJsEngine(platform = platform)
         } else {
-            httpClient?.let { RhinoJsEngine(it) } ?: RhinoJsEngine()
+            httpClient?.let { RhinoJsEngine(it, platform) } ?: RhinoJsEngine(platform = platform)
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

Add a `platform` property to the `maestro` object in JavaScript, so as to determine iOS or Android at runtime.

```
output.welcomeMessage = "Your app is running on " + maestro.platform
```

### Why though?

Previously, an app that requested a few permissions would have lots of this:
```
- tapOn: "Enable Location"
- runFlow:
    when:
      platform: 'Android'
    commands:
      - assertVisible: "Allow access to this device's location?"
      - tapOn: "While using the app"
- runFlow:
    when:
        platform: 'iOS'
    commands:
        - assertVisible: "This app uses your location to show you information about your local environment."
        - tapOn: "Allow While Using App"
- assertVisible:
    id: "location_permission_true"
```

I wanted to set the strings in JavaScript, but this would require prepending the flow with something like:
```
- runFlow:
    when:
      platform: 'Android'
    commands:
      - runScript: 
          file: setPermissionsVars.js
          env:
            MOBILE_OS: 'Android'
- runFlow:
    when:
      platform: 'iOS'
    commands:
      - runScript: 
          file: setPermissionsVars.js
          env:
            MOBILE_OS: 'iOS'
```

After this change:
```
- runScript: setPermissionsVars.js
- tapOn: "Enable Location"
- assertVisible: ${output.locationPermissionAlert}
- tapOn: ${output.locationPermissionButton}
- assertVisible:
    id: "location_permission_true"
```

## Testing
I've tested this with a more trivial example:

flow.yml:
```
appId: org.wikimedia.wikipedia #iOS
#appId: org.wikipedia #Android
jsEngine: graaljs
---
- launchApp
- runScript: 'setSearchTerm.js'
- tapOn: "Search Wikipedia"
- inputText: ${output.searchTerm}

- runFlow:
    when:
      platform: 'Android'
    commands:
      - assertVisible: Robot
- runFlow:
    when:
      platform: 'iOS'
    commands:
      - assertVisible: Fruit.*
```

setSearchTerm.js:
```
output.searchTerm = 'blackberries'
if (maestro.platform == 'android'){
    output.searchTerm = 'robots'
}
if (maestro.platform == 'ios'){
    output.searchTerm = 'apples'
}
```

Tested on iOS and Android, in Rhino & Graal.

