### PR TITLE
Fix exit code for single test

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -298,7 +298,8 @@ class TestCommand : Callable<Int> {
                                 if (!flattenDebugOutput) {
                                     TestDebugReporter.deleteOldFiles()
                                 }
-                                return@newSession Triple(resultSingle, 1, null)
+                                val result = if (resultSingle == 0) 1 else 0
+                                return@newSession Triple(result, 1, null)
                             }
                         }
                     }


### PR DESCRIPTION
## Proposed Changes
change `result` to `resultSingle` for return and calculate `passed` test

## Testing
Run single maestro test
`maestro test testFile.yaml`

## Issues Fixed
since `passed` counts the number of the exit code of `resultSingle` `val passed = results.sumOf { it.first ?: 0 }`,
if the test is passed, the exit code will be 0 and failed 1.
the calculation will be incorrect. hence if we revert the value, the calculation will be correct.