### PR TITLE
Fix changelog and accompanying test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## 1.39.4
+## 1.39.5
 
 Features:
 - Add `waitToSettleTimeoutMs` to other swipe related commands ([#2153](https://github.com/mobile-dev-inc/maestro/pull/2153))

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/ChangeLogUtilsTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/ChangeLogUtilsTest.kt
@@ -15,6 +15,7 @@ class ChangeLogUtilsTest {
 
         val changelog = ChangeLogUtils.formatBody(content, CLI_VERSION.toString())
 
+        assertThat(changelog).isNotNull()
         assertThat(changelog).isNotEmpty()
     }
 


### PR DESCRIPTION
Tests are failing on main right now because the current version number isn't present in the changelog.

Worse, the test isn't failing - it's throwing an NPE instead.

This fixes both.