### PR TITLE
Update JReleaser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -30,6 +30,8 @@ body:
       - label: I have searched the existing issues and didn't find mine.
         required: true
   - type: textarea
+    validations:
+      required: true
     attributes:
       label: Steps to reproduce
       description: >
@@ -47,9 +49,17 @@ body:
         (e.g. Android 9, Android 14 with Play Services, or iOS 18).
 
 
-        In general, try to include as much additional details as possible to
-        make it easier for us to understand and fix the problem. Screenshots and
-        videos are welcome.
+        **It's critical that you include your test flow file**. In general, try
+        to include as much additional details as possible to make it easier for
+        us to understand and fix the problem. Screenshots and videos are
+        welcome.
+
+           > [!TIP]
+          > If you're recording a video on Android, we recommend enabling these options to show taps and gestures:
+          > ```
+          > adb shell settings put system show_touches 1
+          > adb shell settings put system pointer_location 1
+          > ```
 
 
          > [!WARNING]
@@ -63,21 +73,21 @@ body:
         2. Start Android emulator (Pixel 7, API 34, with Google Play)
         3. Build app: `./gradlew :app:assembleDebug`
         4. Run the problematic flow and see it fail: `maestro test .maestro/flow.yaml`
+  - type: textarea
     validations:
       required: true
-  - type: textarea
     attributes:
       label: Actual results
       description: Please explain what is happening.
+  - type: textarea
     validations:
       required: true
-  - type: textarea
     attributes:
       label: Expected results
       description: Please explain what you expect to happen.
+  - type: textarea
     validations:
       required: true
-  - type: textarea
     attributes:
       label: About app
       description: >
@@ -97,7 +107,10 @@ body:
         - This is an open source app, available at https://github.com/wikimedia/wikipedia-ios
         - It's a native iOS app. There is also an Android version, but the issue is only on iOS.
         - It's built mainly with UIKit, minimum iOS deployment target is 13.0
+      
   - type: textarea
+    validations:
+      required: true
     attributes:
       label: About environment
       description: |
@@ -144,15 +157,17 @@ body:
 
         </details>
   - type: input
+    validations:
+      required: true
     attributes:
       label: Maestro version
       description: >
         Provide version of Maestro CLI where the problem occurs. Run
         `maestro --version` to find out.
       placeholder: 1.36.0
+  - type: dropdown
     validations:
       required: true
-  - type: dropdown
     attributes:
       label: How did you install Maestro?
       options:
@@ -161,9 +176,9 @@ body:
         - built from source (please include commit hash in the text area below)
         - other (please specify in the text area below)
       default: 0
-    validations:
-      required: true
   - type: textarea
+    validations:
+      required: false
     attributes:
       label: Anything else?
       description: >
@@ -172,8 +187,6 @@ body:
 
          > [!TIP]
         > You can attach images or log files by clicking this area to highlight it and then dragging files in.
-    validations:
-      required: false
   - type: markdown
     attributes:
       value: >

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionSha256Sum=bed1da33cca0f557ab13691c77f38bb67388119e4794d113e051039b80af9bb1
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -1,9 +1,10 @@
+import org.jreleaser.model.Stereotype
 import java.util.Properties
 
 plugins {
     kotlin("jvm")
     application
-    id("org.jreleaser") version "1.0.0"
+    id("org.jreleaser") version "1.13.1"
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
@@ -92,36 +93,51 @@ jreleaser {
     gitRootSearch.set(true)
 
     project {
-        website.set("https://maestro.mobile.dev")
-        description.set("Maestro CLI")
+        name.set("Maestro CLI")
+        description.set("The easiest way to automate UI testing for your mobile app")
+        links {
+            homepage.set("https://maestro.mobile.dev")
+            bugTracker.set("https://github.com/mobile-dev-inc/maestro/issues")
+        }
         authors.set(listOf("Dmitry Zaytsev", "Amanjeet Singh", "Leland Takamine", "Arthur Saveliev", "Axel Niklasson", "Berik Visschers"))
         license.set("Apache-2.0")
     }
 
-    release {
-        github {
-            owner.set("mobile-dev-inc")
-            name.set("maestro")
-            tagName.set("cli-$CLI_VERSION")
-            releaseName.set("CLI $CLI_VERSION")
-            overwrite.set(true)
-        }
-    }
-
     distributions {
         create("maestro") {
+            stereotype.set(Stereotype.CLI)
+
+            executable {
+                name.set("maestro")
+            }
+
             artifact {
                 setPath("build/distributions/maestro.zip")
             }
-            brew {
-                extraProperties.put("skipJava", "true")
-                setActive("RELEASE")
-                formulaName.set("Maestro")
 
-                repoTap {
-                    owner.set("mobile-dev-inc")
-                    name.set("homebrew-tap")
+            release {
+                github {
+                    repoOwner.set("mobile-dev-inc")
+                    name.set("maestro")
+                    tagName.set("cli-$CLI_VERSION")
+                    releaseName.set("CLI $CLI_VERSION")
+                    overwrite.set(true)
                 }
+            }
+        }
+    }
+
+    packagers {
+        brew {
+            setActive("RELEASE")
+            extraProperties.put("skipJava", "true")
+            formulaName.set("Maestro")
+
+            templateDirectory.set(file("src/jreleaser/distributions/maestro/brew"))
+
+            repoTap {
+                repoOwner.set("mobile-dev-inc")
+                name.set("homebrew-tap")
             }
         }
     }

--- a/maestro-cli/src/jreleaser/distributions/maestro/brew/formula.rb.tpl
+++ b/maestro-cli/src/jreleaser/distributions/maestro/brew/formula.rb.tpl
@@ -1,0 +1,34 @@
+# {{jreleaserCreationStamp}}
+{{#brewRequireRelative}}
+require_relative "{{.}}"
+{{/brewRequireRelative}}
+
+class {{brewFormulaName}} < Formula
+  desc "{{projectDescription}}"
+  homepage "{{projectLinkHomepage}}"
+  url "{{distributionUrl}}"{{#brewDownloadStrategy}}, :using => {{.}}{{/brewDownloadStrategy}}
+  version "{{projectVersion}}"
+  sha256 "{{distributionChecksumSha256}}"
+  license "{{projectLicense}}"
+
+  {{#brewHasLivecheck}}
+  livecheck do
+    {{#brewLivecheck}}
+    {{.}}
+    {{/brewLivecheck}}
+  end
+  {{/brewHasLivecheck}}
+  {{#brewDependencies}}
+  depends_on {{.}}
+  {{/brewDependencies}}
+
+  def install
+    libexec.install Dir["*"]
+    bin.install_symlink "#{libexec}/bin/{{distributionExecutableUnix}}" => "{{distributionExecutableName}}"
+  end
+
+  test do
+    output = shell_output("#{bin}/{{distributionExecutableName}} --version")
+    assert_match "{{projectVersion}}", output
+  end
+end


### PR DESCRIPTION
Our JReleaser version is ~2 years old.

Also we want to customize the brew formula that is geneated, and this requires <some version newer than 1.0>.

So this is required for #1513.