### PR TITLE
Fix support for running multiple web flows

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -164,12 +164,8 @@ class TestCommand : Callable<Int> {
     private val usedPorts = ConcurrentHashMap<Int, Boolean>()
     private val logger = LoggerFactory.getLogger(TestCommand::class.java)
 
-    private fun isWebFlow(): Boolean {
-        if (flowFiles.isSingleFile) {
-            return flowFiles.first().isWebFlow()
-        }
-
-        return false
+    private fun includesWebFlow(): Boolean {
+        return flowFiles.any { it.isWebFlow() }
     }
 
     override fun call(): Int {
@@ -218,7 +214,7 @@ class TestCommand : Callable<Int> {
         val onlySequenceFlows = plan.sequence.flows.isNotEmpty() && plan.flowsToRun.isEmpty() // An edge case
 
         val availableDevices = DeviceService.listConnectedDevices(
-            includeWeb = isWebFlow(),
+            includeWeb = includesWebFlow(),
             host = parent?.host,
             port = parent?.port,
         ).map { it.instanceId }.toSet()
@@ -427,7 +423,7 @@ class TestCommand : Callable<Int> {
     }
 
     private fun getPassedOptionsDeviceIds(): List<String> {
-        val arguments = if (isWebFlow()) {
+        val arguments = if (includesWebFlow()) {
             PrintUtils.warn("Web support is in Beta. We would appreciate your feedback!\n")
             "chromium"
         } else parent?.deviceId


### PR DESCRIPTION
## Proposed changes

Support running multiple web flows in one `test` command. This used to work but broke in some version between 1.35.0 and the latest (1.39.9).

## Testing

```shell
# Workspace containing web flows
maestro test path/to/web-workspace

# Multiple web flows in a directory
maestro test some/directory/web-*.yaml

# Single web flow
maestro test some/directory/web-flow1.yaml

# Workspace containing iOS flows
maestro test path/to/ios-workspace

# Multiple iOS flows in a directory
maestro test some/directory/ios-*.yaml

# Single web flow
maestro test some/directory/ios-flow1.yaml

# A mix of web flows and iOS flows (fails)
maestro test path/to/mixed-workspace
```

I'm not really familiar with the codebase, so I don't know if this change has any unintended consequences not caught by the tests above.

## Issues fixed

https://github.com/mobile-dev-inc/maestro/issues/2269