### PR TITLE
Add start session command to increase speed of tests

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -89,6 +89,7 @@ jobs:
             ./download_apps
             ./install_apps
             ./run_tests
+            ./run_start_session_test
 
       - name: Upload ~/.maestro artifacts
         uses: actions/upload-artifact@v4

--- a/e2e/run_start_session_test
+++ b/e2e/run_start_session_test
@@ -1,0 +1,69 @@
+#!/usr/bin/env sh
+
+set -eu
+
+# The point of this test is to ensure that the 'maestro start-session' works correctly
+# - Running it should reinstall Maestro APKs on device
+# - Running 'maestro test' while a 'maestro start-session' is open should not reinstall Maestro APKs
+
+command -v maestro >/dev/null 2>&1 || { echo "maestro is required" && exit 1; }
+
+[ "$(basename "$PWD")" = "e2e" ] || { echo "must be run from e2e directory" && exit 1; }
+
+get_maestro_apk_install_time() {
+  adb shell dumpsys package dev.mobile.maestro | grep "lastUpdateTime" | awk -F= '{print $2}'
+}
+
+start_maestro_session() {
+  LOG_FILE=$(mktemp)
+  MAX_TIMEOUT=60
+  START_TIME=$(date +%s)
+
+  # Start the Maestro session in the background and redirect output to logs.txt
+  echo "Starting Maestro session..."
+  maestro --device emulator-5554 start-session > "$LOG_FILE" 2>&1 &
+  MAESTRO_START_SESSION_PID=$!
+  trap "kill -9 $MAESTRO_START_SESSION_PID" EXIT
+
+  # Loop to check for the "Maestro session started." message
+  while true; do
+      if grep -q "Maestro session started." "$LOG_FILE"; then
+          echo "Maestro session started successfully."
+          break
+      fi
+      CURRENT_TIME=$(date +%s)
+      ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
+
+      if [ "$ELAPSED_TIME" -ge "$MAX_TIMEOUT" ]; then
+          echo "Timed out waiting for Maestro session to start."
+          break
+      fi
+      sleep 1
+  done
+}
+
+# Test Start session doesn't reinstall APKs
+PREVIOUS_INSTALL_TIME=$(get_maestro_apk_install_time)
+start_maestro_session
+
+# Ensure maestro start-session did reinstall APKs
+AFTER_START_SESSION_INSTALL_TIME=$(get_maestro_apk_install_time)
+
+if [ "$PREVIOUS_INSTALL_TIME" = "$AFTER_START_SESSION_INSTALL_TIME" ]; then
+  echo "'maestro start-session' didn't reinstall APKs while it should have"
+  exit 1
+fi
+
+# Ensure subsequent maestro test do not reinstall APKs
+# We don't really care if the test fails or not since it should be taken care of in run_tests
+maestro --device emulator-5554 test ./flows/nowinandroid/bookmarks.yaml || FAILED=true
+AFTER_TEST_INSTALL_TIME=$(get_maestro_apk_install_time)
+
+if [ "$AFTER_START_SESSION_INSTALL_TIME" != "$AFTER_TEST_INSTALL_TIME" ]; then
+  echo "'maestro test' reinstalled APKs while it shouldn't have"
+  exit 1
+fi
+
+echo $PREVIOUS_INSTALL_TIME
+echo $AFTER_START_SESSION_INSTALL_TIME
+echo $AFTER_TEST_INSTALL_TIME

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -51,7 +51,8 @@ import kotlin.system.exitProcess
         LogoutCommand::class,
         BugReportCommand::class,
         StudioCommand::class,
-        StartDeviceCommand::class
+        StartDeviceCommand::class,
+        StartSessionCommand::class
     ]
 )
 class App {

--- a/maestro-cli/src/main/java/maestro/cli/command/StartSessionCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartSessionCommand.kt
@@ -1,0 +1,53 @@
+package maestro.cli.command
+
+import maestro.cli.App
+import maestro.cli.CliError
+import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
+import maestro.cli.device.Platform
+import maestro.cli.session.MaestroSessionManager
+import maestro.cli.util.DeviceConfigIos.device
+import picocli.CommandLine
+import picocli.CommandLine.Command
+
+@Command(
+    name = "start-session",
+    description = [
+        "Setup Maestro session once, so you can run 'maestro test' faster since the setup is already done.",
+    ],
+    hidden = true
+)
+class StartSessionCommand : Runnable {
+    @CommandLine.Mixin
+    var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
+
+    @CommandLine.ParentCommand
+    private val parent: App? = null
+
+    override fun run() {
+        MaestroSessionManager.newSession(
+            host = parent?.host,
+            port = parent?.port,
+            driverHostPort = parent?.port,
+            deviceId = parent?.deviceId
+        ) { session ->
+            /**
+             * As of now on iOS, the session gets started but this has no impact on subsequent tests
+             * running maestro test after the session would still install the XCTest runner
+             */
+            if (session.device?.platform != Platform.ANDROID) {
+                throw CliError ("This command is only supported for Android devices.")
+            }
+
+            println("Maestro session started. Keep this running in the background.")
+            println("Run your tests with `maestro test <test.yaml>` in another terminal.")
+
+            while (!Thread.interrupted()) {
+                Thread.sleep(100)
+            }
+        }
+    }
+}

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -194,9 +194,6 @@ class AndroidDriver(
         launchArguments: Map<String, Any>,
         sessionId: UUID?,
     ) {
-        if(!open) // pick device flow, no open() invocation
-            open()
-
         if (!isPackageInstalled(appId)) {
             throw IllegalArgumentException("Package $appId is not installed")
         }


### PR DESCRIPTION
## Proposed changes

feat:Add start session command to increase speed of tests

When running on lower end Android devices, Maestro can take a long time to start and to finish the test, since it's installing the APKs + uninstalling at the end (can take ~20s on low end devices)

For instance, we use Flashlight to generate e2e performance reports based on several e2e test iterations and we [recommend heavily the use of Maestro](https://docs.flashlight.dev/test/maestro).
However the time bottleneck of running multiple test iterations is those install/uninstall.

This PR introduces a `start-session` command:
- you start it in one tab and it should do the setup necessary, including uninstalling/installing APKs
- then if you do `maestro test` in another tab, setup won't be done again, and the tests will be fast ⚡

## How it works

I was surprised by how easy it was to do and kudos for that 👏 You guys did a fantastic job there ♥️
The `start-session` command allows us to keep an active session open. Subsequent test command will find the session active in `SessionStore` and use it.
Then `openDriver` will be set to false, and the `AndroidDriver` won't run the `open()` function which does all the heavy setup.
Sadly this isn't the case for iOS, so we don't have it working out of the box.

## Potentially breaking shards? 

⚠️ I had to remove 2 lines of code: I have to be honest, I have to be honest, I didn't manage to understand their purpose 😓. So I'd love some help from @sdfgsdfgd or @igorsmotto  to know why they're needed. 🙏

For reference, I've run a "shard" test with `./maestro test -s 2 tests` including some `launchApp` and it worked for me. Likely I've missed a use-case.

## Testing

- Tested locally + in our AWS Device farm CI
- Also added an e2e test script

| Normal behavior | With active session ⚡ |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/36147a16-6130-4a99-ae00-77062b05915e" /> | <video src="https://github.com/user-attachments/assets/ee8c3c41-e9b7-470f-a9f9-a4670b5a4d52" /> | 

## Issues fixed

Fixes #1096 