### PR TITLE
Fix timeout unit in ScrollUntilVisibleCommand

### DIFF
--- a/e2e/workspaces/demo_app/scrollUntilVisible_timeout.yaml
+++ b/e2e/workspaces/demo_app/scrollUntilVisible_timeout.yaml
@@ -10,5 +10,4 @@ tags:
     timeout: 1000
     optional: true
 - evalScript: ${maestro.endTime = new Date()}
-- evalScript: ${"scrollUntilVisible took " + console.log(maestro.endTime - maestro.startTime) + "ms"}
 - assertTrue: ${maestro.endTime - maestro.startTime < 5000} # Far less than the 20000 default, but enough to allow for processing time

--- a/e2e/workspaces/demo_app/scrollUntilVisible_timeout.yaml
+++ b/e2e/workspaces/demo_app/scrollUntilVisible_timeout.yaml
@@ -1,0 +1,14 @@
+appId: com.example.example
+tags:
+    - passing
+---
+- launchApp:
+    clearState: true
+- evalScript: ${maestro.startTime = new Date()}
+- scrollUntilVisible:
+    element: non-existent
+    timeout: 1000
+    optional: true
+- evalScript: ${maestro.endTime = new Date()}
+- evalScript: ${"scrollUntilVisible took " + console.log(maestro.endTime - maestro.startTime) + "ms"}
+- assertTrue: ${maestro.endTime - maestro.startTime < 5000} # Far less than the 20000 default, but enough to allow for processing time

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -115,8 +115,7 @@ data class ScrollUntilVisibleCommand(
     }
 
     private fun String.timeoutToMillis(): String {
-        val timeout = if (this.toLong() < 0) { DEFAULT_TIMEOUT_IN_MILLIS.toLong() * 1000L } else this.toLong() * 1000L
-        return timeout.toString()
+        return if (this.toLong() < 0) { DEFAULT_TIMEOUT_IN_MILLIS } else this
     }
 
     override fun description(): String {
@@ -132,7 +131,7 @@ data class ScrollUntilVisibleCommand(
     }
 
     companion object {
-        const val DEFAULT_TIMEOUT_IN_MILLIS = "20"
+        const val DEFAULT_TIMEOUT_IN_MILLIS = "20000"
         const val DEFAULT_SCROLL_DURATION = "40"
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
         const val DEFAULT_CENTER_ELEMENT = false

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -433,7 +433,7 @@ internal class YamlCommandReaderTest {
             ScrollUntilVisibleCommand(
                 selector = ElementSelector(textRegex = "Footer"),
                 direction = ScrollDirection.DOWN,
-                timeout = "20",
+                timeout = "20000",
                 scrollDuration = "40",
                 visibilityPercentage = 100,
                 label = "Scroll to the bottom",

--- a/maestro-test/src/test/resources/117_scroll_until_visible_speed.js
+++ b/maestro-test/src/test/resources/117_scroll_until_visible_speed.js
@@ -3,7 +3,7 @@ output.speed = {
 }
 
 output.timeout = {
-    slow: 20
+    slow: 20000
 }
 
 output.element = {


### PR DESCRIPTION
## Proposed changes

The `timeout` in ScrollUntilVisibleCommand should be interpreted as milliseconds: https://maestro.mobile.dev/api-reference/commands/scrolluntilvisible

This was broken by https://github.com/mobile-dev-inc/maestro/pull/2023.

## Testing

Updated and ran tests

## Issues fixed

Fixes https://github.com/mobile-dev-inc/maestro/issues/2108