### PR TITLE
feat: add partial screenshots capability

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -572,6 +572,7 @@ data class EraseTextCommand(
 
 data class TakeScreenshotCommand(
     val path: String,
+    val targetComponentId: String? = null,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -578,7 +578,11 @@ data class TakeScreenshotCommand(
 ) : Command {
 
     override fun description(): String {
-        return label ?: "Take screenshot $path"
+        return label ?: if (targetComponentId != null) {
+            "Take screenshot $path, cropped on component with id $targetComponentId"
+        } else {
+            "Take screenshot $path"
+        }
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): TakeScreenshotCommand {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -46,8 +46,10 @@ import okio.Buffer
 import okio.Sink
 import okio.buffer
 import okio.sink
+import java.awt.image.BufferedImage
 import java.io.File
 import java.lang.Long.max
+import javax.imageio.ImageIO
 
 // TODO(bartkepacia): Use this in onCommandGeneratedOutput.
 //  Caveat:
@@ -747,11 +749,17 @@ class Orchestra(
 
     private fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
         val pathStr = command.path + ".png"
+        val targetComponent = command.targetComponentId?.let { maestro.findElementByIdRegex(regex = Regex(it), timeoutMs = 100) }
+
         val file = screenshotsDir
             ?.let { File(it, pathStr) }
             ?: File(pathStr)
 
-        maestro.takeScreenshot(file, false)
+        if(targetComponent == null){
+            maestro.takeScreenshot(file.sink(), false)
+        }else{
+            maestro.takePartialScreenshot(sink = file.sink(), bounds = targetComponent.bounds, compressed = false)
+        }
 
         return false
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -166,7 +166,7 @@ data class YamlFluentCommand(
             hideKeyboard != null -> listOf(MaestroCommand(HideKeyboardCommand(label = hideKeyboard.label, optional = hideKeyboard.optional)))
             pasteText != null -> listOf(MaestroCommand(PasteTextCommand(label = pasteText.label, optional = pasteText.optional)))
             scroll != null -> listOf(MaestroCommand(ScrollCommand(label = scroll.label, optional = scroll.optional)))
-            takeScreenshot != null -> listOf(MaestroCommand(TakeScreenshotCommand(path = takeScreenshot.path, label = takeScreenshot.label, optional = takeScreenshot.optional)))
+            takeScreenshot != null -> listOf(MaestroCommand(TakeScreenshotCommand(path = takeScreenshot.path, label = takeScreenshot.label, optional = takeScreenshot.optional, targetComponentId = takeScreenshot.targetComponentId)))
             extendedWaitUntil != null -> listOf(extendedWait(extendedWaitUntil))
             stopApp != null -> listOf(
                 MaestroCommand(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlTakeScreenshot.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlTakeScreenshot.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 data class YamlTakeScreenshot(
     val path: String,
     val label: String? = null,
+    val targetComponentId: String? = null,
     val optional: Boolean = false,
 ) {
 


### PR DESCRIPTION
## Proposed changes
This PR extends current capabilities of `takeScreenshot` command with `targetComponentId` prop.

## Motivation
Visual regression testing is something that has been on the horizon for some time #1222. This PR is aiming to fill the gaps and prepare the ground for further development in this area (will fit #2078 great). Component level screenshots are something that will greatly decrease screenshot size and make component-level tests possible.

### Example usage

`test-screenshot.yml`
```yml
appId: com.example.app
---
- launchApp
- takeScreenshot: 
      path: "TestScreen"
```
```terminal
 ║                                                             
 ║  > Flow: test-flow                                          
 ║                                                             
 ║    ✅   Launch app "com.exapmle.com"                                                        
 ║    ✅   Tap on "Test Button"Screen                          
 ║    ✅   Take screenshot TestScreen                          
 ║            
```
`test-component-screenshot.yml`
```yml
appId: com.example.app
---
- launchApp
- takeScreenshot: 
      path: "TestScreen"
      targetComponentId: "test-btn"
```
```terminal
 ║                                                             
 ║  > Flow: test-flow                                          
 ║                                                             
 ║    ✅   Launch app "com.exapmle.com"      
 ║    ✅   Tap on "Test Button"
 ║    ✅   Take screenshot TestScreen, cropped on component with id test-btn
```


| Screenshot | Component Screenshot |
|----------|---------|
| ![Login screen](https://github.com/user-attachments/assets/d6a283ac-a0ac-4071-ba94-868b7932ed1d) | ![TestScreen](https://github.com/user-attachments/assets/caf5e575-f545-4117-b1e9-8f5fdeb76d39) |

## Testing
* would gladly accept any ideas of how to test it with confidence
