### PR TITLE
Fix: dark mode for browser action bar

### DIFF
--- a/maestro-studio/web/src/components/device-and-device-elements/BrowserActionBar.tsx
+++ b/maestro-studio/web/src/components/device-and-device-elements/BrowserActionBar.tsx
@@ -34,7 +34,7 @@ const BrowserActionBar = ({currentUrl, onUrlUpdated, isLoading}: {
       </div>
       <Input
         className={twMerge(
-          "w-full pl-8 pr-1 py-0.5 rounded-full border-2 bg-slate-50",
+          "w-full pl-8 pr-1 py-0.5 rounded-full border-2 bg-slate-50 dark:bg-gray-800",
           isLoading && "bg-gray-100",
         )}
         size="sm"


### PR DESCRIPTION
Prior to this fix it was white-on-white

<img width="736" alt="image" src="https://github.com/user-attachments/assets/1c18b5b5-d6cd-4212-a3eb-eea0580ec5ae" />
