### PR TITLE
Small update to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -30,6 +30,8 @@ body:
       - label: I have searched the existing issues and didn't find mine.
         required: true
   - type: textarea
+    validations:
+      required: true
     attributes:
       label: Steps to reproduce
       description: >
@@ -47,9 +49,10 @@ body:
         (e.g. Android 9, Android 14 with Play Services, or iOS 18).
 
 
-        In general, try to include as much additional details as possible to
-        make it easier for us to understand and fix the problem. Screenshots and
-        videos are welcome.
+        **It's critical that you include your test flow file**. In general, try
+        to include as much additional details as possible to make it easier for
+        us to understand and fix the problem. Screenshots and videos are
+        welcome.
 
            > [!TIP]
           > If you're recording a video on Android, we recommend enabling these options to show taps and gestures:
@@ -70,21 +73,21 @@ body:
         2. Start Android emulator (Pixel 7, API 34, with Google Play)
         3. Build app: `./gradlew :app:assembleDebug`
         4. Run the problematic flow and see it fail: `maestro test .maestro/flow.yaml`
+  - type: textarea
     validations:
       required: true
-  - type: textarea
     attributes:
       label: Actual results
       description: Please explain what is happening.
+  - type: textarea
     validations:
       required: true
-  - type: textarea
     attributes:
       label: Expected results
       description: Please explain what you expect to happen.
+  - type: textarea
     validations:
       required: true
-  - type: textarea
     attributes:
       label: About app
       description: >
@@ -104,7 +107,10 @@ body:
         - This is an open source app, available at https://github.com/wikimedia/wikipedia-ios
         - It's a native iOS app. There is also an Android version, but the issue is only on iOS.
         - It's built mainly with UIKit, minimum iOS deployment target is 13.0
+      
   - type: textarea
+    validations:
+      required: true
     attributes:
       label: About environment
       description: |
@@ -151,15 +157,17 @@ body:
 
         </details>
   - type: input
+    validations:
+      required: true
     attributes:
       label: Maestro version
       description: >
         Provide version of Maestro CLI where the problem occurs. Run
         `maestro --version` to find out.
       placeholder: 1.36.0
+  - type: dropdown
     validations:
       required: true
-  - type: dropdown
     attributes:
       label: How did you install Maestro?
       options:
@@ -168,9 +176,9 @@ body:
         - built from source (please include commit hash in the text area below)
         - other (please specify in the text area below)
       default: 0
-    validations:
-      required: true
   - type: textarea
+    validations:
+      required: false
     attributes:
       label: Anything else?
       description: >
@@ -179,8 +187,6 @@ body:
 
          > [!TIP]
         > You can attach images or log files by clicking this area to highlight it and then dragging files in.
-    validations:
-      required: false
   - type: markdown
     attributes:
       value: >

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -51,6 +51,13 @@ body:
         make it easier for us to understand and fix the problem. Screenshots and
         videos are welcome.
 
+           > [!TIP]
+          > If you're recording a video on Android, we recommend enabling these options to show taps and gestures:
+          > ```
+          > adb shell settings put system show_touches 1
+          > adb shell settings put system pointer_location 1
+          > ```
+
 
          > [!WARNING]
         > Issues that cannot be reproduced are much more likely to be closed.


### PR DESCRIPTION
I remembered about the 2 options that are useful for debugging where actually a UI testing framework tapped.

Follow-up of #1805 

Demo:

<img width="866" alt="Screenshot 2024-07-19 at 00 42 01" src="https://github.com/user-attachments/assets/d367f5b2-6ba7-41c8-8ba3-e434a625d6a7">
