### PR TITLE
feat: add retry functionality

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -801,6 +801,42 @@ data class RepeatCommand(
 
 }
 
+data class RetryCommand(
+    val maxAttempts: String? = null,
+    val commands: List<MaestroCommand>,
+    val config: MaestroConfig?,
+    override val label: String? = null,
+    override val optional: Boolean = false,
+) : CompositeCommand {
+
+    override fun subCommands(): List<MaestroCommand> {
+        return commands
+    }
+
+    override fun config(): MaestroConfig? {
+        return null
+    }
+
+    override fun description(): String {
+        val maxAttempts = maxAttempts?.toIntOrNull() ?: 1
+
+        return when {
+            label != null -> {
+                label
+            }
+            maxAttempts > 1 -> "Retry $maxAttempts times"
+            else -> "Retry indefinitely"
+        }
+    }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return copy(
+            maxAttempts = maxAttempts?.evaluateScripts(jsEngine),
+        )
+    }
+
+}
+
 data class DefineVariablesCommand(
     val env: Map<String, String>,
     override val label: String? = null,

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -802,7 +802,7 @@ data class RepeatCommand(
 }
 
 data class RetryCommand(
-    val maxAttempts: String? = null,
+    val maxRetries: String? = null,
     val commands: List<MaestroCommand>,
     val config: MaestroConfig?,
     override val label: String? = null,
@@ -818,20 +818,19 @@ data class RetryCommand(
     }
 
     override fun description(): String {
-        val maxAttempts = maxAttempts?.toIntOrNull() ?: 1
+        val maxAttempts = maxRetries?.toIntOrNull() ?: 1
 
         return when {
             label != null -> {
                 label
             }
-            maxAttempts > 1 -> "Retry $maxAttempts times"
-            else -> "Retry indefinitely"
+            else -> "Retry $maxAttempts times"
         }
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            maxAttempts = maxAttempts?.evaluateScripts(jsEngine),
+            maxRetries = maxRetries?.evaluateScripts(jsEngine),
         )
     }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -67,6 +67,7 @@ data class MaestroCommand(
     val addMediaCommand: AddMediaCommand? = null,
     val setAirplaneModeCommand: SetAirplaneModeCommand? = null,
     val toggleAirplaneModeCommand: ToggleAirplaneModeCommand? = null,
+    val retryCommand: RetryCommand? = null,
 ) {
 
     constructor(command: Command) : this(
@@ -109,6 +110,7 @@ data class MaestroCommand(
         addMediaCommand = command as? AddMediaCommand,
         setAirplaneModeCommand = command as? SetAirplaneModeCommand,
         toggleAirplaneModeCommand = command as? ToggleAirplaneModeCommand,
+        retryCommand = command as? RetryCommand
     )
 
     fun asCommand(): Command? = when {
@@ -151,6 +153,7 @@ data class MaestroCommand(
         addMediaCommand != null -> addMediaCommand
         setAirplaneModeCommand != null -> setAirplaneModeCommand
         toggleAirplaneModeCommand != null -> toggleAirplaneModeCommand
+        retryCommand != null -> retryCommand
         else -> null
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -340,9 +340,11 @@ data class YamlFluentCommand(
         }
 
 
+        val maxRetries = retry.maxRetries ?: "1"
+
         return MaestroCommand(
             RetryCommand(
-                maxAttempts = retry.maxAttempts ?: "2",
+                maxRetries = maxRetries,
                 commands = commands,
                 label = retry.label,
                 optional = retry.optional,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -79,6 +79,7 @@ data class YamlFluentCommand(
     val addMedia: YamlAddMedia? = null,
     val setAirplaneMode: YamlSetAirplaneMode? = null,
     val toggleAirplaneMode: YamlToggleAirplaneMode? = null,
+    val retry: YamlRetryCommand? = null,
 ) {
 
     @SuppressWarnings("ComplexMethod")
@@ -209,6 +210,9 @@ data class YamlFluentCommand(
             repeat != null -> listOf(
                 repeatCommand(repeat, flowPath, appId)
             )
+            retry != null -> listOf(
+                retryCommand(retry, flowPath, appId)
+            )
             copyTextFrom != null -> listOf(copyTextFromCommand(copyTextFrom))
             runScript != null -> listOf(
                 MaestroCommand(
@@ -315,6 +319,38 @@ data class YamlFluentCommand(
         )
     }
 
+    private fun retryCommand(retry: YamlRetryCommand, flowPath: Path, appId: String): MaestroCommand {
+        if (retry.file == null && retry.commands == null) {
+            throw SyntaxError("Invalid retry command: No file or commands provided")
+        }
+
+        if (retry.file != null && retry.commands != null) {
+            throw SyntaxError("Invalid retry command: Can't provide both file and commands at the same time")
+        }
+
+        val commands = retry.commands
+            ?.flatMap {
+                it.toCommands(flowPath, appId)
+                    .withEnv(retry.env)
+            }
+            ?: retry(flowPath, retry)
+
+        val config = retry.file?.let {
+            readConfig(flowPath, retry.file)
+        }
+
+
+        return MaestroCommand(
+            RetryCommand(
+                maxAttempts = retry.maxAttempts ?: "2",
+                commands = commands,
+                label = retry.label,
+                optional = retry.optional,
+                config = config
+            )
+        )
+    }
+
     private fun travelCommand(command: YamlTravelCommand): MaestroCommand {
         return MaestroCommand(
             TravelCommand(
@@ -383,6 +419,16 @@ data class YamlFluentCommand(
 
         val runFlowPath = resolvePath(flowPath, command.file)
         return YamlCommandReader.readCommands(runFlowPath)
+            .withEnv(command.env)
+    }
+
+    private fun retry(flowPath: Path, command: YamlRetryCommand): List<MaestroCommand> {
+        if (command.file == null) {
+            error("Invalid runFlow command: No file or commands provided")
+        }
+
+        val retryFlowPath = resolvePath(flowPath, command.file)
+        return YamlCommandReader.readCommands(retryFlowPath)
             .withEnv(command.env)
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlRetry.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlRetry.kt
@@ -1,0 +1,10 @@
+package maestro.orchestra.yaml
+
+data class YamlRetryCommand(
+    val maxAttempts: String? = null,
+    val file: String? = null,
+    val commands: List<YamlFluentCommand>? = null,
+    val env: Map<String, String> = emptyMap(),
+    val label: String? = null,
+    val optional: Boolean = false,
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlRetry.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlRetry.kt
@@ -1,7 +1,7 @@
 package maestro.orchestra.yaml
 
 data class YamlRetryCommand(
-    val maxAttempts: String? = null,
+    val maxRetries: String? = null,
     val file: String? = null,
     val commands: List<YamlFluentCommand>? = null,
     val env: Map<String, String> = emptyMap(),

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1,6 +1,7 @@
 package maestro.test
 
 import com.google.common.truth.Truth.assertThat
+import com.oracle.truffle.js.nodes.function.EvalNode
 import maestro.KeyCode
 import maestro.Maestro
 import maestro.MaestroException
@@ -3167,6 +3168,52 @@ class IntegrationTest {
         driver.assertEvents(
             listOf(
                 Event.SwipeElementWithDirection(Point(270, 480), SwipeDirection.UP, expectedDuration.toLong()),
+            )
+        )
+    }
+
+    @Test
+    fun `Case 119 - Retry set of commands with n attempts`() {
+        // Given
+        val commands = readCommands("119_retry_commands")
+
+        var counter = 0
+        val driver = driver {
+            val indicator = element {
+                text = counter.toString()
+                bounds = Bounds(0, 100, 100, 200)
+            }
+
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+                onClick = {
+                    counter++
+                    if (counter == 1) {
+                        throw RuntimeException("Exception for the first time")
+                    }
+                    indicator.text = counter.toString()
+                }
+            }
+
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.Scroll,
+                Event.TakeScreenshot,
+                /**----after retry----**/
+                Event.Scroll,
+                Event.TakeScreenshot,
+                Event.Tap(Point(50, 50)),
+                Event.Scroll,
             )
         )
     }

--- a/maestro-test/src/test/resources/119_retry_commands.yaml
+++ b/maestro-test/src/test/resources/119_retry_commands.yaml
@@ -1,0 +1,10 @@
+appId: com.other.app
+---
+- retry:
+    maxAttempts: 3
+    commands:
+      - scroll
+      - tapOn:
+          text: Button
+          waitToSettleTimeoutMs: 40
+      - scroll

--- a/maestro-test/src/test/resources/119_retry_commands.yaml
+++ b/maestro-test/src/test/resources/119_retry_commands.yaml
@@ -1,7 +1,7 @@
 appId: com.other.app
 ---
 - retry:
-    maxAttempts: 3
+    maxRetries: 3
     commands:
       - scroll
       - tapOn:


### PR DESCRIPTION
## Proposed changes

Adds a retry command to retry a set of commands either inline or from a file. This helps to retry in case of known flakiness.

- Associates with a retry command so that it's easy to know where flakiness is
- Raise a warning insight for local CLI when execution is retried.

API:

```
- retry:
    label: "Go to Cart screen (Flaky crash due to analytics SDK)"
    maxRetries: 3
    commands:
      - scroll
      - tapOn:
          text: Button
          waitToSettleTimeoutMs: 40
      - scroll
```



## Testing

- [x] Integration test
- [x] Cloud

## Issues fixed
