### PR TITLE
Make MaestroCommand toString more concise

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -163,4 +163,10 @@ data class MaestroCommand(
     fun description(): String {
         return asCommand()?.description() ?: "No op"
     }
+
+    override fun toString(): String =
+        asCommand()?.let { command ->
+            val argName = command::class.simpleName?.replaceFirstChar(Char::lowercaseChar) ?: "command"
+            "MaestroCommand($argName=$command)"
+        } ?: "MaestroCommand()"
 }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
@@ -55,4 +55,29 @@ internal class MaestroCommandTest {
         assertThat(description)
             .isEqualTo("Set location with negative coordinates")
     }
+
+    @Test
+    fun `toString (no commands)`() {
+        // given
+        val maestroCommand = MaestroCommand(null)
+
+        // when
+        val toString = maestroCommand.toString()
+
+        // then
+        assertThat(toString).isEqualTo("MaestroCommand()")
+    }
+
+    @Test
+    fun `toString (at least one command)`() {
+        // given
+        val command = BackPressCommand()
+        val maestroCommand = MaestroCommand(command)
+
+        // when
+        val toString = maestroCommand.toString()
+
+        // then
+        assertThat(toString).isEqualTo("MaestroCommand(backPressCommand=$command)")
+    }
 }


### PR DESCRIPTION
## Proposed changes

- Make `MaestroCommand#toString` way shorter and thus all logs and test results more readable
- Basically only keep the arg name for the single non null `Command` inside the `MaestroCommand`

## Testing

- Added unit tests

## Issues fixed

None