### PR TITLE
#1637 [Graaljs] allow import

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -29,6 +29,7 @@ class GraalJsEngine(
         protocols = listOf(Protocol.HTTP_1_1)
     ),
     platform: String = "unknown",
+    private val allowIo: Boolean = false,
 ) : JsEngine {
 
     private val openContexts = HashSet<Context>()
@@ -84,6 +85,7 @@ class GraalJsEngine(
         }
 
         val context = Context.newBuilder("js")
+            .allowIO(allowIo)
             .option("js.strict", "true")
             .logHandler(NULL_HANDLER)
             .out(outputStream)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -231,7 +231,12 @@ class Orchestra(
             config?.ext?.get("jsEngine") == "graaljs" || System.getenv("MAESTRO_USE_GRAALJS") == "true"
         val platform = maestro.cachedDeviceInfo.platform.toString().lowercase()
         jsEngine = if (shouldUseGraalJs) {
-            httpClient?.let { GraalJsEngine(it, platform) } ?: GraalJsEngine(platform = platform)
+            val shouldAllowIo =
+                config?.ext?.get("graalJsAllowIo") == true ||
+                        System.getenv("MAESTRO_GRAALJS_ALLOW_IO") == "true"
+            httpClient?.let { GraalJsEngine(it, platform, shouldAllowIo) }
+                ?: GraalJsEngine(platform = platform, allowIo = shouldAllowIo
+            )
         } else {
             httpClient?.let { RhinoJsEngine(it, platform) } ?: RhinoJsEngine(platform = platform)
         }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1,7 +1,6 @@
 package maestro.test
 
 import com.google.common.truth.Truth.assertThat
-import com.oracle.truffle.js.nodes.function.EvalNode
 import maestro.KeyCode
 import maestro.Maestro
 import maestro.MaestroException
@@ -28,9 +27,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.awt.Color
 import java.io.File
+import java.io.IOException
 import java.nio.file.Paths
 import kotlin.system.measureTimeMillis
 import maestro.orchestra.util.Env.withDefaultEnvVars
+import org.graalvm.polyglot.PolyglotException
 
 class IntegrationTest {
 
@@ -3216,6 +3217,44 @@ class IntegrationTest {
                 Event.Scroll,
             )
         )
+    }
+
+    @Test
+    fun `Case 120 - GraalJs import`() {
+        // given
+        val commands = readCommands("120_graaljs_import")
+        val driver = driver { }
+        val receivedLogs = mutableMapOf<MaestroCommand, List<String>>()
+
+        // when
+        Maestro(driver).use {
+            orchestra(
+                maestro = it,
+                onCommandMetadataUpdate = { command, metadata ->
+                    receivedLogs[command] = metadata.logMessages
+                },
+            ).runFlow(commands)
+        }
+
+        // then
+        assertThat(receivedLogs.values.flatten()).containsExactly(
+            "From script.mjs",
+            "From foo.mjs",
+        )
+    }
+
+    @Test
+    fun `Case 120 - GraalJs import disallowed`() {
+        assertThrows<PolyglotException> {
+            // given
+            val commands = readCommands("120_graaljs_import_disallowed")
+            val driver = driver { }
+
+            // when
+            Maestro(driver).use {
+                orchestra(it).runFlow(commands)
+            }
+        }
     }
 
     private fun orchestra(

--- a/maestro-test/src/test/resources/120_foo.mjs
+++ b/maestro-test/src/test/resources/120_foo.mjs
@@ -1,0 +1,1 @@
+export default function() { console.log('From foo.mjs') }

--- a/maestro-test/src/test/resources/120_graaljs_import.yaml
+++ b/maestro-test/src/test/resources/120_graaljs_import.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+jsEngine: graaljs
+graalJsAllowIo: true
+---
+- runScript: 120_script.mjs

--- a/maestro-test/src/test/resources/120_graaljs_import_disallowed.yaml
+++ b/maestro-test/src/test/resources/120_graaljs_import_disallowed.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+jsEngine: graaljs
+---
+- runScript: 120_script.mjs

--- a/maestro-test/src/test/resources/120_script.mjs
+++ b/maestro-test/src/test/resources/120_script.mjs
@@ -1,0 +1,3 @@
+import foo from 'src/test/resources/120_foo.mjs'
+foo()
+console.log("From script.mjs")


### PR DESCRIPTION
## Proposed changes

This PR adds the option to use `import` directive from within JS scripts.
This can be helpful to better organize large scripts and avoid duplication between flows.
This is done through either the env var `MAESTRO_GRAALJS_ALLOW_IO` or the config `graalJsAllowIo`.

## Specifications

- Scripts that use imports (wether importing or exporting) should be defined with the `mjs` extension
- The importing path is relative to the execution path of Maestro
- See GraalJs documentation about [Modules](https://github.com/oracle/graaljs/blob/master/docs/user/Modules.md#ecmascript-modules-esm)

## Testing

Two integration tests have been added, in order to test cases where it's allowed and not allowed.

## Issues fixed

#1637