### PR TITLE
Fix iOS miss launch arguments with boolean 

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/IOSLaunchArguments.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/IOSLaunchArguments.kt
@@ -7,14 +7,10 @@ object IOSLaunchArguments {
 
         val iOSLaunchArgumentsMap = mutableMapOf<String, Any>()
         forEach { (key, value) ->
-            if (value is Boolean) {
-                iOSLaunchArgumentsMap[key] = value
+            if (!key.startsWith("-")) {
+                iOSLaunchArgumentsMap["-$key"] = value
             } else {
-                if (!key.startsWith("-")) {
-                    iOSLaunchArgumentsMap["-$key"] = value
-                } else {
-                    iOSLaunchArgumentsMap[key] = value
-                }
+                iOSLaunchArgumentsMap[key] = value
             }
         }
         return iOSLaunchArgumentsMap.toList().flatMap { listOf(it.first, it.second.toString()) }


### PR DESCRIPTION
## Proposed changes

add prefix `-` at key for all iOS launch arguments

## Testing

<!--- Please describe how you tested your changes. -->

none

## Issues fixed

link https://github.com/mobile-dev-inc/maestro/issues/2113