### PR TITLE
fix: use environment variables to check for terminal

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
+++ b/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
@@ -40,9 +40,12 @@ class DisableAnsiMixin {
             val parserWithANSIOption = findFirstParserWithMatchedParamLabel(parseResult, "<enableANSIOutput>")
             val mixin = parserWithANSIOption?.commandSpec()?.mixins()?.values?.firstNotNullOfOrNull { it.userObject() as? DisableAnsiMixin }
 
-            val stdoutIsTTY = CLibrary.isatty(CLibrary.STDOUT_FILENO) != 0
+            // Instead of using CLibrary.isatty, use environment variables to detect terminal
+            val forceDisable = System.getenv("MAESTRO_DISABLE_ANSI")?.toBoolean() ?: false
+            val isTTY = !forceDisable && System.getenv("TERM") != null
+
             ansiEnabled = mixin?.enableANSIOutput // Use the param value if it was specified
-                ?: stdoutIsTTY // Otherwise fall back to checking if output is a tty
+                ?: isTTY // Otherwise fall back to checking environment
 
             Ansi.setEnabled(ansiEnabled)
 


### PR DESCRIPTION
Issue #2278 finds CLibrary.isatty gives an error when any `maestro` command is run unless both the --no-color and --no-ansi flags are given. This fix switches to environment variables because on CachyOS Linux and Fedora Linux users consistently got those errors.

## Proposed changes

I switched from using the CLibrary.isatty to using environment variables to check if the call is from a terminal. 

Based on the issue, it seems this may be a Linux specific problem. If the team would rather solve this another way, I am happy to help if you would like to direct me how you want it solved. Otherwise, if the team would prefer to go another direction without my help, that is also understandable. 

## Testing
I ran the `./maestro-cli/build/install/maestro/bin/maestro` command with no flags and got expected output. 
I also got the demo_app in the `e2e/` directory installed on an Android Emulator and ran the tests provided. The output is below.
Ran the `./maestro-cli/build/install/maestro/bin/maestro --device emulator-5554 test e2e/workspaces/demo_app` command.
<details>
  <summary>Output from tests</summary>

```console
Maestro on  fix-cli [!?]
➜ ./maestro-cli/build/install/maestro/bin/maestro --device emulator-5554 test e2e/workspaces/demo_app

Waiting for flows to complete...
[Passed] ai_complex (4s)
[Passed] ai_simple (0s)
[Passed] commands_optional_tournee (40s)
[Failed] commands_tour (1m 8s) (Assertion is false: id: com.google.android.inputmethod.latin:id/key_pos_shift is visible)
[Failed] fail_fast (1s) (Assertion is false: false is true)
[Failed] fail_launchApp (0s) (Unable to launch app com.nonexistent: Package com.nonexistent is not installed)
[Failed] fail_launchApp_nonDefault (0s) (Unable to launch app com.nonexistent: Package com.nonexistent is not installed)
[Failed] fail_not_found (18s) (Element not found: Id matching regex: non-existent-id)
[Failed] fail_visible (18s) (Assertion is false: id: non-existent-id is visible)
[Failed] fail_visible_extended (2s) (Assertion is false: id: non-existent-id is visible)
[Passed] fill_form (16s)
[Passed] long_input_text (49s)
[Passed] relatives (20s)
[Passed] scrollUntilVisible_timeout (3s)
[Passed] swipe (8s)

7/15 Flows Failed

```
</details>


## Issues fixed
Possible fix for Issue #2278 

## Feedback welcome
I am new to Maestro, so I would appreciate any feedback on how I solved the issue, if I should delete the comments in the code, and anything else that would help the team or project better.