### PR TITLE
Fetch, format and display changelog in the CLI update message

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -42,6 +42,7 @@ import picocli.CommandLine.Command
 import picocli.CommandLine.Option
 import java.util.Properties
 import kotlin.system.exitProcess
+import maestro.cli.util.ChangeLogUtils
 
 @Command(
     name = "maestro",
@@ -155,7 +156,7 @@ fun main(args: Array<String>) {
             "A new version of the Maestro CLI is available ($newVersion).\n",
             "See what's new:",
             "https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#$anchor",
-            if (changelog == null) "" else "\n${changelog.joinToString("\n")}\n",
+            ChangeLogUtils.print(changelog),
             "Upgrade command:",
             "curl -Ls \"https://get.maestro.mobile.dev\" | bash",
         ).joinToString("\n").box())

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -147,11 +147,18 @@ fun main(args: Array<String>) {
 
     val newVersion = Updates.checkForUpdates()
     if (newVersion != null) {
+        Updates.fetchChangelogAsync()
         System.err.println()
-        System.err.println(
-            ("A new version of the Maestro CLI is available ($newVersion). Upgrade command:\n" +
-                    "curl -Ls \"https://get.maestro.mobile.dev\" | bash").box()
-        )
+        val changelog = Updates.getChangelog()
+        val anchor = newVersion.toString().replace(".", "")
+        System.err.println(listOf(
+            "A new version of the Maestro CLI is available ($newVersion).\n",
+            "See what's new:",
+            "https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#$anchor",
+            if (changelog == null) "" else "\n${changelog.joinToString("\n")}\n",
+            "Upgrade command:",
+            "curl -Ls \"https://get.maestro.mobile.dev\" | bash",
+        ).joinToString("\n").box())
     }
 
     if (commandLine.isVersionHelpRequested) {

--- a/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
+++ b/maestro-cli/src/main/java/maestro/cli/update/Updates.kt
@@ -7,8 +7,8 @@ import maestro.cli.util.EnvUtils.CLI_VERSION
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import okhttp3.OkHttpClient
-import okhttp3.Request
+import maestro.cli.util.ChangeLogUtils
+import maestro.cli.util.ChangeLog
 
 object Updates {
     private val DEFAULT_THREAD_FACTORY = Executors.defaultThreadFactory()
@@ -65,22 +65,13 @@ object Updates {
         }
     }
 
-    private fun fetchChangelog(): List<String>? {
+    private fun fetchChangelog(): ChangeLog {
         if (CLI_VERSION == null) {
             return null
         }
-        val request = Request.Builder()
-            .url("https://raw.githubusercontent.com/mobile-dev-inc/maestro/main/CHANGELOG.md")
-            .build()
-        val content = OkHttpClient().newCall(request).execute().body?.string()
-        val body = content?.split("\n## ")?.map { it.lines() }
         val version = fetchUpdates()?.toString() ?: return null
-        return body
-            ?.first { it.first().startsWith(version) }
-            ?.drop(1)
-            ?.map { it.trim().replace("**", "") }
-            ?.map { it.replace("\\[(.*?)]\\(.*?\\)".toRegex(), "$1") }
-            ?.filter { it.isNotEmpty() && it.startsWith("- ") }
+        val content = ChangeLogUtils.fetchContent()
+        return ChangeLogUtils.formatBody(content, version)
     }
 
     @Synchronized

--- a/maestro-cli/src/main/java/maestro/cli/util/ChangeLogUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/ChangeLogUtils.kt
@@ -1,0 +1,27 @@
+package maestro.cli.util
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+typealias ChangeLog = List<String>?
+
+object ChangeLogUtils {
+
+    fun formatBody(content: String?, version: String): ChangeLog = content
+        ?.split("\n## ")?.map { it.lines() }
+        ?.first { it.first().startsWith(version) }
+        ?.drop(1)
+        ?.map { it.trim().replace("**", "") }
+        ?.map { it.replace("\\[(.*?)]\\(.*?\\)".toRegex(), "$1") }
+        ?.filter { it.isNotEmpty() && it.startsWith("- ") }
+
+    fun fetchContent(): String? {
+        val request = Request.Builder()
+            .url("https://raw.githubusercontent.com/mobile-dev-inc/maestro/main/CHANGELOG.md")
+            .build()
+        return OkHttpClient().newCall(request).execute().body?.string()
+    }
+
+    fun print(changelog: ChangeLog): String =
+        changelog?.let { "\n${it.joinToString("\n")}\n" }.orEmpty()
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/ChangeLogUtilsTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/ChangeLogUtilsTest.kt
@@ -1,0 +1,78 @@
+package maestro.cli.util
+
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.jupiter.api.Test
+
+class ChangeLogUtilsTest {
+
+    private val changelogFile = File(System.getProperty("user.dir"), "../CHANGELOG.md")
+
+    @Test
+    fun `test format last version`() {
+        val content = changelogFile.readText()
+
+        val changelog = ChangeLogUtils.formatBody(content, "1.38.1")
+
+        assertThat(changelog).containsExactly(
+            "- New commands AI visual testing: assertWithAI and assertNoDefectsWithAI",
+            "- Enable basic support for Maestro uploads while keeping maestro cloud functioning",
+        )
+    }
+
+    @Test
+    fun `test format link and no paragraph`() {
+        val content = changelogFile.readText()
+
+        val changelog = ChangeLogUtils.formatBody(content, "1.37.9")
+
+        assertThat(changelog).containsExactly(
+            "- Revert iOS landscape mode fix (#1916)",
+        )
+    }
+
+    @Test
+    fun `test format no subheader`() {
+        val content = changelogFile.readText()
+
+        val changelog = ChangeLogUtils.formatBody(content, "1.37.1")
+
+        assertThat(changelog).containsExactly(
+            "- Fix crash when `flutter` or `xcodebuild` is not installed (#1839)",
+        )
+    }
+
+    @Test
+    fun `test format strong no paragraph and no sublist`() {
+        val content = changelogFile.readText()
+
+        val changelog = ChangeLogUtils.formatBody(content, "1.37.0")
+
+        assertThat(changelog).containsExactly(
+            "- Sharding tests for parallel execution on many devices 🎉 (#1732 by Kaan)",
+            "- Reports in HTML (#1750 by Depa Panjie Purnama)",
+            "- Homebrew is back!",
+            "- Current platform exposed in JavaScript (#1747 by Dan Caseley)",
+            "- Control airplane mode (#1672 by NyCodeGHG)",
+            "- New `killApp` command (#1727 by Alexandre Favre)",
+            "- Fix cleaning up retries in iOS driver (#1669)",
+            "- Fix some commands not respecting custom labels (#1762 by Dan Caseley)",
+            "- Fix “Protocol family unavailable” when rerunning iOS tests (#1671 by Stanisław Chmiela)",
+        )
+    }
+
+    @Test
+    fun `test print`() {
+        val content = changelogFile.readText()
+        val changelog = ChangeLogUtils.formatBody(content, "1.17.1")
+
+        val printed = ChangeLogUtils.print(changelog)
+
+        assertThat(printed).isEqualTo(
+            "\n" +
+            "- Tweak: Remove Maestro Studio icon from Mac dock\n" +
+            "- Tweak: Prefer port 9999 for Maestro Studio app\n" +
+            "- Fix: Fix Maestro Studio conditional code snippet\n"
+        )
+    }
+}


### PR DESCRIPTION
## Proposed changes

- Fetch, the changelog from Github's `CHANGELOG.md`
- Filter the changes related to the proposed version
- Format them to be suitable for CLI display (remove links, bold and keep only top-level bullets)

## Testing

- Hardcoded some versions as proposed for update and built the project


### Latest version (patches)
```
╭───────────────────────────────────────────────────────────────────────────╮
│                                                                           │
│   A new version of the Maestro CLI is available (1.37.9).                 │
│                                                                           │
│   See what's new:                                                         │
│   https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#1379   │
│                                                                           │
│   - Revert iOS landscape mode fix (#1916)                                 │
│                                                                           │
│   Upgrade command:                                                        │
│   curl -Ls "https://get.maestro.mobile.dev" | bash                        │
│                                                                           │
╰───────────────────────────────────────────────────────────────────────────╯
```
### Big releases (minor versions)
```
╭───────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                               │
│   A new version of the Maestro CLI is available (1.37.0).                                     │
│                                                                                               │
│   See what's new:                                                                             │
│   https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#1370                       │
│                                                                                               │
│   - Sharding tests for parallel execution on many devices 🎉 (#1732 by Kaan)                  │
│   - Reports in HTML (#1750 by Depa Panjie Purnama)                                            │
│   - Homebrew is back!                                                                         │
│   - Current platform exposed in JavaScript (#1747 by Dan Caseley)                             │
│   - Control airplane mode (#1672 by NyCodeGHG)                                                │
│   - New `killApp` command (#1727 by Alexandre Favre)                                          │
│   - Fix cleaning up retries in iOS driver (#1669)                                             │
│   - Fix some commands not respecting custom labels (#1762 by Dan Caseley)                     │
│   - Fix “Protocol family unavailable” when rerunning iOS tests (#1671 by Stanisław Chmiela)   │
│                                                                                               │
│   Upgrade command:                                                                            │
│   curl -Ls "https://get.maestro.mobile.dev" | bash                                            │
│                                                                                               │
╰───────────────────────────────────────────────────────────────────────────────────────────────╯
```
```
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                               │
│   A new version of the Maestro CLI is available (1.35.0).                                                                     │
│                                                                                                                               │
│   See what's new:                                                                                                             │
│   https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#1350                                                       │
│                                                                                                                               │
│   - Change: Adds view class to Android hierarchy output                                                                       │
│   - Change: Improves description of maestro start-device command to include device locale as well                             │
│   - Change: Adds scrollable attribute to Android view hierarchy output                                                        │
│   - Feature: Adds childOf attribute to selector to select from children of a container                                        │
│   - Feature: Adds label attribute to customize the CLI output of maestro commands                                             │
│   - Fix: Fixing “Unsupported architecture UNKNOWN” on linux environment when calling maestro attempts to create devices       │
│   - Fix: Allow maestro to work below API level 25 for Android                                                                 │
│   - Fix: IllegalArgumentException on swipe operation for iOS if the coordinates beyond device width and height are selected   │
│                                                                                                                               │
│   Upgrade command:                                                                                                            │
│   curl -Ls "https://get.maestro.mobile.dev" | bash                                                                            │
│                                                                                                                               │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
```
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                         │
│   A new version of the Maestro CLI is available (1.30.0).                                                                                               │
│                                                                                                                                                         │
│   See what's new:                                                                                                                                       │
│   https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#1300                                                                                 │
│                                                                                                                                                         │
│   - Feature: onFlowStart / onFlowComplete hooks                                                                                                         │
│   - Feature: Maestro Studio revamp                                                                                                                      │
│   - improved design                                                                                                                                     │
│   - search components panel                                                                                                                             │
│   - improved drag-and-drop                                                                                                                              │
│   - Feature: Introduce `--app-binary-id` parameter for Maestro Cloud upload action to be able to re-use a previously uploaded app for different flows   │
│   - Feature: Implement Experimental GraalJsEngine (ECMAScript 2022 compliant)                                                                           │
│   - Fix: Save xctest xcodebuild logs output to system temp dir                                                                                          │
│   - Fix: Close existing screen recording if it was left open.                                                                                           │
│   - Thanks, @carlosmuvi, for the contribution!                                                                                                          │
│   - Fix: Execute sequential Flows even if no other Flows are present                                                                                    │
│   - Fix: Various XCTestClient connection improvements                                                                                                   │
│   - Deprecate: `assertOutgoingRequestsCommand`                                                                                                          │
│   - Deprecate: Network Mocking feature                                                                                                                  │
│   - Deprecate: Maestro Mock Server feature                                                                                                              │
│                                                                                                                                                         │
│   Upgrade command:                                                                                                                                      │
│   curl -Ls "https://get.maestro.mobile.dev" | bash                                                                                                      │
│                                                                                                                                                         │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
### Non existing version (no changelog)
```
╭──────────────────────────────────────────────────────────────────────────╮
│                                                                          │
│   A new version of the Maestro CLI is available (2.0.0).                 │
│                                                                          │
│   See what's new:                                                        │
│   https://github.com/mobile-dev-inc/maestro/blob/main/CHANGELOG.md#200   │
│                                                                          │
│   Upgrade command:                                                       │
│   curl -Ls "https://get.maestro.mobile.dev" | bash                       │
│                                                                          │
╰──────────────────────────────────────────────────────────────────────────╯
```

## Issues fixed

Fixes #776 