### PR TITLE
Fix flow files arity

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -76,7 +76,7 @@ class TestCommand : Callable<Int> {
     @CommandLine.ParentCommand
     private val parent: App? = null
 
-    @CommandLine.Parameters(description = ["One or more flow files or folders containing flow files"])
+    @CommandLine.Parameters(description = ["One or more flow files or folders containing flow files"], arity = "1..*")
     private var flowFiles: Set<File> = emptySet()
 
     @Option(


### PR DESCRIPTION
## Proposed changes

#### Before

```
> maestro test

Flow directories do not contain any Flow files:
```

#### After 

```
> maestro test
Missing required parameter: '<flowFiles>'
Usage: maestro test [...]
```
