### PR TITLE
Add maestro check-syntax command

### DIFF
--- a/maestro
+++ b/maestro
@@ -2,4 +2,10 @@
 
 set -e
 
-./gradlew :maestro-cli:installDist -q && ./maestro-cli/build/install/maestro/bin/maestro "$@"
+if [ -t 0 ]; then
+  input=""
+else
+  input=$(cat -)
+fi
+
+./gradlew :maestro-cli:installDist -q && echo "$input" | ./maestro-cli/build/install/maestro/bin/maestro "$@"

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -23,6 +23,7 @@ import maestro.MaestroException
 import maestro.cli.analytics.Analytics
 import maestro.cli.command.BugReportCommand
  import maestro.cli.command.ChatCommand
+import maestro.cli.command.CheckSyntaxCommand
 import maestro.cli.command.CloudCommand
 import maestro.cli.command.DownloadSamplesCommand
 import maestro.cli.command.LoginCommand
@@ -64,6 +65,7 @@ import kotlin.system.exitProcess
         StartDeviceCommand::class,
         GenerateCompletion::class,
         ChatCommand::class,
+        CheckSyntaxCommand::class,
     ]
 )
 class App {

--- a/maestro-cli/src/main/java/maestro/cli/command/CheckSyntaxCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CheckSyntaxCommand.kt
@@ -1,0 +1,41 @@
+package maestro.cli.command
+
+import maestro.cli.CliError
+import maestro.orchestra.error.SyntaxError
+import maestro.orchestra.yaml.YamlCommandReader
+import picocli.CommandLine
+import java.io.File
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+    name = "check-syntax",
+    description = [
+        "Check syntax of Maestro code"
+    ],
+    hidden = true
+)
+class CheckSyntaxCommand : Callable<Int> {
+
+    @CommandLine.Parameters(
+        index = "0",
+        description = ["Check syntax of Maestro flow file or \"-\" for stdin"],
+    )
+    private lateinit var file: File
+
+    override fun call(): Int {
+        val maestroCode = if (file.path == "-") {
+            System.`in`.readBytes().toString(Charsets.UTF_8)
+        } else {
+            if (!file.exists()) throw CliError("File does not exist: ${file.absolutePath}")
+            file.readText()
+        }
+        if (maestroCode.isBlank()) throw CliError("Maestro code is empty.")
+        try {
+            YamlCommandReader.checkSyntax(maestroCode)
+            println("OK")
+        } catch (e: SyntaxError) {
+            throw CliError(e.message)
+        }
+        return 0
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -28,6 +28,7 @@ import maestro.orchestra.WorkspaceConfig
 import maestro.orchestra.error.SyntaxError
 import maestro.utils.drawTextBox
 import java.nio.file.Path
+import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.readText
 
@@ -69,6 +70,10 @@ object YamlCommandReader {
     }
 
     fun formatCommands(commands: List<String>): String = MaestroFlowParser.formatCommands(commands)
+
+    fun checkSyntax(maestroCode: String) = mapParsingErrors(Paths.get("/syntax-checker/")) {
+        MaestroFlowParser.checkSyntax(maestroCode)
+    }
 
     private fun <T> mapParsingErrors(path: Path, block: () -> T): T {
         try {

--- a/tmp.sh
+++ b/tmp.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [ -t 0 ]; then
+  input=""
+else
+  input=$(cat -)
+fi
+
+echo "Hello $input"


### PR DESCRIPTION
✔️  Single command
```bash
$ echo "tapOn: foo" | maestro check-syntax -

OK
```

✔️  Full flow
```bash
$ cat << EOF  | maestro check-syntax -
appId: com.example.app
---
- tapOn: foo
EOF

OK
```

✔️  List of commands
```bash
$ cat << EOF  | maestro check-syntax -
- tapOn: foo
- inputText: bar
EOF

OK
```

✔️  File input
```bash
$ maestro check-syntax MyFlow.yaml

OK
```

✔️  Errors
```bash
$ cat << EOF  | maestro check-syntax -
- tapOn: foo
- inp
EOF

/syntax-checker:2
╭────────────────────────────────────────────────────────────────────────────────╮
│ 1 | - tapOn: foo                                                               │
│ 2 | - inp                                                                      │
│          ^                                                                     │
│ ╭────────────────────────────────────────────────────────────────────────────╮ │
│ │ `inp` is not a valid command.                                              │ │
│ │                                                                            │ │
│ │ Did you mean one of: inputRandomText, inputRandomNumber, inputRandomEmail, │ │
│ │ inputRandomPersonName, inputText                                           │ │
│ │                                                                            │ │
│ │ > https://docs.maestro.dev/api-reference/commands                          │ │
│ ╰────────────────────────────────────────────────────────────────────────────╯ │
│ 3 |                                                                            │
╰────────────────────────────────────────────────────────────────────────────────╯
```