### PR TITLE
Delete `scripts/publish_ios_sdk.sh`

### DIFF
--- a/scripts/publish_ios_sdk.sh
+++ b/scripts/publish_ios_sdk.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-set -e
-
-export MAESTRO_SDK_VERSION=$(grep VERSION_NAME gradle.properties | cut -d'=' -f2)
-
-pod trunk push --allow-warnings


### PR DESCRIPTION
## Proposed Changes

The iOS SDK was removed in #1176. This seems to be a leftover.