### PR TITLE
Add Composite reporter that generates JUnit and HTML

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -369,8 +369,6 @@ class CloudInteractor(
         val reportOutputSink = reportFormat.fileExtension
             ?.let { extension ->
                 (reportOutput ?: File("report$extension"))
-                    .sink()
-                    .buffer()
             }
 
         if (reportOutputSink != null) {
@@ -403,7 +401,7 @@ class CloudInteractor(
         reportFormat: ReportFormat,
         passed: Boolean,
         suiteResult: TestExecutionSummary.SuiteResult,
-        reportOutputSink: BufferedSink,
+        reportOutput: File,
         testSuiteName: String?
     ) {
         ReporterFactory.buildReporter(reportFormat, testSuiteName)
@@ -412,7 +410,7 @@ class CloudInteractor(
                     passed = passed,
                     suites = listOf(suiteResult)
                 ),
-                reportOutputSink,
+                reportOutput,
             )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -533,9 +533,12 @@ class TestCommand : Callable<Int> {
         val reporter = ReporterFactory.buildReporter(format, testSuiteName)
 
         format.fileExtension?.let { extension ->
-            (output ?: File("report$extension")).sink()
-        }?.also { sink ->
-            reporter.report(this, sink)
+            (output ?: File("report$extension"))
+        }?.also { file ->
+            reporter.report(
+                this,
+                file,
+            )
         }
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/report/CompositeTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/CompositeTestSuiteReporter.kt
@@ -1,0 +1,42 @@
+package maestro.cli.report
+
+import maestro.cli.model.TestExecutionSummary
+import java.io.File
+
+class CompositeTestSuiteReporter(val reporters: Set<TestSuiteReporter>, override val fileExtension: String?) : TestSuiteReporter {
+    override fun report(
+        summary: TestExecutionSummary,
+        out: File
+    ) {
+        val baseReportDirectory = getBaseReportDirectory(out)
+
+        reporters.forEach { reporter ->
+            val reportFolder = File(baseReportDirectory, simpleReportFolderName(reporter))
+            reportFolder.mkdirs()
+
+            val reportFile = File(reportFolder, "report${reporter.fileExtension}")
+
+            if (reportFile.exists()) {
+                reportFile.delete()
+            }
+
+            reporter.report(summary, reportFile)
+        }
+    }
+
+    private fun getBaseReportDirectory(out: File): File {
+        return if (out.absoluteFile.isDirectory) {
+            out.absoluteFile
+        } else {
+            out.absoluteFile.parentFile
+        }
+    }
+
+    private fun simpleReportFolderName(reporter: TestSuiteReporter): String {
+        return reporter.javaClass.simpleName.replace(interfaceName, "")
+    }
+
+    companion object {
+        private val interfaceName = TestSuiteReporter::class.simpleName!!
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
@@ -3,15 +3,16 @@ package maestro.cli.report
 import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
 import maestro.cli.model.TestExecutionSummary
-import okio.Sink
 import okio.buffer
+import okio.sink
+import java.io.File
 
-class HtmlTestSuiteReporter : TestSuiteReporter {
-    override fun report(summary: TestExecutionSummary, out: Sink) {
-        val bufferedOut = out.buffer()
-        val htmlContent = buildHtmlReport(summary)
-        bufferedOut.writeUtf8(htmlContent)
-        bufferedOut.close()
+class HtmlTestSuiteReporter(override val fileExtension: String?) : TestSuiteReporter {
+  override fun report(summary: TestExecutionSummary, out: File) {
+    val bufferedOut = out.sink().buffer()
+    val htmlContent = buildHtmlReport(summary)
+    bufferedOut.writeUtf8(htmlContent)
+    bufferedOut.close()
     }
 
     private fun buildHtmlReport(summary: TestExecutionSummary): String {

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -12,13 +12,15 @@ import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
-import okio.Sink
 import okio.buffer
+import okio.sink
+import java.io.File
 import kotlin.time.DurationUnit
 
 class JUnitTestSuiteReporter(
     private val mapper: ObjectMapper,
-    private val testSuiteName: String?
+    private val testSuiteName: String?,
+    override val fileExtension: String?
 ) : TestSuiteReporter {
 
     private fun suiteResultToTestSuite(suite: TestExecutionSummary.SuiteResult) = TestSuite(
@@ -49,12 +51,12 @@ class JUnitTestSuiteReporter(
 
     override fun report(
         summary: TestExecutionSummary,
-        out: Sink
+        out: File
     ) {
         mapper
             .writerWithDefaultPrettyPrinter()
             .writeValue(
-                out.buffer().outputStream(),
+                out.sink().buffer().outputStream(),
                 TestSuites(
                     suites = summary
                         .suites
@@ -99,13 +101,14 @@ class JUnitTestSuiteReporter(
 
     companion object {
 
-        fun xml(testSuiteName: String? = null) = JUnitTestSuiteReporter(
+        fun xml(testSuiteName: String?, fileExtension: String?) = JUnitTestSuiteReporter(
             mapper = XmlMapper().apply {
                 registerModule(KotlinModule.Builder().build())
                 setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
             },
-            testSuiteName = testSuiteName
+            testSuiteName = testSuiteName,
+            fileExtension = fileExtension,
         )
 
     }

--- a/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
@@ -3,9 +3,32 @@ package maestro.cli.report
 enum class ReportFormat(
     val fileExtension: String?
 ) {
+    JUNIT(".xml") {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return JUnitTestSuiteReporter.xml(testSuiteName, fileExtension)
+        }
+    },
+    HTML(".html") {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return HtmlTestSuiteReporter(fileExtension)
+        }
+    },
+    COMPOSITE(".composite") {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return CompositeTestSuiteReporter(
+                setOf(
+                    HTML.createReporter(testSuiteName),
+                    JUNIT.createReporter(testSuiteName)
+                ),
+                fileExtension
+            )
+        }
+    },
+    NOOP(null) {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return TestSuiteReporter.NOOP
+        }
+    };
 
-    JUNIT(".xml"),
-    HTML(".html"),
-    NOOP(null),
-
+    abstract fun createReporter(testSuiteName: String?): TestSuiteReporter
 }

--- a/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
@@ -1,16 +1,7 @@
 package maestro.cli.report
 
-import maestro.cli.model.TestExecutionSummary
-import okio.BufferedSink
-
 object ReporterFactory {
-
     fun buildReporter(format: ReportFormat, testSuiteName: String?): TestSuiteReporter {
-        return when (format) {
-            ReportFormat.JUNIT -> JUnitTestSuiteReporter.xml(testSuiteName)
-            ReportFormat.NOOP -> TestSuiteReporter.NOOP
-            ReportFormat.HTML -> HtmlTestSuiteReporter()
-        }
+        return format.createReporter(testSuiteName)
     }
-
 }

--- a/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
@@ -1,24 +1,27 @@
 package maestro.cli.report
 
 import maestro.cli.model.TestExecutionSummary
-import okio.Sink
+import java.io.File
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 interface TestSuiteReporter {
+    val fileExtension: String?
 
     /**
      * Writes the report for [summary] to [out] in the format specified by the implementation.
      */
     fun report(
         summary: TestExecutionSummary,
-        out: Sink,
+        out: File,
     )
 
     companion object {
         val NOOP: TestSuiteReporter = object : TestSuiteReporter {
-            override fun report(summary: TestExecutionSummary, out: Sink) {
+            override val fileExtension: String? = null
+
+            override fun report(summary: TestExecutionSummary, out: File) {
                 // no-op
             }
         }

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -50,7 +50,7 @@ class TestSuiteInteractor(
 
     suspend fun runTestSuite(
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan,
-        reportOut: Sink?,
+        reportOut: File?,
         env: Map<String, String>,
         debugOutputPath: Path,
         testOutputDir: Path? = null

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/CompositeTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/CompositeTestSuiteReporterTest.kt
@@ -1,0 +1,33 @@
+package maestro.cli.report
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class CompositeTestSuiteReporterTest {
+
+    @Test
+    fun `Composite test report created`() {
+        // Given
+        val reportFormat = ReportFormat.COMPOSITE
+
+        // When
+        val reporter = reportFormat.createReporter("testSuiteName")
+
+        // Then
+        assertThat(reporter is CompositeTestSuiteReporter).isTrue()
+    }
+
+    @Test
+    fun `Composite test report contains JUNIT and HTML reports`() {
+        // Given
+        val reportFormat = ReportFormat.COMPOSITE
+
+        // When
+        val reporter = reportFormat.createReporter("testSuiteName")
+        val reporters = (reporter as CompositeTestSuiteReporter).reporters
+
+        // Then
+        assertThat(reporters.any { it is JUnitTestSuiteReporter }).isTrue()
+        assertThat(reporters.any { it is HtmlTestSuiteReporter }).isTrue()
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -1,23 +1,23 @@
 package maestro.cli.report
 
 import com.google.common.truth.Truth.assertThat
-import okio.Buffer
 import org.junit.jupiter.api.Test
+import java.io.File
 
 class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
 
     @Test
     fun `XML - Test passed`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml()
-        val sink = Buffer()
+        val testee = JUnitTestSuiteReporter.xml(null, null)
+        val reportOutput = File("tmpReportOutput")
 
         // When
         testee.report(
             summary = testSuccessWithWarning,
-            out = sink
+            out = reportOutput
         )
-        val resultStr = sink.readUtf8()
+        val resultStr = reportOutput.readText(Charsets.UTF_8)
 
         // Then
         assertThat(resultStr).isEqualTo(
@@ -37,15 +37,15 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `XML - Test failed`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml()
-        val sink = Buffer()
+        val testee = JUnitTestSuiteReporter.xml(null, null)
+        val reportOutput = File("tmpReportOutput")
 
         // When
         testee.report(
             summary = testSuccessWithError,
-            out = sink
+            out = reportOutput
         )
-        val resultStr = sink.readUtf8()
+        val resultStr = reportOutput.readText(Charsets.UTF_8)
 
         // Then
         assertThat(resultStr).isEqualTo(
@@ -67,15 +67,15 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `XML - Custom test suite name is used when present`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml("Custom test suite name")
-        val sink = Buffer()
+        val testee = JUnitTestSuiteReporter.xml("Custom test suite name", "fileExtension")
+        val reportOutput = File("tmpReportOutput")
 
         // When
         testee.report(
             summary = testSuccessWithWarning,
-            out = sink
+            out = reportOutput
         )
-        val resultStr = sink.readUtf8()
+        val resultStr = reportOutput.readText(Charsets.UTF_8)
 
         // Then
         assertThat(resultStr).isEqualTo(


### PR DESCRIPTION
## Proposed changes

Adds feature to generate both reports: JUnit and HTML
Useful for CI, when JUnit XML is consumed by CI, and HTML for People to view.

copilot:summary

## Testing
Launching tests with `composite` report:

```
maestro \
      test \
      pathToTests \
      --format composite \
      --output "reports_dir/"

```

Reports will be generated in:

- `reports_dir/JUnit/report.xml`
- `reports_dir/Html/report.html`


<!--- Please describe how you tested your changes. -->

## Issues fixed
