### PR TITLE
chore: add e2e tests for optional

### DIFF
--- a/e2e/workspaces/wikipedia/android-advanced-flow.yaml
+++ b/e2e/workspaces/wikipedia/android-advanced-flow.yaml
@@ -7,6 +7,9 @@ tags:
 - runFlow: subflows/onboarding-android.yaml
 - tapOn:
     id: "org.wikipedia:id/search_container"
+- tapOn:
+    text: "Non existent view"
+    optional: true
 - runScript: scripts/getSearchQuery.js
 - inputText: ${output.result}
 - assertVisible: ${output.result}

--- a/e2e/workspaces/wikipedia/ios-advanced-flow.yaml
+++ b/e2e/workspaces/wikipedia/ios-advanced-flow.yaml
@@ -13,7 +13,9 @@ tags:
     commands:
       - tapOn:
           text: "Continue without logging in"
-
+- tapOn:
+    text: "Non existent view"
+    optional: true
 - tapOn: Search Wikipedia
 - runScript: scripts/getSearchQuery.js
 - inputText: ${output.result}

--- a/e2e/workspaces/wikipedia/subflows/onboarding-android.yaml
+++ b/e2e/workspaces/wikipedia/subflows/onboarding-android.yaml
@@ -3,6 +3,9 @@ appId: org.wikipedia
 - launchApp:
     clearState: true
 - tapOn:
+      text: "Non existent view"
+      optional: true
+- tapOn:
     id: "org.wikipedia:id/fragment_onboarding_forward_button"
 - tapOn:
     id: "org.wikipedia:id/fragment_onboarding_forward_button"

--- a/e2e/workspaces/wikipedia/subflows/onboarding-ios.yaml
+++ b/e2e/workspaces/wikipedia/subflows/onboarding-ios.yaml
@@ -10,3 +10,6 @@ appId: org.wikimedia.wikipedia
           duration: 400
       - waitForAnimationToEnd
 - tapOn: Get started
+- tapOn:
+    text: "Non existent view"
+    optional: true


### PR DESCRIPTION
There were 2 issues with optional commands, this PR creates tests for the issues:

1. The optional flag on the selector was removed that broke deserialization and the change was not backward compatible.  The optional flag on the selector was removed from the test itself which prevented catching this regression. After observing this issue, the optional flag from selector is now deprecated.

2. Optional flags now throw command skipped exception. This was handled for the commands present in main flow but was missing in composite commands like runFlow. The addition to subFlow is suppose to catch those problem.