### PR TITLE
feat: add element type to attributes for iOS

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -191,6 +191,7 @@ class IOSDriver(
 
     private fun mapViewHierarchy(element: AXElement): TreeNode {
         val attributes = mutableMapOf<String, String>()
+        attributes["elementType"] = element.elementType.toString()
         attributes["accessibilityText"] = element.label
         attributes["title"] = element.title ?: ""
         attributes["value"] = element.value ?: ""


### PR DESCRIPTION
## Proposed changes

Exposing element type allows for better accessibility testing. This is vital information to understand what element is in the hierarchy.
