### PR TITLE
Open link e2e test

### DIFF
--- a/e2e/workspaces/demo_app/open_link.yaml
+++ b/e2e/workspaces/demo_app/open_link.yaml
@@ -1,0 +1,32 @@
+appId: com.example.example
+tags:
+    - passing
+---
+- launchApp:
+    appId: com.android.chrome
+    clearState: true
+    optional: true
+
+- launchApp:
+    clearState: true
+
+- openLink: 'https://maestro.mobile.dev'
+- assertVisible:
+    id: 'signin_fre_dismiss_button|send_report_checkbox|terms_accept'
+
+- openLink:
+    link: 'https://maestro.mobile.dev'
+    browser: true
+- assertVisible:
+    id: 'signin_fre_dismiss_button|send_report_checkbox|terms_accept'
+
+- openLink:
+    link: 'https://maestro.mobile.dev'
+    browser: true
+    autoVerify: true
+- assertVisible: 'Maestro Documentation'
+
+- openLink:
+    link: 'https://maestro.mobile.dev'
+    autoVerify: true
+- assertVisible: 'Flutter Demo Home Page'

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -231,6 +231,7 @@ class AndroidDriver(
         }
 
         shell("pm clear $appId")
+        shell("pm reset-app-links --user 0 $appId")
     }
 
     override fun clearKeychain() {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -578,6 +578,14 @@ class AndroidDriver(
         // Welcome to Chrome screen "Add account to device"
         filterById("$chrome:id/signin_fre_dismiss_button")?.let { tap(it.bounds.center()) }
         waitForAppToSettle(null, null)
+        // Ad privacy feature
+        filterById("$chrome:id/more_button")?.let { tap(it.bounds.center()) }
+        filterById("$chrome:id/no_button")?.let { tap(it.bounds.center()) }
+        waitForAppToSettle(null, null)
+        // Other ad privacy feature
+        filterById("$chrome:id/more_button")?.let { tap(it.bounds.center()) }
+        filterById("$chrome:id/ack_button")?.let { tap(it.bounds.center()) }
+        waitForAppToSettle(null, null)
         // Turn on Sync screen
         filterById("$chrome:id/negative_button")?.let { tap(it.bounds.center()) }
         waitForAppToSettle(null, null)


### PR DESCRIPTION
## Proposed changes

- Add an E2E test showcasing `openLink` behavior on the demo app

## Testing

- Run the e2e scenario on an Android emulator

## Issues fixed

Linked comment https://github.com/mobile-dev-inc/maestro/pull/1999#issuecomment-2324290092
Linked PR https://github.com/mobile-dev-inc/demo_app/pull/4