### PR TITLE
Fix off-by-one when specifying count with eraseText

### DIFF
--- a/maestro-android/src/androidTest/java/dev/mobile/maestro/MaestroDriverService.kt
+++ b/maestro-android/src/androidTest/java/dev/mobile/maestro/MaestroDriverService.kt
@@ -290,7 +290,7 @@ class Service(
             val charactersToErase = request.charactersToErase
             Log.d("Maestro", "Erasing text $charactersToErase")
 
-            for (i in 0..charactersToErase) {
+            for (i in 1..charactersToErase) {
                 uiDevice.pressDelete()
             }
 


### PR DESCRIPTION
## Proposed changes

Self-evident 1 character change to fix a problem where we're always deleting 1 character extra. Background in the linked issue.

## Testing

```
- inputText: 'testing'
- assertVisible: 'testing'
- eraseText: '3'
- assertNotVisible: 'testing'
- assertVisible: 'test'
```

## Issues fixed

#2122 