### PR TITLE
fix: add waitToSettleTimeOut on swipe commands

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -122,7 +122,8 @@ class Maestro(
         endPoint: Point? = null,
         startRelative: String? = null,
         endRelative: String? = null,
-        duration: Long
+        duration: Long,
+        waitToSettleTimeoutMs: Int? = null
     ) {
         val deviceInfo = deviceInfo()
 
@@ -146,23 +147,23 @@ class Maestro(
             }
         }
 
-        waitForAppToSettle()
+        waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
-    fun swipe(swipeDirection: SwipeDirection, uiElement: UiElement, durationMs: Long) {
+    fun swipe(swipeDirection: SwipeDirection, uiElement: UiElement, durationMs: Long, waitToSettleTimeoutMs: Int?) {
         LOGGER.info("Swiping ${swipeDirection.name} on element: $uiElement")
         driver.swipe(uiElement.bounds.center(), swipeDirection, durationMs)
 
-        waitForAppToSettle()
+        waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
-    fun swipeFromCenter(swipeDirection: SwipeDirection, durationMs: Long) {
+    fun swipeFromCenter(swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
         val deviceInfo = deviceInfo()
 
         LOGGER.info("Swiping ${swipeDirection.name} from center")
         val center = Point(x = deviceInfo.widthGrid / 2, y = deviceInfo.heightGrid / 2)
         driver.swipe(center, swipeDirection, durationMs)
-        waitForAppToSettle()
+        waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
     fun scrollVertical() {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -55,6 +55,7 @@ data class SwipeCommand(
     val startRelative: String? = null,
     val endRelative: String? = null,
     val duration: Long = DEFAULT_DURATION_IN_MILLIS,
+    val waitToSettleTimeoutMs: Int? = null,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -102,6 +103,7 @@ data class ScrollUntilVisibleCommand(
     val scrollDuration: String = DEFAULT_SCROLL_DURATION,
     val visibilityPercentage: Int,
     val timeout: String = DEFAULT_TIMEOUT_IN_MILLIS,
+    val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
     override val label: String? = null,
     override val optional: Boolean = false,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -502,7 +502,7 @@ class Orchestra(
                 }
             } catch (ignored: MaestroException.ElementNotFound) {
             }
-            maestro.swipeFromCenter(direction, durationMs = command.scrollDuration.toLong())
+            maestro.swipeFromCenter(direction, durationMs = command.scrollDuration.toLong(), waitToSettleTimeoutMs = command.waitToSettleTimeoutMs)
         } while (System.currentTimeMillis() < endTime)
 
         throw MaestroException.ElementNotFound(
@@ -1138,18 +1138,19 @@ class Orchestra(
         when {
             elementSelector != null && direction != null -> {
                 val uiElement = findElement(elementSelector, optional = command.optional)
-                maestro.swipe(direction, uiElement.element, command.duration)
+                maestro.swipe(direction, uiElement.element, command.duration, waitToSettleTimeoutMs = command.waitToSettleTimeoutMs)
             }
 
             startRelative != null && endRelative != null -> {
-                maestro.swipe(startRelative = startRelative, endRelative = endRelative, duration = command.duration)
+                maestro.swipe(startRelative = startRelative, endRelative = endRelative, duration = command.duration, waitToSettleTimeoutMs = command.waitToSettleTimeoutMs)
             }
 
-            direction != null -> maestro.swipe(swipeDirection = direction, duration = command.duration)
+            direction != null -> maestro.swipe(swipeDirection = direction, duration = command.duration, waitToSettleTimeoutMs = command.waitToSettleTimeoutMs)
             start != null && end != null -> maestro.swipe(
                 startPoint = start,
                 endPoint = end,
-                duration = command.duration
+                duration = command.duration,
+                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
             )
 
             else -> error("Illegal arguments for swiping")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -499,7 +499,7 @@ data class YamlFluentCommand(
 
     private fun swipeCommand(swipe: YamlSwipe): MaestroCommand {
         when (swipe) {
-            is YamlSwipeDirection -> return MaestroCommand(SwipeCommand(direction = swipe.direction, duration = swipe.duration, label = swipe.label, optional = swipe.optional))
+            is YamlSwipeDirection -> return MaestroCommand(SwipeCommand(direction = swipe.direction, duration = swipe.duration, label = swipe.label, optional = swipe.optional, waitToSettleTimeoutMs = swipe.waitToSettleTimeoutMs))
             is YamlCoordinateSwipe -> {
                 val start = swipe.start
                 val end = swipe.end
@@ -518,11 +518,11 @@ data class YamlFluentCommand(
                     }
                 endPoint = Point(endPoints[0], endPoints[1])
 
-                return MaestroCommand(SwipeCommand(startPoint = startPoint, endPoint = endPoint, duration = swipe.duration, label = swipe.label, optional = swipe.optional))
+                return MaestroCommand(SwipeCommand(startPoint = startPoint, endPoint = endPoint, duration = swipe.duration, label = swipe.label, optional = swipe.optional, waitToSettleTimeoutMs = swipe.waitToSettleTimeoutMs))
             }
             is YamlRelativeCoordinateSwipe -> {
                 return MaestroCommand(
-                    SwipeCommand(startRelative = swipe.start, endRelative = swipe.end, duration = swipe.duration, label = swipe.label, optional = swipe.optional)
+                    SwipeCommand(startRelative = swipe.start, endRelative = swipe.end, duration = swipe.duration, label = swipe.label, optional = swipe.optional, waitToSettleTimeoutMs = swipe.waitToSettleTimeoutMs)
                 )
             }
             is YamlSwipeElement -> return swipeElementCommand(swipe)
@@ -543,6 +543,7 @@ data class YamlFluentCommand(
                 duration = swipeElement.duration,
                 label = swipeElement.label,
                 optional = swipeElement.optional,
+                waitToSettleTimeoutMs = swipeElement.waitToSettleTimeoutMs
             )
         )
     }
@@ -625,6 +626,7 @@ data class YamlFluentCommand(
                 centerElement = yaml.centerElement,
                 label = yaml.label,
                 optional = yaml.optional,
+                waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -12,6 +12,7 @@ data class YamlScrollUntilVisible(
     val speed: String = ScrollUntilVisibleCommand.DEFAULT_SCROLL_DURATION,
     val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE,
     val centerElement: Boolean = ScrollUntilVisibleCommand.DEFAULT_CENTER_ELEMENT,
+    val waitToSettleTimeoutMs: Int? = null,
     val label: String? = null,
     val optional: Boolean = false,
 )

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -2,6 +2,7 @@ package maestro.orchestra.yaml
 
 import com.google.common.truth.Truth.assertThat
 import maestro.KeyCode
+import maestro.Point
 import maestro.ScrollDirection
 import maestro.SwipeDirection
 import maestro.TapRepeat
@@ -600,6 +601,46 @@ internal class YamlCommandReaderTest {
             KillAppCommand(
                 appId = "com.example.app"
             ),
+        )
+    }
+
+    @Test
+    fun waitToSettleTimeoutMsCommands(
+        @YamlFile("027_waitToSettleTimeoutMs.yaml") commands: List<Command>
+    ) {
+        assertThat(commands).containsExactly(
+            ApplyConfigurationCommand(MaestroConfig(
+                appId = "com.example.app"
+            )),
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(idRegex = "maybe-later"),
+                direction = ScrollDirection.DOWN,
+                waitToSettleTimeoutMs = 50,
+                centerElement = false,
+                visibilityPercentage = 100
+            ),
+            SwipeCommand(
+                startRelative = "90%, 50%",
+                endRelative = "10%, 50%",
+                waitToSettleTimeoutMs = 50
+            ),
+            SwipeCommand(
+                direction = SwipeDirection.LEFT,
+                duration = 400L,
+                waitToSettleTimeoutMs = 50
+            ),
+            SwipeCommand(
+                direction = SwipeDirection.LEFT,
+                duration = 400L,
+                elementSelector = ElementSelector(idRegex = "feeditem_identifier"),
+                waitToSettleTimeoutMs = 50,
+            ),
+            SwipeCommand(
+                startPoint = Point(x = 100, y = 200),
+                endPoint = Point(x = 300, y = 400),
+                waitToSettleTimeoutMs = 50,
+                duration = 400L
+            )
         )
     }
 

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/027_waitToSettleTimeoutMs.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/027_waitToSettleTimeoutMs.yaml
@@ -1,0 +1,23 @@
+appId: com.example.app
+---
+- scrollUntilVisible:
+    element:
+      id: "maybe-later"
+    waitToSettleTimeoutMs: 50
+    direction: DOWN
+- swipe:
+    start: 90%, 50%
+    end: 10%, 50%
+    waitToSettleTimeoutMs: 50
+- swipe:
+    direction: LEFT
+    waitToSettleTimeoutMs: 50
+- swipe:
+    from:
+      id: "feeditem_identifier"
+    direction: LEFT
+    waitToSettleTimeoutMs: 50
+- swipe:
+    start: 100, 200
+    end: 300, 400
+    waitToSettleTimeoutMs: 50


### PR DESCRIPTION
## Proposed changes

Adding `waitToSettleTimeoutMs` to the swipe commands that do waitForAppToSettle call. This is to control the wait time if there are repeatable animations on the screen. 

Using this option would help users to wait less on the screens where app is settled but have repeatable animations.

## Testing

- [ ] Locally

## Issues fixed
