### PR TITLE
Pass failing commands via studio API

### DIFF
--- a/maestro-studio/server/src/main/java/maestro/studio/DeviceService.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/DeviceService.kt
@@ -99,13 +99,15 @@ object DeviceService {
         }
     }
 
-    private fun executeCommands(maestro: Maestro, commands: List<MaestroCommand>): Throwable? {
+    private fun executeCommands(maestro: Maestro, commands: List<MaestroCommand>) {
         var failure: Throwable? = null
         val result = Orchestra(maestro, onCommandFailed = { _, _, throwable ->
             failure = throwable
             Orchestra.ErrorResolution.FAIL
         }).executeCommands(commands)
-        return if (result) null else (failure ?: RuntimeException("Command execution failed"))
+        if (failure != null) {
+            throw RuntimeException("Command execution failed")
+        }
     }
 
     private fun treeToElements(tree: TreeNode): List<UIElement> {


### PR DESCRIPTION
## Proposed changes

copilot:summary

## Testing
- built locally
- ran failing and succeeding assertion

## Issues fixed
- #1617 failing assertions shows up in studio ui