### PR TITLE
Remove `optional` field from selectors

### DIFF
--- a/e2e/workspaces/demo_app/commands_optional_tournee.yaml
+++ b/e2e/workspaces/demo_app/commands_optional_tournee.yaml
@@ -6,6 +6,12 @@ tags:
 ---
 - launchApp:
     clearState: true
+- assertVisible:
+    id: ${ "com.example.example:id/toolbar_title" }
+    optional: true
+- assertNotVisible:
+    text: Flutter Demo Home Page
+    optional: true
 - assertTrue:
     condition: ${ false }
     label: Warn
@@ -36,4 +42,4 @@ tags:
     element:
       id: non-existent-id
       optional: true
-    # optional: true
+    optional: true

--- a/e2e/workspaces/demo_app/commands_optional_tournee.yaml
+++ b/e2e/workspaces/demo_app/commands_optional_tournee.yaml
@@ -7,7 +7,7 @@ tags:
 - launchApp:
     clearState: true
 - assertVisible:
-    id: ${ "com.example.example:id/toolbar_title" }
+    id: non-existent-id
     optional: true
 - assertNotVisible:
     text: Flutter Demo Home Page

--- a/e2e/workspaces/demo_app/commands_optional_tournee.yaml
+++ b/e2e/workspaces/demo_app/commands_optional_tournee.yaml
@@ -1,0 +1,39 @@
+# This flow is to ensure that commands with optional flag are not failing the flow.
+appId: com.example.example
+tags:
+    - android
+    - passing
+---
+- launchApp:
+    clearState: true
+- assertTrue:
+    condition: ${ false }
+    label: Warn
+    optional: true
+- tapOn:
+    id: non-existent-id
+    optional: true
+- doubleTapOn:
+    id: non-existent-id
+    optional: true
+- longPressOn:
+    id: non-existent-id
+    optional: true
+- copyTextFrom:
+    id: non-existent-id
+    optional: true
+- launchApp:
+    appId: non.existend.app.id
+    optional: true
+- tapOn:
+    id: non-existent-id
+    repeat: 3
+    delay: 500
+    optional: true
+# - swipe:
+#     optional: true
+- scrollUntilVisible:
+    element:
+      id: non-existent-id
+      optional: true
+    # optional: true

--- a/e2e/workspaces/demo_app/fail_fast.yaml
+++ b/e2e/workspaces/demo_app/fail_fast.yaml
@@ -5,5 +5,6 @@ tags:
 ---
 - launchApp:
     clearState: true
-- tapOn:
-    id: non-existent-id-to-fail-this-test
+- assertTrue:
+    condition: ${ false }
+    label: Fail the flow

--- a/e2e/workspaces/demo_app/fail_not_found.yaml
+++ b/e2e/workspaces/demo_app/fail_not_found.yaml
@@ -1,0 +1,9 @@
+appId: com.example.example
+tags:
+    - android
+    - failing
+---
+- launchApp:
+    clearState: true
+- tapOn:
+    id: non-existent-id

