### PR TITLE
Only check if flows are webflows

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
@@ -1,6 +1,7 @@
 package maestro.cli.util
 
 import maestro.orchestra.yaml.YamlCommandReader
+import maestro.utils.StringUtils.toRegexSafe
 import java.io.File
 import java.util.zip.ZipInputStream
 
@@ -18,7 +19,11 @@ object FileUtils {
     fun File.isWebFlow(): Boolean {
         if (isDirectory) {
             return listFiles()
-                ?.any { it.isWebFlow() }
+                ?.any { 
+                    it.getName().matches(".+\\.y[a]?ml".toRegexSafe(RegexOption.IGNORE_CASE)) &&
+                    !it.getName().matches("config.y[a]?ml".toRegexSafe(RegexOption.IGNORE_CASE)) &&
+                    it.isWebFlow() 
+                }
                 ?: false
         }
 


### PR DESCRIPTION
## Proposed changes

When running `maestro cloud` on a folder that contains non-flows (JS, Readme, config.yaml) the command would fail because every file was checked for isWebFlow(), and some can't be parsed as flows.

This would lead to this error:

```
Flow files must contain a config section and a commands section separated by "---". For example:

appId: com.example
---
- launchApp

The stack trace was:
maestro.orchestra.error.SyntaxError: Error reading ./parsing-arrays/config.yaml
Flow files must contain a config section and a commands section separated by "---". For example:

appId: com.example
---
- launchApp
        at maestro.orchestra.yaml.YamlCommandReader.readConfigAndCommands(YamlCommandReader.kt:99)
        at maestro.orchestra.yaml.YamlCommandReader.readConfig(YamlCommandReader.kt:60)
        at maestro.cli.util.FileUtils.isWebFlow(FileUtils.kt:25)
        at maestro.cli.util.FileUtils.isWebFlow(FileUtils.kt:21)
        at maestro.cli.cloud.CloudInteractor.upload(CloudInteractor.kt:111)
        at maestro.cli.command.CloudCommand.call(CloudCommand.kt:205)
        at maestro.cli.command.CloudCommand.call(CloudCommand.kt:42)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
        at picocli.CommandLine.access$1300(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2358)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2352)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2314)
        at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
        at picocli.CommandLine$RunLast.execute(CommandLine.java:2316)
        at maestro.cli.DisableAnsiMixin$Companion.executionStrategy(DisableAnsiMixin.kt:22)
        at picocli.CommandLine.execute(CommandLine.java:2078)
        at maestro.cli.AppKt.main(App.kt:144)
```

This PR enhances the check to filter early on files for yaml (but not config.yaml)

## Testing

`./installLocally.sh` and `maestro cloud` a folder
