### PR TITLE
Delete apks after using them

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -525,6 +525,7 @@ class AndroidDriver(
         val appNameResult = runCatching {
             val apkFile = AndroidAppFiles.getApkFile(dadb, appId)
             val appName = ApkFile(apkFile).apkMeta.name
+            apkFile.delete()
             appName
         }
         if (appNameResult.isSuccess) {
@@ -775,7 +776,9 @@ class AndroidDriver(
     private fun setAllPermissions(appId: String, permissionValue: String) {
         val permissionsResult = runCatching {
             val apkFile = AndroidAppFiles.getApkFile(dadb, appId)
-            ApkFile(apkFile).apkMeta.usesPermissions
+            val permissions = ApkFile(apkFile).apkMeta.usesPermissions
+            apkFile.delete()
+            permissions
         }
         if (permissionsResult.isSuccess) {
             permissionsResult.getOrNull()?.let {
@@ -964,6 +967,7 @@ class AndroidDriver(
         if (!isPackageInstalled("dev.mobile.maestro")) {
             throw IllegalStateException("dev.mobile.maestro was not installed")
         }
+        maestroAppApk.delete()
     }
 
     private fun installMaestroServerApp() {
@@ -981,6 +985,7 @@ class AndroidDriver(
         if (!isPackageInstalled("dev.mobile.maestro.test")) {
             throw IllegalStateException("dev.mobile.maestro.test was not installed")
         }
+        maestroServerApk.delete()
     }
 
     private fun installMaestroApks() {


### PR DESCRIPTION
## Proposed changes

- Delete temp APKs after being done using them

## Testing

- `./gradlew test`
- Check presence of apks in tmp folder after cleaning it up and running a flow test

```
> ls $TMPDIR*.apk
/var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-app10071856759043844538.apk    /var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-server13015259718004766817.apk
/var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-app10167667838027668975.apk    /var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-server13421232218955671026.apk
/var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-app10340836042534871539.apk    /var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-server13852331780224097929.apk
/var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-app10876012227926208134.apk    /var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-server13895901897188273805.apk

> rm $TMPDIR*.apk

> ls $TMPDIR*.apk
zsh: no matches found: /var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/*.apk

> maestro test flow.yml
[...]

> ls $TMPDIR*.apk
/var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-app10071856759043844538.apk    /var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/maestro-server13015259718004766817.apk

> rm $TMPDIR*.apk

> ./maestro-cli/build/install/maestro/bin/maestro test flow.yaml
[...]

> ls $TMPDIR*.apk
zsh: no matches found: /var/folders/5b/3tmqgg6n74s6gmg1980h87k40000gn/T/*.apk
```

## Issues fixed

Fixes #1005 