### PR TITLE
[RFC] measurement for device commands

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.impldep.org.junit.experimental.categories.Categories.CategoryFilter.include
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
 plugins {
@@ -17,8 +18,9 @@ tasks.named("compileKotlin", KotlinCompilationTask::class.java) {
 }
 
 dependencies {
-    implementation("dev.mobile:maestro-client:1.38.1")
-    implementation("dev.mobile:maestro-orchestra:1.38.1")
-    implementation("dev.mobile:maestro-ios:1.38.1")
+    implementation(project(":maestro-utils"))
+    implementation(project(":maestro-client"))
+    implementation(project(":maestro-orchestra"))
+    implementation(project(":maestro-ios"))
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ junit = "5.10.2"
 kotlin = "1.8.22"
 kotlinResult = "1.1.18"
 ktor = "2.3.6"
+micrometerObservation = "1.13.4"
 mockk = "1.12.0"
 mozillaRhino = "1.7.14"
 picocli = "4.6.3"
@@ -101,6 +102,7 @@ ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+micrometer-observation = { module = "io.micrometer:micrometer-observation", version.ref = "micrometerObservation" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mozilla-rhino = { module = "org.mozilla:rhino", version.ref = "mozillaRhino" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ kotlin = "1.8.22"
 kotlinResult = "1.1.18"
 ktor = "2.3.6"
 micrometerObservation = "1.13.4"
+micrometerCore = "1.13.4"
 mockk = "1.12.0"
 mozillaRhino = "1.7.14"
 picocli = "4.6.3"
@@ -102,6 +103,7 @@ ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
 ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
 ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-server-status-pages = { module = "io.ktor:ktor-server-status-pages", version.ref = "ktor" }
+micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometerCore" }
 micrometer-observation = { module = "io.micrometer:micrometer-observation", version.ref = "micrometerObservation" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mozilla-rhino = { module = "org.mozilla:rhino", version.ref = "mozillaRhino" }

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -15,10 +15,10 @@ import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.util.CiUtils
 import maestro.cli.util.EnvUtils
 import maestro.cli.util.PrintUtils
+import maestro.utils.HttpClient
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
-import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -32,21 +32,21 @@ import okio.IOException
 import okio.buffer
 import java.io.File
 import java.nio.file.Path
-import java.util.UUID
-import java.util.concurrent.TimeUnit
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
+import kotlin.time.Duration.Companion.minutes
 
 class ApiClient(
     private val baseUrl: String,
 ) {
 
-    private val client = OkHttpClient.Builder()
-        .readTimeout(5, TimeUnit.MINUTES)
-        .writeTimeout(5, TimeUnit.MINUTES)
-        .protocols(listOf(Protocol.HTTP_1_1))
-        .addInterceptor(SystemInformationInterceptor())
-        .build()
+    private val client = HttpClient.build(
+        name = "ApiClient",
+        readTimeout = 5.minutes,
+        writeTimeout = 5.minutes,
+        protocols = listOf(Protocol.HTTP_1_1),
+        interceptors = listOf(SystemInformationInterceptor()),
+    )
 
     val domain: String
         get() {

--- a/maestro-cli/src/main/java/maestro/cli/util/ChangeLogUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/ChangeLogUtils.kt
@@ -1,9 +1,9 @@
 package maestro.cli.util
 
-import okhttp3.OkHttpClient
+import maestro.cli.util.EnvUtils.CLI_VERSION
+import maestro.utils.HttpClient
 import okhttp3.Request
 import java.io.File
-import maestro.cli.util.EnvUtils.CLI_VERSION
 
 typealias ChangeLog = List<String>?
 
@@ -21,7 +21,7 @@ object ChangeLogUtils {
         val request = Request.Builder()
             .url("https://raw.githubusercontent.com/mobile-dev-inc/maestro/main/CHANGELOG.md")
             .build()
-        return OkHttpClient().newCall(request).execute().body?.string()
+        return HttpClient.build("ChangeLogUtils").newCall(request).execute().body?.string()
     }
 
     fun print(changelog: ChangeLog): String =

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -197,7 +197,7 @@ class AndroidDriver(
         launchArguments: Map<String, Any>,
         sessionId: UUID?,
     ) {
-        metrics.measured("launchApp", mapOf("appId" to appId)) {
+        metrics.measured("operation", mapOf("command" to "launchApp", "appId" to appId)) {
             if(!open) // pick device flow, no open() invocation
                 open()
 
@@ -220,21 +220,21 @@ class AndroidDriver(
     }
 
     override fun stopApp(appId: String) {
-        metrics.measured("stopApp", mapOf("appId" to appId)) {
+        metrics.measured("operation", mapOf("command" to "stopApp", "appId" to appId)) {
             // Note: If the package does not exist, this call does *not* throw an exception
             shell("am force-stop $appId")
         }
     }
 
     override fun killApp(appId: String) {
-        metrics.measured("killApp", mapOf("appId" to appId)) {
+        metrics.measured("operation", mapOf("command" to "killApp", "appId" to appId)) {
             // Kill is the adb command needed to trigger System-initiated Process Death
             shell("am kill $appId")
         }
     }
 
     override fun clearAppState(appId: String) {
-        metrics.measured("clearAppState", mapOf("appId" to appId)) {
+        metrics.measured("operation", mapOf("command" to "clearAppState", "appId" to appId)) {
             if (!isPackageInstalled(appId)) {
                 return@measured
             }
@@ -248,7 +248,7 @@ class AndroidDriver(
     }
 
     override fun tap(point: Point) {
-        metrics.measured("tap") {
+        metrics.measured("operation", mapOf("command" to "tap")) {
             runDeviceCall {
                 blockingStubWithTimeout.tap(
                     tapRequest {
@@ -261,13 +261,13 @@ class AndroidDriver(
     }
 
     override fun longPress(point: Point) {
-        metrics.measured("longPress") {
+        metrics.measured("operation", mapOf("command" to "longPress")) {
             dadb.shell("input swipe ${point.x} ${point.y} ${point.x} ${point.y} 3000")
         }
     }
 
     override fun pressKey(code: KeyCode) {
-        metrics.measured("pressKey") {
+        metrics.measured("operation", mapOf("command" to "pressKey")) {
             val intCode: Int = when (code) {
                 KeyCode.ENTER -> 66
                 KeyCode.BACKSPACE -> 67
@@ -307,7 +307,7 @@ class AndroidDriver(
     }
 
     override fun contentDescriptor(excludeKeyboardElements: Boolean): TreeNode {
-        return metrics.measured("contentDescriptor") {
+        return metrics.measured("operation", mapOf("command" to "contentDescriptor")) {
             val response = callViewHierarchy()
 
             val document = documentBuilderFactory
@@ -366,13 +366,13 @@ class AndroidDriver(
     }
 
     override fun scrollVertical() {
-        metrics.measured("scrollVertical") {
+        metrics.measured("operation", mapOf("command" to "scrollVertical")) {
             swipe(SwipeDirection.UP, 400)
         }
     }
 
     override fun isKeyboardVisible(): Boolean {
-        return metrics.measured("isKeyboardVisible") {
+        return metrics.measured("operation", mapOf("command" to "isKeyboardVisible")) {
             val root = contentDescriptor().let {
                 val deviceInfo = deviceInfo()
                 val filtered = it.filterOutOfBounds(
@@ -390,7 +390,7 @@ class AndroidDriver(
     }
 
     override fun swipe(swipeDirection: SwipeDirection, durationMs: Long) {
-        metrics.measured("swipeWithDirection", mapOf("direction" to swipeDirection.name, "durationMs" to durationMs.toString())) {
+        metrics.measured("operation", mapOf("command" to "swipeWithDirection", "direction" to swipeDirection.name, "durationMs" to durationMs.toString())) {
             val deviceInfo = deviceInfo()
             when (swipeDirection) {
                 SwipeDirection.UP -> {
@@ -445,7 +445,7 @@ class AndroidDriver(
     }
 
     override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
-        metrics.measured("swipeWithElementPoint", mapOf("direction" to direction.name, "durationMs" to durationMs.toString())) {
+        metrics.measured("operation", mapOf("command" to "swipeWithElementPoint", "direction" to direction.name, "durationMs" to durationMs.toString())) {
             val deviceInfo = deviceInfo()
             when (direction) {
                 SwipeDirection.UP -> {
@@ -472,20 +472,20 @@ class AndroidDriver(
     }
 
     private fun directionalSwipe(durationMs: Long, start: Point, end: Point) {
-        metrics.measured("directionalSwipe", mapOf("durationMs" to durationMs.toString())) {
+        metrics.measured("operation", mapOf("command" to "directionalSwipe", "durationMs" to durationMs.toString())) {
             dadb.shell("input swipe ${start.x} ${start.y} ${end.x} ${end.y} $durationMs")
         }
     }
 
     override fun backPress() {
-        metrics.measured("backPress") {
+        metrics.measured("operation", mapOf("command" to "backPress")) {
             dadb.shell("input keyevent 4")
             Thread.sleep(300)
         }
     }
 
     override fun hideKeyboard() {
-        metrics.measured("hideKeyboard") {
+        metrics.measured("operation", mapOf("command" to "hideKeyboard")) {
             dadb.shell("input keyevent 4") // 'Back', which dismisses the keyboard before handing over to navigation
             Thread.sleep(300)
             waitForAppToSettle(null, null)
@@ -493,7 +493,7 @@ class AndroidDriver(
     }
 
     override fun takeScreenshot(out: Sink, compressed: Boolean) {
-        metrics.measured("takeScreenshot", mapOf("compressed" to compressed.toString())) {
+        metrics.measured("operation", mapOf("command" to "takeScreenshot", "compressed" to compressed.toString())) {
             runDeviceCall {
                 val response = blockingStubWithTimeout.screenshot(screenshotRequest {})
                 out.buffer().use {
@@ -504,7 +504,7 @@ class AndroidDriver(
     }
 
     override fun startScreenRecording(out: Sink): ScreenRecording {
-        return metrics.measured("startScreenRecording") {
+        return metrics.measured("operation", mapOf("command" to "startScreenRecording")) {
 
             val deviceScreenRecordingPath = "/sdcard/maestro-screenrecording.mp4"
 
@@ -533,7 +533,7 @@ class AndroidDriver(
     }
 
     override fun inputText(text: String) {
-        metrics.measured("inputText") {
+        metrics.measured("operation", mapOf("command" to "inputText")) {
             runDeviceCall {
                 blockingStubWithTimeout.inputText(inputTextRequest {
                     this.text = text
@@ -543,7 +543,7 @@ class AndroidDriver(
     }
 
     override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
-        metrics.measured("openLink", mapOf("appId" to appId, "autoVerify" to autoVerify.toString(), "browser" to browser.toString())) {
+        metrics.measured("operation", mapOf("command" to "openLink", "appId" to appId, "autoVerify" to autoVerify.toString(), "browser" to browser.toString())) {
             if (browser) {
                 openBrowser(link)
             } else {
@@ -631,7 +631,7 @@ class AndroidDriver(
         .map { parts: Array<String> -> parts[1] }
 
     override fun setLocation(latitude: Double, longitude: Double) {
-        metrics.measured("setLocation") {
+        metrics.measured("operation", mapOf("command" to "setLocation")) {
             shell("appops set dev.mobile.maestro android:mock_location allow")
 
             runDeviceCall {
@@ -646,7 +646,7 @@ class AndroidDriver(
     }
 
     override fun eraseText(charactersToErase: Int) {
-        metrics.measured("eraseText", mapOf("charactersToErase" to charactersToErase.toString())) {
+        metrics.measured("operation", mapOf("command" to "eraseText", "charactersToErase" to charactersToErase.toString())) {
             runDeviceCall {
                 blockingStubWithTimeout.eraseAllText(
                     eraseAllTextRequest {
@@ -658,20 +658,20 @@ class AndroidDriver(
     }
 
     override fun setProxy(host: String, port: Int) {
-        metrics.measured("setProxy") {
+        metrics.measured("operation", mapOf("command" to "setProxy")) {
             shell("""settings put global http_proxy "${host}:${port}"""")
             proxySet = true
         }
     }
 
     override fun resetProxy() {
-        metrics.measured("resetProxy") {
+        metrics.measured("operation", mapOf("command" to "resetProxy")) {
             shell("settings put global http_proxy :0")
         }
     }
 
     override fun isShutdown(): Boolean {
-        return metrics.measured("isShutdown") {
+        return metrics.measured("operation", mapOf("command" to "isShutdown")) {
             channel.isShutdown
         }
     }
@@ -681,7 +681,7 @@ class AndroidDriver(
     }
 
     override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int?): ViewHierarchy? {
-        return metrics.measured("waitForAppToSettle", mapOf("appId" to appId, "timeoutMs" to timeoutMs.toString())) {
+        return metrics.measured("operation", mapOf("command" to "waitForAppToSettle", "appId" to appId, "timeoutMs" to timeoutMs.toString())) {
             if (appId != null) {
                 waitForWindowToSettle(appId, initialHierarchy, timeoutMs)
             } else {
@@ -713,13 +713,13 @@ class AndroidDriver(
     }
 
     override fun waitUntilScreenIsStatic(timeoutMs: Long): Boolean {
-        return metrics.measured("waitUntilScreenIsStatic") {
+        return metrics.measured("operation", mapOf("command" to "waitUntilScreenIsStatic", "timeoutMs" to timeoutMs.toString())) {
             ScreenshotUtils.waitUntilScreenIsStatic(timeoutMs, SCREENSHOT_DIFF_THRESHOLD, this)
         }
     }
 
     override fun capabilities(): List<Capability> {
-        return metrics.measured("capabilities") {
+        return metrics.measured("operation", mapOf("command" to "capabilities")) {
             listOf(
                 Capability.FAST_HIERARCHY
             )
@@ -727,7 +727,7 @@ class AndroidDriver(
     }
 
     override fun setPermissions(appId: String, permissions: Map<String, String>) {
-        metrics.measured("setPermissions", mapOf("appId" to appId)) {
+        metrics.measured("operation", mapOf("command" to "setPermissions", "appId" to appId)) {
             val mutable = permissions.toMutableMap()
             mutable.remove("all")?.let { value ->
                 setAllPermissions(appId, value)
@@ -743,7 +743,7 @@ class AndroidDriver(
     }
 
     override fun addMedia(mediaFiles: List<File>) {
-        metrics.measured("addMedia", mapOf("mediaFilesCount" to mediaFiles.size.toString())) {
+        metrics.measured("operation", mapOf("command" to "addMedia", "mediaFilesCount" to mediaFiles.size.toString())) {
             LOGGER.info("[Start] Adding media files")
             mediaFiles.forEach { addMediaToDevice(it) }
             LOGGER.info("[Done] Adding media files")
@@ -751,7 +751,7 @@ class AndroidDriver(
     }
 
     override fun isAirplaneModeEnabled(): Boolean {
-        return metrics.measured("isAirplaneModeEnabled") {
+        return metrics.measured("operation", mapOf("command" to "isAirplaneModeEnabled")) {
             when (val result = shell("cmd connectivity airplane-mode").trim()) {
                 "No shell command implementation.", "" -> {
                     LOGGER.debug("Falling back to old airplane mode read method")
@@ -770,7 +770,7 @@ class AndroidDriver(
     }
 
     override fun setAirplaneMode(enabled: Boolean) {
-        metrics.measured("setAirplaneMode") {
+        metrics.measured("operation", mapOf("command" to "setAirplaneMode", "enabled" to enabled.toString())) {
             // fallback to old way on API < 28
             if (getDeviceApiLevel() < 28) {
                 val num = if (enabled) 1 else 0
@@ -800,7 +800,7 @@ class AndroidDriver(
     }
 
     fun setDeviceLocale(country: String, language: String): Int {
-        return metrics.measured("setDeviceLocale") {
+        return metrics.measured("operation", mapOf("command" to "setDeviceLocale", "country" to country, "language" to language)) {
             dadb.shell("pm grant dev.mobile.maestro android.permission.CHANGE_CONFIGURATION")
             val response =
                 dadb.shell("am broadcast -a dev.mobile.maestro.locale -n dev.mobile.maestro/.receivers.LocaleSettingReceiver --es lang $language --es country $country")
@@ -1027,7 +1027,7 @@ class AndroidDriver(
     }
 
     fun installMaestroDriverApp() {
-        metrics.measured("installMaestroDriverApp") {
+        metrics.measured("operation", mapOf("command" to "installMaestroDriverApp")) {
             uninstallMaestroDriverApp()
 
             val maestroAppApk = File.createTempFile("maestro-app", ".apk")
@@ -1070,7 +1070,7 @@ class AndroidDriver(
     }
 
     fun uninstallMaestroDriverApp() {
-        metrics.measured("uninstallMaestroDriverApp") {
+        metrics.measured("operation", mapOf("command" to "uninstallMaestroDriverApp")) {
             if (isPackageInstalled("dev.mobile.maestro")) {
                 uninstall("dev.mobile.maestro")
             }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -65,7 +65,7 @@ class AndroidDriver(
     private var open = false
     private val hostPort: Int = hostPort ?: DefaultDriverHostPort
 
-    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withLabels(mapOf("platform" to "android"))
+    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "android"))
 
     private val channel = ManagedChannelBuilder.forAddress("localhost", this.hostPort)
         .usePlaintext()

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -65,7 +65,7 @@ class AndroidDriver(
     private var open = false
     private val hostPort: Int = hostPort ?: DefaultDriverHostPort
 
-    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "android"))
+    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "android", "emulatorName" to emulatorName))
 
     private val channel = ManagedChannelBuilder.forAddress("localhost", this.hostPort)
         .usePlaintext()

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -36,6 +36,7 @@ import maestro.android.AndroidAppFiles
 import maestro.android.AndroidLaunchArguments.toAndroidLaunchArguments
 import maestro.utils.BlockingStreamObserver
 import maestro.utils.MaestroTimer
+import maestro.utils.Metrics
 import maestro.utils.MetricsProvider
 import maestro.utils.ScreenshotUtils
 import maestro.utils.StringUtils.toRegexSafe
@@ -61,11 +62,12 @@ class AndroidDriver(
     private val dadb: Dadb,
     hostPort: Int? = null,
     private var emulatorName: String = "",
-) : Driver {
+    private val metricsProvider: Metrics = MetricsProvider.getInstance(),
+    ) : Driver {
     private var open = false
     private val hostPort: Int = hostPort ?: DefaultDriverHostPort
 
-    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "android", "emulatorName" to emulatorName))
+    private val metrics = metricsProvider.withPrefix("maestro.driver").withTags(mapOf("platform" to "android", "emulatorName" to emulatorName))
 
     private val channel = ManagedChannelBuilder.forAddress("localhost", this.hostPort)
         .usePlaintext()

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -43,7 +43,7 @@ class IOSDriver(
     private val insights: Insights = NoopInsights
 ) : Driver {
 
-    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withLabels(mapOf("platform" to "ios"))
+    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "ios"))
 
     private var appId: String? = null
     private var proxySet = false

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -40,10 +40,11 @@ import kotlin.collections.set
 
 class IOSDriver(
     private val iosDevice: IOSDevice,
-    private val insights: Insights = NoopInsights
-) : Driver {
+    private val insights: Insights = NoopInsights,
+    private val metricsProvider: Metrics = MetricsProvider.getInstance(),
+    ) : Driver {
 
-    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "ios", "deviceId" to iosDevice.deviceId).filterValues { it != null }.mapValues { it.value!! })
+    private val metrics = metricsProvider.withPrefix("maestro.driver").withTags(mapOf("platform" to "ios", "deviceId" to iosDevice.deviceId).filterValues { it != null }.mapValues { it.value!! })
 
     private var appId: String? = null
     private var proxySet = false

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -43,7 +43,7 @@ class IOSDriver(
     private val insights: Insights = NoopInsights
 ) : Driver {
 
-    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "ios"))
+    private val metrics = MetricsProvider.getInstance().withPrefix("maestro.driver").withTags(mapOf("platform" to "ios", "deviceId" to iosDevice.deviceId).filterValues { it != null }.mapValues { it.value!! })
 
     private var appId: String? = null
     private var proxySet = false

--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -1,5 +1,6 @@
 package maestro.js
 
+import maestro.utils.HttpClient
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import org.graalvm.polyglot.Context
@@ -10,6 +11,7 @@ import java.io.ByteArrayOutputStream
 import java.util.concurrent.TimeUnit
 import java.util.logging.Handler
 import java.util.logging.LogRecord
+import kotlin.time.Duration.Companion.minutes
 
 private val NULL_HANDLER = object : Handler() {
     override fun publish(record: LogRecord?) {}
@@ -20,11 +22,12 @@ private val NULL_HANDLER = object : Handler() {
 }
 
 class GraalJsEngine(
-    httpClient: OkHttpClient = OkHttpClient.Builder()
-        .readTimeout(5, TimeUnit.MINUTES)
-        .writeTimeout(5, TimeUnit.MINUTES)
-        .protocols(listOf(Protocol.HTTP_1_1))
-        .build(),
+    httpClient: OkHttpClient = HttpClient.build(
+        name = "GraalJsEngine",
+        readTimeout = 5.minutes,
+        writeTimeout = 5.minutes,
+        protocols = listOf(Protocol.HTTP_1_1)
+    ),
     platform: String = "unknown",
 ) : JsEngine {
 

--- a/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
@@ -1,17 +1,19 @@
 package maestro.js
 
+import maestro.utils.HttpClient
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.ScriptableObject
-import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.minutes
 
 class RhinoJsEngine(
-    httpClient: OkHttpClient = OkHttpClient.Builder()
-        .readTimeout(5, TimeUnit.MINUTES)
-        .writeTimeout(5, TimeUnit.MINUTES)
-        .protocols(listOf(Protocol.HTTP_1_1))
-        .build(),
+    httpClient: OkHttpClient = HttpClient.build(
+        name="RhinoJsEngine",
+        readTimeout=5.minutes,
+        writeTimeout=5.minutes,
+        protocols=listOf(Protocol.HTTP_1_1)
+    ),
     platform: String = "unknown",
 ) : JsEngine {
 

--- a/maestro-client/src/main/java/maestro/mockserver/MockInteractor.kt
+++ b/maestro-client/src/main/java/maestro/mockserver/MockInteractor.kt
@@ -2,7 +2,7 @@ package maestro.mockserver
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import okhttp3.OkHttpClient
+import maestro.utils.HttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import java.nio.file.Paths
@@ -12,6 +12,7 @@ import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.readText
 import kotlin.math.max
+import kotlin.time.Duration.Companion.minutes
 
 data class Auth(
     val teamId: UUID,
@@ -39,11 +40,12 @@ data class GetEventsResponse(
 )
 
 class MockInteractor {
-    private val client = OkHttpClient.Builder()
-        .readTimeout(5, TimeUnit.MINUTES)
-        .writeTimeout(5, TimeUnit.MINUTES)
-        .protocols(listOf(Protocol.HTTP_1_1))
-        .build()
+    private val client = HttpClient.build(
+        name = "MockInteractor",
+        readTimeout = 5.minutes,
+        writeTimeout = 5.minutes,
+        protocols = listOf(Protocol.HTTP_1_1)
+    )
 
     fun getCachedAuthToken(): String? {
         if (!System.getProperty("MAESTRO_CLOUD_API_KEY").isNullOrEmpty()) return System.getProperty("MAESTRO_CLOUD_API_KEY")

--- a/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
+++ b/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
@@ -30,7 +30,7 @@ class XCTestDriverClientTest {
             setBody(mapper.writeValueAsString(error))
         }
         mockWebServer.enqueue(mockResponse)
-        mockWebServer.start(InetAddress.getByName( "localhost"), 22087)
+        mockWebServer.start(InetAddress.getByName("localhost"), 22087)
         val httpUrl = mockWebServer.url("/deviceInfo")
 
         // when
@@ -61,7 +61,7 @@ class XCTestDriverClientTest {
             setBody(mapper.writeValueAsString(expectedDeviceInfo))
         }
         mockWebServer.enqueue(mockResponse)
-        mockWebServer.start(InetAddress.getByName( "localhost"), 22087)
+        mockWebServer.start(InetAddress.getByName("localhost"), 22087)
         val httpUrl = mockWebServer.url("/deviceInfo")
 
         // when

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -2,23 +2,24 @@ package xcuitest
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import hierarchy.ViewHierarchy
+import maestro.utils.HttpClient
 import maestro.utils.network.XCUITestServerError
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
-import okhttp3.logging.HttpLoggingInterceptor
 import org.slf4j.LoggerFactory
 import xcuitest.api.*
 import xcuitest.installer.XCTestInstaller
 import java.io.IOException
-import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.seconds
 
 class XCTestDriverClient(
     private val installer: XCTestInstaller,
-    private val okHttpClient: OkHttpClient = OkHttpClient.Builder()
-        .connectTimeout(1, TimeUnit.SECONDS)
-        .readTimeout(200, TimeUnit.SECONDS)
-        .build()
+    private val okHttpClient: OkHttpClient = HttpClient.build(
+        name = "XCTestDriverClient",
+        readTimeout = 200.seconds,
+        connectTimeout = 1.seconds
+    )
 ) {
     private val logger = LoggerFactory.getLogger(XCTestDriverClient::class.java)
 

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -45,7 +45,7 @@ class LocalXCTestInstaller(
     private var xcTestProcess: Process? = null
 
     override fun uninstall(): Boolean {
-        return metrics.measured("uninstall") {
+        return metrics.measured("operation", mapOf("command" to "uninstall")) {
             // FIXME(bartekpacia): This method probably doesn't have to care about killing the XCTest Runner process.
             //  Just uninstalling should suffice. It automatically kills the process.
 
@@ -84,7 +84,7 @@ class LocalXCTestInstaller(
     }
 
     override fun start(): XCTestClient? {
-        return metrics.measured("start") {
+        return metrics.measured("operation", mapOf("command" to "start")) {
             logger.info("start()")
 
             if (useXcodeTestRunner) {
@@ -125,7 +125,9 @@ class LocalXCTestInstaller(
     }.getOrDefault(SERVER_LAUNCH_TIMEOUT_MS)
 
     override fun isChannelAlive(): Boolean {
-        return xcTestDriverStatusCheck()
+        return metrics.measured("operation", mapOf("command" to "isChannelAlive")) {
+        return@measured xcTestDriverStatusCheck()
+        }
     }
 
     private fun ensureOpen(): Boolean {

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -2,6 +2,7 @@ package xcuitest.installer
 
 import maestro.utils.HttpClient
 import maestro.utils.MaestroTimer
+import maestro.utils.Metrics
 import maestro.utils.MetricsProvider
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -23,15 +24,16 @@ class LocalXCTestInstaller(
     private val host: String = "[::1]",
     private val enableXCTestOutputFileLogging: Boolean,
     private val defaultPort: Int,
+    private val metricsProvider: Metrics = MetricsProvider.getInstance(),
     private val httpClient: OkHttpClient = HttpClient.build(
         name = "XCUITestDriverStatusCheck",
         connectTimeout = 1.seconds,
         readTimeout = 100.seconds,
-    )
-) : XCTestInstaller {
+    ),
+    ) : XCTestInstaller {
 
     private val logger = LoggerFactory.getLogger(LocalXCTestInstaller::class.java)
-    private val metrics = MetricsProvider.getInstance().withPrefix("xcuitest.installer").withTags(mapOf("kind" to "local", "deviceId" to deviceId, "host" to host))
+    private val metrics = metricsProvider.withPrefix("xcuitest.installer").withTags(mapOf("kind" to "local", "deviceId" to deviceId, "host" to host))
 
     /**
      * If true, allow for using a xctest runner started from Xcode.

--- a/maestro-utils/build.gradle.kts
+++ b/maestro-utils/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 dependencies {
     api(libs.square.okio)
+    implementation(libs.micrometer.observation)
 
     testImplementation(libs.mockk)
     testImplementation(libs.junit.jupiter.api)

--- a/maestro-utils/build.gradle.kts
+++ b/maestro-utils/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 
 dependencies {
     api(libs.square.okio)
+    implementation(libs.square.okhttp)
+    implementation(libs.micrometer.core)
     implementation(libs.micrometer.observation)
 
     testImplementation(libs.mockk)

--- a/maestro-utils/src/main/kotlin/HttpClient.kt
+++ b/maestro-utils/src/main/kotlin/HttpClient.kt
@@ -67,7 +67,7 @@ object HttpClient {
         writeTimeout: Duration = 10.seconds,
         interceptors: List<Interceptor> = emptyList(),
         networkInterceptors: List<Interceptor> = emptyList(),
-        protocols: List<Protocol> = listOf(Protocol.HTTP_2),
+        protocols: List<Protocol> = listOf(Protocol.HTTP_1_1),
         metrics: Metrics = MetricsProvider.getInstance()
     ): OkHttpClient {
         var b = OkHttpClient.Builder()
@@ -92,8 +92,8 @@ object HttpClient {
             })
             .protocols(protocols)
 
-        b = networkInterceptors.map { b.addNetworkInterceptor(it) }.last()
-        b = interceptors.map { b.addInterceptor(it) }.last()
+        b = networkInterceptors.map { b.addNetworkInterceptor(it) }.lastOrNull() ?: b
+        b = interceptors.map { b.addInterceptor(it) }.lastOrNull() ?: b
 
         return b.build()
     }

--- a/maestro-utils/src/main/kotlin/HttpClient.kt
+++ b/maestro-utils/src/main/kotlin/HttpClient.kt
@@ -1,0 +1,88 @@
+package maestro.utils
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import okhttp3.Call
+import okhttp3.EventListener
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+
+class MetricsEventListener(
+    private val registry: Metrics,
+    private val clientName: String,
+) : EventListener() {
+    private val sample = registry.startTimer()
+
+    override fun callStart(call: Call) {
+        registry.counter(
+            "http.client.requests",
+            mapOf(
+                "client" to clientName,
+                "method" to call.request().method,
+                "url" to call.request().url.host
+            )
+        ).increment()
+    }
+
+    override fun callEnd(call: Call) {
+        sample.stop(
+            registry.timer(
+                "http.client.request.duration",
+                mapOf(
+                    "client" to clientName,
+                    "method" to call.request().method,
+                    "url" to call.request().url.host
+                )
+            )
+        )
+    }
+
+    override fun callFailed(call: Call, e: IOException) {
+        registry.counter(
+            "http.client.errors",
+            mapOf(
+                "client" to clientName,
+                "method" to call.request().method,
+                "url" to call.request().url.host,
+                "exception" to e.javaClass.simpleName
+            )
+        ).increment()
+    }
+
+    class Factory(
+        private val registry: Metrics,
+        private val clientName: String,
+    ) : EventListener.Factory {
+        override fun create(call: Call): EventListener =
+            MetricsEventListener(registry, clientName)
+    }
+}
+
+// utility object to build http clients with metrics
+object HttpClient {
+    fun build(
+        name: String,
+        connectTimeout: Duration = 10.seconds,
+        readTimeout: Duration = 10.seconds,
+        writeTimeout: Duration = 10.seconds,
+        interceptors: List<Interceptor> = emptyList(),
+        networkInterceptors: List<Interceptor> = emptyList(),
+        protocols: List<Protocol> = listOf(Protocol.HTTP_2),
+        metrics: Metrics = MetricsProvider.getInstance()
+    ): OkHttpClient {
+        var b = OkHttpClient.Builder()
+            .eventListenerFactory(MetricsEventListener.Factory(metrics, name))
+            .connectTimeout(connectTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            .readTimeout(readTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            .writeTimeout(writeTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            .protocols(protocols)
+
+        b = networkInterceptors.map { b.addNetworkInterceptor(it) }.last()
+        b = interceptors.map { b.addInterceptor(it) }.last()
+
+        return b.build()
+    }
+}

--- a/maestro-utils/src/main/kotlin/Metrics.kt
+++ b/maestro-utils/src/main/kotlin/Metrics.kt
@@ -41,6 +41,7 @@ open class Metrics(
 ) {
     fun <T> measured(name: String, tags: Map<String, String?> = emptyMap(), block: () -> T): T {
         val timer = Timer.builder(prefixed(prefix, name)).tags(toTags(tags)).register(registry)
+        counter(prefixed(prefix, "$name.calls"), tags).increment()
 
         val t0 = System.currentTimeMillis()
         try {
@@ -64,10 +65,6 @@ open class Metrics(
     // get a metrics object that adds labels to all metrics
     fun withTags(tags: Map<String, String>): Metrics {
         return Metrics(registry, prefix, this.tags + tags)
-    }
-
-    fun startTimer(): Timer.Sample {
-        return Timer.start(registry)
     }
 
     fun counter(name: String, labels: Map<String, String?> = emptyMap()): Counter {

--- a/maestro-utils/src/main/kotlin/Metrics.kt
+++ b/maestro-utils/src/main/kotlin/Metrics.kt
@@ -1,5 +1,12 @@
 package maestro.utils
 
+import io.micrometer.core.instrument.Counter
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tag
+import io.micrometer.core.instrument.Timer
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import java.util.concurrent.TimeUnit
+
 
 // singleton to provide a metric manager across maestro code since there's so many singleton objects and passing it around would be a massive change
 object MetricsProvider {
@@ -14,26 +21,64 @@ object MetricsProvider {
     }
 }
 
-interface Metrics {
-    fun <T> measured(name: String, labels: Map<String, String?> = emptyMap(), block: () -> T): T
-
-    // get a metrics object that adds a certain prefix to all metrics
-    fun withPrefix(prefix: String): Metrics
-
-    // get a metrics object that adds labels to all metrics
-    fun withLabels(labels: Map<String, String>): Metrics
+private fun toTags(map: Map<String, String?>): Iterable<Tag> {
+    return map.filterValues {
+        it != null
+    }.map { Tag.of(it.key, it.value) }.toList()
 }
 
-class NoOpMetrics : Metrics {
-    override fun <T> measured(name: String, labels: Map<String, String?>, block: () -> T): T {
-        return block()
+private fun prefixed(prefix: String?, name: String): String {
+    if (prefix == null) {
+        return name
+    }
+    return "$prefix.$name"
+}
+
+open class Metrics(
+    val registry: MeterRegistry,
+    val prefix: String? = null,
+    val tags: Map<String, String?> = emptyMap(),
+) {
+    fun <T> measured(name: String, tags: Map<String, String?> = emptyMap(), block: () -> T): T {
+        val timer = Timer.builder(prefixed(prefix, name)).tags(toTags(tags)).register(registry)
+
+        val t0 = System.currentTimeMillis()
+        try {
+            return block()
+        } catch (e: Exception) {
+            registry.counter(
+                prefixed(prefix, "$name.errors"),
+                toTags(tags + ("exception" to e.javaClass.simpleName))
+            ).increment()
+            throw e
+        } finally {
+            timer.record(System.currentTimeMillis() - t0, TimeUnit.MILLISECONDS)
+        }
     }
 
-    override fun withPrefix(prefix: String): Metrics {
-        return this
+    // get a metrics object that adds a certain prefix to all metrics
+    fun withPrefix(prefix: String): Metrics {
+        return Metrics(registry, prefixed(this.prefix, prefix))
     }
 
-    override fun withLabels(labels: Map<String, String>): Metrics {
-        return this
+    // get a metrics object that adds labels to all metrics
+    fun withTags(tags: Map<String, String>): Metrics {
+        return Metrics(registry, prefix, this.tags + tags)
     }
+
+    fun startTimer(): Timer.Sample {
+        return Timer.start(registry)
+    }
+
+    fun counter(name: String, labels: Map<String, String?> = emptyMap()): Counter {
+        return Counter.builder(prefixed(prefix, name)).tags(toTags(tags + labels)).register(registry)
+    }
+
+    fun timer(name: String, labels: Map<String, String?> = emptyMap()): Timer {
+        return Timer.builder(prefixed(prefix, name)).tags(toTags(tags + labels)).register(registry)
+    }
+}
+
+class NoOpMetrics : Metrics(SimpleMeterRegistry(), "noop", emptyMap()) {
+
 }

--- a/maestro-utils/src/main/kotlin/Metrics.kt
+++ b/maestro-utils/src/main/kotlin/Metrics.kt
@@ -1,0 +1,39 @@
+package maestro.utils
+
+
+// singleton to provide a metric manager across maestro code since there's so many singleton objects and passing it around would be a massive change
+object MetricsProvider {
+    private var metrics: Metrics = NoOpMetrics()
+
+    fun setMetrics(metrics: Metrics) {
+        this.metrics = metrics
+    }
+
+    fun getInstance(): Metrics {
+        return metrics
+    }
+}
+
+interface Metrics {
+    fun <T> measured(name: String, labels: Map<String, String?> = emptyMap(), block: () -> T): T
+
+    // get a metrics object that adds a certain prefix to all metrics
+    fun withPrefix(prefix: String): Metrics
+
+    // get a metrics object that adds labels to all metrics
+    fun withLabels(labels: Map<String, String>): Metrics
+}
+
+class NoOpMetrics : Metrics {
+    override fun <T> measured(name: String, labels: Map<String, String?>, block: () -> T): T {
+        return block()
+    }
+
+    override fun withPrefix(prefix: String): Metrics {
+        return this
+    }
+
+    override fun withLabels(labels: Map<String, String>): Metrics {
+        return this
+    }
+}


### PR DESCRIPTION
The idea here is to introduce micrometer management across the board, starting w/ individual commands on ios and android. This will allow us to identify potential bottlenecks, errors at the command level, etc

The default implementation is a noop - it won't collect or send metrics anywhere. Users of maestro (eg robin itself) can hook them up so we get metrics for tests that run in the platform.

The idea is to also auto-instrument http requests (using okhttp), such that we can tell cases where retries are happening more than they should, etc