### PR TITLE
Fix android open link verify

### DIFF
--- a/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
@@ -40,7 +40,13 @@ object AndroidAppFiles {
     fun getApkFile(dadb: Dadb, appId: String): File {
         val apkPath = dadb.shell("pm path $appId").output.removePrefix("package:").trim()
         val dst = File.createTempFile("tmp", ".apk")
-        dadb.pull(dst, apkPath)
+        try {
+            dadb.pull(dst, apkPath)
+        } catch (e: IOException) {
+            val newApkPath = "/sdcard/$appId.apk"
+            dadb.shell("cp $apkPath $newApkPath")
+            dadb.pull(dst, newApkPath)
+        }
         return dst
     }
 

--- a/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
@@ -38,9 +38,7 @@ object AndroidAppFiles {
     }
 
     fun getApkFile(dadb: Dadb, appId: String): File {
-        val apkPath = dadb.shell("pm list packages -f --user 0 | grep $appId | head -1")
-            .output.substringAfterLast("package:").substringBefore("=$appId")
-        apkPath.substringBefore("=$appId")
+        val apkPath = dadb.shell("pm path $appId").output.removePrefix("package:").trim()
         val dst = File.createTempFile("tmp", ".apk")
         dadb.pull(dst, apkPath)
         return dst

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -603,13 +603,12 @@ class AndroidDriver(
             installedPackages.contains("com.android.chrome") -> {
                 dadb.shell("am start -a android.intent.action.VIEW -d \"$link\" com.android.chrome")
             }
-
             installedPackages.contains("org.mozilla.firefox") -> {
                 dadb.shell("am start -a android.intent.action.VIEW -d \"$link\" org.mozilla.firefox")
             }
-
             else -> {
                 dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
+                autoVerifyWithChooser("org.chromium.webview_shell")
             }
         }
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -516,7 +516,7 @@ class AndroidDriver(
     }
 
     private fun autoVerifyLinkFromSettings(appId: String, link: String) {
-        val apiLevel = dadb.shell("getprop ro.build.version.sdk").output.trim().toInt()
+        val apiLevel = getDeviceApiLevel()
         if (apiLevel <= 30) return
         val domain = runCatching { URI.create(link).toURL().host }.getOrNull() ?: return
         val packageOption = "--package $appId"

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -510,7 +510,8 @@ class AndroidDriver(
         else dadb.shell("am start -a android.intent.action.VIEW -d \"$link\"")
 
         if (autoVerify) {
-            autoVerifyApp(appId)
+            if (appId != null && !browser) autoVerifyWithChooser(appId)
+            autoVerifyChromeOnboarding()
         }
     }
 
@@ -530,7 +531,7 @@ class AndroidDriver(
         }
     }
 
-    private fun autoVerifyApp(appId: String?) {
+    private fun autoVerifyWithChooser(appId: String) {
         val appNameResult = runCatching {
             val apkFile = AndroidAppFiles.getApkFile(dadb, appId)
             val appName = ApkFile(apkFile).apkMeta.name
@@ -564,7 +565,7 @@ class AndroidDriver(
         LOGGER.info("Aborting autoVerify. Could not find app name element for $appName")
     }
 
-    private fun autoVerifyChromeAgreement() {
+    private fun autoVerifyChromeOnboarding() {
         val chrome = "com.android.chrome"
         if (!isPackageInstalled(chrome)) return
         Thread.sleep(100) // Lets enough time for the transition to Chrome to start

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -565,9 +565,23 @@ class AndroidDriver(
     }
 
     private fun autoVerifyChromeAgreement() {
-        filterById("com.android.chrome:id/terms_accept")?.let { tap(it.bounds.center()) }
+        val chrome = "com.android.chrome"
+        if (!isPackageInstalled(chrome)) return
+        Thread.sleep(100) // Lets enough time for the transition to Chrome to start
+        waitUntilScreenIsStatic(3000)
+        // Welcome to Chrome screen "Accept & continue"
+        filterById("$chrome:id/send_report_checkbox")?.let { tap(it.bounds.center()) }
+        filterById("$chrome:id/negative_button")?.let { tap(it.bounds.center()) }
+        filterById("$chrome:id/terms_accept")?.let { tap(it.bounds.center()) }
         waitForAppToSettle(null, null)
-        filterById("com.android.chrome:id/negative_button")?.let { tap(it.bounds.center()) }
+        // Welcome to Chrome screen "Add account to device"
+        filterById("$chrome:id/signin_fre_dismiss_button")?.let { tap(it.bounds.center()) }
+        waitForAppToSettle(null, null)
+        // Turn on Sync screen
+        filterById("$chrome:id/negative_button")?.let { tap(it.bounds.center()) }
+        waitForAppToSettle(null, null)
+        // Chrome Notifications screen
+        filterById("$chrome:id/negative_button")?.let { tap(it.bounds.center()) }
     }
 
     private fun filterByText(textRegex: String): UiElement? {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -526,7 +526,7 @@ class AndroidDriver(
             val apkFile = AndroidAppFiles.getApkFile(dadb, appId)
             val appName = ApkFile(apkFile).apkMeta.name
             apkFile.delete()
-            appName
+            appName ?: error("App has no label on main activity.")
         }
         if (appNameResult.isSuccess) {
             val appName = appNameResult.getOrThrow()


### PR DESCRIPTION
## Proposed changes

### TL;DR 

I fixed a whole lot of stuff that was wrong with the `autoVerify`. It should now work as expected.

> [!NOTE]
> I cherry picked the commit from #1998 locally as I seemed to stumble on that same issue in other places as I tested

### Long version

- I started investigating this #1956 issue. It was pretty straightforward to reproduce and fix.
  - The origin is due to the fact that the reading of the app name to tap on the right cell of the Chooser is done through `apkMeta.name` 
  - This value which contains the value defined in `<application android:label="name">` in the Manifest. Which obviously is not mandatory, not guaranteed to be there, and even better, not what the chooser shows as value
  - The fix was simply to check the nullability of the value and throw if it's nullable (because it's a `String!` from Java-world)
  - However, while doing this, I noticed the code related to `autoVerify` and I opened another can of worms...
- `autoVerify` is supposed to do 2 things. Select the right app from the Chooser and validate some of the onboarding screens from Chrome. Both had issues in the way they were implemented
  - Chrome onboarding
    - Depending on the version of Android and Chrome that you have, there are different variations of up to 4 onboarding screens
    - I just fixed the function to handle all of those
  - Selection of the wanted app
    - Before API 31 (Android 12) you always get a Chooser if your app has declared an IntentFilter with ACTION_VIEW on the domain
      - I fixed the code that selects the right app from the Chooser
      - I kept the selection of "Just once" over "Always" even though I've hesitated to switch it 🤔 
      - This is still not perfect as we ultimately would need to get the result of something like 
`intent.resolveActivity(packageManager)` in order to get the labels associated with the right Activities
    - Starting from API 31, there's no more Chooser but there's the whole "Open by default" settings menu
      - I added handling for all of that automatically when `autoVerify` is selected
      - I did not reverse the setting after the link is opened. I think it makes more sense like that I think. Maybe we should align "Just once" in the Chooser? 

## Testing

This is interesting to test. I'm not sure how we can automate that (or if we should). It would make a lot of integration tests. How were the various drivers tested?

### What I did

- First I had a very simple test flow
```
appId: dev.mobile.maestro.app
---
- openLink:
    link: 'https://maestro.mobile.dev'
    autoVerify: true
    browser: false
- openLink:
    link: 'https://maestro.mobile.dev'
    autoVerify: true
    browser: true
```
- I created a new module with a very barebones app `dev.mobile.maestro.app` that I used to test the null name
```
    <application>
        <activity
            android:name=".MainActivity"
            android:exported="true"
            >
            <intent-filter>
                <category android:name="android.intent.category.LAUNCHER"/>
                <action android:name="android.intent.action.MAIN"/>
            </intent-filter>
            <intent-filter>
                <action android:name="android.intent.action.VIEW" />
                <category android:name="android.intent.category.DEFAULT" />
                <category android:name="android.intent.category.BROWSABLE" />
                <data android:scheme="https" />
                <data android:host="maestro.mobile.dev" />
            </intent-filter>
        </activity>
    </application>
```
```
class MainActivity : Activity() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(TextView(this).apply { text = "${applicationInfo.name}" })
    }
}
```
- I created a whole bunch of brand new emulators (API 24, 25, 26, 28, 32, 33, 34, 35)
- And then I ran the flow over and over on all the emulators until everything ran as expected
- In order to get the different Chrome screens, you have to Force stop and Clear data for it and they are a bit random

### Chrome

| Accept | Sign in | Sync | Notifications |
|-------|------|------|------|
| ![chrome_welcome_accept](https://github.com/user-attachments/assets/95a899f7-a375-455c-91ff-e15e2cbf6c79) | ![chrome_welcome_account](https://github.com/user-attachments/assets/9e265994-16ed-4200-bfe4-deb570fcd749) | ![chrome_sync](https://github.com/user-attachments/assets/8e790d27-fe89-470d-a28b-1bda8853f59d) | ![chrome_notifications](https://github.com/user-attachments/assets/e16f8fb1-02fe-450e-800d-da566553a200) |

### Chooser

| New | App | Browser |
|-----|-----|-----|
| ![Screenshot_20240902_034915](https://github.com/user-attachments/assets/25e99dff-586e-4937-8b5f-5c75117e23a4) | ![Screenshot_1725245194](https://github.com/user-attachments/assets/03eab7b7-dc2f-49e3-9a1d-7e194512e1d8) | ![Screenshot_1725245113](https://github.com/user-attachments/assets/7ef72ac2-8771-4c00-a071-47c9435e7ff8) |

### Open by default

| Before | After |
|------|------|
| ![Screenshot_1725244809](https://github.com/user-attachments/assets/35055d26-c1fc-4c93-b15b-ebb7e7bb54a0) | ![Screenshot_1725244813](https://github.com/user-attachments/assets/158cbf2c-4e2b-4191-97ed-ee143fad8fc4) |

## Issues fixed

Fixes #1956 (Definitely fixed)
Fixes #1397 (Fixed in spirit but not in letter. I think it's just better to use `autoVerify` for that purpose and not add another option)
