### PR TITLE
fix: assert condition command timeout parsing

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -372,7 +372,7 @@ data class AssertCommand(
 
 data class AssertConditionCommand(
     val condition: Condition,
-    private val timeout: String? = null,
+    val timeout: String? = null,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {


### PR DESCRIPTION
## Proposed changes

Removing private access modifier from timeout field

## Issues fixed

Private modifier on timeout field is preventing the field to be populated on deserialization.
