### PR TITLE
Fix "E2E prod" workflow

### DIFF
--- a/.github/workflows/test-e2e-prod.yaml
+++ b/.github/workflows/test-e2e-prod.yaml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   test-cloud-production:
-    # this job is the same as e2e-production in mobile-dev-inc/monorepo
+    # This job is copied from "e2e-production" in mobile-dev-inc/monorepo.
+    # We want it here so open-source users can also have some visibility into it.
+
     runs-on: ubuntu-latest
     if: github.repository == 'mobile-dev-inc/maestro'
 

--- a/.github/workflows/test-e2e-prod.yaml
+++ b/.github/workflows/test-e2e-prod.yaml
@@ -38,7 +38,7 @@ jobs:
             --apiKey ${{ secrets.E2E_MOBILE_DEV_API_KEY }} \
             --timeout 180 \
             --fail-on-cancellation \
-            --include-tags=advanced 
+            --include-tags=advanced \
             samples/sample.zip samples
 
       - name: Run Android test

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -36,7 +36,7 @@ jobs:
 
   test-local-android:
     name: Test on Android
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     if: github.repository == 'mobile-dev-inc/maestro'
     needs: build
     


### PR DESCRIPTION
was always failing because of a missing `\` in shell cmd