### PR TITLE
Add Gradle distribution verification to project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,26 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: 8
 
-      - uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Test
         run: ./gradlew test
+
+
+  validation:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Proposed Changes

It's a security best practice to verify the Gradle distribution used within the project to protect against a supply-chain-style attack. These have been observed in the wild previously and are easily mitigated through the use of the `distributionSha256Sum` Gradle property [^1]

This PR adds the expected Gradle distro verification for Gradle Wrapper 7.6 by calling the `gradlew wrapper` task as follows:

```sh
./gradlew wrapper --gradle-version=7.6 --distribution-type=bin --gradle-distribution-sha256-sum=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
```

The checksums for Gradle distributions are available via Gradle's website[^2] and the above can be verified.

> [!IMPORTANT]
> Post-merging, whenever the Gradle version is updated, the above command should be repeated with the checksum for the new version

## Testing
Verified the project builds correctly and downloads Gradle Wrapper with the expected checksum

[^1]: https://www.spght.dev/articles/23-07-2023/gradle-security
[^2]: https://gradle.org/release-checksums/