### PR TITLE
don't try to rm folder that doesn't exist

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -391,12 +391,17 @@ object LocalSimulatorUtils {
             )
         )
 
-        runCommand(
-            listOf(
-                "rm", "-rf",
-                "$homedir/Library/Developer/CoreSimulator/Devices/$deviceId/data/Library/Keychains"
+        val keychainFolder = "$homedir/Library/Developer/CoreSimulator/Devices/$deviceId/data/Library/Keychains"
+        if (File(keychainFolder).exists()) {
+            runCommand(
+                listOf(
+                    "rm", "-rf",
+                    keychainFolder
+                )
             )
-        )
+        } else {
+            logger.info("Keychain folder $keychainFolder does not exist, skipping rm")
+        }
 
         runCommand(
             listOf(


### PR DESCRIPTION
In some cases (eg a fresh ios16 simulator), the Keychains folder doesn't actually exist, so deleting it returns a non-zero status code (which bubbles up as an exception).

This prevents that by not deleting if it doesn't exist