### PR TITLE
Fix system path separators for config globbing

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -63,7 +63,7 @@ object WorkspaceExecutionPlanner {
         val globs = workspaceConfig.flows ?: listOf("*")
 
         val matchers = globs.flatMap { glob ->
-            directories.map { it.fileSystem.getPathMatcher("glob:${it.pathString}/$glob") }
+            directories.map { it.fileSystem.getPathMatcher(escapeSlashesForWindows("glob:${it.pathString}${it.fileSystem.separator}$glob")) }
         }
 
         val unsortedFlowFiles = flowFiles + flowFilesInDirs.filter { path ->
@@ -174,6 +174,10 @@ object WorkspaceExecutionPlanner {
 
     private fun parseFileName(file: Path): String {
         return file.fileName.toString().substringBeforeLast(".")
+    }
+
+    private fun escapeSlashesForWindows(pathString: String): String {
+        return pathString.replace("\\","\\\\")
     }
 
     data class FlowSequence(


### PR DESCRIPTION
## Proposed changes

Fix globbing for flows via config on Windows

## Testing

Tested on Windows 11 and macOS 15.3.1, running `maestro test someFolder` where someFolder contains a config, and the config has a valid flows key.

## Issues fixed

#2279