### PR TITLE
Add console.log messages directly to the maestro log

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -172,6 +172,7 @@ class Orchestra(
                         command,
                         metadata.copy(logMessages = metadata.logMessages + msg)
                     )
+                    logger.info("JsConsole: $msg")
                 }
 
                 val evaluatedCommand = command.evaluateScripts(jsEngine)


### PR DESCRIPTION
## Proposed changes

Whenever you used something like `runScript: myscript.js` and the script contained a `console.log`, then you needed to go find the log line in the logs here

```
20:08:50.313 [ INFO] maestro.cli.runner.MaestroCommandRunner.invoke: Run loggingInJS_simple.js metadata CommandMetadata(numberOfRuns=null, evaluatedCommand=MaestroCommand(runScriptCommand=RunScriptCommand(script=console.log('A simple message'), env={}, sourceDescription=loggingInJS_simple.js, condition=null, label=null, optional=false)), logMessages=[A simple message], insight=Insight(message=, level=NONE))
``` 

This PR adds additional explicit logging:

```
20:08:50.314 [ INFO] maestro.orchestra.Orchestra.invoke: JsConsole: A simple message
```

## Testing

Tested on Linux with https://github.com/Fishbowler/maestro-examples/tree/main/logging

