### PR TITLE
`maestro cloud`: gracefully handle run cancellation by user

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -462,11 +462,16 @@ data class UploadStatus(
         WARNING,
     }
 
+
+    // These values must match backend monorepo models
+    // in package models.benchmark.BenchmarkCancellationReason
     enum class CancellationReason {
         BENCHMARK_DEPENDENCY_FAILED,
         INFRA_ERROR,
         OVERLAPPING_BENCHMARK,
-        TIMEOUT
+        TIMEOUT,
+        CANCELED_BY_USER,
+        RUN_EXPIRED,
     }
 }
 

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -109,7 +109,9 @@ object TestSuiteStatusView {
                 UploadStatus.CancellationReason.TIMEOUT -> "Timeout"
                 UploadStatus.CancellationReason.OVERLAPPING_BENCHMARK -> "Skipped"
                 UploadStatus.CancellationReason.BENCHMARK_DEPENDENCY_FAILED -> "Skipped"
-                else -> "Canceled"
+                UploadStatus.CancellationReason.CANCELED_BY_USER -> "Canceled by user"
+                UploadStatus.CancellationReason.RUN_EXPIRED -> "Run expired"
+                else -> "Canceled (unknown reason)"
             }
         }
 


### PR DESCRIPTION
fix #1901