### PR TITLE
Add filename to env

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Path
 import kotlin.concurrent.thread
+import maestro.orchestra.util.Env.withDefaultEnvVars
 
 /**
  * Knows how to run a single Maestro flow (either one-shot or continuously).
@@ -52,7 +53,7 @@ object TestRunner {
 
         val result = runCatching(resultView, maestro) {
             val commands = YamlCommandReader.readCommands(flowFile.toPath())
-                .withEnv(env)
+                .withEnv(env.withDefaultEnvVars(flowFile.nameWithoutExtension))
 
             YamlCommandReader.getConfig(commands)?.name?.let {
                 aiOutput = aiOutput.copy(flowName = it)
@@ -108,7 +109,7 @@ object TestRunner {
 
                 val commands = YamlCommandReader
                     .readCommands(flowFile.toPath())
-                    .withEnv(env)
+                    .withEnv(env.withDefaultEnvVars(flowFile.nameWithoutExtension))
 
                 // Restart the flow if anything has changed
                 if (commands != previousCommands) {

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -28,6 +28,7 @@ import java.io.File
 import java.nio.file.Path
 import kotlin.system.measureTimeMillis
 import kotlin.time.Duration.Companion.seconds
+import maestro.orchestra.util.Env.withDefaultEnvVars
 
 /**
  * Similar to [TestRunner], but:
@@ -191,7 +192,7 @@ class TestSuiteInteractor(
             try {
                 val commands = YamlCommandReader
                     .readCommands(flowFile.toPath())
-                    .withEnv(env)
+                    .withEnv(env.withDefaultEnvVars(flowFile.nameWithoutExtension))
 
                 YamlCommandReader.getConfig(commands)?.name?.let { flowName = it }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -46,5 +46,5 @@ object Env {
     }
 
     fun Map<String, String>.withDefaultEnvVars(fileName: String? = null) =
-        fileName?.let { this + mapOf("FILENAME" to fileName) } ?: this
+        fileName?.let { this + mapOf("MAESTRO_FILENAME" to fileName) } ?: this
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -44,4 +44,7 @@ object Env {
 
         return mutable
     }
+
+    fun Map<String, String>.withDefaultEnvVars(fileName: String? = null) =
+        fileName?.let { this + mapOf("FILENAME" to fileName) } ?: this
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -116,7 +116,7 @@ object YamlCommandReader {
         val commands = parser.readValueAs<List<YamlFluentCommand>>(
             object : TypeReference<List<YamlFluentCommand>>() {}
         )
-        return config.copy(env = config.env.withDefaultEnvVars(flowPath.nameWithoutExtension)) to commands
+        return config.copy(env = config.env) to commands
     }
 
     private fun <T> mapParsingErrors(path: Path, block: () -> T): T {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -30,12 +30,14 @@ import java.nio.file.Path
 import kotlin.io.path.absolute
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.isDirectory
+import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.readText
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
 import maestro.orchestra.error.SyntaxError
+import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withEnv
 
 object YamlCommandReader {
@@ -114,7 +116,7 @@ object YamlCommandReader {
         val commands = parser.readValueAs<List<YamlFluentCommand>>(
             object : TypeReference<List<YamlFluentCommand>>() {}
         )
-        return config to commands
+        return config.copy(env = config.env.withDefaultEnvVars(flowPath.nameWithoutExtension)) to commands
     }
 
     private fun <T> mapParsingErrors(path: Path, block: () -> T): T {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -15,9 +15,8 @@ data class YamlConfig(
     val env: Map<String, String> = emptyMap(),
     val onFlowStart: YamlOnFlowStart?,
     val onFlowComplete: YamlOnFlowComplete?,
+    private val ext: MutableMap<String, Any?> = mutableMapOf<String, Any?>()
 ) {
-
-    private val ext = mutableMapOf<String, Any?>()
 
     @JsonAnySetter
     fun setOtherField(key: String, other: Any?) {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -77,7 +77,6 @@ internal class YamlCommandReaderTest {
                 ApplyConfigurationCommand(MaestroConfig(
                     appId = "com.example.app"
                 )),
-                DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "002_launchApp")),
                 LaunchAppCommand(
                     appId = "com.example.app"
                 ),
@@ -92,7 +91,6 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "003_launchApp_withClearState")),
             LaunchAppCommand(
                 appId = "com.example.app",
                 clearState = true,
@@ -136,7 +134,6 @@ internal class YamlCommandReaderTest {
                     "extraArray" to listOf("itemA")
                 )
             )),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "008_config_unknownKeys")),
             LaunchAppCommand(
                 appId = "com.example.app",
             ),
@@ -179,7 +176,6 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "017_launchApp_otherPackage")),
             LaunchAppCommand(
                 appId = "com.other.app"
             ),
@@ -194,7 +190,6 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "018_backPress_string")),
             BackPressCommand(),
         )
     }
@@ -207,7 +202,6 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "019_scroll_string")),
             ScrollCommand(),
         )
     }
@@ -221,7 +215,6 @@ internal class YamlCommandReaderTest {
                 appId = "com.example.app",
                 name = "Example Flow"
             )),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "020_config_name")),
             LaunchAppCommand(
                 appId = "com.example.app"
             ),
@@ -245,7 +238,6 @@ internal class YamlCommandReaderTest {
                     appId = "com.example.app"
                 )
             ),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "flow")),
             LaunchAppCommand(
                 appId = "com.example.app"
             )
@@ -279,7 +271,6 @@ internal class YamlCommandReaderTest {
                     )
                 )
             ),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "022_on_flow_start_complete")),
             LaunchAppCommand(
                 appId = "com.example.app"
             )
@@ -296,7 +287,6 @@ internal class YamlCommandReaderTest {
                     appId="com.example.app"
                 )
             ),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "023_labels")),
 
             // Taps
             TapOnElementCommand(
@@ -531,7 +521,6 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(
                 config= MaestroConfig(appId= "com.example.app")
             ),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "024_string_non_string_commands")),
             InputTextCommand(text = "correct horse battery staple"),
             InputTextCommand(text = "correct horse battery staple"),
             InputTextCommand(text = "4"),
@@ -608,7 +597,6 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app"
             )),
-            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "025_killApp")),
             KillAppCommand(
                 appId = "com.example.app"
             ),

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -77,7 +77,7 @@ internal class YamlCommandReaderTest {
                 ApplyConfigurationCommand(MaestroConfig(
                     appId = "com.example.app"
                 )),
-                DefineVariablesCommand(env = mapOf("FILENAME" to "002_launchApp")),
+                DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "002_launchApp")),
                 LaunchAppCommand(
                     appId = "com.example.app"
                 ),
@@ -92,7 +92,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "003_launchApp_withClearState")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "003_launchApp_withClearState")),
             LaunchAppCommand(
                 appId = "com.example.app",
                 clearState = true,
@@ -136,7 +136,7 @@ internal class YamlCommandReaderTest {
                     "extraArray" to listOf("itemA")
                 )
             )),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "008_config_unknownKeys")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "008_config_unknownKeys")),
             LaunchAppCommand(
                 appId = "com.example.app",
             ),
@@ -179,7 +179,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "017_launchApp_otherPackage")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "017_launchApp_otherPackage")),
             LaunchAppCommand(
                 appId = "com.other.app"
             ),
@@ -194,7 +194,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "018_backPress_string")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "018_backPress_string")),
             BackPressCommand(),
         )
     }
@@ -207,7 +207,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "019_scroll_string")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "019_scroll_string")),
             ScrollCommand(),
         )
     }
@@ -221,7 +221,7 @@ internal class YamlCommandReaderTest {
                 appId = "com.example.app",
                 name = "Example Flow"
             )),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "020_config_name")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "020_config_name")),
             LaunchAppCommand(
                 appId = "com.example.app"
             ),
@@ -245,7 +245,7 @@ internal class YamlCommandReaderTest {
                     appId = "com.example.app"
                 )
             ),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "flow")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "flow")),
             LaunchAppCommand(
                 appId = "com.example.app"
             )
@@ -279,7 +279,7 @@ internal class YamlCommandReaderTest {
                     )
                 )
             ),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "022_on_flow_start_complete")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "022_on_flow_start_complete")),
             LaunchAppCommand(
                 appId = "com.example.app"
             )
@@ -296,7 +296,7 @@ internal class YamlCommandReaderTest {
                     appId="com.example.app"
                 )
             ),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "023_labels")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "023_labels")),
 
             // Taps
             TapOnElementCommand(
@@ -531,7 +531,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(
                 config= MaestroConfig(appId= "com.example.app")
             ),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "024_string_non_string_commands")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "024_string_non_string_commands")),
             InputTextCommand(text = "correct horse battery staple"),
             InputTextCommand(text = "correct horse battery staple"),
             InputTextCommand(text = "4"),
@@ -608,7 +608,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app"
             )),
-            DefineVariablesCommand(env = mapOf("FILENAME" to "025_killApp")),
+            DefineVariablesCommand(env = mapOf("MAESTRO_FILENAME" to "025_killApp")),
             KillAppCommand(
                 appId = "com.example.app"
             ),

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -15,6 +15,7 @@ import maestro.orchestra.ClearStateCommand
 import maestro.orchestra.Command
 import maestro.orchestra.Condition
 import maestro.orchestra.CopyTextFromCommand
+import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.EraseTextCommand
 import maestro.orchestra.EvalScriptCommand
@@ -76,6 +77,7 @@ internal class YamlCommandReaderTest {
                 ApplyConfigurationCommand(MaestroConfig(
                     appId = "com.example.app"
                 )),
+                DefineVariablesCommand(env = mapOf("FILENAME" to "002_launchApp")),
                 LaunchAppCommand(
                     appId = "com.example.app"
                 ),
@@ -90,6 +92,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "003_launchApp_withClearState")),
             LaunchAppCommand(
                 appId = "com.example.app",
                 clearState = true,
@@ -133,6 +136,7 @@ internal class YamlCommandReaderTest {
                     "extraArray" to listOf("itemA")
                 )
             )),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "008_config_unknownKeys")),
             LaunchAppCommand(
                 appId = "com.example.app",
             ),
@@ -175,6 +179,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "017_launchApp_otherPackage")),
             LaunchAppCommand(
                 appId = "com.other.app"
             ),
@@ -189,6 +194,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "018_backPress_string")),
             BackPressCommand(),
         )
     }
@@ -201,6 +207,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
             )),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "019_scroll_string")),
             ScrollCommand(),
         )
     }
@@ -214,6 +221,7 @@ internal class YamlCommandReaderTest {
                 appId = "com.example.app",
                 name = "Example Flow"
             )),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "020_config_name")),
             LaunchAppCommand(
                 appId = "com.example.app"
             ),
@@ -237,6 +245,7 @@ internal class YamlCommandReaderTest {
                     appId = "com.example.app"
                 )
             ),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "flow")),
             LaunchAppCommand(
                 appId = "com.example.app"
             )
@@ -270,6 +279,7 @@ internal class YamlCommandReaderTest {
                     )
                 )
             ),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "022_on_flow_start_complete")),
             LaunchAppCommand(
                 appId = "com.example.app"
             )
@@ -286,6 +296,7 @@ internal class YamlCommandReaderTest {
                     appId="com.example.app"
                 )
             ),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "023_labels")),
 
             // Taps
             TapOnElementCommand(
@@ -520,6 +531,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(
                 config= MaestroConfig(appId= "com.example.app")
             ),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "024_string_non_string_commands")),
             InputTextCommand(text = "correct horse battery staple"),
             InputTextCommand(text = "correct horse battery staple"),
             InputTextCommand(text = "4"),
@@ -596,6 +608,7 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app"
             )),
+            DefineVariablesCommand(env = mapOf("FILENAME" to "025_killApp")),
             KillAppCommand(
                 appId = "com.example.app"
             ),

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -30,6 +30,7 @@ import java.io.File
 import java.nio.file.Paths
 import maestro.orchestra.error.SyntaxError
 import kotlin.system.measureTimeMillis
+import maestro.orchestra.util.Env.withDefaultEnvVars
 
 class IntegrationTest {
 
@@ -739,20 +740,19 @@ class IntegrationTest {
     @Test
     fun `Case 028 - Env`() {
         // Given
-        val commands = readCommands("028_env")
-            .withEnv(
-                mapOf(
-                    "APP_ID" to "com.example.app",
-                    "BUTTON_ID" to "button_id",
-                    "BUTTON_TEXT" to "button_text",
-                    "PASSWORD" to "testPassword",
-                    "NON_EXISTENT_TEXT" to "nonExistentText",
-                    "NON_EXISTENT_ID" to "nonExistentId",
-                    "URL" to "secretUrl",
-                    "LAT" to "37.82778",
-                    "LNG" to "-122.48167",
-                )
+        val commands = readCommands("028_env") {
+            mapOf(
+                "APP_ID" to "com.example.app",
+                "BUTTON_ID" to "button_id",
+                "BUTTON_TEXT" to "button_text",
+                "PASSWORD" to "testPassword",
+                "NON_EXISTENT_TEXT" to "nonExistentText",
+                "NON_EXISTENT_ID" to "nonExistentId",
+                "URL" to "secretUrl",
+                "LAT" to "37.82778",
+                "LNG" to "-122.48167",
             )
+        }
 
         val driver = driver {
 
@@ -1329,12 +1329,11 @@ class IntegrationTest {
     @Test
     fun `Case 049 - Run flow conditionally`() {
         // Given
-        val commands = readCommands("049_run_flow_conditionally")
-            .withEnv(
-                mapOf(
-                    "NOT_CLICKED" to "Not Clicked"
-                )
+        val commands = readCommands("049_run_flow_conditionally") {
+            mapOf(
+                "NOT_CLICKED" to "Not Clicked"
             )
+        }
 
         val driver = driver {
             val indicator = element {
@@ -1553,12 +1552,11 @@ class IntegrationTest {
     @Test
     fun `Case 057 - Pass inner env variables to runFlow`() {
         // Given
-        val commands = readCommands("057_runFlow_env")
-            .withEnv(
-                mapOf(
-                    "OUTER_ENV" to "Outer Parameter"
-                )
+        val commands = readCommands("057_runFlow_env") {
+            mapOf(
+                "OUTER_ENV" to "Outer Parameter"
             )
+        }
 
         val driver = driver {
         }
@@ -1612,12 +1610,11 @@ class IntegrationTest {
     @Test
     fun `Case 060 - Pass env param to an env param`() {
         // given
-        val commands = readCommands("060_pass_env_to_env")
-            .withEnv(
-                mapOf(
-                    "PARAM" to "Value"
-                )
+        val commands = readCommands("060_pass_env_to_env") {
+            mapOf(
+                "PARAM" to "Value"
             )
+        }
         val driver = driver { }
 
         // when
@@ -2043,12 +2040,11 @@ class IntegrationTest {
     @Test
     fun `Case 077 - Env special characters`() {
         // Given
-        val commands = readCommands("077_env_special_characters")
-            .withEnv(
-                mapOf(
-                    "OUTER" to "!@#\$&*()_+{}|:\"<>?[]\\\\;',./"
-                )
+        val commands = readCommands("077_env_special_characters") {
+            mapOf(
+                "OUTER" to "!@#\$&*()_+{}|:\"<>?[]\\\\;',./"
             )
+        }
 
         val driver = driver {
             // No elements
@@ -3132,10 +3128,11 @@ class IntegrationTest {
         return driver
     }
 
-    private fun readCommands(caseName: String): List<MaestroCommand> {
+    private fun readCommands(caseName: String, withEnv: () -> Map<String, String> = { emptyMap() }): List<MaestroCommand> {
         val resource = javaClass.classLoader.getResource("$caseName.yaml")
             ?: throw IllegalArgumentException("File $caseName.yaml not found")
         return YamlCommandReader.readCommands(Paths.get(resource.toURI()))
+            .withEnv(withEnv().withDefaultEnvVars(caseName))
     }
 
 }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -7,6 +7,7 @@ import maestro.MaestroException
 import maestro.Point
 import maestro.SwipeDirection
 import maestro.orchestra.ApplyConfigurationCommand
+import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
@@ -556,6 +557,11 @@ class IntegrationTest {
                         config = MaestroConfig(
                             appId = "com.example.app"
                         )
+                    )
+                ),
+                MaestroCommand(
+                    DefineVariablesCommand(
+                        env = mapOf("FILENAME" to "020_parse_config")
                     )
                 ),
                 MaestroCommand(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -561,7 +561,7 @@ class IntegrationTest {
                 ),
                 MaestroCommand(
                     DefineVariablesCommand(
-                        env = mapOf("FILENAME" to "020_parse_config")
+                        env = mapOf("MAESTRO_FILENAME" to "020_parse_config")
                     )
                 ),
                 MaestroCommand(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -555,15 +555,15 @@ class IntegrationTest {
         assertThat(commands).isEqualTo(
             listOf(
                 MaestroCommand(
+                    DefineVariablesCommand(
+                        env = mapOf("MAESTRO_FILENAME" to "020_parse_config")
+                    )
+                ),
+                MaestroCommand(
                     ApplyConfigurationCommand(
                         config = MaestroConfig(
                             appId = "com.example.app"
                         )
-                    )
-                ),
-                MaestroCommand(
-                    DefineVariablesCommand(
-                        env = mapOf("MAESTRO_FILENAME" to "020_parse_config")
                     )
                 ),
                 MaestroCommand(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -41,8 +41,8 @@ class IntegrationTest {
 
     @AfterEach
     internal fun tearDown() {
-        File("screenshot.png").delete()
-        File("recording.mp4").delete()
+        File("041_take_screenshot_with_filename.png").delete()
+        File("099_screen_recording.mp4").delete()
     }
 
     @Test
@@ -1112,6 +1112,7 @@ class IntegrationTest {
                 Event.TakeScreenshot,
             )
         )
+        assert(File("041_take_screenshot_with_filename.png").exists())
     }
 
     @Test
@@ -2662,6 +2663,7 @@ class IntegrationTest {
                 Event.StopRecording,
             )
         )
+        assert(File("099_screen_recording.mp4").exists())
     }
 
     @Test

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1717,8 +1717,10 @@ class IntegrationTest {
                 Event.InputText("Sub"),
                 Event.InputText("Main"),
                 Event.InputText("Sub"),
+                Event.InputText("064_js_files"),
                 Event.InputText("Hello, Input Parameter!"),
                 Event.InputText("Hello, Evaluated Parameter!"),
+                Event.InputText("064_js_files"),
             )
         )
     }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -45,6 +45,7 @@ class IntegrationTest {
     internal fun tearDown() {
         File("041_take_screenshot_with_filename.png").delete()
         File("099_screen_recording.mp4").delete()
+        File("028_env.mp4").delete()
     }
 
     @Test
@@ -780,8 +781,10 @@ class IntegrationTest {
                 Event.InputText("\${PASSWORD} is testPassword"),
                 Event.OpenLink("https://example.com/secretUrl"),
                 Event.SetLocation(latitude = 37.82778, longitude = -122.48167),
+                Event.StartRecording,
             )
         )
+        assert(File("028_env.mp4").exists())
     }
 
     @Test

--- a/maestro-test/src/test/resources/028_env.yaml
+++ b/maestro-test/src/test/resources/028_env.yaml
@@ -21,3 +21,4 @@ appId: com.example.app
 - setLocation:
     latitude: ${LAT}
     longitude: ${LNG}
+- startRecording: ${MAESTRO_FILENAME}

--- a/maestro-test/src/test/resources/041_take_screenshot.yaml
+++ b/maestro-test/src/test/resources/041_take_screenshot.yaml
@@ -1,3 +1,3 @@
 appId: com.example.app
 ---
-- takeScreenshot: ${FILENAME}_with_filename
+- takeScreenshot: ${MAESTRO_FILENAME}_with_filename

--- a/maestro-test/src/test/resources/041_take_screenshot.yaml
+++ b/maestro-test/src/test/resources/041_take_screenshot.yaml
@@ -1,3 +1,3 @@
 appId: com.example.app
 ---
-- takeScreenshot: screenshot
+- takeScreenshot: ${FILENAME}_with_filename

--- a/maestro-test/src/test/resources/064_js_files.yaml
+++ b/maestro-test/src/test/resources/064_js_files.yaml
@@ -6,6 +6,7 @@ appId: com.example.app
 - inputText: ${output.sharedResult}
 - inputText: ${output.mainFlow.result}
 - inputText: ${output.subFlow.result}
+- inputText: ${output.subFlowFileName}
 - runScript:
     file: 064_script_with_args.js
     env:
@@ -16,3 +17,4 @@ appId: com.example.app
     env:
       parameter: ${'Evaluated Parameter'}
 - inputText: ${output.resultWithParameters}
+- inputText: ${output.fileName}

--- a/maestro-test/src/test/resources/064_script.js
+++ b/maestro-test/src/test/resources/064_script.js
@@ -2,3 +2,4 @@ output.sharedResult = 'Main'
 output.mainFlow = {
   result: 'Main'
 }
+output.fileName = MAESTRO_FILENAME

--- a/maestro-test/src/test/resources/064_script_alt.js
+++ b/maestro-test/src/test/resources/064_script_alt.js
@@ -2,3 +2,4 @@ output.sharedResult = 'Sub'
 output.subFlow = {
   result: 'Sub'
 }
+output.subFlowFileName = MAESTRO_FILENAME

--- a/maestro-test/src/test/resources/099_screen_recording.yaml
+++ b/maestro-test/src/test/resources/099_screen_recording.yaml
@@ -1,4 +1,4 @@
 appId: com.other.app
 ---
-- startRecording: ${FILENAME}
+- startRecording: ${MAESTRO_FILENAME}
 - stopRecording

--- a/maestro-test/src/test/resources/099_screen_recording.yaml
+++ b/maestro-test/src/test/resources/099_screen_recording.yaml
@@ -1,4 +1,4 @@
 appId: com.other.app
 ---
-- startRecording: recording
+- startRecording: ${FILENAME}
 - stopRecording


### PR DESCRIPTION
## Proposed changes

- Set `FILENAME` env value to the flow file's name
- This happens only in the context of the test and does not alter the system env

## Testing

I updated 2 of the integration tests to use the `FILENAME` env var and check their correct naming

Run ./gradlew :maestro-test:test
Run ./gradlew :maestro-orchestra:test
Run ./gradlew :maestro-orchestra-models:test

## Issues fixed

Fixes #1616 