### PR TITLE
Fixes Root cause of sharding race condition and allows driver to run on a custom port

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -83,6 +83,9 @@ class App {
     @Option(names = ["--port"], hidden = true)
     var port: Int? = null
 
+    @Option(names = ["--driver-host-port"], hidden = true)
+    var driverHostPort: Int? = null
+
     @Option(
         names = ["--device", "--udid"],
         description = ["(Optional) Device ID to run on explicitly, can be a comma separated list of IDs: --device \"Emulator_1,Emulator_2\" "],

--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -61,7 +61,7 @@ class PrintHierarchyCommand : Runnable {
         MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             deviceId = parent?.deviceId,
             platform = parent?.platform,
         ) { session ->

--- a/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
@@ -66,7 +66,7 @@ class QueryCommand : Runnable {
         MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             deviceId = parent?.deviceId,
             platform = parent?.platform,
         ) { session ->

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -108,7 +108,7 @@ class RecordCommand : Callable<Int> {
         return MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             deviceId = deviceId,
             platform = parent?.platform,
         ) { session ->

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -99,7 +99,7 @@ class StartDeviceCommand : Callable<Int> {
                 PrintUtils.message(if (p == Platform.IOS) "Launching simulator..." else "Launching emulator...")
                 DeviceService.startDevice(
                     device = device,
-                    driverHostPort = parent?.port
+                    driverHostPort = parent?.driverHostPort,
                 )
             }
         } catch (e: LocaleValidationIosException) {

--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -53,7 +53,7 @@ class StudioCommand : Callable<Int> {
         MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             deviceId = parent?.deviceId,
             platform = parent?.platform,
             isStudio = true

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -355,7 +355,7 @@ class TestCommand : Callable<Int> {
     }
 
     private fun selectPort(effectiveShards: Int): Int =
-        if (effectiveShards == 1) 7001
+        if (effectiveShards == 1) parent?.driverHostPort ?: 7001
         else (7001..7128).shuffled().find { port ->
             usedPorts.putIfAbsent(port, true) == null
         } ?: error("No available ports found")

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -72,8 +72,7 @@ object MaestroSessionManager {
         val heartbeatFuture = executor.scheduleAtFixedRate(
             {
                 try {
-                    Thread.sleep(1000) // Add a 1-second delay here for fixing race condition
-                    SessionStore.heartbeat(sessionId, selectedDevice.platform)
+                    SessionStore.heartbeat(sessionId, selectedDevice.platform, selectedDevice.deviceId)
                 } catch (e: Exception) {
                     logger.error("Failed to record heartbeat", e)
                 }
@@ -85,9 +84,9 @@ object MaestroSessionManager {
 
         val session = createMaestro(
             selectedDevice = selectedDevice,
-            connectToExistingSession = SessionStore.hasActiveSessions(
-                sessionId,
-                selectedDevice.platform
+            connectToExistingSession = SessionStore.hasActiveSessionOnDevice(
+                selectedDevice.platform,
+                selectedDevice.deviceId
             ),
             isStudio = isStudio,
             isHeadless = isHeadless,
@@ -95,9 +94,9 @@ object MaestroSessionManager {
         )
         Runtime.getRuntime().addShutdownHook(thread(start = false) {
             heartbeatFuture.cancel(true)
-            SessionStore.delete(sessionId, selectedDevice.platform)
+            SessionStore.delete(sessionId, selectedDevice.platform, selectedDevice.deviceId)
             runCatching { ScreenReporter.reportMaxDepth() }
-            if (SessionStore.activeSessions().isEmpty()) {
+            if (!SessionStore.hasActiveSessionOnDevice(selectedDevice.platform, selectedDevice.deviceId)) {
                 session.close()
             }
         })

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -123,6 +123,7 @@ object MaestroSessionManager {
             return SelectedDevice(
                 platform = device.platform,
                 device = device,
+                deviceId = deviceId,
             )
         }
 


### PR DESCRIPTION
**This PR has two parts**
1. **Parallel session execution**
    1. Fixes The root cause of
        1. #1853
        2. #1867
    2. Add support for
        1. #1485
        2. #1818 
3. **Adds --driver-host-port support for Driver server similar to --port for dadb server.**
--------------------------
### Part 1: Parallel session execution
#### Steps to reproduce
1. Run parallel sessions on different devices using multiple instance of maestro cli.
    1. Test will run in one instance but will fail in another due to grpc io exception.
<img width="1470" alt="Screenshot 2025-02-28 at 9 23 57 AM" src="https://github.com/user-attachments/assets/0314ec03-7f0a-4c0e-b6ac-69724fddf4ea" />
4. This same issue was faced for sharding flow in this issue #1853 and was fixed by a hack in this PR #1867

#### Root cause of the issue
1. Maestro test execution logs of the errored session shows that Issue happens when maestro makes first call to the driver server on mobile device.
```
09:23:13.850 [ INFO] maestro.Maestro.invoke: Getting device info
09:23:23.295 [ERROR] maestro.cli.runner.TestRunner.runCatching: Failed to run flow
io.grpc.StatusRuntimeException: UNAVAILABLE: io exception
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:275)
```
2. On checking logcat log of the device, found that for this errored session no driver app was installed and no instrumentation command was triggered and the device driver didn't receive the ``device info`` request.
3. This is happening because of `connectToExistingSession` feature which reconnects to existing session in case of some interruption or retries of session execution occurs.
    1. How `connectToExistingSession` feature  works?
        1. This feature was implemented before introducing sharding feature  #1732 
        2. On every new session creation it checks in keystore (~/.maestro/sessions) if any session other than current one exists that were active in last 21 second. If yes, **then skip setting up the driver on the device** (Assuming driver was set already in last session) #575
    2. Why this feature doesn't goes well with sharding and create issues?
        1. Sharding runs parallel sessions on **different devices**
        2. Due to `connectToExistingSession` it skips setting up driver on devices of session which were created after the first session initialisation of the shard (race condition).
            1. Heartbeat creates entry of session_platform key and timestamp as value on session creation and keeps updating it every 5 sec during whole session lifecycle.
        3. Since the device of the second session doesn't have the android server setup, grpc call couldn't find any server on that particular port and gives  io exception.
    3. Why PR #1867 (Adding a delay of 1 sec while recording first heartbeat) solves the issue?
        1. In sharding multiple session creation happens parallely at the same time.
        2. Session creation gets done in the very first sec and doesn't finds any existing session in key value storage and doesn't skip any driver setup on any device.

### Part 2: Add custom port support for driver
1. In case of sharding, a random free port(7001..7128) gets allocated for driver server while in case of one shard/no shard a fix port 7001 gets allocated for driver server.
2. When running parallel session using multiple cli instances, same 7001 port gets allocated for different device and creates issue.
--------------------------------------------------
## Proposed changes
### Parallel session
1. For `connectToExistingSession`, Instead of relying on presence of any existing session for that particular platform, rely on if any session for that particular **deviceId**  and platform is present in the keystore.
5. Why to use deviceId?
    1. A session gets always mapped to a single device id and in case of session reconnect/retry, we would want to reconnect to existing device that was used initially in the session and not any random device.

### Custom port for driver
1. Allow --driver-host-port setting for device driver to start server on.
    1. Previously value of --port was getting assigned to device driver server but was reverted back due to adb port clash here https://github.com/mobile-dev-inc/Maestro/pull/2235#discussion_r1909245270
    2. This custom port will allow user's to let maestro start driver server on any given port.
copilot:summary

## Testing
1. Ran multiple instances of maestro cli on a real android device and on a android simulator with custom driver ports
```
1. Maestro/maestro-cli/build/install/maestro/bin/maestro  --driver-host-port 8001 --device=Y9HE5L4L8P9T4P99  test run-test.yml

3. Maestro/maestro-cli/build/install/maestro/bin/maestro  --device=emulator-5554 --driver-host-port 8003 test run-test.yml
```
<img width="1428" alt="Screenshot 2025-02-28 at 10 03 33 AM" src="https://github.com/user-attachments/assets/a803526a-9804-4faf-ad39-eeeb5d658014" />

2. Ran sharding tests on two android devices
<img width="1468" alt="Screenshot 2025-02-28 at 10 15 20 AM" src="https://github.com/user-attachments/assets/1847d23d-cff4-48fb-a2a4-8d24a1038cce" />
3. New session device id keystore format 
<img width="800" alt="Screenshot 2025-02-28 at 11 42 01 AM" src="https://github.com/user-attachments/assets/7de254a1-f28e-4228-9f89-bf05c301762f" />


## Issues fixed

 #1853
 #1867
 #1485
 https://github.com/mobile-dev-inc/Maestro/pull/2235#discussion_r1909245270
