### PR TITLE
Improve set permissions logs and avoid affecting location permissions

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -437,6 +437,7 @@ object LocalSimulatorUtils {
 
         if (permissionsArgument.isNotEmpty()) {
             try {
+                logger.info("[Start] Setting permissions via pinned applesimutils")
                 runCommand(
                     listOf(
                         "$homedir/.maestro/deps/applesimutils",
@@ -448,9 +449,10 @@ object LocalSimulatorUtils {
                         permissionsArgument
                     )
                 )
-                logger.info("[Done] Setting permissions through applesimutils")
+                logger.info("[Done] Setting permissions pinned applesimutils")
             } catch (e: Exception) {
-                logger.error("Exception while setting permissions through applesimutils ${e.message}", e)
+                logger.error("Exception while setting permissions through pinned applesimutils ${e.message}", e)
+                logger.info("[Start] Setting permissions via applesimutils as fallback")
                 runCommand(
                     listOf(
                         "applesimutils",
@@ -462,6 +464,7 @@ object LocalSimulatorUtils {
                         permissionsArgument
                     )
                 )
+                logger.info("[Done] Setting permissions via applesimutils as fallback")
             }
         }
     }

--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -416,7 +416,7 @@ object LocalSimulatorUtils {
         )
     }
 
-    fun setPermissions(deviceId: String, bundleId: String, permissions: Map<String, String>) {
+    fun setAppleSimutilsPermissions(deviceId: String, bundleId: String, permissions: Map<String, String>) {
         val permissionsMap = permissions.toMutableMap()
         if (permissionsMap.containsKey("all")) {
             val value = permissionsMap.remove("all")

--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -436,7 +436,6 @@ object LocalSimulatorUtils {
             .joinToString(",")
 
         if (permissionsArgument.isNotEmpty()) {
-            logger.info("[Start] Setting permissions through applesimutils")
             try {
                 runCommand(
                     listOf(
@@ -465,11 +464,9 @@ object LocalSimulatorUtils {
                 )
             }
         }
-
-        setSimctlPermissions(deviceId, bundleId, permissions)
     }
 
-    private fun setSimctlPermissions(deviceId: String, bundleId: String, permissions: Map<String, String>) {
+    fun setSimctlPermissions(deviceId: String, bundleId: String, permissions: Map<String, String>) {
         val permissionsMap = permissions.toMutableMap()
 
         permissionsMap.remove("all")?.let { value ->

--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -436,6 +436,7 @@ object LocalSimulatorUtils {
             .joinToString(",")
 
         if (permissionsArgument.isNotEmpty()) {
+            logger.info("[Start] Setting permissions through applesimutils")
             try {
                 runCommand(
                     listOf(
@@ -448,7 +449,9 @@ object LocalSimulatorUtils {
                         permissionsArgument
                     )
                 )
+                logger.info("[Done] Setting permissions through applesimutils")
             } catch (e: Exception) {
+                logger.error("Exception while setting permissions through applesimutils ${e.message}", e)
                 runCommand(
                     listOf(
                         "applesimutils",

--- a/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/simctl/SimctlIOSDevice.kt
@@ -9,6 +9,7 @@ import xcuitest.api.DeviceInfo
 import okio.Sink
 import okio.buffer
 import okio.source
+import org.slf4j.LoggerFactory
 import util.IOSLaunchArguments.toIOSLaunchArguments
 import util.LocalSimulatorUtils
 import java.io.File
@@ -20,6 +21,11 @@ import java.util.UUID
 class SimctlIOSDevice(
     override val deviceId: String,
 ) : IOSDevice {
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(SimctlIOSDevice::class.java)
+    }
+
     private var screenRecording: LocalSimulatorUtils.ScreenRecording? = null
 
     override fun open() {
@@ -161,7 +167,13 @@ class SimctlIOSDevice(
     }
 
     override fun setPermissions(id: String, permissions: Map<String, String>) {
+        logger.info("[Start] Setting permissions through applesimutils")
         LocalSimulatorUtils.setPermissions(deviceId, id, permissions)
+        logger.info("[Done] Setting permissions through applesimutils")
+
+        logger.info("[Start] Setting Permissions through simctl")
+        LocalSimulatorUtils.setSimctlPermissions(deviceId, id, permissions)
+        logger.info("[Done] Setting Permissions through simctl")
     }
 
     override fun eraseText(charactersToErase: Int) {


### PR DESCRIPTION
## Proposed changes

Adds finer-grained logs for the set permissions operations performed using simctl and applesimutils. We've observed instances where applesimutils fails to set permissions, which can lead to another issue of not setting location permissions. 

This PR also decouples the simctl and applesimutil permission so that they don't couple each other.

## Testing

- [x] Locally
- [ ] Cloud

## Issues fixed
