### PR TITLE
fix: also handle on runDevice call

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -1189,11 +1189,27 @@ class AndroidDriver(
             call()
         } catch (throwable: StatusRuntimeException) {
             val status = Status.fromThrowable(throwable)
-            if (status.code == Status.Code.DEADLINE_EXCEEDED) {
-                closed = true
-                throw MaestroException.DriverTimeout("Android driver unreachable")
+            when (status.code) {
+                Status.Code.DEADLINE_EXCEEDED -> {
+                    LOGGER.error("Device call failed on android with $status", throwable)
+                    closed = true
+                    throw MaestroException.DriverTimeout("Android driver unreachable")
+                }
+                Status.Code.UNAVAILABLE -> {
+                    if (throwable.cause is IOException || throwable.message?.contains("io exception", ignoreCase = true) == true) {
+                        LOGGER.error("Not able to reach the gRPC server while doing android device call")
+                        closed = true
+                        throw throwable
+                    } else {
+                        LOGGER.error("Received UNAVAILABLE status with message: ${throwable.message} while doing android device call", throwable)
+                        throw throwable
+                    }
+                }
+                else -> {
+                    LOGGER.error("Unexpected error: ${status.code} - ${throwable.message} and cause ${throwable.cause} while doing android device call", throwable)
+                    throw throwable
+                }
             }
-            throw throwable
         }
     }
 


### PR DESCRIPTION
## Proposed changes

Unavailable io exception can also happen during runDevice call which can again lead to stuck tests on our infra. This was already fixed on view hierarchy but this was missed.

## Testing

- [ ] Locally

## Issues fixed
