### PR TITLE
Add Commands and Screenshots to HTML report

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -324,8 +324,6 @@ class CloudInteractor(
         val reportOutputSink = reportFormat.fileExtension
             ?.let { extension ->
                 (reportOutput ?: File("report$extension"))
-                    .sink()
-                    .buffer()
             }
 
         if (reportOutputSink != null) {
@@ -352,7 +350,7 @@ class CloudInteractor(
         reportFormat: ReportFormat,
         passed: Boolean,
         suiteResult: TestExecutionSummary.SuiteResult,
-        reportOutputSink: BufferedSink,
+        reportOutput: File,
         testSuiteName: String?
     ) {
         ReporterFactory.buildReporter(reportFormat, testSuiteName)
@@ -361,7 +359,7 @@ class CloudInteractor(
                     passed = passed,
                     suites = listOf(suiteResult)
                 ),
-                reportOutputSink,
+                reportOutput,
             )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -352,11 +352,10 @@ class TestCommand : Callable<Int> {
 
         format.fileExtension?.let { extension ->
             (output ?: File("report$extension"))
-                .sink()
-        }?.also { sink ->
+        }?.also { file ->
             reporter.report(
                 this,
-                sink,
+                file,
             )
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -1,5 +1,10 @@
 package maestro.cli.model
 
+import maestro.MaestroException
+import maestro.cli.report.CommandDebugMetadata
+import maestro.cli.report.ScreenshotDebugMetadata
+import maestro.orchestra.MaestroCommand
+import java.util.*
 import kotlin.time.Duration
 
 data class TestExecutionSummary(
@@ -26,6 +31,8 @@ data class TestExecutionSummary(
 
     data class Failure(
         val message: String,
+        val commands: IdentityHashMap<MaestroCommand, CommandDebugMetadata>? = null,
+        val screenshots: MutableList<ScreenshotDebugMetadata>? = null,
+        var exception: MaestroException? = null
     )
-
 }

--- a/maestro-cli/src/main/java/maestro/cli/report/CompositeTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/CompositeTestSuiteReporter.kt
@@ -1,0 +1,42 @@
+package maestro.cli.report
+
+import maestro.cli.model.TestExecutionSummary
+import java.io.File
+
+class CompositeTestSuiteReporter(val reporters: Set<TestSuiteReporter>, override val fileExtension: String?) : TestSuiteReporter {
+    override fun report(
+        summary: TestExecutionSummary,
+        out: File
+    ) {
+        val baseReportDirectory = getBaseReportDirectory(out)
+
+        reporters.forEach { reporter ->
+            val reportFolder = File(baseReportDirectory, simpleReportFolderName(reporter))
+            reportFolder.mkdirs()
+
+            val reportFile = File(reportFolder, "report${reporter.fileExtension}")
+
+            if (reportFile.exists()) {
+                reportFile.delete()
+            }
+
+            reporter.report(summary, reportFile)
+        }
+    }
+
+    private fun getBaseReportDirectory(out: File): File {
+        return if (out.absoluteFile.isDirectory) {
+            out.absoluteFile
+        } else {
+            out.absoluteFile.parentFile
+        }
+    }
+
+    private fun simpleReportFolderName(reporter: TestSuiteReporter): String {
+        return reporter.javaClass.simpleName.replace(interfaceName, "")
+    }
+
+    companion object {
+        private val interfaceName = TestSuiteReporter::class.simpleName!!
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
@@ -1,14 +1,15 @@
 package maestro.cli.report
 
 import maestro.cli.model.TestExecutionSummary
-import okio.Sink
 import okio.buffer
 import kotlinx.html.*
 import kotlinx.html.stream.appendHTML
+import okio.sink
+import java.io.File
 
-class HtmlTestSuiteReporter : TestSuiteReporter {
-  override fun report(summary: TestExecutionSummary, out: Sink) {
-    val bufferedOut = out.buffer()
+class HtmlTestSuiteReporter(override val fileExtension: String?) : TestSuiteReporter {
+  override fun report(summary: TestExecutionSummary, out: File) {
+    val bufferedOut = out.sink().buffer()
     val htmlContent = buildHtmlReport(summary)
     bufferedOut.writeUtf8(htmlContent)
     bufferedOut.close()

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -12,22 +12,24 @@ import com.fasterxml.jackson.dataformat.xml.ser.ToXmlGenerator
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
-import okio.Sink
 import okio.buffer
+import okio.sink
+import java.io.File
 
 class JUnitTestSuiteReporter(
     private val mapper: ObjectMapper,
-    private val testSuiteName: String?
+    private val testSuiteName: String?,
+    override val fileExtension: String?
 ) : TestSuiteReporter {
 
     override fun report(
         summary: TestExecutionSummary,
-        out: Sink
+        out: File
     ) {
         mapper
             .writerWithDefaultPrettyPrinter()
             .writeValue(
-                out.buffer().outputStream(),
+                out.sink().buffer().outputStream(),
                 TestSuites(
                     suites = summary
                         .suites
@@ -93,13 +95,14 @@ class JUnitTestSuiteReporter(
 
     companion object {
 
-        fun xml(testSuiteName: String? = null) = JUnitTestSuiteReporter(
+        fun xml(testSuiteName: String?, fileExtension: String?) = JUnitTestSuiteReporter(
             mapper = XmlMapper().apply {
                 registerModule(KotlinModule.Builder().build())
                 setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
             },
-            testSuiteName = testSuiteName
+            testSuiteName = testSuiteName,
+            fileExtension = fileExtension,
         )
 
     }

--- a/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
@@ -3,9 +3,32 @@ package maestro.cli.report
 enum class ReportFormat(
     val fileExtension: String?
 ) {
+    JUNIT(".xml") {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return JUnitTestSuiteReporter.xml(testSuiteName, fileExtension)
+        }
+    },
+    HTML(".html") {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return HtmlTestSuiteReporter(fileExtension)
+        }
+    },
+    COMPOSITE(".composite") {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return CompositeTestSuiteReporter(
+                setOf(
+                    HTML.createReporter(testSuiteName),
+                    JUNIT.createReporter(testSuiteName)
+                ),
+                fileExtension
+            )
+        }
+    },
+    NOOP(null) {
+        override fun createReporter(testSuiteName: String?): TestSuiteReporter {
+            return TestSuiteReporter.NOOP
+        }
+    };
 
-    JUNIT(".xml"),
-    HTML(".html"),
-    NOOP(null),
-
+    abstract fun createReporter(testSuiteName: String?): TestSuiteReporter
 }

--- a/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
@@ -1,16 +1,7 @@
 package maestro.cli.report
 
-import maestro.cli.model.TestExecutionSummary
-import okio.BufferedSink
-
 object ReporterFactory {
-
     fun buildReporter(format: ReportFormat, testSuiteName: String?): TestSuiteReporter {
-        return when (format) {
-            ReportFormat.JUNIT -> JUnitTestSuiteReporter.xml(testSuiteName)
-            ReportFormat.NOOP -> TestSuiteReporter.NOOP
-            ReportFormat.HTML -> HtmlTestSuiteReporter()
-        }
+        return format.createReporter(testSuiteName)
     }
-
 }

--- a/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
@@ -1,21 +1,23 @@
 package maestro.cli.report
 
 import maestro.cli.model.TestExecutionSummary
-import okio.Sink
+import java.io.File
 
 interface TestSuiteReporter {
+    val fileExtension: String?
 
     fun report(
         summary: TestExecutionSummary,
-        out: Sink,
+        out: File,
     )
 
     companion object {
         val NOOP: TestSuiteReporter = object : TestSuiteReporter {
-            override fun report(summary: TestExecutionSummary, out: Sink) {
+            override val fileExtension: String? = null
+
+            override fun report(summary: TestExecutionSummary, out: File) {
                 // no-op
             }
         }
     }
-
 }

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -239,6 +239,9 @@ class TestSuiteInteractor(
             failure = if (flowStatus == FlowStatus.ERROR) {
                 TestExecutionSummary.Failure(
                     message = errorMessage ?: debug.exception?.message ?: "Unknown error",
+                    commands = debug.commands,
+                    screenshots = debug.screenshots,
+                    exception = debug.exception
                 )
             } else null,
             duration = flowDuration,

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -35,7 +35,7 @@ class TestSuiteInteractor(
 
     fun runTestSuite(
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan,
-        reportOut: Sink?,
+        reportOut: File?,
         env: Map<String, String>,
         debugOutputPath: Path
     ): TestExecutionSummary {

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/CompositeTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/CompositeTestSuiteReporterTest.kt
@@ -1,0 +1,33 @@
+package maestro.cli.report
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class CompositeTestSuiteReporterTest {
+
+    @Test
+    fun `Composite test report created`() {
+        // Given
+        val reportFormat = ReportFormat.COMPOSITE
+
+        // When
+        val reporter = reportFormat.createReporter("testSuiteName")
+
+        // Then
+        assertThat(reporter is CompositeTestSuiteReporter).isTrue()
+    }
+
+    @Test
+    fun `Composite test report contains JUNIT and HTML reports`() {
+        // Given
+        val reportFormat = ReportFormat.COMPOSITE
+
+        // When
+        val reporter = reportFormat.createReporter("testSuiteName")
+        val reporters = (reporter as CompositeTestSuiteReporter).reporters
+
+        // Then
+        assertThat(reporters.any { it is JUnitTestSuiteReporter }).isTrue()
+        assertThat(reporters.any { it is HtmlTestSuiteReporter }).isTrue()
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -3,8 +3,8 @@ package maestro.cli.report
 import com.google.common.truth.Truth.assertThat
 import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
-import okio.Buffer
 import org.junit.jupiter.api.Test
+import java.io.File
 import kotlin.time.Duration.Companion.seconds
 
 class JUnitTestSuiteReporterTest {
@@ -12,7 +12,7 @@ class JUnitTestSuiteReporterTest {
     @Test
     fun `XML - Test passed`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml()
+        val testee = JUnitTestSuiteReporter.xml(null, null)
 
         val summary = TestExecutionSummary(
             passed = true,
@@ -38,14 +38,14 @@ class JUnitTestSuiteReporterTest {
                 )
             )
         )
-        val sink = Buffer()
+        val reportOutput = File("tmpReportOutput")
 
         // When
         testee.report(
             summary = summary,
-            out = sink
+            out = reportOutput
         )
-        val resultStr = sink.readUtf8()
+        val resultStr = reportOutput.readText(Charsets.UTF_8)
 
         // Then
         assertThat(resultStr).isEqualTo(
@@ -65,7 +65,7 @@ class JUnitTestSuiteReporterTest {
     @Test
     fun `XML - Test failed`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml()
+        val testee = JUnitTestSuiteReporter.xml(null, null)
 
         val summary = TestExecutionSummary(
             passed = false,
@@ -91,14 +91,14 @@ class JUnitTestSuiteReporterTest {
                 )
             )
         )
-        val sink = Buffer()
+        val reportOutput = File("tmpReportOutput")
 
         // When
         testee.report(
             summary = summary,
-            out = sink
+            out = reportOutput
         )
-        val resultStr = sink.readUtf8()
+        val resultStr = reportOutput.readText(Charsets.UTF_8)
 
         // Then
         assertThat(resultStr).isEqualTo(
@@ -120,7 +120,7 @@ class JUnitTestSuiteReporterTest {
     @Test
     fun `XML - Custom test suite name is used when present`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml("Custom test suite name")
+        val testee = JUnitTestSuiteReporter.xml("Custom test suite name", "fileExtension")
 
         val summary = TestExecutionSummary(
             passed = true,
@@ -145,14 +145,14 @@ class JUnitTestSuiteReporterTest {
                 )
             )
         )
-        val sink = Buffer()
+        val reportOutput = File("tmpReportOutput")
 
         // When
         testee.report(
             summary = summary,
-            out = sink
+            out = reportOutput
         )
-        val resultStr = sink.readUtf8()
+        val resultStr = reportOutput.readText(Charsets.UTF_8)
 
         // Then
         assertThat(resultStr).isEqualTo(


### PR DESCRIPTION
## Proposed changes
Add Commands and Screenshots to HTML report
This is a draft. it depends on changes in this PR https://github.com/mobile-dev-inc/maestro/pull/1855

This adds to HTML report a list of commands and detailed errors and a screenshot.

Here is an example of HTML report

![Screenshot 2024-07-31 at 21 09 55](https://github.com/user-attachments/assets/54d053dc-0a50-497e-ae7b-2e59949fa8e9)

The diff here contains changes from https://github.com/mobile-dev-inc/maestro/pull/1855
to see changes that only add Screenshots and Commands - here https://github.com/mobile-dev-inc/maestro/commit/c2eee05314257b58722f5008f477b2e3b00a473d

copilot:summary

## Testing


<!--- Please describe how you tested your changes. -->

## Issues fixed
