### PR TITLE
Add configuration file parameter to test, cloud and record commands

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -56,6 +56,9 @@ class CloudCommand : Callable<Int> {
     @CommandLine.Parameters(hidden = true, arity = "0..2", description = ["App file and/or Flow file i.e <appFile> <flowFile>"])
     private lateinit var files: List<File>
 
+    @Option(names = ["--config"], description = ["Optional .yaml configuration file for Flows. If not provided, Maestro will look for a config.yaml file in the root directory."])
+    private var configFile: File? = null
+
     @Option(names = ["--app-file"], description = ["App binary to run your Flows against"])
     private var appFile: File? = null
 
@@ -200,6 +203,7 @@ class CloudCommand : Callable<Int> {
                     input = flowsFile.toPath().toAbsolutePath(),
                     includeTags = includeTags,
                     excludeTags = excludeTags,
+                    config = configFile,
                 )
         } catch (e: Exception) {
             throw CliError("Upload aborted. Received error when evaluating workspace: ${e.message}")
@@ -207,6 +211,10 @@ class CloudCommand : Callable<Int> {
     }
 
     private fun validateFiles() {
+
+        if (configFile != null && configFile?.exists()?.not() == true) {
+            throw CliError("The config file ${configFile?.absolutePath} does not exist.")
+        }
 
         // Maintains backwards compatibility for this syntax: maestro cloud <appFile> <workspace>
         // App file can be optional now

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -56,6 +56,9 @@ class RecordCommand : Callable<Int> {
     @CommandLine.Parameters
     private lateinit var flowFile: File
 
+    @Option(names = ["--config"], description = ["Optional .yaml configuration file for Flows. If not provided, Maestro will look for a config.yaml file in the root directory."])
+    private var configFile: File? = null
+
     @Option(names = ["-e", "--env"])
     private var env: Map<String, String> = emptyMap()
 
@@ -80,6 +83,9 @@ class RecordCommand : Callable<Int> {
             throw CliError("--platform option was deprecated. You can remove it to run your test.")
         }
 
+        if (configFile != null && configFile?.exists()?.not() == true) {
+            throw CliError("The config file ${configFile?.absolutePath} does not exist.")
+        }
 
         TestDebugReporter.install(debugOutputPathAsString = debugOutput)
         val path = TestDebugReporter.getDebugOutputPath()

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -76,7 +76,7 @@ class TestCommand : Callable<Int> {
     @CommandLine.Parameters
     private lateinit var flowFile: File
 
-    @Option(names = ["--config"])
+    @Option(names = ["--config"], description = ["Optional .yaml configuration file for Flows. If not provided, Maestro will look for a config.yaml file in the root directory."])
     private var configFile: File? = null
 
     @Option(
@@ -155,7 +155,7 @@ class TestCommand : Callable<Int> {
         }
 
         if (configFile != null && configFile?.exists()?.not() == true) {
-            PrintUtils.warn("The file ${configFile?.absolutePath} does not exist.")
+            throw CliError("The config file ${configFile?.absolutePath} does not exist.")
         }
 
         val executionPlan = try {

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -76,6 +76,9 @@ class TestCommand : Callable<Int> {
     @CommandLine.Parameters
     private lateinit var flowFile: File
 
+    @Option(names = ["--config"])
+    private var configFile: File? = null
+
     @Option(
         names = ["-s", "--shards"],
         description = ["Number of parallel shards to distribute tests across"]
@@ -151,11 +154,16 @@ class TestCommand : Callable<Int> {
             throw CliError("--platform option was deprecated. You can remove it to run your test.")
         }
 
+        if (configFile != null && configFile?.exists()?.not() == true) {
+            PrintUtils.warn("The file ${configFile?.absolutePath} does not exist.")
+        }
+
         val executionPlan = try {
             WorkspaceExecutionPlanner.plan(
                 flowFile.toPath().toAbsolutePath(),
                 includeTags,
-                excludeTags
+                excludeTags,
+                configFile,
             )
         } catch (e: ValidationError) {
             throw CliError(e.message)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -6,6 +6,7 @@ import maestro.orchestra.WorkspaceConfig
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.ExecutionOrderPlanner.getFlowsToRunInSequence
 import maestro.orchestra.yaml.YamlCommandReader
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.*
@@ -17,6 +18,7 @@ object WorkspaceExecutionPlanner {
         input: Path,
         includeTags: List<String>,
         excludeTags: List<String>,
+        config: File?,
     ): ExecutionPlan {
         if (input.notExists()) {
             throw ValidationError("""
@@ -41,10 +43,13 @@ object WorkspaceExecutionPlanner {
         }
 
         // Filter flows based on flows config
-
-        val workspaceConfig = findConfigFile(input)
-            ?.let { YamlCommandReader.readWorkspaceConfig(it) }
-            ?: WorkspaceConfig()
+        val workspaceConfig = if(config?.exists() == true) {
+            YamlCommandReader.readWorkspaceConfig(config.toPath().toAbsolutePath())
+        } else {
+            findConfigFile(input)
+                ?.let { YamlCommandReader.readWorkspaceConfig(it) }
+                ?: WorkspaceConfig()
+        }
 
         val globs = workspaceConfig.flows ?: listOf("*")
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerErrorsTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerErrorsTest.kt
@@ -48,7 +48,7 @@ internal class WorkspaceExecutionPlannerErrorsTest {
         val excludeTags = path.resolve("excludeTags.txt").takeIf { it.isRegularFile() }?.readLines() ?: emptyList()
         try {
             val inputPath = singleFlowFilePath?.let { workspacePath.resolve(it) } ?: workspacePath
-            WorkspaceExecutionPlanner.plan(inputPath, includeTags, excludeTags)
+            WorkspaceExecutionPlanner.plan(inputPath, includeTags, excludeTags, null)
             assertWithMessage("No exception was not thrown. Ensure this test case triggers a ValidationError.").fail()
         } catch (e: Exception) {
             if (e !is ValidationError) {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -14,6 +14,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/000_individual_file/flow.yaml"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -29,6 +30,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/001_simple"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -45,6 +47,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/002_subflows"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -61,6 +64,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/003_include_tags"),
             includeTags = listOf("included"),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -76,6 +80,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/004_exclude_tags"),
             includeTags = listOf(),
             excludeTags = listOf("excluded"),
+            config = null,
         )
 
         // Then
@@ -92,6 +97,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/005_custom_include_pattern"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -108,6 +114,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/006_include_subfolders"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -126,6 +133,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/007_empty_config"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -142,6 +150,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/008_literal_pattern"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -157,6 +166,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/009_custom_config_fields"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -173,6 +183,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/010_global_include_tags"),
             includeTags = listOf("featureB"),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -190,6 +201,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/011_global_exclude_tags"),
             includeTags = listOf(),
             excludeTags = listOf("featureA"),
+            config = null,
         )
 
         // Then
@@ -207,6 +219,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/012_local_deterministic_order"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -224,6 +237,7 @@ internal class WorkspaceExecutionPlannerTest {
             input = path("/workspaces/013_execution_order"),
             includeTags = listOf(),
             excludeTags = listOf(),
+            config = null,
         )
 
         // Then
@@ -238,6 +252,22 @@ internal class WorkspaceExecutionPlannerTest {
             path("/workspaces/013_execution_order/flowCWithCustomName.yaml"),
             path("/workspaces/013_execution_order/flowD.yaml"),
         ).inOrder()
+    }
+
+    @Test
+    internal fun `014 - Config not null`() {
+        // When
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = path("/workspaces/014_config_not_null"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = path("/workspaces/014_config_not_null/config/another_config.yml").toFile(),
+        )
+
+        // Then
+        assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/014_config_not_null/flowA.yaml"),
+        )
     }
 
     private fun path(pathStr: String): Path {

--- a/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/config.yml
+++ b/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/config.yml
@@ -1,0 +1,3 @@
+includeTags:
+  - included
+  - excluded

--- a/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/config/another_config.yml
+++ b/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/config/another_config.yml
@@ -1,0 +1,2 @@
+includeTags:
+  - included

--- a/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/flowA.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/flowA.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+tags:
+  - included
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/flowB.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/014_config_not_null/flowB.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+tags:
+  - excluded
+---
+- launchApp


### PR DESCRIPTION
## Proposed changes

The idea behind this PR is to allow multiple configurations for the same test suite. This comes really handy when having the same app with multiple flavors/schemas: you can run the same test on apps having the same structure but different app ids without injecting it via CI/CD.

This changes add a new parameter `--config` to the following commands:
`$ maestro cloud`
`$ maestro test`
`$ maestro record`

The parameter is a path for the configuration file used for the flows.

Examples of use:
`$ maestro test --config config/another_config.yml`

## Testing

- Create a config file with a different name or a directory which is not the root.
- Execute:
- `$ maestro test --config your_path_to_the_config/file.yml`