### PR TITLE
Fix Android Parallel/Shards Race Condition

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -74,6 +74,7 @@ object MaestroSessionManager {
         val heartbeatFuture = executor.scheduleAtFixedRate(
             {
                 try {
+                    Thread.sleep(1000) // Add a 1-second delay here for fixing race condition
                     SessionStore.heartbeat(sessionId, selectedDevice.platform)
                 } catch (e: Exception) {
                     logger.error("Failed to record heartbeat", e)


### PR DESCRIPTION
## Proposed changes

I think this is because of the shards race condition
So by adding a delay will fix the race condition

## Testing

<!--- Please describe how you tested your changes. -->

## Issues fixed
https://github.com/mobile-dev-inc/maestro/issues/1853 Unable to run parallel/sharded tests on Android