### PR TITLE
fix: install debug reporter in maestro cloud command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -19,12 +19,14 @@
 
 package maestro.cli.command
 
+import maestro.cli.App
 import maestro.cli.CliError
 import maestro.cli.DisableAnsiMixin
 import maestro.cli.ShowHelpMixin
 import maestro.cli.api.ApiClient
 import maestro.cli.cloud.CloudInteractor
 import maestro.cli.report.ReportFormat
+import maestro.cli.report.TestDebugReporter
 import maestro.cli.util.PrintUtils
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
@@ -34,6 +36,7 @@ import java.io.File
 import java.util.concurrent.Callable
 import java.util.concurrent.TimeUnit
 import maestro.orchestra.util.Env.withDefaultEnvVars
+import kotlin.io.path.absolutePathString
 
 @CommandLine.Command(
     name = "cloud",
@@ -162,8 +165,16 @@ class CloudCommand : Callable<Int> {
     @Option(hidden = true, names = ["--timeout"], description = ["Minutes to wait until all flows complete"])
     private var resultWaitTimeout = 60
 
-    override fun call(): Int {
+    @CommandLine.ParentCommand
+    private val parent: App? = null
 
+    override fun call(): Int {
+        TestDebugReporter.install(
+            debugOutputPathAsString = null,
+            flattenDebugOutput = false,
+            printToConsole = parent?.verbose == true,
+        )
+        
         validateFiles()
         validateWorkSpace()
 


### PR DESCRIPTION
## Proposed changes

Cloud command logs from `WorkspaceExecutionPlanner` is getting output on terminal. Install the debug reporter to output on file instead.

## Testing

Locally running maestro cloud command

## Issues fixed
