### PR TITLE
Don't kill SSE on exception

### DIFF
--- a/maestro-studio/server/src/main/java/maestro/studio/DeviceService.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/DeviceService.kt
@@ -79,9 +79,14 @@ object DeviceService {
             call.response.cacheControl(CacheControl.NoCache(null))
             call.respondBytesWriter(contentType = ContentType.Text.EventStream) {
                 while (true) {
-                    val deviceScreen = getDeviceScreen(maestro)
-                    writeStringUtf8("data: $deviceScreen\n\n")
-                    flush()
+                    try {
+                        val deviceScreen = getDeviceScreen(maestro)
+                        writeStringUtf8("data: $deviceScreen\n\n")
+                        flush()
+                    } catch (e: Exception) {
+                        // Ignoring the exception to prevent SSE stream from dying
+                        e.printStackTrace()
+                    }
                 }
             }
         }


### PR DESCRIPTION
I noticed that whenever `/api/device-screen/sse` hits an exception from device service, it would kill the stream, making Studio app unresponsive (until it is opened again).

To prevent that, we are logging and swallowing the exception to keep SSE stream alive.