### PR TITLE
Evaluate script conditions eagerly

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -599,6 +599,30 @@ class Orchestra(
             }
         }
 
+        condition.scriptCondition?.let { value ->
+            // Note that script should have been already evaluated by this point
+
+            if (value.isBlank()) {
+                return false
+            }
+
+            if (value.equals("false", ignoreCase = true)) {
+                return false
+            }
+
+            if (value == "undefined") {
+                return false
+            }
+
+            if (value == "null") {
+                return false
+            }
+
+            if (value.toDoubleOrNull() == 0.0) {
+                return false
+            }
+        }
+
         condition.visible?.let {
             try {
                 findElement(
@@ -631,30 +655,6 @@ class Orchestra(
 
             // Element was actually visible
             if (result != true) {
-                return false
-            }
-        }
-
-        condition.scriptCondition?.let { value ->
-            // Note that script should have been already evaluated by this point
-
-            if (value.isBlank()) {
-                return false
-            }
-
-            if (value.equals("false", ignoreCase = true)) {
-                return false
-            }
-
-            if (value == "undefined") {
-                return false
-            }
-
-            if (value == "null") {
-                return false
-            }
-
-            if (value.toDoubleOrNull() == 0.0) {
                 return false
             }
         }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -2651,6 +2651,33 @@ class IntegrationTest {
     }
 
     @Test
+    fun `Case 098 - Execute conditions eagerly`() {
+        // Given
+        val commands = readCommands("098_runscript_conditionals_eager")
+
+        // 'Click me' is not present in the view hierarchy
+        val driver = driver {}
+
+        val receivedLogs = mutableListOf<String>()
+
+        // When
+        Maestro(driver).use {
+            orchestra(
+                maestro = it,
+                onCommandMetadataUpdate = { _, metadata ->
+                    receivedLogs += metadata.logMessages
+                }
+            ).runFlow(commands)
+        }
+
+        // Then
+        // test completes
+        driver.assertEvents(emptyList())
+        // and script did not run
+        assertThat(receivedLogs).isEmpty()
+    }
+
+    @Test
     fun `Case 099 - Screen recording`() {
         // Given
         val commands = readCommands("099_screen_recording")

--- a/maestro-test/src/test/resources/098_runscript_conditionals_eager.yaml
+++ b/maestro-test/src/test/resources/098_runscript_conditionals_eager.yaml
@@ -1,0 +1,7 @@
+appId: com.other.app
+---
+- runScript:
+    when:
+      true: ${ 1 + 1 != 2 }
+      visible: Click me
+    file: 098_runScript.js


### PR DESCRIPTION
## Proposed changes

- Conditions are already evaluated eagerly, meaning that as soon as a failing condition is evaluated, the flow is exited
- However, the order currently is not ideal. We evaluate `platform`, `visible`, `notVisible` and then `true`
- `visible` and `notVisible` take a lot of time to run when they are not satisfied, as there's a default timeout to check the hierarchy for the presence of an element
- Moving the evaluation of `true` in the 2nd position makes a lot of cases run much faster

As an example, in our flows we had to do stuff like this to workaround this use case 

```
- runFlow:
    when:
      true: ${ !output.skipLegalConsent }
    commands:
      - runFlow:
          when:
            visible:
              id: 'privacy_policy_confirm|.*button1'
          commands:
              - [...]
```

This saves several seconds each time ([17s exactly](https://github.com/mobile-dev-inc/maestro/blob/16ac25dfdf193b28ed6a8ded8abd17da864101b8/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt#L76-L77))

## Testing

- Added an integration test that makes sure the `visible` does not even run if there's a false `true` before

## Issues fixed

None