### PR TITLE
Add option to use Chrome dev tools for Android WebView hierarchy

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -1,7 +1,6 @@
 package maestro.cli.command
 
 import maestro.cli.App
-import maestro.cli.CliError
 import maestro.cli.DisableAnsiMixin
 import maestro.cli.ShowHelpMixin
 import maestro.cli.report.TestDebugReporter
@@ -13,7 +12,6 @@ import maestro.cli.view.faint
 import maestro.studio.MaestroStudio
 import picocli.CommandLine
 import java.awt.Desktop
-import java.net.ServerSocket
 import java.net.URI
 import java.util.concurrent.Callable
 import maestro.cli.util.getFreePort
@@ -46,6 +44,13 @@ class StudioCommand : Callable<Int> {
     )
     private var noWindow: Boolean? = null
 
+    @CommandLine.Option(
+        names = ["--android-webview-hierarchy"],
+        description = ["Set to \"devtools\" to use Chrome dev tools for Android WebView hierarchy"],
+        hidden = true,
+    )
+    private var androidWebViewHierarchy: String? = null
+
     override fun call(): Int {
 
         TestDebugReporter.install(debugOutputPathAsString = debugOutput, printToConsole = parent?.verbose == true)
@@ -58,6 +63,8 @@ class StudioCommand : Callable<Int> {
             platform = parent?.platform,
             isStudio = true
         ) { session ->
+            session.maestro.setAndroidChromeDevToolsEnabled(androidWebViewHierarchy == "devtools")
+
             val port = getFreePort()
             MaestroStudio.start(port, session.maestro)
 

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -102,4 +102,6 @@ interface Driver {
     fun isAirplaneModeEnabled(): Boolean
 
     fun setAirplaneMode(enabled: Boolean)
+
+    fun setAndroidChromeDevToolsEnabled(enabled: Boolean) = Unit
 }

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -613,6 +613,10 @@ class Maestro(
         driver.setAirplaneMode(enabled)
     }
 
+    fun setAndroidChromeDevToolsEnabled(enabled: Boolean) {
+        driver.setAndroidChromeDevToolsEnabled(enabled)
+    }
+
     companion object {
 
         private val LOGGER = LoggerFactory.getLogger(Maestro::class.java)

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
@@ -1,0 +1,161 @@
+package maestro.android.chromedevtools
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import com.fasterxml.jackson.databind.type.TypeFactory
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import dadb.Dadb
+import maestro.Maestro
+import maestro.TreeNode
+import okio.use
+import kotlin.system.measureTimeMillis
+
+private data class RuntimeResponse<T>(
+    val result: RemoteObject<T>
+)
+
+private data class RemoteObject<T>(
+    val type: String,
+    val value: T,
+)
+
+data class WebViewInfo(
+    val socketName: String,
+    val webSocketDebuggerUrl: String,
+    val visible: Boolean,
+    val screenX: Int,
+    val screenY: Int,
+    val width: Int,
+    val height: Int,
+)
+
+private data class WebViewResponse(
+    val description: String,
+    val webSocketDebuggerUrl: String,
+)
+
+private data class WebViewDescription(
+    val visible: Boolean,
+    val screenX: Int,
+    val screenY: Int,
+    val width: Int,
+    val height: Int,
+)
+
+private data class DevToolsResponse<T>(
+    val id: Int,
+    val result: T,
+)
+
+class DadbChromeDevToolsClient(private val dadb: Dadb) {
+
+    private val json = jacksonObjectMapper().configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+    private val httpClient = DadbHttpClient(dadb)
+
+    private val script = Maestro::class.java.getResourceAsStream("/maestro-web.js")?.let {
+        it.bufferedReader().use { br ->
+            br.readText()
+        }
+    } ?: error("Could not read maestro web script")
+
+    fun getWebViewTreeNodes(): List<TreeNode> {
+        return getWebViewInfos()
+            .filter { it.visible }
+            .map { info ->
+                evaluateScript<RuntimeResponse<TreeNode>>(info.socketName, info.webSocketDebuggerUrl, "$script; maestro.viewportX = ${info.screenX}; maestro.viewportY = ${info.screenY}; maestro.viewportWidth = ${info.width}; maestro.viewportHeight = ${info.height}; window.maestro.getContentDescription();").result.value
+            }
+    }
+
+    inline fun <reified T> evaluateScript(socketName: String, webSocketDebuggerUrl: String, script: String) = makeRequest<T>(
+        socketName = socketName,
+        webSocketDebuggerUrl = webSocketDebuggerUrl,
+        method = "Runtime.evaluate",
+        params = mapOf(
+            "expression" to script,
+            "returnByValue" to true,
+        ),
+    )
+
+    inline fun <reified T> makeRequest(socketName: String, webSocketDebuggerUrl: String, method: String, params: Any?): T {
+        val resultTypeReference = object : TypeReference<T>() {}
+        return makeRequest(resultTypeReference, socketName, webSocketDebuggerUrl, method, params)
+    }
+
+    fun <T> makeRequest(resultTypeReference: TypeReference<T>, socketName: String, webSocketDebuggerUrl: String, method: String, params: Any?): T {
+        val request = json.writeValueAsString(mapOf("id" to 1, "method" to method, "params" to params))
+        val response = dadb.open("localabstract:$socketName").use { stream ->
+            DadbWebSocketClient(stream, webSocketDebuggerUrl).use { client ->
+                client.connect()
+                client.sendText(request)
+                client.readFrame().payload.string(Charsets.UTF_8)
+            }
+        }
+        return try {
+            val resultType = TypeFactory.defaultInstance().constructType(resultTypeReference)
+            val responseType = TypeFactory.defaultInstance()
+                .constructParametricType(DevToolsResponse::class.java, resultType)
+            json.readValue<DevToolsResponse<T>>(response, responseType).result
+        } catch (e: JsonProcessingException) {
+            throw IllegalStateException("Failed to parse DOM snapshot: $response", e)
+        }
+    }
+
+    fun getWebViewInfos(): List<WebViewInfo> {
+        return getWebViewSocketNames().flatMap(::getWebViewInfos)
+    }
+
+    private fun getWebViewInfos(socketName: String): List<WebViewInfo> {
+        val destination = "localabstract:$socketName"
+        // Host and port don't matter here but must be set
+        val response = httpClient.get(destination, "http://localhost:9222/json")
+        if (response.statusCode != 200) {
+            throw IllegalStateException("Failed to get WebView info from $destination.\n$response")
+        }
+
+        return try {
+            json.readValue<List<WebViewResponse>>(response.body.toByteArray()).map { parsed ->
+                val description = json.readValue(parsed.description, WebViewDescription::class.java)
+                WebViewInfo(
+                    socketName = socketName,
+                    webSocketDebuggerUrl = parsed.webSocketDebuggerUrl,
+                    visible = description.visible,
+                    screenX = description.screenX,
+                    screenY = description.screenY,
+                    width = description.width,
+                    height = description.height,
+                )
+            }
+        } catch (e: JsonProcessingException) {
+            throw IllegalStateException("Failed to parse WebView chrome dev tools response: ${response.body.string(Charsets.UTF_8)}", e)
+        }
+    }
+
+    private fun getWebViewSocketNames(): List<String> {
+        val response = dadb.shell("cat /proc/net/unix")
+        if (response.exitCode != 0) {
+            throw IllegalStateException("Failed get WebView socket names. Command 'cat /proc/net/unix' failed: ${response.allOutput}")
+        }
+        return response.allOutput.trim().lines().mapNotNull { line ->
+            line.split(Regex("\\s+")).lastOrNull()?.takeIf { it.startsWith(WEB_VIEW_SOCKET_PREFIX) }?.substring(1)
+        }
+    }
+
+    companion object {
+        private const val WEB_VIEW_SOCKET_PREFIX = "@webview_devtools_remote_"
+    }
+}
+
+fun main() {
+    (Dadb.discover() ?: throw IllegalStateException("No devices found")).use { dadb ->
+        measureTimeMillis {
+            DadbChromeDevToolsClient(dadb).apply {
+                getWebViewTreeNodes().forEach {
+                    println(it)
+                }
+            }
+        }.also { println("time: $it") }
+    }
+}

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/DadbHttpClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/DadbHttpClient.kt
@@ -1,0 +1,134 @@
+package maestro.android.chromedevtools
+
+import dadb.AdbStream
+import dadb.Dadb
+import okio.BufferedSink
+import okio.BufferedSource
+import okio.ByteString
+import java.net.URI
+
+/**
+ * Minimal container for an HTTP response: the status line, status code, headers, and body.
+ */
+data class HttpResponse(
+    val statusLine: String,
+    val statusCode: Int,
+    val headers: Map<String, String>,
+    val body: ByteString
+)
+
+/**
+ * A very simple HTTP client that connects via [Dadb] to the specified [destination].
+ *
+ * Usage:
+ *
+ *  val client = DadbHttpClient(
+ *      dadb = myDadb,
+ *      destination = "localabstract:some-unix-socket"
+ *  )
+ *
+ *  val response = client.get("http://example.com/some/path?query=123")
+ *  println("Status: ${response.statusLine}")
+ *  println("Body: ${response.body.utf8()}")
+ */
+class DadbHttpClient(
+    private val dadb: Dadb,
+) {
+
+    /**
+     * Send a single GET request to [url] via adb [destination] and return the entire [HttpResponse].
+     *
+     * Opens (and closes) a new [AdbStream] for each request.
+     */
+    fun get(destination: String, url: String): HttpResponse {
+        // Parse the URL
+        val uri = URI(url)
+        require(uri.scheme.equals("http", ignoreCase = true)) {
+            "Only http:// is supported in this example (got ${uri.scheme})"
+        }
+
+        val host = uri.host ?: throw IllegalArgumentException("URL must have a host.")
+        val port = if (uri.port == -1) 80 else uri.port
+        // Build the path + optional query
+        val pathWithQuery = buildString {
+            append(if (uri.path.isNullOrEmpty()) "/" else uri.path)
+            if (!uri.query.isNullOrEmpty()) {
+                append("?").append(uri.query)
+            }
+        }
+
+        // Open an AdbStream to the provided destination
+        dadb.open(destination).use { stream ->
+            val source: BufferedSource = stream.source
+            val sink: BufferedSink = stream.sink
+
+            // Write a simple GET request
+            sink.writeUtf8("GET $pathWithQuery HTTP/1.1\r\n")
+            sink.writeUtf8("Connection: close\r\n")
+            sink.writeUtf8("Host: $host:$port\r\n")
+            sink.writeUtf8("\r\n")
+            sink.flush()
+
+            // Read the status line (e.g., "HTTP/1.1 200 OK")
+            val statusLine = source.readUtf8LineStrict()
+            // Extract status code from status line
+            val tokens = statusLine.split(" ")
+            val statusCode = tokens.getOrNull(1)?.toIntOrNull() ?: -1
+
+            // Read headers until blank line
+            val headers = mutableMapOf<String, String>()
+            while (true) {
+                val line = source.readUtf8Line() ?: break
+                if (line.isBlank()) {
+                    break
+                }
+                val parts = line.split(":", limit = 2)
+                if (parts.size == 2) {
+                    val headerName = parts[0].trim()
+                    val headerValue = parts[1].trim()
+                    headers[headerName] = headerValue
+                }
+            }
+
+            // If we have a Content-Length, read that many bytes. Otherwise read until EOF.
+            val contentLength = headers["Content-Length"]?.toIntOrNull() ?: -1
+            val body = if (contentLength >= 0) {
+                source.readByteString(contentLength.toLong())
+            } else {
+                source.readByteString()
+            }
+
+            return HttpResponse(
+                statusLine = statusLine,
+                statusCode = statusCode,
+                headers = headers,
+                body = body
+            )
+        }
+    }
+}
+
+/**
+ * Example usage (ensure you have a valid Dadb instance and a destination that supports HTTP).
+ */
+fun main() {
+    // Acquire a Dadb device. Adjust discovery or create a Dadb instance as needed.
+    val dadb = Dadb.discover() ?: error("No devices found")
+
+    dadb.use { d ->
+        // Suppose there's a process listening for HTTP requests on localabstract:some_unix_socket
+        val client = DadbHttpClient(d)
+
+        // Make an HTTP GET request
+        val response = client.get("localabstract:webview_devtools_remote_5664", "http://localhost/json")
+
+        println("Status line: ${response.statusLine}")
+        println("Status code: ${response.statusCode}")
+        println("Headers:")
+        response.headers.forEach { (k, v) ->
+            println("  $k: $v")
+        }
+        println("Body:")
+        println(response.body.utf8())
+    }
+}

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/DadbWebSocketClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/DadbWebSocketClient.kt
@@ -1,0 +1,345 @@
+package maestro.android.chromedevtools
+
+import dadb.AdbStream
+import dadb.Dadb
+import okio.BufferedSink
+import okio.BufferedSource
+import okio.ByteString
+import okio.ByteString.Companion.encodeUtf8
+import okio.use
+import java.io.Closeable
+import java.net.URI
+import java.security.MessageDigest
+import java.util.Base64
+import kotlin.experimental.xor
+import kotlin.random.Random
+import kotlin.system.measureTimeMillis
+
+/**
+ * AdbStream represents an underlying transport that provides a [BufferedSource] and [BufferedSink].
+ * We assume it's already connected at the TCP-like level so we can perform an HTTP handshake.
+ *
+ * interface AdbStream : AutoCloseable {
+ *     val source: BufferedSource
+ *     val sink: BufferedSink
+ * }
+ */
+
+/**
+ * A minimal set of WebSocket opcodes from RFC 6455
+ */
+object Opcode {
+    const val CONTINUATION = 0x0
+    const val TEXT = 0x1
+    const val BINARY = 0x2
+    const val CLOSE = 0x8
+    const val PING = 0x9
+    const val PONG = 0xA
+}
+
+/**
+ * A sealed class representing different WebSocket frames.
+ */
+sealed class Frame(val opcode: Int, open val payload: ByteString) {
+    data class TextFrame(override val payload: ByteString) : Frame(Opcode.TEXT, payload)
+    data class BinaryFrame(override val payload: ByteString) : Frame(Opcode.BINARY, payload)
+    data class CloseFrame(override val payload: ByteString) : Frame(Opcode.CLOSE, payload)
+    data class PingFrame(override val payload: ByteString) : Frame(Opcode.PING, payload)
+    data class PongFrame(override val payload: ByteString) : Frame(Opcode.PONG, payload)
+    data class ContinuationFrame(override val payload: ByteString) : Frame(Opcode.CONTINUATION, payload)
+}
+
+/**
+ * A simple WebSocket client that:
+ * 1) Performs the handshake.
+ * 2) Sends and receives WebSocket frames over the provided AdbStream.
+ */
+class DadbWebSocketClient(
+    private val adbStream: AdbStream,
+    private val url: String
+) : Closeable {
+
+    private val source: BufferedSource = adbStream.source
+    private val sink: BufferedSink = adbStream.sink
+
+    // Whether the handshake has completed
+    private var isConnected = false
+
+    /**
+     * Parse the URL and perform a WebSocket handshake.
+     * Throws an exception if the handshake fails.
+     */
+    fun connect() {
+        val uri = URI(url)
+        require(uri.scheme.equals("ws", ignoreCase = true)) {
+            "Only ws:// is supported in this example (got ${uri.scheme})"
+        }
+
+        val host = uri.host ?: throw IllegalArgumentException("URL must have a host.")
+        // For a simple example, if port is missing, default to 80 for ws
+        val port = if (uri.port == -1) 80 else uri.port
+        val pathWithQuery = buildString {
+            append(if (uri.path.isNullOrEmpty()) "/" else uri.path)
+            if (!uri.query.isNullOrEmpty()) {
+                append("?").append(uri.query)
+            }
+        }
+
+        // Generate a Sec-WebSocket-Key
+        val wsKey = generateWebSocketKey()
+
+        // Send the HTTP upgrade request
+        sink.writeUtf8("GET $pathWithQuery HTTP/1.1\r\n")
+        sink.writeUtf8("Host: $host:$port\r\n")
+        sink.writeUtf8("Upgrade: websocket\r\n")
+        sink.writeUtf8("Connection: Upgrade\r\n")
+        sink.writeUtf8("Sec-WebSocket-Key: $wsKey\r\n")
+        sink.writeUtf8("Sec-WebSocket-Version: 13\r\n")
+        sink.writeUtf8("\r\n")
+        sink.flush()
+
+        // Read the response status line
+        val statusLine = source.readUtf8LineStrict()
+        if (!statusLine.contains("101")) {
+            throw IllegalStateException("Failed to switch protocols: $statusLine")
+        }
+
+        // Read headers until an empty line
+        var secWebSocketAccept: String? = null
+        while (true) {
+            val line = source.readUtf8Line() ?: break
+            if (line.isBlank()) break
+            val parts = line.split(":", limit = 2)
+            if (parts.size == 2) {
+                val headerName = parts[0].trim()
+                val headerValue = parts[1].trim()
+                if (headerName.equals("Sec-WebSocket-Accept", ignoreCase = true)) {
+                    secWebSocketAccept = headerValue
+                }
+            }
+        }
+
+        // Validate the Sec-WebSocket-Accept
+        val expectedAccept = computeAcceptKey(wsKey)
+        if (secWebSocketAccept == null || secWebSocketAccept != expectedAccept) {
+            throw IllegalStateException(
+                "Invalid Sec-WebSocket-Accept. expected=$expectedAccept, got=$secWebSocketAccept"
+            )
+        }
+
+        isConnected = true
+    }
+
+    /**
+     * Read a single WebSocket frame from the stream.
+     * This blocks until a frame is available or an error occurs.
+     */
+    fun readFrame(): Frame {
+        // The first byte: FIN bit (1 bit), RSV1-3 (3 bits), Opcode (4 bits)
+        val b0 = source.readByte().toInt() and 0xFF
+        val fin = (b0 shr 7) and 1
+        val opcode = b0 and 0x0F
+
+        // The second byte: Mask bit (1 bit), Payload length (7 bits)
+        val b1 = source.readByte().toInt() and 0xFF
+        val maskFlag = (b1 shr 7) and 1
+        var payloadLen = (b1 and 0x7F).toLong()
+
+        when (payloadLen) {
+            126L -> {
+                // 126 means the next 2 bytes define the length
+                payloadLen = source.readShort().toLong() and 0xFFFF
+            }
+            127L -> {
+                // 127 means the next 8 bytes define the length
+                payloadLen = source.readLong()
+            }
+        }
+
+        // If the mask bit is set, we need to read the mask key (4 bytes)
+        val maskKey = if (maskFlag == 1) {
+            source.readByteArray(4)
+        } else {
+            null
+        }
+
+        // Read the payload
+        val payload = source.readByteString(payloadLen)
+
+        // Unmask if needed
+        val realPayload = if (maskKey != null) unmask(payload, maskKey) else payload
+
+        return when (opcode) {
+            Opcode.TEXT -> Frame.TextFrame(realPayload)
+            Opcode.BINARY -> Frame.BinaryFrame(realPayload)
+            Opcode.CLOSE -> Frame.CloseFrame(realPayload)
+            Opcode.PING -> Frame.PingFrame(realPayload)
+            Opcode.PONG -> Frame.PongFrame(realPayload)
+            Opcode.CONTINUATION -> Frame.ContinuationFrame(realPayload)
+            else -> {
+                // For unknown opcodes in a robust implementation, you might close the connection
+                throw IllegalStateException("Unknown opcode: $opcode")
+            }
+        }
+    }
+
+    /**
+     * Send a WebSocket frame over the connection.
+     * By RFC 6455, clients MUST set the mask bit on every frame they send.
+     */
+    fun sendFrame(frame: Frame) {
+        if (!isConnected) {
+            throw IllegalStateException("Not connected; did you call connect() successfully?")
+        }
+
+        // Determine the opcode
+        val opcode = frame.opcode
+        val payload = frame.payload
+
+        // Set FIN = 1 (we don't handle fragmentation in this simple example)
+        val b0 = (0x80 or (opcode and 0x0F)).toByte()
+
+        // We must mask the frame from a client
+        val maskKey = ByteArray(4).apply { Random.nextBytes(this) }
+        val maskedPayload = mask(payload, maskKey)
+        val length = maskedPayload.size.toLong()
+
+        val header = mutableListOf<Byte>()
+        header.add(b0)
+
+        // Now, build the second byte + extended length if needed
+        when {
+            length < 126 -> {
+                // second byte: 10000000 (0x80 for mask) + length
+                header.add((0x80 or (length.toInt() and 0x7F)).toByte())
+            }
+            length <= 0xFFFF -> {
+                // second byte: 10000000 + 126
+                header.add((0x80 or 126).toByte())
+                // 16-bit length
+                header.add(((length ushr 8) and 0xFF).toByte())
+                header.add((length and 0xFF).toByte())
+            }
+            else -> {
+                // second byte: 10000000 + 127
+                header.add((0x80 or 127).toByte())
+                // 64-bit length
+                for (shift in (7 downTo 0)) {
+                    header.add(((length ushr (shift * 8)) and 0xFF).toByte())
+                }
+            }
+        }
+
+        // Write header
+        sink.write(header.toByteArray())
+
+        // Write masking key
+        sink.write(maskKey)
+
+        // Write masked payload
+        sink.write(maskedPayload)
+
+        sink.flush()
+    }
+
+    /**
+     * Convenience method to send a text message.
+     */
+    fun sendText(text: String) {
+        val payload = text.encodeUtf8()
+        sendFrame(Frame.TextFrame(payload))
+    }
+
+    /**
+     * Convenience method to send a ping.
+     */
+    fun sendPing(payload: ByteString = ByteString.EMPTY) {
+        sendFrame(Frame.PingFrame(payload))
+    }
+
+    /**
+     * Convenience method to send a pong.
+     */
+    fun sendPong(payload: ByteString = ByteString.EMPTY) {
+        sendFrame(Frame.PongFrame(payload))
+    }
+
+    /**
+     * Convenience method to send a close frame.
+     */
+    fun sendClose(payload: ByteString = ByteString.EMPTY) {
+        sendFrame(Frame.CloseFrame(payload))
+    }
+
+    /**
+     * Closes the underlying AdbStream.
+     */
+    override fun close() {
+        adbStream.close()
+    }
+
+    /**
+     * Utility to generate the random base64 key for the handshake.
+     */
+    private fun generateWebSocketKey(): String {
+        val randomBytes = ByteArray(16).also { Random.nextBytes(it) }
+        return Base64.getEncoder().encodeToString(randomBytes)
+    }
+
+    /**
+     * Compute the Sec-WebSocket-Accept from the key, as per RFC 6455.
+     */
+    private fun computeAcceptKey(key: String): String {
+        val magicString = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+        val sha1 = MessageDigest.getInstance("SHA-1")
+        sha1.update(key.toByteArray(Charsets.UTF_8))
+        sha1.update(magicString.toByteArray(Charsets.UTF_8))
+        val result = sha1.digest()
+        return Base64.getEncoder().encodeToString(result)
+    }
+
+    /**
+     * Apply mask to a payload. For client -> server frames, we must always mask.
+     */
+    private fun mask(payload: ByteString, key: ByteArray): ByteArray {
+        val bytes = payload.toByteArray()
+        for (i in bytes.indices) {
+            bytes[i] = bytes[i] xor key[i % 4]
+        }
+        return bytes
+    }
+
+    /**
+     * Unmask a masked payload from the server (rare, since servers usually do not mask).
+     */
+    private fun unmask(payload: ByteString, key: ByteArray): ByteString {
+        val bytes = payload.toByteArray()
+        for (i in bytes.indices) {
+            bytes[i] = bytes[i] xor key[i % 4]
+        }
+        return ByteString.of(*bytes)
+    }
+}
+
+
+fun main() {
+    (Dadb.discover() ?: throw IllegalStateException("No devices found")).use { dadb ->
+        measureTimeMillis {
+            dadb.open("localabstract:chrome_devtools_remote").use { stream ->
+                DadbWebSocketClient(stream, "ws://localhost:9222/devtools/page/14").use { client ->
+                    client.connect()
+                    client.sendText("""
+                        {
+                            "id": 1,
+                            "method": "DOMSnapshot.getSnapshot",
+                            "params": {
+                                "depth": -1
+                            }
+                        }
+                    """.trimIndent())
+                    println(client.readFrame().payload.string(Charsets.UTF_8))
+                }
+            }
+        }.also { println(it) }
+    }
+}

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -18,8 +18,19 @@
 
     const getNodeBounds = (node) => {
         const rect = node.getBoundingClientRect()
+        const vpx = maestro.viewportX;
+        const vpy = maestro.viewportY;
+        const vpw = maestro.viewportWidth || window.innerWidth;
+        const vph = maestro.viewportHeight || window.innerHeight;
 
-        return `[${Math.round(rect.x)},${Math.round(rect.y)}][${Math.round(rect.x+rect.width)},${Math.round(rect.y+rect.height)}]`
+        const scaleX = vpw / window.innerWidth;
+        const scaleY = vph / window.innerHeight;
+        const l = rect.x * scaleX + vpx;
+        const t = rect.y * scaleY + vpy;
+        const r = (rect.x + rect.width) * scaleX + vpx;
+        const b = (rect.y + rect.height) * scaleY + vpy;
+
+        return `[${Math.round(l)},${Math.round(t)}][${Math.round(r)},${Math.round(b)}]`
     }
 
     const isDocumentLoading = () => document.readyState !== 'complete'
@@ -34,7 +45,8 @@
       }
 
       if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
-        attributes['resource-id'] = node.id || node.ariaLabel || node.name || node.title || node.htmlFor || node.attributes['data-testid']?.value
+        const title = typeof node.title === 'string' ? node.title : null
+        attributes['resource-id'] = node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
       }
 
       if (node.tagName.toLowerCase() === 'body') {
@@ -48,6 +60,11 @@
     }
 
     // -------------- Public API --------------
+    maestro.viewportX = 0;
+    maestro.viewportY = 0;
+    maestro.viewportWidth = 0;
+    maestro.viewportHeight = 0;
+
     maestro.getContentDescription = () => {
         return traverse(document.body)
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -116,6 +116,7 @@ class Orchestra(
         val config = YamlCommandReader.getConfig(commands)
 
         initJsEngine(config)
+        initAndroidChromeDevTools(config)
 
         onFlowStart(commands)
 
@@ -169,6 +170,8 @@ class Orchestra(
         if (shouldReinitJsEngine) {
             initJsEngine(config)
         }
+
+        initAndroidChromeDevTools(config)
 
         commands
             .forEachIndexed { index, command ->
@@ -243,6 +246,11 @@ class Orchestra(
         } else {
             httpClient?.let { RhinoJsEngine(it, platform) } ?: RhinoJsEngine(platform = platform)
         }
+    }
+
+    private fun initAndroidChromeDevTools(config: MaestroConfig?) {
+        val shouldEnableAndroidChromeDevTools = config?.ext?.get("androidWebViewHierarchy") == "devtools"
+        maestro.setAndroidChromeDevToolsEnabled(shouldEnableAndroidChromeDevTools)
     }
 
     private fun initAI(): AI? {


### PR DESCRIPTION
Add an option to use Chrome dev tools to build the Android WebView hierarchy.

eg.
```
appId: com.example.app
androidWebViewHierarchy: devtools
---
- launchApp
```

Also adds an option to studio CLI command to do the same:

```
maestro studio --android-webview-hierarchy=devtools
```