### PR TITLE
fix: exclude duplicates

### DIFF
--- a/maestro-client/build.gradle.kts
+++ b/maestro-client/build.gradle.kts
@@ -105,6 +105,10 @@ tasks.named("compileKotlin", KotlinCompilationTask::class.java) {
     }
 }
 
+tasks.withType<Jar> {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.S01)
 }


### PR DESCRIPTION
## Proposed changes

./gradlew maestro-client:javaSourcesJar fails because of duplicates. Fixing that by defining strategy.

## Testing

[x] Locally running flow with cli build

## Issues fixed
