### PR TITLE
Remove all mentions of idb

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -49,7 +49,6 @@ import kotlin.system.exitProcess
 object MaestroSessionManager {
     private const val defaultHost = "localhost"
     private const val defaultXctestHost = "[::1]"
-    private const val defaultIdbPort = 10882
     private const val defaultXcTestPort = 22087
 
     private val executor = Executors.newScheduledThreadPool(1)
@@ -210,20 +209,6 @@ object MaestroSessionManager {
             }
 
             dadb.close()
-
-            true
-        } catch (_: Exception) {
-            false
-        }
-    }
-
-    private fun isIOS(host: String?, port: Int?): Boolean {
-        return try {
-            val channel = ManagedChannelBuilder.forAddress(host ?: defaultHost, port ?: defaultIdbPort)
-                .usePlaintext()
-                .build()
-
-            channel.shutdownNow()
 
             true
         } catch (_: Exception) {

--- a/maestro-ios/README.md
+++ b/maestro-ios/README.md
@@ -1,30 +1,20 @@
 # iOS Device Config
 
-A wrapper around idb to communicate with iOS devices.
+A wrapper around `simctl` and XCTest to communicate with iOS devices.
 
 ## Prerequisites
 
-### idb
-To test on iOS devices you need to install [Facebook's idb tool](https://fbidb.io/).
-
 ### Xcode
-Install Xcode 13 (command line tools are not enough, install the full IDE).
+
+Install the latest Xcode (Command Line Tools are not enough, install the full IDE).
 
 ### IntelliJ setup
-If you are working with this module, update your IntelliJ config (Help -> Edit Custom Properties) by including the following lines:
+
+If you are working with this subproject, update your IntelliJ config (Help -> Edit Custom Properties) by including the following lines:
 
 ```
 # Needed for working with idb.proto definition
 idea.max.intellisense.filesize=4000
 ```
 
-Restart the IDE
-
-## Testing on iOS devices
-
-1. List the devices with `idb_companion --list 1`
-2. Pick a simulator from the list and note its UDID
-3. Launch the simulator with `idb_companion --boot {udid}`
-4. Connect to the simulator with `idb_companion --udid {udid}`
-
-You are good to go!
+Then restart the IDE.


### PR DESCRIPTION
Maestro doesn't use `idb` in any way since [v1.31.0](https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#1310).