### PR TITLE
Add some automation to help manage GitHub issues

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -1,0 +1,39 @@
+# Close issues that have had "waiting for customer response" label for too long.
+
+# This workflow is based on a very similar one from Flutter
+# https://github.com/flutter/flutter/blob/3.22.0/.github/workflows/no-response.yaml
+
+name: close inactive issues
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    if: github.repository == 'mobile-dev-inc/maestro'
+    steps:
+      - uses: godofredoc/no-response@0ce2dc0e63e1c7d2b87752ceed091f6d32c9df09
+        with:
+          token: ${{ github.token }}
+          closeComment: >
+            Without additional information, we can't resolve this issue. We're
+            therefore reluctantly going to close it.
+
+            Feel free to open a new issue with all the required information
+            provided, including a [minimal, reproducible sample]. Make sure to
+            diligently fill out the issue template.
+
+            Thank you for your contribution to our open-source community!
+
+            [minimal, reproducible sample]: https://stackoverflow.com/help/minimal-reproducible-example
+          # Number of days of inactivity before an issue is closed.
+          daysUntilClose: 14
+          # Only issues with this label will be closed (if they are inactive).
+          responseRequiredLabel: waiting for customer response

--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -27,8 +27,9 @@ jobs:
             therefore reluctantly going to close it.
 
             Feel free to open a new issue with all the required information
-            provided, including a [minimal, reproducible sample]. Make sure to
-            diligently fill out the issue template.
+            provided, including a [minimal, reproducible sample]. When creating
+            a new issue, please make sure to diligently fill out the issue
+            template.
 
             Thank you for your contribution to our open-source community!
 

--- a/.github/workflows/lock-closed-issues.yml
+++ b/.github/workflows/lock-closed-issues.yml
@@ -1,0 +1,35 @@
+# Lock closed issues that have been inactive for a while.
+
+# This workflow is copied from Flutter
+# https://github.com/flutter/flutter/blob/3.22.0/.github/workflows/lock.yaml
+
+name: lock closed issues
+
+permissions:
+  issues: write
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  lock:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    if: github.repository == 'mobile-dev-inc/maestro'
+    steps:
+      - uses: dessant/lock-threads@v5
+        with:
+          process-only: issues
+          github-token: ${{ github.token }}
+          # Number of days of inactivity before a closed issue is locked.
+          issue-inactive-days: 7
+          issue-comment: >
+            This issue has been automatically locked since there has not been
+            any recent activity after it was closed. If you are still
+            experiencing a similar problem, please file a new issue. Make
+            sure to follow the template and provide all the information
+            necessary to reproduce the issue.
+
+            Thank you for helping keep us our issue tracker clean!


### PR DESCRIPTION
Automate triage process a bit.

## Proposed Changes

Add 2 new periodic scheduled GitHub Actions workflows:

- `close-inactive-issues` - close issues that have had the "waiting for customer response" label for too long (configurable)

- `lock-closed-issues` - lock issues that have been closed for long enough (configurable). to prevent people from "reviving" old issue from the graveyard. There are no downsides to creating a new issue with up-to-date info and referencing the old, closed one.

Generally, the new triage workflow I propose is:
1. Open a new issue, read through it, make sure it is reproducible, or at least we know what's happening
2. If it's not reproducible/we don't know what's happening, ask for more information and assign the **waiting for customer response** label
3. When the user/customer responds, the `waiting for customer response` label is automatically removed. This means the issue will not be closed, even if we don't have time to look at it.

If the customer doesn't respond within _some timeframe_, their issue will get closed, and then locked.

This process is based on [Flutter's triage process](https://github.com/flutter/flutter/blob/9ab8b6e15043de9627941e186d58711312dbd256/docs/triage/README.md) (I think they got it sorted really well - they have to, they're huge).

## Notes

- **All existing closed issues will be locked**. This may be big, we may not want it. We can wait with this change. I want feedback.

- None of the existing issues will be closed. We don't want to close any issues unless we're sure they're invalid/outdated etc. In other words, this will only apply to issues that will have the `waiting for customer response` label – which is 0 now.

## Testing

This workflow is basically copy-pasted from the Flutter project, where it has been working well for years.

## Issues Fixed

n/a
