### PR TITLE
Fix platform argument

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -151,6 +151,15 @@ class TestCommand : Callable<Int> {
     )
     private var excludeTags: List<String> = emptyList()
 
+    @Option(names = ["-p", "--platform"], description = ["Select a platform to run on"])
+    var platform: String? = null
+
+    @Option(
+        names = ["--device", "--udid"],
+        description = ["Device ID to run on explicitly, can be a comma separated list of IDs: --device \"Emulator_1,Emulator_2\" "],
+    )
+    var deviceId: String? = null
+
     @CommandLine.Spec
     lateinit var commandSpec: CommandLine.Model.CommandSpec
 
@@ -224,7 +233,7 @@ class TestCommand : Callable<Int> {
             }
             .ifEmpty {
                 connectedDevices
-                    .filter { it.platform == Platform.fromString(parent?.platform) }
+                    .filter { it.platform == Platform.fromString(platform ?: parent?.platform) }
                     .map { it.instanceId }.toSet()
             }
             .toList()
@@ -306,7 +315,7 @@ class TestCommand : Callable<Int> {
             port = parent?.port,
             driverHostPort = driverHostPort,
             deviceId = deviceId,
-            platform = parent?.platform,
+            platform = platform ?: parent?.platform,
         ) { session ->
             val maestro = session.maestro
             val device = session.device
@@ -422,7 +431,7 @@ class TestCommand : Callable<Int> {
         val arguments = if (isWebFlow()) {
             PrintUtils.warn("Web support is an experimental feature and may be removed in future versions.\n")
             "chromium"
-        } else parent?.deviceId
+        } else deviceId ?: parent?.deviceId
         val deviceIds = arguments
             .orEmpty()
             .split(",")


### PR DESCRIPTION
## Proposed changes

- Fix issue with platform not working for iOS
  - This was due to `selectDevice` being passed the platform as well as a deviceId corresponding to the first available device
  - The fix is to filter available devices on the given platform if passed. Which makes sense
- Add test specific `platform` and `device` argument  in order to facilitate commands like `maestro test flow.yml --platform android` which did not work before

## Testing

- Run commands with 1 android and 1 iOS device running
  - `maestro test flow.yml --platform android`
  - `maestro test flow.yml --platform ios`
  - `maestro --platform android test flow.yml`
  - `maestro --platform ios test flow.yml`
  - `maestro --platform android test flow.yml --platform ios`
  - `maestro test flow.yml --platform ios --device emulator-5554`

## Issues fixed

Fixes #2037 