### PR TITLE
Js log dollar sign

### DIFF
--- a/maestro-client/src/main/java/maestro/debuglog/LogConfig.kt
+++ b/maestro-client/src/main/java/maestro/debuglog/LogConfig.kt
@@ -13,9 +13,11 @@ object LogConfig {
 
     private const val DEFAULT_FILE_LOG_PATTERN = "%d{HH:mm:ss.SSS} [%5level] %logger.%method: %msg%n"
     private const val DEFAULT_CONSOLE_LOG_PATTERN = "%highlight([%5level]) %msg%n"
+    private const val DEFAULT_LOG_LEVEL = "ALL"
 
     private val FILE_LOG_PATTERN: String = System.getenv("MAESTRO_CLI_LOG_PATTERN_FILE") ?: DEFAULT_FILE_LOG_PATTERN
     private val CONSOLE_LOG_PATTERN: String = System.getenv("MAESTRO_CLI_LOG_PATTERN_CONSOLE") ?: DEFAULT_CONSOLE_LOG_PATTERN
+    private val LOG_LEVEL: String = System.getenv("MAESTRO_CLI_LOG_LEVEL") ?: DEFAULT_LOG_LEVEL
 
     fun configure(logFileName: String, printToConsole: Boolean) {
         val loggerContext = LoggerFactory.getILoggerFactory() as LoggerContext
@@ -27,7 +29,7 @@ object LogConfig {
             createAndAddConsoleAppender(loggerContext)
         }
 
-        loggerContext.getLogger("ROOT").level = Level.ALL
+        loggerContext.getLogger("ROOT").level = Level.toLevel(LOG_LEVEL, Level.ALL)
     }
 
     private fun createAndAddConsoleAppender(loggerContext: LoggerContext) {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -8,7 +8,7 @@ import maestro.orchestra.MaestroCommand
 object Env {
 
     fun String.evaluateScripts(jsEngine: JsEngine): String {
-        val result = "(?<!\\\\)\\\$\\{([^\$]*)}".toRegex()
+        val result = "(?<!\\\\)\\\$\\{(.*?)}".toRegex()
             .replace(this) { match ->
                 val script = match.groups[1]?.value ?: ""
 
@@ -20,7 +20,7 @@ object Env {
             }
 
         return result
-            .replace("\\\\\\\$\\{([^\$]*)}".toRegex()) { match ->
+            .replace("\\\\\\\$\\{(.*?)}".toRegex()) { match ->
                 match.value.substringAfter('\\')
             }
     }

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
@@ -3,10 +3,12 @@ package maestro.orchestra.util
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlin.random.Random
+import maestro.js.GraalJsEngine
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
+import maestro.orchestra.util.Env.evaluateScripts
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
@@ -60,4 +62,20 @@ class EnvTest {
 
         assertThat(withEnv).containsExactly(defineVariables, applyConfig)
     }
+
+    @Test
+    fun `evaluateScripts regex`() {
+        val engine = GraalJsEngine()
+        val inputs = listOf(
+            "${'$'}{console.log('Hello!')}",
+            "${'$'}{console.log('Hello Money! $')}",
+            "${'$'}{console.log('$')}",
+        )
+
+        val evaluated = inputs.map { it.evaluateScripts(engine) }
+
+        // "undefined" is the expected output when evaluating console.log successfully
+        assertThat(evaluated).containsExactly("undefined", "undefined", "undefined")
+    }
+
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -173,6 +173,7 @@ class Orchestra(
                         command,
                         metadata.copy(logMessages = metadata.logMessages + msg)
                     )
+                    jsLogger.info(msg)
                 }
 
                 val evaluatedCommand = command.evaluateScripts(jsEngine)
@@ -1386,5 +1387,6 @@ class Orchestra(
         private const val MAX_ERASE_CHARACTERS = 50
         private const val MAX_RETRIES_ALLOWED = 3
         private val logger = LoggerFactory.getLogger(Orchestra::class.java)
+        private val jsLogger = LoggerFactory.getLogger("maestro.js.JsEngine.console.log")
     }
 }


### PR DESCRIPTION
## Proposed changes

- I updated the regexes in `fun String.evaluateScripts(jsEngine: JsEngine)` to not prevent the script to have any dollar sign
- I'm confident this fixes the linked issue
- I'm not confident enough this does not brake on a weird edge case
- I tried thinking of some JS content that contains a dollar sign and that would brake due to this change but I don't have any idea. Maybe you'll find one
- I added forwarding of the js console to maestro log file
- I added a `MAESTRO_CLI_LOG_LEVEL` env var to limit log output level if needed

## Testing

- Added unit test
- Tested with following e2e file
```yaml
appId: com.example.example
---
- launchApp
- evalScript: ${console.log('Hello!')}
- evalScript: ${console.log('Hello money! $')}
- evalScript: ${console.log('Hello money! \$')}
- evalScript: ${console.log('$')}
- evalScript: ${console.log('\$')}
```
```
 ║
 ║  > Flow: dollar
 ║
 ║    ✅   Launch app "com.example.example"
 ║    ✅   Run ${console.log('Hello!')}
 ║         Log messages:
 ║           Hello!
 ║    ✅   Run ${console.log('Hello money! $')}
 ║         Log messages:
 ║           Hello money! $
 ║    ✅   Run ${console.log('Hello money! \$')}
 ║         Log messages:
 ║           Hello money! $
 ║    ✅   Run ${console.log('$')}
 ║         Log messages:
 ║           $
 ║    ✅   Run ${console.log('\$')}
 ║         Log messages:
 ║           $
 ║
```

## Issues fixed

Fixes #1760
