### PR TITLE
Actions: add timeouts

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -6,8 +6,9 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: macos-latest
-    if: github.repository == 'mobile-dev-inc/maestro'
+    timeout-minutes: 20
 
     steps:
       - name: Clone repository
@@ -34,8 +35,8 @@ jobs:
 
   test-local-android:
     name: Test on Android
+    timeout-minutes: 30
     runs-on: ubuntu-latest
-    if: github.repository == 'mobile-dev-inc/maestro'
     needs: build
     
     env:


### PR DESCRIPTION
Motivated by https://github.com/mobile-dev-inc/maestro/actions/runs/10646443357/job/29513363306?pr=1955, which had some bug and was running for 6 hrs (maximum run time)