### PR TITLE
properly closing maestro sessions

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -41,7 +41,7 @@ class Maestro(
      val driver: Driver,
 ) : AutoCloseable {
 
-    private val sessionId = UUID.randomUUID()
+    val sessionId = UUID.randomUUID()
 
     val deviceName: String
         get() = driver.name()


### PR DESCRIPTION
## Proposed changes

Noticed that the close function in maestroSessionManager wasn't really closing sessions. That happened because the SessionStore creates the session again with the heartbeat.

To handle this correctly we need to cancel the hearbeat before closing the session
## Testing

<!--- Please describe how you tested your changes. -->

## Issues fixed
