### PR TITLE
fix: properly set closing driver state

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -398,9 +398,23 @@ class AndroidDriver(
             blockingStubWithTimeout.viewHierarchy(viewHierarchyRequest {})
         } catch (throwable: StatusRuntimeException) {
             val status = Status.fromThrowable(throwable)
-            if (status.code == Status.Code.DEADLINE_EXCEEDED) {
-                LOGGER.error("Timeout while fetching view hierarchy")
-                throw MaestroException.DriverTimeout("Android driver unreachable")
+            when (status.code) {
+                Status.Code.DEADLINE_EXCEEDED -> {
+                    LOGGER.error("Timeout while fetching view hierarchy")
+                    closed = true
+                    throw MaestroException.DriverTimeout("Android driver unreachable")
+                }
+                Status.Code.UNAVAILABLE -> {
+                    if (throwable.cause is IOException || throwable.message?.contains("io exception", ignoreCase = true) == true) {
+                        LOGGER.error("Not able to reach the gRPC server while fetching view hierarchy")
+                        closed = true
+                    } else {
+                        LOGGER.error("Received UNAVAILABLE status with message: ${throwable.message}")
+                    }
+                }
+                else -> {
+                    LOGGER.error("Unexpected error: ${status.code} - ${throwable.message}")
+                }
             }
 
             // There is a bug in Android UiAutomator that rarely throws an NPE while dumping a view hierarchy.


### PR DESCRIPTION
## Proposed changes

We were not properly close variable state that skips closing driver if grpc server shuts down suddenly in between of test execution. This is already done on all the calls except the viewHierarchy call.


## Testing

- [ ] Locally
- [ ] Cloud

## Issues fixed
