### PR TITLE
fix: e2e race condition in scrollUntilVisible timeout test

### DIFF
--- a/e2e/workspaces/demo_app/scrollUntilVisible_timeout.yaml
+++ b/e2e/workspaces/demo_app/scrollUntilVisible_timeout.yaml
@@ -10,4 +10,4 @@ tags:
     timeout: 1000
     optional: true
 - evalScript: ${maestro.endTime = new Date()}
-- assertTrue: ${maestro.endTime - maestro.startTime < 5000} # Far less than the 20000 default, but enough to allow for processing time
+- assertTrue: ${maestro.endTime - maestro.startTime < 12000} # Far less than the 20000 default, but enough to allow for processing time


### PR DESCRIPTION
A timeout test story:

- Test used to take nearly 5s
- Test now takes about 6s
- Test wants to prove it's less than 20 seconds, so tested for 5.
- Now tests for 12.
