### PR TITLE
Allow for redacting/hiding sensitive test in `inputText` command

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -478,8 +478,10 @@ class Maestro(
         return driver.waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs)
     }
 
-    fun inputText(text: String) {
-        LOGGER.info("Inputting text: $text")
+    fun inputText(text: String) = inputText(text, text)
+
+    fun inputText(text: String, redacted: String) {
+        LOGGER.info("Inputting text: $redacted")
 
         driver.inputText(text)
         waitForAppToSettle()

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -464,13 +464,17 @@ data class InputTextCommand(
     val redacted: String get() = if (redact) "[REDACTED]" else text
 
     override fun description(): String {
-        return label ?: "Input text $text"
+        return label ?: "Input text $redacted"
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): InputTextCommand {
         return copy(
             text = text.evaluateScripts(jsEngine)
         )
+    }
+
+    override fun toString(): String {
+        return "InputTextCommand(text=$redacted,label=$label)"
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -458,7 +458,10 @@ data class InputTextCommand(
     val text: String,
     override val label: String? = null,
     override val optional: Boolean = false,
+    val redact: Boolean = false,
 ) : Command {
+
+    val redacted: String get() = if (redact) "[REDACTED]" else text
 
     override fun description(): String {
         return label ?: "Input text $text"

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -20,7 +20,9 @@
 package maestro.orchestra
 
 import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
 import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import maestro.KeyCode
 import maestro.Point
@@ -457,6 +459,7 @@ data class ExtractTextWithAICommand(
     }
 }
 
+@JsonSerialize(using = InputTextCommand.Serializer::class)
 data class InputTextCommand(
     val text: String,
     override val label: String? = null,
@@ -480,10 +483,7 @@ data class InputTextCommand(
         return "InputTextCommand(text=$redacted,label=$label)"
     }
 
-    class Serializer : StdSerializer<InputTextCommand> {
-
-        constructor() : super(InputTextCommand::class.java)
-        constructor(item: Class<InputTextCommand>) : super(item)
+    class Serializer : JsonSerializer<InputTextCommand>() {
 
         override fun serialize(value: InputTextCommand, gen: JsonGenerator, provider: SerializerProvider) = with (gen) {
             writeStartObject()

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -19,6 +19,9 @@
 
 package maestro.orchestra
 
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import maestro.KeyCode
 import maestro.Point
 import maestro.ScrollDirection
@@ -475,6 +478,20 @@ data class InputTextCommand(
 
     override fun toString(): String {
         return "InputTextCommand(text=$redacted,label=$label)"
+    }
+
+    class Serializer : StdSerializer<InputTextCommand> {
+
+        constructor() : super(InputTextCommand::class.java)
+        constructor(item: Class<InputTextCommand>) : super(item)
+
+        override fun serialize(value: InputTextCommand, gen: JsonGenerator, provider: SerializerProvider) = with (gen) {
+            writeStartObject()
+            writeStringField("text", value.redacted)
+            if (value.label != null) writeStringField("label", value.label)
+            if (value.redact) writeBooleanField("redact", true)
+            writeEndObject()
+        }
     }
 }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -897,10 +897,10 @@ class Orchestra(
                 .canEncode(command.text)
 
             if (!isAscii) {
-                throw UnicodeNotSupportedError(command.text)
+                throw UnicodeNotSupportedError(command.redacted)
             }
         }
-        maestro.inputText(command.text)
+        maestro.inputText(command.text, command.redacted)
 
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -208,7 +208,8 @@ data class YamlFluentCommand(
                     InputTextCommand(
                         text = inputText.text,
                         label = inputText.label,
-                        optional = inputText.optional
+                        optional = inputText.optional,
+                        redact = inputText.redact
                     )
                 )
             )
@@ -219,7 +220,8 @@ data class YamlFluentCommand(
                         inputType = InputRandomType.TEXT,
                         length = inputRandomText.length,
                         label = inputRandomText.label,
-                        optional = inputRandomText.optional
+                        optional = inputRandomText.optional,
+                        redact = inputRandomText.redact
                     )
                 )
             )
@@ -230,7 +232,8 @@ data class YamlFluentCommand(
                         inputType = InputRandomType.NUMBER,
                         length = inputRandomNumber.length,
                         label = inputRandomNumber.label,
-                        optional = inputRandomNumber.optional
+                        optional = inputRandomNumber.optional,
+                        redact = inputRandomNumber.redact
                     )
                 )
             )
@@ -240,7 +243,8 @@ data class YamlFluentCommand(
                     InputRandomCommand(
                         inputType = InputRandomType.TEXT_EMAIL_ADDRESS,
                         label = inputRandomEmail.label,
-                        optional = inputRandomEmail.optional
+                        optional = inputRandomEmail.optional,
+                        redact = inputRandomEmail.redact
                     )
                 )
             )
@@ -250,7 +254,8 @@ data class YamlFluentCommand(
                     InputRandomCommand(
                         inputType = InputRandomType.TEXT_PERSON_NAME,
                         label = inputRandomPersonName.label,
-                        optional = inputRandomPersonName.optional
+                        optional = inputRandomPersonName.optional,
+                        redact = inputRandomPersonName.redact
                     )
                 )
             )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlInputText.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlInputText.kt
@@ -7,6 +7,7 @@ data class YamlInputText(
     val text: String,
     val label: String? = null,
     val optional: Boolean = false,
+    val redact: Boolean = false,
 ) {
 
     companion object {
@@ -19,7 +20,8 @@ data class YamlInputText(
                 is Map<*, *> -> {
                     val input = text.getOrDefault("text", "") as String
                     val label = text.getOrDefault("label", null) as String?
-                    return YamlInputText(input, label)
+                    val redact = text.getOrDefault("redact", "false") as Boolean
+                    return YamlInputText(input, label, redact)
                 }
                 is Int, is Long, is Char, is Boolean, is Float, is Double -> text.toString()
                 else -> throw UnsupportedOperationException("Cannot deserialize input text with data type ${text.javaClass}")

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -280,6 +280,30 @@ internal class MaestroCommandSerializationTest {
     }
 
     @Test
+    fun `serialize redacted InputTextCommand`() {
+        // given
+        val command = MaestroCommand(
+            InputTextCommand("secret password", redact = true)
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "inputTextCommand" : {
+                "text" : "[REDACTED]",
+                "redact" : true
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+    }
+
+    @Test
     fun `serialize LaunchAppCommand`() {
         // given
         val command = MaestroCommand(
@@ -595,7 +619,10 @@ internal class MaestroCommandSerializationTest {
             .writerWithDefaultPrettyPrinter()
             .writeValueAsString(this)
 
+    private val module = KotlinModule.Builder().build()
+        .addSerializer(InputTextCommand.Serializer())
+
     private val objectMapper = ObjectMapper()
         .setSerializationInclusion(Include.NON_NULL)
-        .registerModule(KotlinModule.Builder().build())
+        .registerModule(module)
 }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -285,11 +285,6 @@ internal class MaestroCommandSerializationTest {
         val command = MaestroCommand(
             InputTextCommand("secret password", redact = true)
         )
-
-        // when
-        val serializedCommandJson = command.toJson()
-
-        // then
         @Language("json")
         val expectedJson = """
             {
@@ -299,8 +294,17 @@ internal class MaestroCommandSerializationTest {
               }
             }
           """.trimIndent()
+
+        // when
+        val serializedCommandJson = command.toJson()
+        val deserializedCommand = objectMapper.readValue(serializedCommandJson, MaestroCommand::class.java)
+
+        // then
+        val expectedDeserialized = MaestroCommand(InputTextCommand("[REDACTED]", redact = true))
         assertThat(serializedCommandJson)
             .isEqualTo(expectedJson)
+        assertThat(deserializedCommand)
+            .isEqualTo(expectedDeserialized)
     }
 
     @Test
@@ -619,10 +623,7 @@ internal class MaestroCommandSerializationTest {
             .writerWithDefaultPrettyPrinter()
             .writeValueAsString(this)
 
-    private val module = KotlinModule.Builder().build()
-        .addSerializer(InputTextCommand.Serializer())
-
     private val objectMapper = ObjectMapper()
         .setSerializationInclusion(Include.NON_NULL)
-        .registerModule(module)
+        .registerModule(KotlinModule.Builder().build())
 }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -342,7 +342,8 @@ internal class YamlCommandReaderTest {
             // Inputs
             InputTextCommand(
                 text = "correct horse battery staple",
-                label = "Enter my secret password"
+                label = "Enter my secret password",
+                redact = true
             ),
             InputRandomCommand(
                 inputType = InputRandomType.TEXT_EMAIL_ADDRESS,

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/023_labels.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/023_labels.yaml
@@ -29,6 +29,7 @@ appId: com.example.app
 - inputText:
       text: "correct horse battery staple"
       label: "Enter my secret password"
+      redact: true
 - inputRandomEmail:
       label: "Enter a random email address"
 - inputRandomPersonName:

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -344,7 +344,8 @@ class IntegrationTest {
         // No test failure
         driver.assertHasEvent(Event.InputText("Hello World"))
         driver.assertHasEvent(Event.InputText("user@example.com"))
-        driver.assertCurrentTextInput("Hello Worlduser@example.com")
+        driver.assertHasEvent(Event.InputText("secret password"))
+        driver.assertCurrentTextInput("Hello Worlduser@example.comsecret password")
     }
 
     @Test

--- a/maestro-test/src/test/resources/012_input_text.yaml
+++ b/maestro-test/src/test/resources/012_input_text.yaml
@@ -2,3 +2,6 @@ appId: com.example.app
 ---
 - inputText: "Hello World"
 - inputText: user@example.com
+- inputText:
+    text: "secret password"
+    redact: true


### PR DESCRIPTION
## Proposed changes

- Add a `redact` boolean field to the `inputText` command
- In the case it's set to `true`, replace the value of `text` to `"[REDACTED]"` in the following locations:
  - The console output when `--format=NOOP`
  - `maestro.log`
  - `commands-(<flow>).json`

I chose to use `redact` instead of `mask` and `[REDACTED]` instead of `XXXX` as it seemed clearer but feel free to ask if you want it changed back.

## Testing

I added 3 test cases: 
 - The JSON serialization of the `InputTextCommand` (No deserialization though)
 - The correct parsing of the Yaml `redact` field
 - The correct input of the non-redacted text value

I ran the following commands:
- Run `./gradlew :maestro-test:test`
- Run `./gradlew :maestro-cli:test`
- Run `./gradlew :maestro-client:test`
- Run `./gradlew :maestro-orchestra:test`
- Run `./gradlew :maestro-orchestra-models:test`

### Manual tests

The tests below have been done manually. I tried seeing how to automate them, but ideally, this needs to be able to intercept the `LOGGER` calls in `IntegrationTest.kt`. Please advise if you want me to add tests for the cases below.

- Build the cli and then run `012_input_text.yaml`
  - Run `./gradlew maestro-cli:installDist`
  - Run `./maestro-cli/build/install/maestro/bin/maestro test maestro-test/src/test/resources/012_input_text.yaml`
  - Check for the absence of the value "secret password"
    - In the console output
    - In `~/.maestro/tests/<timestamp>/maestro.log`
    - In `~/.maestro/tests/<timestamp>/commands-(012_input_text.yaml).json` 
  - Replace "secret password" with "💸" in `012_input_text.yaml`
    - Run the flow `012_input_text.yaml` on an Android device
    - Check for the absence of the value "💸" in the same locations (console output, `maestro.log` and `commands-(012_input_text.yaml).json`)

Here are sample files with the results:

[commands-(012_input_text.yaml).json](https://github.com/user-attachments/files/16737631/commands-.012_input_text.yaml.json)
[maestro.log](https://github.com/user-attachments/files/16737632/maestro.log)
[output.txt](https://github.com/user-attachments/files/16737644/output.txt)

With "💸" replacing "secret password" on Android :

[commands-(012_input_text.yaml).json](https://github.com/user-attachments/files/16737642/commands-.012_input_text.yaml.json)
[maestro.log](https://github.com/user-attachments/files/16737643/maestro.log)
[output.txt](https://github.com/user-attachments/files/16737645/output.txt)

## Issues fixed

Fixes #1226