### PR TITLE
Add command-line switch to omit folders from debug output

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -167,7 +167,9 @@ class TestCommand : Callable<Int> {
                     debugOutputPath = debugOutputPath
                 )
 
-                TestDebugReporter.deleteOldFiles()
+                if(!flattenDebugOutput){
+                    TestDebugReporter.deleteOldFiles()
+                }
                 if (suiteResult.passed) {
                     0
                 } else {
@@ -176,7 +178,9 @@ class TestCommand : Callable<Int> {
                 }
             } else {
                 if (continuous) {
-                    TestDebugReporter.deleteOldFiles()
+                    if(!flattenDebugOutput){
+                        TestDebugReporter.deleteOldFiles()
+                    }
                     TestRunner.runContinuous(maestro, device, flowFile, env)
                 } else {
                     val resultView = if (DisableAnsiMixin.ansiEnabled) AnsiResultView() else PlainTextResultView()
@@ -184,7 +188,9 @@ class TestCommand : Callable<Int> {
                     if (resultSingle == 1) {
                         printExitDebugMessage()
                     }
-                    TestDebugReporter.deleteOldFiles()
+                    if(!flattenDebugOutput){
+                        TestDebugReporter.deleteOldFiles()
+                    }
                     return@newSession resultSingle
                 }
             }

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -88,6 +88,12 @@ class TestCommand : Callable<Int> {
     private var debugOutput: String? = null
 
     @Option(
+        names = ["--flatten-debug-output"],
+        description = ["Don't create subfolders or timestamps for each run. Useful for CI."]
+    )
+    private var flattenDebugOutput: Boolean = false
+
+    @Option(
         names = ["--include-tags"],
         description = ["List of tags that will remove the Flows that does not have the provided tags"],
         split = ",",
@@ -130,7 +136,7 @@ class TestCommand : Callable<Int> {
 
         env = env.withInjectedShellEnvVars()
 
-        TestDebugReporter.install(debugOutputPathAsString = debugOutput)
+        TestDebugReporter.install(debugOutputPathAsString = debugOutput, flattenDebugOutput = flattenDebugOutput)
         val debugOutputPath = TestDebugReporter.getDebugOutputPath()
         
         return MaestroSessionManager.newSession(parent?.host, parent?.port, deviceId) { session ->

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -89,7 +89,7 @@ class TestCommand : Callable<Int> {
 
     @Option(
         names = ["--flatten-debug-output"],
-        description = ["Don't create subfolders or timestamps for each run. Useful for CI."]
+        description = ["All file outputs from the test case are created in the folder without subfolders or timestamps for each run. It can be used with --debug-output. Useful for CI."]
     )
     private var flattenDebugOutput: Boolean = false
 
@@ -167,7 +167,7 @@ class TestCommand : Callable<Int> {
                     debugOutputPath = debugOutputPath
                 )
 
-                if(!flattenDebugOutput){
+                if (!flattenDebugOutput) {
                     TestDebugReporter.deleteOldFiles()
                 }
                 if (suiteResult.passed) {

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -33,6 +33,7 @@ object TestDebugReporter {
 
     private var debugOutputPath: Path? = null
     private var debugOutputPathAsString: String? = null
+    private var flattenDebugOutput: Boolean = false
 
     init {
 
@@ -114,8 +115,9 @@ object TestDebugReporter {
         logger.info("---------------------")
     }
 
-    fun install(debugOutputPathAsString: String?) {
+    fun install(debugOutputPathAsString: String?, flattenDebugOutput: Boolean = false) {
         this.debugOutputPathAsString = debugOutputPathAsString
+        this.flattenDebugOutput = flattenDebugOutput
         val path = getDebugOutputPath()
         LogConfig.configure(path.absolutePathString() + "/maestro.log")
         logSystemInfo()
@@ -125,10 +127,11 @@ object TestDebugReporter {
     fun getDebugOutputPath(): Path {
         if (debugOutputPath != null) return debugOutputPath as Path
 
-        val dateFormat = "yyyy-MM-dd_HHmmss"
-        val dateFormatter = DateTimeFormatter.ofPattern(dateFormat)
-        val folderName = dateFormatter.format(LocalDateTime.now())
-        val debugOutput = Paths.get(debugOutputPathAsString ?: System.getProperty("user.home"), ".maestro", "tests", folderName)
+        val preamble = if(flattenDebugOutput) arrayOf("") else arrayOf(".maestro", "tests")
+        val foldername = if(flattenDebugOutput) "" else DateTimeFormatter.ofPattern("yyyy-MM-dd_HHmmss").format(LocalDateTime.now())
+        val debugRootPath = if(debugOutputPathAsString != null) debugOutputPathAsString!! else System.getProperty("user.home")
+        val debugOutput = Paths.get(debugRootPath, *preamble, foldername)
+        
         if (!debugOutput.exists()) {
             Files.createDirectories(debugOutput)
         }

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -127,16 +127,20 @@ object TestDebugReporter {
     fun getDebugOutputPath(): Path {
         if (debugOutputPath != null) return debugOutputPath as Path
 
-        val preamble = if(flattenDebugOutput) arrayOf("") else arrayOf(".maestro", "tests")
-        val foldername = if(flattenDebugOutput) "" else DateTimeFormatter.ofPattern("yyyy-MM-dd_HHmmss").format(LocalDateTime.now())
-        val debugRootPath = if(debugOutputPathAsString != null) debugOutputPathAsString!! else System.getProperty("user.home")
-        val debugOutput = Paths.get(debugRootPath, *preamble, foldername)
+        val debugRootPath = if(debugOutputPathAsString != null) debugOutputPathAsString!! else System.getProperty("user.home")        
+        val debugOutput = if(flattenDebugOutput) Paths.get(debugRootPath) else buildDefaultDebugOutputPath(debugRootPath)
         
         if (!debugOutput.exists()) {
             Files.createDirectories(debugOutput)
         }
         debugOutputPath = debugOutput
         return debugOutput
+    }
+
+    fun buildDefaultDebugOutputPath(debugRootPath: String): Path {
+        val preamble = arrayOf(".maestro", "tests")
+        val foldername = DateTimeFormatter.ofPattern("yyyy-MM-dd_HHmmss").format(LocalDateTime.now())
+        return Paths.get(debugRootPath, *preamble, foldername)
     }
 
 }


### PR DESCRIPTION
Continuing #1445 
Fixes #1427 

Adding a `--flatten-debug-output` switch that will remove the datetime folder, as well as `/.maestro/tests/` from the path, leaving the debug output exactly where the user defined.

(Updated with feedback from previous PR to remove 

## Proposed Changes

Added a new option `--flatten-debug-output` to the `test` command in `maestro-cli` to simplify the test output folder structure for CI environments. Updated the `TestDebugReporter` class to handle this option and generate the output path accordingly.

## Testing

I'm using a simple flow to force an error:
```
appId: com.example
---
- assertTrue: 
    condition: ${ 1 === 2 }
    label: 1 is the same as 2
```

No params:
```
 ⇒ ./maestro test scratch.yaml 
Running on emulator-5554      
                              
 ║                            
 ║  > Flow                    
 ║                            
 ║    ❌  Does 1 equal 2?     
 ║                            
                              
Assertion is false: false is true

==== Debug output (logs & screenshots) ====

/Users/danc/.maestro/tests/2024-05-17_150239
```

Just the debug option:
```
 ⇒ ./maestro test --debug-output /tmp/maestro scratch.yaml                    
Running on emulator-5554        
                                
 ║                              
 ║  > Flow                      
 ║                              
 ║    ❌  1 is the same as 2    
 ║                              
                                
Assertion is false: false is true

==== Debug output (logs & screenshots) ====

/tmp/maestro/.maestro/tests/2024-05-17_150426
```

With the new option:
```
 ⇒ ./maestro test --debug-output /tmp/maestro --flatten-debug-output  scratch.yaml
Running on emulator-5554        
                                
 ║                              
 ║  > Flow                      
 ║                              
 ║    ❌  1 is the same as 2    
 ║                              
                                
Assertion is false: false is true

==== Debug output (logs & screenshots) ====

/tmp/maestro
```

Full file listing of /tmp/maestro after above:
```
 ⇒ find /tmp/maestro 
/tmp/maestro
/tmp/maestro/screenshot-❌-1715954725865-(scratch.yaml).png
/tmp/maestro/commands-(scratch.yaml).json
/tmp/maestro/.maestro
/tmp/maestro/.maestro/tests
/tmp/maestro/.maestro/tests/2024-05-17_150426
/tmp/maestro/.maestro/tests/2024-05-17_150426/commands-(scratch.yaml).json
/tmp/maestro/.maestro/tests/2024-05-17_150426/maestro.log
/tmp/maestro/.maestro/tests/2024-05-17_150426/screenshot-❌-1715954675177-(scratch.yaml).png
/tmp/maestro/maestro.log
```

## Issues Fixed

#1427 