### PR TITLE
ApiClient: print stack trace when retry fails

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -291,12 +291,13 @@ class ApiClient(
 
         val body = bodyBuilder.build()
 
-        fun retry(message: String): UploadResponse {
+        fun retry(message: String, e: Throwable? = null): UploadResponse {
             if (completedRetries >= maxRetryCount) {
+                e?.printStackTrace()
                 throw CliError(message)
             }
 
-            PrintUtils.message("$message, retrying...")
+            PrintUtils.message("$message, retrying (${completedRetries+1}/$maxRetryCount)...")
             Thread.sleep(BASE_RETRY_DELAY_MS + (2000 * completedRetries))
 
             return upload(
@@ -333,7 +334,7 @@ class ApiClient(
 
             client.newCall(request).execute()
         } catch (e: IOException) {
-            return retry("Upload failed due to socket exception")
+            return retry("Upload failed due to socket exception", e)
         }
 
         response.use {


### PR DESCRIPTION
To help pinpoint root cause of #1856

This is how it will look like:

<img width="747" alt="Screenshot 2024-08-02 at 16 25 38" src="https://github.com/user-attachments/assets/9ed482eb-c7e6-496f-b7b0-8ec6630e4b61">
