### PR TITLE
fix: throw exception when max retries reached

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -584,7 +584,7 @@ class Orchestra(
             } catch (exception: Throwable) {
                 if (attempt == maxRetries) {
                     logger.error("Max retries ($maxRetries) reached. Commands failed.", exception)
-                    break
+                    throw exception
                 }
 
                 val message = "Retrying the commands due to an error: ${exception.message} while execution (Attempt ${attempt + 1})"


### PR DESCRIPTION
## Proposed changes

Throw the final exception if max retries are reached instead of breaking the flow.

## Testing

Locally tested

## Issues fixed
