### PR TITLE
Safer install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -113,6 +113,15 @@ if [[ "$cygwin" == 'true' ]]; then
 fi
 unzip -qo "$maestro_zip_file" -d "$maestro_tmp_folder"
 
+# Empty destinations
+echo "* Remove previous installation (if any)"
+if [[ -d "$MAESTRO_DIR/lib" ]]; then
+  rm -rf "${MAESTRO_DIR:?}/lib"
+fi
+if [[ -d "$MAESTRO_DIR/bin" ]]; then
+  rm -rf "${MAESTRO_DIR:?}/bin"
+fi
+
 # Copy in place
 echo "* Copying archive contents..."
 cp -rf "${maestro_tmp_folder}"/maestro/* "$MAESTRO_DIR"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -62,7 +62,6 @@ export MAESTRO_DIR
 # Local variables
 maestro_tmp_folder="${MAESTRO_DIR}/tmp"
 maestro_bash_profile="${HOME}/.bash_profile"
-maestro_profile="${HOME}/.profile"
 maestro_bashrc="${HOME}/.bashrc"
 maestro_zshrc="${ZDOTDIR:-${HOME}}/.zshrc"
 


### PR DESCRIPTION
## Proposed changes

Remove existing files from bin and lib as part of an upgrade/install

## Testing

- Run locally over 1.39.9 (succeeded)
- Run locally over 1.39.9 with some extra and some renamed files (all gone)
- Run locally with no ~/.maestro directory (succeeded)

