### PR TITLE
fix(logback): Adding logback.xml to maestro-client main to avoid DEBUG messages on every command

### DIFF
--- a/maestro-cli/src/main/resources/logback-test.xml
+++ b/maestro-cli/src/main/resources/logback-test.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%-5level] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.micrometer.common.util.internal.logging" level="WARN" />
+
+    <logger name="CONSOLE" level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>


### PR DESCRIPTION
## Proposed changes

Adding a logback.xml file to maestro-cli main folder

## Testing

<!--- Please describe how you tested your changes. -->

## Issues fixed

We were receiving a very unpleasent message on every maestro command
```
07:52:08.527 [pool-1-thread-1] DEBUG io.micrometer.common.util.internal.logging.InternalLoggerFactory - Using SLF4J as the default logging framework
1.39.7
```

Since the logback.xml only existed in the test folder. Now that we have it on main as well, things are back on track