### PR TITLE
Add `--help` flag to all commands

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -55,7 +55,10 @@ class App {
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
 
-    @Option(names = ["-v", "--version"], versionHelp = true)
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
+
+    @Option(names = ["-v", "--version"], versionHelp = true, description = ["Display CLI version"])
     var requestedVersion: Boolean? = false
 
     @Option(names = ["-p", "--platform"], hidden = true)

--- a/maestro-cli/src/main/java/maestro/cli/ShowHelpMixin.kt
+++ b/maestro-cli/src/main/java/maestro/cli/ShowHelpMixin.kt
@@ -1,0 +1,12 @@
+package maestro.cli
+
+import picocli.CommandLine
+
+class ShowHelpMixin {
+    @CommandLine.Option(
+        names = ["-h", "--help"],
+        usageHelp = true,
+        description = ["Display help message"],
+    )
+    var help = false
+}

--- a/maestro-cli/src/main/java/maestro/cli/command/BugReportCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/BugReportCommand.kt
@@ -1,6 +1,7 @@
 package maestro.cli.command
 
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.debuglog.DebugLogStore
 import picocli.CommandLine
 import java.util.concurrent.Callable
@@ -15,6 +16,9 @@ class BugReportCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     override fun call(): Int {
         val message = """

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -21,6 +21,7 @@ package maestro.cli.command
 
 import maestro.cli.CliError
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.cloud.CloudInteractor
 import maestro.cli.report.ReportFormat
@@ -48,6 +49,9 @@ class CloudCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.Parameters(hidden = true, arity = "0..2", description = ["App file and/or Flow file i.e <appFile> <flowFile>"])
     private lateinit var files: List<File>

--- a/maestro-cli/src/main/java/maestro/cli/command/DownloadSamplesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/DownloadSamplesCommand.kt
@@ -2,6 +2,7 @@ package maestro.cli.command
 
 import kotlinx.coroutines.runBlocking
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.util.FileDownloader
 import maestro.cli.util.PrintUtils.err
 import maestro.cli.util.PrintUtils.message
@@ -22,6 +23,9 @@ class DownloadSamplesCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @Option(names = ["-o", "--output"], description = ["Output directory"])
     private var outputDirectory: File? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/LoginCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/LoginCommand.kt
@@ -1,6 +1,7 @@
 package maestro.cli.command
 
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.auth.Auth
 import maestro.cli.util.PrintUtils.message
@@ -17,6 +18,9 @@ class LoginCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.Option(names = ["--apiUrl"], description = ["API base URL"])
     private var apiUrl: String = "https://api.mobile.dev"

--- a/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
@@ -1,6 +1,7 @@
 package maestro.cli.command
 
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import org.fusesource.jansi.Ansi
 import picocli.CommandLine
 import java.nio.file.Path
@@ -18,6 +19,9 @@ class LogoutCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     private val cachedAuthTokenFile: Path = Paths.get(System.getProperty("user.home"), ".mobiledev", "authtoken")
 

--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import maestro.cli.App
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.view.green
 import maestro.cli.view.yellow
@@ -42,6 +43,9 @@ class PrintHierarchyCommand : Runnable {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.ParentCommand
     private val parent: App? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
@@ -22,9 +22,9 @@ package maestro.cli.command
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import maestro.ElementFilter
 import maestro.Filters
-import maestro.Filters.asFilter
 import maestro.cli.App
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.view.red
 import maestro.orchestra.Orchestra
@@ -46,6 +46,9 @@ class QueryCommand : Runnable {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.ParentCommand
     private val parent: App? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -22,6 +22,7 @@ package maestro.cli.command
 import maestro.cli.App
 import maestro.cli.CliError
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.runner.TestRunner
@@ -45,6 +46,9 @@ class RecordCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.ParentCommand
     private val parent: App? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -2,6 +2,7 @@ package maestro.cli.command
 
 import maestro.cli.App
 import maestro.cli.CliError
+import maestro.cli.ShowHelpMixin
 import maestro.cli.device.DeviceCreateUtil
 import maestro.cli.device.DeviceService
 import maestro.cli.device.Platform
@@ -27,6 +28,9 @@ import java.util.concurrent.Callable
     ]
 )
 class StartDeviceCommand : Callable<Int> {
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.ParentCommand
     private val parent: App? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -3,6 +3,7 @@ package maestro.cli.command
 import maestro.cli.App
 import maestro.cli.CliError
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.view.blue
@@ -25,6 +26,9 @@ class StudioCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.ParentCommand
     private val parent: App? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.sync.Semaphore
 import maestro.cli.App
 import maestro.cli.CliError
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.device.DeviceCreateUtil
 import maestro.cli.device.DeviceService
 import maestro.cli.device.PickDeviceView
@@ -65,6 +66,9 @@ class TestCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.ParentCommand
     private val parent: App? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/UploadCommand.kt
@@ -20,6 +20,7 @@
 package maestro.cli.command
 
 import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.cloud.CloudInteractor
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
@@ -40,6 +41,9 @@ class UploadCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
 
     @CommandLine.Parameters(description = ["App binary to run your Flows against"])
     private lateinit var appFile: File


### PR DESCRIPTION
## Proposed Changes

This tiny PR adds makes the `-h`/`--help` flag work for the root command and all subcommands.

## Testing

It's a small change so I tested it locally, and it works.

## Issues Fixed

n/a