### PR TITLE
Move env parsing and defaults to the runner to fix continuous

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -46,8 +46,6 @@ import maestro.cli.util.PrintUtils
 import maestro.cli.insights.TestAnalysisManager
 import maestro.cli.view.box
 import maestro.orchestra.error.ValidationError
-import maestro.orchestra.util.Env.withDefaultEnvVars
-import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner.ExecutionPlan
 import maestro.utils.isSingleFile
@@ -374,10 +372,6 @@ class TestCommand : Callable<Int> {
             } else {
                 PlainTextResultView()
             }
-
-        env = env
-            .withInjectedShellEnvVars()
-            .withDefaultEnvVars(flowFile)
 
         val resultSingle = TestRunner.runSingle(
             maestro = maestro,

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -19,6 +19,8 @@ import maestro.cli.util.PrintUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.util.Env.withEnv
+import maestro.orchestra.util.Env.withDefaultEnvVars
+import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import maestro.orchestra.yaml.YamlCommandReader
 import org.slf4j.LoggerFactory
 import java.io.File
@@ -52,9 +54,13 @@ object TestRunner {
             flowFile = flowFile,
         )
 
+        val updatedEnv = env
+            .withInjectedShellEnvVars()
+            .withDefaultEnvVars(flowFile)
+
         val result = runCatching(resultView, maestro) {
             val commands = YamlCommandReader.readCommands(flowFile.toPath())
-                .withEnv(env)
+                .withEnv(updatedEnv)
 
             val flowName = YamlCommandReader.getConfig(commands)?.name
             if (flowName != null) {
@@ -112,9 +118,13 @@ object TestRunner {
                     join()
                 }
 
+                val updatedEnv = env
+                    .withInjectedShellEnvVars()
+                    .withDefaultEnvVars(flowFile)
+
                 val commands = YamlCommandReader
                     .readCommands(flowFile.toPath())
-                    .withEnv(env)
+                    .withEnv(updatedEnv)
 
                 val flowName = YamlCommandReader.getConfig(commands)?.name
 


### PR DESCRIPTION
Should also fix the same for `maestro record`

## Testing

I've been able to test my fix using a little example flow: https://github.com/Fishbowler/maestro-examples/tree/main/env-vars
- With Maestro installed via curl -fsSL "https://get.maestro.mobile.dev/" | bash this works as is, using maestro test
- It doesn't work if I update run.sh to use maestro test -c
- My new Maestro branch works for both

## Issues fixed

#2310 