### PR TITLE
brew: bring back `openjdk` as dependency

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -114,7 +114,6 @@ jreleaser {
                 setPath("build/distributions/maestro.zip")
             }
             brew {
-                extraProperties.put("skipJava", "true")
                 setActive("RELEASE")
                 formulaName.set("Maestro")
 


### PR DESCRIPTION
## Proposed changes

We need openjdk as dependency in our formula.

## Testing

-

## Issues fixed

related to #1513 