### PR TITLE
chore: added log for null hierarchy

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -248,6 +248,7 @@ class XCTestDriverClient(
         pathString: String,
         responseBodyAsString: String,
     ): String {
+        logger.warn("Status code: $code, body: $responseBodyAsString");
         val error = mapper.readValue(responseBodyAsString, Error::class.java)
         when {
             code in 400..499 -> {

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
@@ -80,8 +80,12 @@ struct ViewHierarchyHandler: HTTPHandler {
     }
 
     func getHierarchyWithFallback(_ element: XCUIElement) throws -> AXElement {
+        logger.info("Starting getHierarchyWithFallback for element: \(element.debugDescription)")
+
         do {
             var hierarchy = try elementHierarchy(xcuiElement: element)
+            logger.info("Successfully retrieved element hierarchy. Depth: \(hierarchy.depth())")
+
             if hierarchy.depth() < snapshotMaxDepth {
                 return hierarchy
             }
@@ -118,11 +122,17 @@ struct ViewHierarchyHandler: HTTPHandler {
                 }
 
                 let alerts = logger.measure(message: "Fetch alert hierarchy") {
-                    fullScreenAlertHierarchy(element)
+                    fullScreenAlertHierarchy(element) {
+                        logger.info("Alert hierarchy fetched successfully.")
+                    } else {
+                        logger.warning("No alerts found in app hierarchy.")
+                    }
                 }
 
-                let other = try logger.measure(message: "Fetch other custom element from window") {
-                    try customWindowElements(element)
+                let other = try? customWindowElements(element) {
+                    logger.info("Custom window elements fetched successfully.")
+                } else {
+                    logger.warning("No custom window elements found.")
                 }
                 return AXElement(children: [
                     other,

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
@@ -37,8 +37,10 @@ struct ViewHierarchyHandler: HTTPHandler {
             let body = try JSONEncoder().encode(viewHierarchy)
             return HTTPResponse(statusCode: .ok, body: body)
         } catch let error as AppError {
+            logger.error("AppError in handleRequest, RequestBody:\(requestBody) Error:\(error)");
             return error.httpResponse
         } catch let error {
+            logger.error("Error in handleRequest, RequestBody:\(requestBody) Error:\(error)");
             return AppError(message: "Snapshot failure while getting view hierarchy. Error: \(error.localizedDescription)").httpResponse
         }
     }
@@ -122,17 +124,7 @@ struct ViewHierarchyHandler: HTTPHandler {
                 }
 
                 let alerts = logger.measure(message: "Fetch alert hierarchy") {
-                    fullScreenAlertHierarchy(element) {
-                        logger.info("Alert hierarchy fetched successfully.")
-                    } else {
-                        logger.warning("No alerts found in app hierarchy.")
-                    }
-                }
-
-                let other = try? customWindowElements(element) {
-                    logger.info("Custom window elements fetched successfully.")
-                } else {
-                    logger.warning("No custom window elements found.")
+                    fullScreenAlertHierarchy(element)
                 }
                 return AXElement(children: [
                     other,

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
@@ -37,10 +37,10 @@ struct ViewHierarchyHandler: HTTPHandler {
             let body = try JSONEncoder().encode(viewHierarchy)
             return HTTPResponse(statusCode: .ok, body: body)
         } catch let error as AppError {
-            logger.error("AppError in handleRequest, RequestBody:\(requestBody) Error:\(error)");
+            logger.error("AppError in handleRequest, Error:\(error)");
             return error.httpResponse
         } catch let error {
-            logger.error("Error in handleRequest, RequestBody:\(requestBody) Error:\(error)");
+            logger.error("Error in handleRequest, Error:\(error)");
             return AppError(message: "Snapshot failure while getting view hierarchy. Error: \(error.localizedDescription)").httpResponse
         }
     }
@@ -125,6 +125,10 @@ struct ViewHierarchyHandler: HTTPHandler {
 
                 let alerts = logger.measure(message: "Fetch alert hierarchy") {
                     fullScreenAlertHierarchy(element)
+                }
+
+                let other = try logger.measure(message: "Fetch other custom element from window") {
+                    try customWindowElements(element)
                 }
                 return AXElement(children: [
                     other,


### PR DESCRIPTION
When there is null hierarchy, 
```val error = mapper.readValue(responseBodyAsString, Error::class.java)```
fails, and we don't get the status code and error message. Added a warn log before it so that we can know the status code and error message.