### PR TITLE
copy/pasting a list of commands from maestro studio now has the correct formatting when pasting into a yaml file

### DIFF
--- a/maestro-studio/web/src/components/commands/ReplView.tsx
+++ b/maestro-studio/web/src/components/commands/ReplView.tsx
@@ -27,10 +27,10 @@ const getFlowText = (selected: ReplCommand[]): string => {
     
     // Process the parameter lines
     for (let i = 1; i < lines.length; i++) {
-      const line = lines[i].trim();
-      if (line) {
-        // Parameters should have 4-space indentation
-        combinedYaml += '    ' + line + '\n';
+      if (lines[i].trim()) {
+        // Parameters should have appropriate indentation.
+        // Given we're adding 2 characters for '- ', we add 2 spaces to subsequent lines.
+        combinedYaml += '  ' + lines[i] + '\n';
       }
     }
   });


### PR DESCRIPTION
Copy/pasting a list of commands from maestro studio directly into VS code yaml file looks like:
<img width="277" alt="image" src="https://github.com/user-attachments/assets/c47c88a1-427a-48aa-8292-ab6283663f1f" />

Notice it's missing the dash "-" and lacks proper indenting. Tests won't run unless you manually go fix all the formatting.

After a few changes, now it correctly pastes with correct format: 
<img width="278" alt="image" src="https://github.com/user-attachments/assets/3ad477bb-bd81-40da-aab4-3b7291574d18" />


## Proposed changes

copilot:summary

## Testing

Tested with this list of commands, copy/pasting back and forth: 
<img width="1362" alt="image" src="https://github.com/user-attachments/assets/ff308f5a-7e72-4ae4-9b08-f762144ab707" />


## Issues fixed
