### PR TITLE
# Add UI Automation Flag to Not Suppress Accessibility Services (Android)

### DIFF
--- a/maestro-android/src/androidTest/java/dev/mobile/maestro/MaestroDriverService.kt
+++ b/maestro-android/src/androidTest/java/dev/mobile/maestro/MaestroDriverService.kt
@@ -80,6 +80,7 @@ class MaestroDriverService {
             .setActionAcknowledgmentTimeout(0L)
             .setWaitForIdleTimeout(0L)
             .setWaitForSelectorTimeout(0L)
+            .setUiAutomationFlags(UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)
 
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val uiDevice = UiDevice.getInstance(instrumentation)


### PR DESCRIPTION
# Add UI Automation Flag to Not Suppress Accessibility Services (Android)

## Proposed Changes

This PR introduces a modification to the `MaestroDriverService.kt` file to add a UI automation flag that prevents the suppression of accessibility services during testing on Android devices. This change allows for more comprehensive testing scenarios where accessibility services need to remain active.

### Background

While Maestro supports both iOS and Android, this change specifically targets the Android implementation. By default, UiAutomation suppresses accessibility services on Android. However, in some testing scenarios, it's crucial to have these services running to accurately simulate real-world conditions or test accessibility features.

### Implementation

The change is implemented in the `grpcServer()` function of the `MaestroDriverService` class:

```kotlin
@Test
fun grpcServer() {
    Configurator.getInstance()
        .setActionAcknowledgmentTimeout(0L)
        .setWaitForIdleTimeout(0L)
        .setWaitForSelectorTimeout(0L)
        .setUiAutomationFlags(UiAutomation.FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES)

    // ... rest of the function
}
```

This modification sets the UI automation flags to include `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` using the `setUiAutomationFlags()` method of the `Configurator` instance.

### Usage

For more information about the `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` flag and its usage, please refer to the [Android Developer Documentation](https://developer.android.com/reference/android/app/UiAutomation#FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES).

## Testing

After testing with my own app, I have confirmed that the Accessibility service will not be disabled when using a local Maestro build with the specified flag and setting `stopApp=false` under `launchApp`.