### PR TITLE
Implement setTimeout/clearTimeout in Maestro's JavaScript Environment

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsTimer.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsTimer.kt
@@ -1,0 +1,84 @@
+package maestro.js
+
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class GraalJsTimer {
+    private val scheduler: ScheduledExecutorService = Executors.newSingleThreadScheduledExecutor()
+    private val timeouts = ConcurrentHashMap<Int, ScheduledFuture<*>>()
+    private var timeoutCounter = 0
+    private var activeTimersCount = AtomicInteger(0)
+    private var activeTimers = CountDownLatch(0)
+
+    val setTimeout = ProxyExecutable { args ->
+        val callback = args[0] as Value
+        val delay = (args[1] as Value).asLong()
+        val restArgs = args.drop(2).toTypedArray()
+        setTimeout(callback, delay, *restArgs)
+    }
+
+    val clearTimeout = ProxyExecutable { args ->
+        val timeoutId = (args[0] as Value).asInt()
+        clearTimeout(timeoutId)
+        null
+    }
+
+    private fun setTimeout(callback: Value, delay: Long, vararg args: Any?): Int {
+        val timeoutId = timeoutCounter++
+        
+        synchronized(this) {
+            if (activeTimersCount.getAndIncrement() == 0) {
+                activeTimers = CountDownLatch(1)
+            }
+        }
+        
+        val future = scheduler.schedule({
+            try {
+                callback.executeVoid(*args)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            } finally {
+                timeouts.remove(timeoutId)
+                if (activeTimersCount.decrementAndGet() == 0) {
+                    activeTimers.countDown()
+                }
+            }
+        }, delay, TimeUnit.MILLISECONDS)
+        
+        timeouts[timeoutId] = future
+        return timeoutId
+    }
+
+    private fun clearTimeout(timeoutId: Int) {
+        timeouts.remove(timeoutId)?.let { future ->
+            future.cancel(false)
+            if (activeTimersCount.decrementAndGet() == 0) {
+                activeTimers.countDown()
+            }
+        }
+    }
+
+    fun waitForActiveTimers(timeout: Long = 30_000) {
+        if (activeTimersCount.get() > 0) {
+            activeTimers.await(timeout, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    fun close() {
+        scheduler.shutdown()
+        try {
+            if (!scheduler.awaitTermination(5, TimeUnit.SECONDS)) {
+                scheduler.shutdownNow()
+            }
+        } catch (e: InterruptedException) {
+            scheduler.shutdownNow()
+        }
+    }
+} 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -435,7 +435,7 @@ class Orchestra(
 
     private fun evalScriptCommand(command: EvalScriptCommand): Boolean {
         command.scriptString.evaluateScripts(jsEngine)
-
+        waitForTimersIfGraal()
         // We do not actually know if there were any mutations, but we assume there were
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -441,25 +441,34 @@ class Orchestra(
     }
 
     private fun runScriptCommand(command: RunScriptCommand): Boolean {
-        return if (evaluateCondition(command.condition, commandOptional = command.optional)) {
-            jsEngine.evaluateScript(
-                script = command.script,
-                env = command.env,
-                sourceName = command.sourceDescription,
-                runInSubScope = true,
-            )
-
-            // We do not actually know if there were any mutations, but we assume there were
-            true
-        } else {
+        if (!evaluateCondition(command.condition, command.optional)) {
             throw CommandSkipped
         }
+    
+        jsEngine.evaluateScript(
+            script = command.script,
+            env = command.env,
+            sourceName = command.sourceDescription,
+            runInSubScope = true,
+        )
+    
+        waitForTimersIfGraal()
+        
+        // We do not actually know if there were any mutations, but we assume there were
+        return true
     }
-
+    
     private fun waitForAnimationToEndCommand(command: WaitForAnimationToEndCommand): Boolean {
         maestro.waitForAnimationToEnd(command.timeout)
 
         return true
+    }
+
+    private fun waitForTimersIfGraal() {
+        val engine = jsEngine
+        if (engine is GraalJsEngine) {
+            engine.waitForActiveTimers()
+        }
     }
 
     private fun defineVariablesCommand(command: DefineVariablesCommand): Boolean {

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsTimerTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsTimerTest.kt
@@ -1,0 +1,87 @@
+package maestro.test
+
+import com.google.common.truth.Truth.assertThat
+import maestro.js.GraalJsEngine
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+
+class GraalJsTimerTest {
+    private lateinit var engine: GraalJsEngine
+
+    @BeforeEach
+    fun setUp() {
+        engine = GraalJsEngine()
+    }
+
+    @Test
+    fun `setTimeout executes callback after delay`() {
+        engine.evaluateScript("""
+            setTimeout(() => {
+                output.executed = true;
+            }, 100);
+        """.trimIndent())
+        engine.waitForActiveTimers()
+        
+        val result = engine.evaluateScript("output.executed")
+        assertThat(result.asBoolean()).isTrue()
+    }
+
+    @Test
+    fun `setTimeout with multiple timers executes all callbacks`() {
+        engine.evaluateScript("""
+            setTimeout(() => { output.first = true; }, 100);
+            setTimeout(() => { output.second = true; }, 200);
+        """.trimIndent())
+        engine.waitForActiveTimers()
+        
+        val first = engine.evaluateScript("output.first")
+        val second = engine.evaluateScript("output.second")
+        assertThat(first.asBoolean()).isTrue()
+        assertThat(second.asBoolean()).isTrue()
+    }
+
+    @Test
+    fun `clearTimeout cancels timer execution`() {
+        engine.evaluateScript("""
+            output.executed = false;
+            const id = setTimeout(() => {
+                output.executed = true;
+            }, 1000);
+            clearTimeout(id);
+        """.trimIndent())
+        engine.waitForActiveTimers()
+        
+        val result = engine.evaluateScript("output.executed")
+        assertThat(result.asBoolean()).isFalse()
+    }
+
+    @Test
+    fun `setTimeout passes arguments to callback`() {
+        engine.evaluateScript("""
+            setTimeout((a, b) => {
+                output.sum = a + b;
+            }, 100, 1, 2);
+        """.trimIndent())
+        engine.waitForActiveTimers()
+        
+        val result = engine.evaluateScript("output.sum")
+        assertThat(result.asInt()).isEqualTo(3)
+    }
+
+    @Test
+    fun `setTimeout actually waits for specified duration`() {
+        val startTime = System.currentTimeMillis()
+        engine.evaluateScript("""
+            setTimeout(() => {
+                output.done = true;
+            }, 5000);
+        """.trimIndent())
+        engine.waitForActiveTimers()
+        val endTime = System.currentTimeMillis()
+        val elapsedTime = endTime - startTime
+
+        val result = engine.evaluateScript("output.done")
+        assertThat(result.asBoolean()).isTrue()
+        assertThat(elapsedTime).isAtLeast(5000L)
+    }
+} 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3218,6 +3218,35 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 120 - setTimeout executes after specified delay`() {
+        // Given
+        val commands = readCommands("120_set_time_out")
+        val driver = driver { }
+        val receivedLogs = mutableListOf<String>()
+
+        // When
+        Maestro(driver).use { maestro ->
+            orchestra(
+                maestro,
+                onCommandMetadataUpdate = { _, metadata ->
+                    metadata.logMessages.forEach { log ->
+                        receivedLogs.add(log)
+                    }
+                }
+            ).runFlow(commands)
+        }
+
+        // Then
+        assertThat(receivedLogs).containsExactly(
+            "Start",
+            "First timeout",
+            "Second timeout",
+            "Third timeout",
+            "End"
+        ).inOrder()
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/120_set_time_out.js
+++ b/maestro-test/src/test/resources/120_set_time_out.js
@@ -1,0 +1,3 @@
+setTimeout(() => {
+    console.log("First timeout");
+}, 5000);

--- a/maestro-test/src/test/resources/120_set_time_out.yaml
+++ b/maestro-test/src/test/resources/120_set_time_out.yaml
@@ -1,0 +1,9 @@
+appId: com.other.app
+jsEngine: graaljs
+---
+- evalScript: ${console.log("Start");}
+- runScript:
+    file: 120_set_time_out.js
+- evalScript: ${setTimeout(() => { console.log("Second timeout"); }, 1000);}
+- evalScript: ${setTimeout(() => { console.log("Third timeout"); }, 2000);}
+- evalScript: ${console.log("End");}


### PR DESCRIPTION
## Proposed changes
This PR implements the standard JavaScript timer functions (`setTimeout`/`clearTimeout`) in Maestro's GraalJS environment, which previously didn't include these functions.

## Changes

### GraalJsTimer.kt
- Implemented new `GraalJsTimer` class to handle JavaScript timer functionality
- Added thread-safe timer management using `AtomicInteger`
- Implemented proper timer tracking with `CountDownLatch`
- Added cleanup handling for timer resources

### GraalJsEngine.kt
- Added timer bindings to the JavaScript context
- Exposed `setTimeout` and `clearTimeout` functions
- Added timer cleanup in engine close

### Orchestra.kt
- Added support for waiting on active timers in script execution
- Improved script condition handling with proper null safety
- Added timer completion checks before finishing script execution

## Implementation Details
The implementation follows JavaScript's standard timer behavior:
- `setTimeout(callback, delay, ...args)` returns a numeric timer ID
- `clearTimeout(timeoutId)` cancels a pending timeout
- Timer management is thread-safe and properly cleaned up
- Test execution waits for pending timeouts

## Why This Matters
This implementation aligns Maestro's JavaScript environment with the JavaScript standard ecosystem, enabling essential asynchronous patterns in Maestro scripting. While the immediate use case involves polling mechanisms, it unlocks numerous scenarios including:

- Waiting for an OTP code by periodically checking with setTimeout
- Handling network response delays
- Implementing retry logic with backoff
- Creating non-blocking delays in test sequences

## Testing

Tested with various scenarios:
- Short and long timeouts
- Multiple concurrent timeouts
- Timer cancellation
- Resource cleanup
