### PR TITLE
Add null check in childNafCheck to handle case when child node is null

### DIFF
--- a/maestro-android/src/androidTest/java/dev/mobile/maestro/ViewHierarchy.kt
+++ b/maestro-android/src/androidTest/java/dev/mobile/maestro/ViewHierarchy.kt
@@ -220,6 +220,7 @@ object ViewHierarchy {
         val childCount = node.childCount
         for (x in 0 until childCount) {
             val childNode = node.getChild(x)
+            if (childNode == null) continue;
             if (!safeCharSeqToString(childNode.contentDescription).isEmpty()
                 || !safeCharSeqToString(childNode.text).isEmpty()
             ) return true


### PR DESCRIPTION
Seeing this NPE show up in Maestro Cloud and Robin. Incorporating this AOSP fix that didn't exist when the code was copied over into Maestro: https://android-review.googlesource.com/c/platform/frameworks/support/+/2631315/2/test/uiautomator/uiautomator/src/main/java/androidx/test/uiautomator/AccessibilityNodeInfoDumper.java
