### PR TITLE
fix: adjust server timeout to longer duration

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -243,7 +243,7 @@ class LocalXCTestInstaller(
         private const val UI_TEST_RUNNER_APP_BUNDLE_ID =
             "dev.mobile.maestro-driver-iosUITests.xctrunner"
 
-        private const val SERVER_LAUNCH_TIMEOUT_MS = 15000L
+        private const val SERVER_LAUNCH_TIMEOUT_MS = 120000L
         private const val MAESTRO_DRIVER_STARTUP_TIMEOUT = "MAESTRO_DRIVER_STARTUP_TIMEOUT"
     }
 


### PR DESCRIPTION
This is done because with the current 15 seconds driver was failing to setup sometime.

Keeping to 2 minutes which I've noticed being sufficient when we use maestro on CI.