### PR TITLE
rightsizing connections to speed up xctest process

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -50,8 +50,8 @@ class XCTestDriverClient(
     }
 
     private val okHttpClient = OkHttpClient.Builder()
-        .connectTimeout(40, TimeUnit.SECONDS)
-        .readTimeout(100, TimeUnit.SECONDS)
+        .connectTimeout(1, TimeUnit.SECONDS)
+        .readTimeout(200, TimeUnit.SECONDS)
         .apply {
             httpInterceptor?.let {
                 this.addInterceptor(it)

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -142,7 +142,7 @@ class LocalXCTestInstaller(
             .build()
 
         val okHttpClient = OkHttpClient.Builder()
-            .connectTimeout(40, TimeUnit.SECONDS)
+            .connectTimeout(1, TimeUnit.SECONDS)
             .readTimeout(100, TimeUnit.SECONDS)
             .build()
 


### PR DESCRIPTION
- large connectTimeouts are only useful when you're dealing with a flaky network - eg trying to connect to something over 3G. In this case, having the timeouts at 40 means that _if xctestserver isn't running on the other side_, the connection will hang for 40 seconds, then die. We use those connections inside a retry loop, which means the retry loop is 40x slower than it should be

- readtimeout is set to 100 seconds, but there are cases (eg getting a flutter view hierarchy) where it actually takes _longer_ than that to complete. Bumping it up.


same applies to the installer:
- if connection is taking more than 1 seconds, it's an indication the installer is hung, so it doesn't make sense to wait more.