--- a/e2e/workspaces/demo_app/relatives.yaml
+++ b/e2e/workspaces/demo_app/relatives.yaml
@@ -1,0 +1,27 @@
+appId: com.example.example
+tags:
+    - android
+    - passing
+---
+- launchApp:
+    clearState: true
+- tapOn: Nesting Test
+- assertVisible:
+    id: level-0
+- assertVisible:
+    id: level-0
+    containsChild:
+      id: level-1
+      containsChild:
+        id: level-2
+      rightOf:
+        text: left side
+      leftOf:
+        text: right side
+      below: top side
+      above: bottom side
+- assertNotVisible:
+    id: level-0
+    containsChild:
+      id: level-1
+      below: bottom side

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ElementSelector.kt
@@ -32,7 +32,6 @@ data class ElementSelector(
     val rightOf: ElementSelector? = null,
     val containsChild: ElementSelector? = null,
     val containsDescendants: List<ElementSelector>? = null,
-    val optional: Boolean = false,
     val traits: List<ElementTrait>? = null,
     val index: String? = null,
     val enabled: Boolean? = null,
@@ -122,13 +121,7 @@ data class ElementSelector(
             descriptions.add("Child of: ${it.description()}")
         }
 
-        val combined = descriptions.joinToString(", ")
-
-        return if (optional) {
-            "(Optional) $combined"
-        } else {
-            combined
-        }
+        return descriptions.joinToString(", ")
     }
 
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -847,18 +847,18 @@ class Orchestra(
         command: TapOnElementCommand,
         retryIfNoChange: Boolean,
         waitUntilVisible: Boolean,
-        config: MaestroConfig?
+        config: MaestroConfig?,
     ): Boolean {
         val result = findElement(command.selector, optional = command.optional)
         maestro.tap(
-            result.element,
-            result.hierarchy,
-            retryIfNoChange,
-            waitUntilVisible,
-            command.longPress ?: false,
-            config?.appId,
+            element = result.element,
+            initialHierarchy = result.hierarchy,
+            retryIfNoChange = retryIfNoChange,
+            waitUntilVisible = waitUntilVisible,
+            longPress = command.longPress ?: false,
+            appId = config?.appId,
             tapRepeat = command.repeat,
-            waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
+            waitToSettleTimeoutMs = command.waitToSettleTimeoutMs,
         )
 
         return true
@@ -866,14 +866,14 @@ class Orchestra(
 
     private fun tapOnPoint(
         command: TapOnPointCommand,
-        retryIfNoChange: Boolean
+        retryIfNoChange: Boolean,
     ): Boolean {
         maestro.tap(
-            command.x,
-            command.y,
-            retryIfNoChange,
-            command.longPress ?: false,
-            tapRepeat = command.repeat
+            x = command.x,
+            y = command.y,
+            retryIfNoChange = retryIfNoChange,
+            longPress = command.longPress ?: false,
+            tapRepeat = command.repeat,
         )
 
         return true

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -334,15 +334,11 @@ class Orchestra(
 
     private fun assertConditionCommand(command: AssertConditionCommand): Boolean {
         val timeout = (command.timeoutMs() ?: lookupTimeoutMs)
-        if (!evaluateCondition(command.condition, timeoutMs = timeout)) {
-            if (!isOptional(command.condition)) {
-                throw MaestroException.AssertionFailure(
-                    message = "Assertion is false: ${command.condition.description()}",
-                    hierarchyRoot = maestro.viewHierarchy().root,
-                )
-            } else {
-                throw CommandSkipped
-            }
+        if (!evaluateCondition(command.condition, timeoutMs = timeout, commandOptional = command.optional)) {
+            throw MaestroException.AssertionFailure(
+                message = "Assertion is false: ${command.condition.description()}",
+                hierarchyRoot = maestro.viewHierarchy().root,
+            )
         }
 
         return false
@@ -411,11 +407,6 @@ class Orchestra(
         false
     }
 
-    private fun isOptional(condition: Condition): Boolean {
-        return condition.visible?.optional == true
-                || condition.notVisible?.optional == true
-    }
-
     private fun evalScriptCommand(command: EvalScriptCommand): Boolean {
         command.scriptString.evaluateScripts(jsEngine)
 
@@ -424,7 +415,7 @@ class Orchestra(
     }
 
     private fun runScriptCommand(command: RunScriptCommand): Boolean {
-        return if (evaluateCondition(command.condition)) {
+        return if (evaluateCondition(command.condition, commandOptional = command.optional)) {
             jsEngine.evaluateScript(
                 script = command.script,
                 env = command.env,
@@ -496,7 +487,7 @@ class Orchestra(
 
         do {
             try {
-                val element = findElement(command.selector, 500).element
+                val element = findElement(command.selector, command.optional, 500).element
                 val visibility = element.getVisiblePercentage(deviceInfo.widthGrid, deviceInfo.heightGrid)
 
                 if (command.centerElement && visibility > 0.1 && retryCenterCount <= maxRetryCenterCount) {
@@ -542,7 +533,7 @@ class Orchestra(
         val checkCondition: () -> Boolean = {
             command.condition
                 ?.evaluateScripts(jsEngine)
-                ?.let { evaluateCondition(it) } != false
+                ?.let { evaluateCondition(it, commandOptional = command.optional) } != false
         }
 
         while (checkCondition() && counter < maxRuns) {
@@ -587,7 +578,7 @@ class Orchestra(
     }
 
     private fun runFlowCommand(command: RunFlowCommand, config: MaestroConfig?): Boolean {
-        return if (evaluateCondition(command.condition)) {
+        return if (evaluateCondition(command.condition, command.optional)) {
             runSubFlow(command.commands, config, command.config)
         } else {
             throw CommandSkipped
@@ -596,6 +587,7 @@ class Orchestra(
 
     private fun evaluateCondition(
         condition: Condition?,
+        commandOptional: Boolean,
         timeoutMs: Long? = null,
     ): Boolean {
         if (condition == null) {
@@ -610,7 +602,11 @@ class Orchestra(
 
         condition.visible?.let {
             try {
-                findElement(it, timeoutMs = adjustedToLatestInteraction(timeoutMs ?: optionalLookupTimeoutMs))
+                findElement(
+                    selector = it,
+                    timeoutMs = adjustedToLatestInteraction(timeoutMs ?: optionalLookupTimeoutMs),
+                    optional = commandOptional,
+                )
             } catch (ignored: MaestroException.ElementNotFound) {
                 return false
             }
@@ -619,7 +615,11 @@ class Orchestra(
         condition.notVisible?.let {
             val result = MaestroTimer.withTimeout(adjustedToLatestInteraction(timeoutMs ?: optionalLookupTimeoutMs)) {
                 try {
-                    findElement(it, timeoutMs = 500L)
+                    findElement(
+                        selector = it,
+                        timeoutMs = 500L,
+                        optional = commandOptional,
+                    )
 
                     // If we got to that point, the element is still visible.
                     // Returning null to keep waiting.
@@ -850,7 +850,7 @@ class Orchestra(
         config: MaestroConfig?
     ): Boolean {
         return try {
-            val result = findElement(command.selector)
+            val result = findElement(command.selector, optional = command.optional)
             maestro.tap(
                 result.element,
                 result.hierarchy,
@@ -864,11 +864,7 @@ class Orchestra(
 
             true
         } catch (e: MaestroException.ElementNotFound) {
-            if (!command.selector.optional) {
-                throw e
-            } else {
-                false
-            }
+            throw e
         }
     }
 
@@ -931,16 +927,15 @@ class Orchestra(
 
     private fun findElement(
         selector: ElementSelector,
-        timeoutMs: Long? = null
+        optional: Boolean,
+        timeoutMs: Long? = null,
     ): FindElementResult {
-        val timeout = timeoutMs
-            ?: adjustedToLatestInteraction(
-                if (selector.optional) {
-                    optionalLookupTimeoutMs
-                } else {
-                    lookupTimeoutMs
-                }
+        val timeout =
+            timeoutMs ?: adjustedToLatestInteraction(
+                if (optional) optionalLookupTimeoutMs
+                else lookupTimeoutMs,
             )
+
         val (description, filterFunc) = buildFilter(
             selector,
             deviceInfo(),
@@ -1055,7 +1050,7 @@ class Orchestra(
         selector.containsChild
             ?.let {
                 descriptions += "Contains child: ${it.description()}"
-                filters += Filters.containsChild(findElement(it).element).asFilter()
+                filters += Filters.containsChild(findElement(it, optional = false).element).asFilter()
             }
 
         selector.containsDescendants
@@ -1148,7 +1143,7 @@ class Orchestra(
         val end = command.endPoint
         when {
             elementSelector != null && direction != null -> {
-                val uiElement = findElement(elementSelector)
+                val uiElement = findElement(elementSelector, optional = command.optional)
                 maestro.swipe(direction, uiElement.element, command.duration)
             }
 
@@ -1170,11 +1165,11 @@ class Orchestra(
 
     private fun adjustedToLatestInteraction(timeMs: Long) = max(
         0,
-        timeMs - (System.currentTimeMillis() - timeMsOfLastInteraction)
+        timeMs - (System.currentTimeMillis() - timeMsOfLastInteraction),
     )
 
     private fun copyTextFromCommand(command: CopyTextFromCommand): Boolean {
-        val result = findElement(command.selector)
+        val result = findElement(command.selector, optional = command.optional)
         copiedText = resolveText(result.element.treeNode.attributes)
             ?: throw MaestroException.UnableToCopyTextFromElement("Element does not contain text to copy: ${result.element}")
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -849,23 +849,19 @@ class Orchestra(
         waitUntilVisible: Boolean,
         config: MaestroConfig?
     ): Boolean {
-        return try {
-            val result = findElement(command.selector, optional = command.optional)
-            maestro.tap(
-                result.element,
-                result.hierarchy,
-                retryIfNoChange,
-                waitUntilVisible,
-                command.longPress ?: false,
-                config?.appId,
-                tapRepeat = command.repeat,
-                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
-            )
+        val result = findElement(command.selector, optional = command.optional)
+        maestro.tap(
+            result.element,
+            result.hierarchy,
+            retryIfNoChange,
+            waitUntilVisible,
+            command.longPress ?: false,
+            config?.appId,
+            tapRepeat = command.repeat,
+            waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
+        )
 
-            true
-        } catch (e: MaestroException.ElementNotFound) {
-            throw e
-        }
+        return true
     }
 
     private fun tapOnPoint(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -588,7 +588,6 @@ data class YamlFluentCommand(
             selected = selector.selected,
             checked = selector.checked,
             focused = selector.focused,
-            optional = selector.optional ?: false,
             childOf = selector.childOf?.let { toElementSelector(it) }
         )
     }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -33,8 +33,7 @@ internal class MaestroCommandSerializationTest {
             {
               "tapOnElement" : {
                 "selector" : {
-                  "textRegex" : "[A-f0-9]",
-                  "optional" : false
+                  "textRegex" : "[A-f0-9]"
                 },
                 "retryIfNoChange" : false,
                 "waitUntilVisible" : true,
@@ -235,12 +234,10 @@ internal class MaestroCommandSerializationTest {
             {
               "assertCommand" : {
                 "visible" : {
-                  "textRegex" : "[A-f0-9]",
-                  "optional" : false
+                  "textRegex" : "[A-f0-9]"
                 },
                 "notVisible" : {
-                  "textRegex" : "\\s",
-                  "optional" : false
+                  "textRegex" : "\\s"
                 },
                 "optional" : false
               }


### PR DESCRIPTION
The selector-level `optional` argument has been superseded by the command-level `optional` argument in #1946.

This PR is a follow up of #1946 (specifically, [this comment](https://github.com/mobile-dev-inc/maestro/pull/1946#issuecomment-2329230482))