### PR TITLE
Add sensitive field to inputText

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -477,8 +477,13 @@ class Maestro(
         return driver.waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs)
     }
 
-    fun inputText(text: String) {
-        LOGGER.info("Inputting text: $text")
+    fun inputText(text: String, sensitive: Boolean = false) {
+        LOGGER.info("Inputting text:".let {
+            if (sensitive)
+                "$it ${"".padEnd(text.length, '*')}"
+            else
+                "$it $text"
+        })
 
         driver.inputText(text)
         waitForAppToSettle()

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -426,18 +426,37 @@ data class AssertWithAICommand(
 
 data class InputTextCommand(
     val text: String,
+    val sensitive: Boolean = false,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
 
     override fun description(): String {
-        return label ?: "Input text $text"
+        if (label != null) {
+            return label
+        }
+        val defaultLabelPrefix = "Input text "
+        if (sensitive) {
+            return defaultLabelPrefix + "".padEnd(text.length, '*')
+        } else {
+            return defaultLabelPrefix + text
+        }
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): InputTextCommand {
         return copy(
             text = text.evaluateScripts(jsEngine)
         )
+    }
+
+    override fun toString(): String {
+        val thisText = if (sensitive) {
+            "".padEnd(text.length, '*')
+        } else {
+            text
+        }
+
+        return "InputTextCommand(text=$thisText, sensitive=$sensitive, label=$label, optional=$optional)"
     }
 }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -836,7 +836,7 @@ class Orchestra(
             }
         }
 
-        maestro.inputText(command.text)
+        maestro.inputText(command.text, command.sensitive)
 
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -142,7 +142,7 @@ data class YamlFluentCommand(
                     addMediaCommand = addMediaCommand(addMedia, flowPath)
                 )
             )
-            inputText != null -> listOf(MaestroCommand(InputTextCommand(text = inputText.text, label = inputText.label, optional = inputText.optional)))
+            inputText != null -> listOf(MaestroCommand(InputTextCommand(text = inputText.text, sensitive = inputText.sensitive, label = inputText.label, optional = inputText.optional)))
             inputRandomText != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT, length = inputRandomText.length, label = inputRandomText.label, optional = inputRandomText.optional)))
             inputRandomNumber != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.NUMBER, length = inputRandomNumber.length, label = inputRandomNumber.label, optional = inputRandomNumber.optional)))
             inputRandomEmail != null -> listOf(MaestroCommand(InputRandomCommand(inputType = InputRandomType.TEXT_EMAIL_ADDRESS, label = inputRandomEmail.label, optional = inputRandomEmail.optional)))

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlInputText.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlInputText.kt
@@ -5,6 +5,7 @@ import java.lang.UnsupportedOperationException
 
 data class YamlInputText(
     val text: String,
+    val sensitive: Boolean = false,
     val label: String? = null,
     val optional: Boolean = false,
 ) {
@@ -18,8 +19,10 @@ data class YamlInputText(
                 is String -> text
                 is Map<*, *> -> {
                     val input = text.getOrDefault("text", "") as String
+                    val sensitive = text.getOrDefault("sensitive", false) as Boolean
                     val label = text.getOrDefault("label", null) as String?
-                    return YamlInputText(input, label)
+                    val optional = text.getOrDefault("optional", false) as Boolean
+                    return YamlInputText(text = input, sensitive = sensitive, label = label, optional = optional)
                 }
                 is Int, is Long, is Char, is Boolean, is Float, is Double -> text.toString()
                 else -> throw UnsupportedOperationException("Cannot deserialize input text with data type ${text.javaClass}")

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -266,6 +266,7 @@ internal class MaestroCommandSerializationTest {
             {
               "inputTextCommand" : {
                 "text" : "Hello, world!",
+                "sensitive" : false,
                 "optional" : false
               }
             }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandTest.kt
@@ -57,6 +57,19 @@ internal class MaestroCommandTest {
     }
 
     @Test
+    fun `description (sensitive text)`() {
+        // given
+        val maestroCommand = MaestroCommand(InputTextCommand("password", true))
+
+        // when
+        val description = maestroCommand.description()
+
+        // then
+        assertThat(description)
+            .isEqualTo("Input text ********")
+    }
+
+    @Test
     fun `toString (no commands)`() {
         // given
         val maestroCommand = MaestroCommand(null)


### PR DESCRIPTION
## Proposed changes

Adds a `sensitive` flag to the inputText command to keep the data being inputted from being printed to console or logs.

```
- inputText:
    text: $ecr3ts
    sensitive: true
```

will output this to the console:

```
 ║    ✅   Input text *******      
````

and this to the logs:

```
12:08:22.605 [ INFO] maestro.cli.runner.MaestroCommandRunner.invoke: Input text ******* RUNNING
12:08:22.606 [ INFO] maestro.cli.runner.MaestroCommandRunner.invoke: Input text ******* metadata CommandMetadata(numberOfRuns=null, evaluatedCommand=MaestroCommand(inputTextCommand=InputTextCommand(text=*******, sensitive=true, label=null, optional=false)), logMessages=[], insight=Insight(message=, level=NONE))
12:08:22.607 [ INFO] maestro.Maestro.inputText: Inputting text: *******
12:08:25.154 [ INFO] maestro.cli.runner.MaestroCommandRunner.invoke: Input text ******* COMPLETED
```

Todo:
* Await some feedback on #1226 on what to do with the debug commands JSON file - I'm concerned that either eliding or preserving will upset someone.

## Testing

Added tests. Ran em all. There's a couple of unrelated failures being fixed in #2080 

Ran a flow locally using `./maestro` and scrutinised the console, as well as the output in `¬/.maestro/tests`

## Issues fixed

Fixes #1226