### PR TITLE
maestro: making AI commands work

### DIFF
--- a/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/CloudPredictionAIEngine.kt
@@ -1,0 +1,18 @@
+package maestro.ai
+
+import maestro.ai.cloud.Defect
+import maestro.ai.Prediction
+
+class CloudAIPredictionEngine(private val apiKey: String) : AIPredictionEngine {
+    override suspend fun findDefects(screen: ByteArray): List<Defect> {
+        return Prediction.findDefects(apiKey, screen)
+    }
+
+    override suspend fun performAssertion(screen: ByteArray, assertion: String): Defect? {
+        return Prediction.performAssertion(apiKey, screen, assertion)
+    }
+
+    override suspend fun extractText(screen: ByteArray, query: String): String {
+        return Prediction.extractText(apiKey, query, screen)
+    }
+}

--- a/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
+++ b/maestro-ai/src/main/java/maestro/ai/IAPredictionEngine.kt
@@ -1,0 +1,9 @@
+package maestro.ai
+
+import maestro.ai.cloud.Defect
+
+interface AIPredictionEngine {
+    suspend fun findDefects(screen: ByteArray): List<Defect>
+    suspend fun performAssertion(screen: ByteArray, assertion: String): Defect?
+    suspend fun extractText(screen: ByteArray, query: String): String
+}

--- a/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
+++ b/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
@@ -73,11 +73,11 @@ class Auth(
     private val apiClient: ApiClient
 ) {
 
-    fun getAuthToken(apiKey: String?): String {
+    fun getAuthToken(apiKey: String?, triggerSignIn: Boolean = true): String {
         return apiKey // Check for API key
             ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
             ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
-            ?: triggerSignInFlow() // Otherwise, trigger the sign-in flow
+            ?: if (triggerSignIn) triggerSignInFlow() else throw IllegalStateException("No API key provided and no cached auth token found") // Otherwise, trigger the sign-in flow
     }
 
     fun getAuthTokenSimple(apiKey: String?): String? {

--- a/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
+++ b/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
@@ -25,6 +25,7 @@ import maestro.cli.util.PrintUtils.info
 import maestro.cli.util.PrintUtils.message
 import maestro.cli.util.PrintUtils.success
 import maestro.cli.util.getFreePort
+import maestro.cli.util.EnvUtils
 
 private const val SUCCESS_HTML = """
     <!DOCTYPE html>
@@ -71,6 +72,20 @@ private const val FAILURE_HTML = """
 class Auth(
     private val apiClient: ApiClient
 ) {
+
+    fun getAuthToken(apiKey: String?): String {
+        return apiKey // Check for API key
+            ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
+            ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
+            ?: triggerSignInFlow() // Otherwise, trigger the sign-in flow
+    }
+
+    fun getAuthTokenSimple(apiKey: String?): String? {
+        message("Using API key from environment: $apiKey")
+        return apiKey // Check for API key
+            ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
+            ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
+    }
 
     fun getCachedAuthToken(): String? {
         if (!cachedAuthTokenFile.exists()) return null

--- a/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
+++ b/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
@@ -73,15 +73,13 @@ class Auth(
     private val apiClient: ApiClient
 ) {
 
-    fun getAuthToken(apiKey: String?, triggerSignIn: Boolean = true): String {
-        return apiKey // Check for API key
-            ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
-            ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
-            ?: if (triggerSignIn) triggerSignInFlow() else throw IllegalStateException("No API key provided and no cached auth token found") // Otherwise, trigger the sign-in flow
-    }
-
-    fun getAuthTokenSimple(apiKey: String?): String? {
-        message("Using API key from environment: $apiKey")
+    fun getAuthToken(apiKey: String?, triggerSignIn: Boolean = true): String? {
+        if (triggerSignIn) {
+            return apiKey // Check for API key
+                ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
+                ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
+                ?: triggerSignInFlow() // Otherwise, trigger the sign-in flow
+        }
         return apiKey // Check for API key
             ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
             ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -82,7 +82,7 @@ class CloudInteractor(
         if (mapping?.exists() == false) throw CliError("File does not exist: ${mapping.absolutePath}")
         if (async && reportFormat != ReportFormat.NOOP) throw CliError("Cannot use --format with --async")
 
-        val authToken = getAuthToken(apiKey)
+        val authToken = auth.getAuthToken(apiKey)
 
         PrintUtils.message("Uploading Flow(s)...")
 
@@ -452,19 +452,12 @@ class CloudInteractor(
         )
     }
 
-    private fun getAuthToken(apiKey: String?): String {
-        return apiKey // Check for API key
-            ?: auth.getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
-            ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
-            ?: auth.triggerSignInFlow() // Otherwise, trigger the sign-in flow
-    }
-
     fun analyze(
         apiKey: String?,
         debugFiles: AnalysisDebugFiles,
         debugOutputPath: Path,
     ): Int {
-        val authToken = getAuthToken(apiKey)
+        val authToken = auth.getAuthToken(apiKey)
 
         PrintUtils.info("\n\uD83D\uDD0E Analyzing Flow(s)...")
 

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -83,6 +83,7 @@ class CloudInteractor(
         if (async && reportFormat != ReportFormat.NOOP) throw CliError("Cannot use --format with --async")
 
         val authToken = auth.getAuthToken(apiKey)
+        if (authToken == null) throw CliError("Failed to get authentication token")
 
         PrintUtils.message("Uploading Flow(s)...")
 
@@ -458,6 +459,7 @@ class CloudInteractor(
         debugOutputPath: Path,
     ): Int {
         val authToken = auth.getAuthToken(apiKey)
+        if (authToken == null) throw CliError("Failed to get authentication token")
 
         PrintUtils.info("\n\uD83D\uDD0E Analyzing Flow(s)...")
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -45,6 +45,8 @@ import maestro.cli.util.FileUtils.isWebFlow
 import maestro.cli.util.PrintUtils
 import maestro.cli.insights.TestAnalysisManager
 import maestro.cli.view.box
+import maestro.cli.api.ApiClient
+import maestro.cli.auth.Auth
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner.ExecutionPlan
@@ -167,6 +169,10 @@ class TestCommand : Callable<Int> {
 
     @Option(names = ["--api-key"], description = ["[Beta] API key"])
     private var apiKey: String? = null
+
+    private val client: ApiClient = ApiClient(baseUrl = apiUrl)
+    private val auth: Auth = Auth(client)
+    private val authToken: String? = auth.getAuthTokenSimple(apiKey)
 
     @Option(
         names = ["--reinstall-driver"],
@@ -353,7 +359,7 @@ class TestCommand : Callable<Int> {
                     if (!flattenDebugOutput) {
                         TestDebugReporter.deleteOldFiles()
                     }
-                    TestRunner.runContinuous(maestro, device, flowFile, env, analyze)
+                    TestRunner.runContinuous(maestro, device, flowFile, env, analyze, authToken)
                 } else {
                     runSingleFlow(maestro, device, flowFile, debugOutputPath)
                 }
@@ -387,7 +393,8 @@ class TestCommand : Callable<Int> {
             env = env,
             resultView = resultView,
             debugOutputPath = debugOutputPath,
-            analyze = analyze
+            analyze = analyze,
+            apiKey = authToken,
         )
 
         if (resultSingle == 1) {

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -172,7 +172,7 @@ class TestCommand : Callable<Int> {
 
     private val client: ApiClient = ApiClient(baseUrl = apiUrl)
     private val auth: Auth = Auth(client)
-    private val authToken: String? = auth.getAuthTokenSimple(apiKey)
+    private val authToken: String? = auth.getAuthToken(apiKey, triggerSignIn = false)
 
     @Option(
         names = ["--reinstall-driver"],

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -56,6 +56,7 @@ object MaestroCommandRunner {
         commands: List<MaestroCommand>,
         debugOutput: FlowDebugOutput,
         aiOutput: FlowAIOutput,
+        apiKey: String? = null,
         analyze: Boolean = false
     ): Boolean {
         val config = YamlCommandReader.getConfig(commands)
@@ -181,7 +182,8 @@ object MaestroCommandRunner {
                         defects = defects,
                     )
                 )
-            }
+            },
+            apiKey = apiKey,    
         )
 
         val flowSuccess = orchestra.runFlow(commands)

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -46,7 +46,8 @@ object TestRunner {
         env: Map<String, String>,
         resultView: ResultView,
         debugOutputPath: Path,
-        analyze: Boolean = false
+        analyze: Boolean = false,
+        apiKey: String? = null,
     ): Int {
         val debugOutput = FlowDebugOutput()
         var aiOutput = FlowAIOutput(
@@ -76,6 +77,7 @@ object TestRunner {
                 debugOutput = debugOutput,
                 aiOutput = aiOutput,
                 analyze = analyze,
+                apiKey = apiKey,
             )
         }
 
@@ -103,6 +105,7 @@ object TestRunner {
         flowFile: File,
         env: Map<String, String>,
         analyze: Boolean = false,
+        apiKey: String? = null,
     ): Nothing {
         val resultView = AnsiResultView("> Press [ENTER] to restart the Flow\n\n", useEmojis = !EnvUtils.isWindows())
 
@@ -146,7 +149,8 @@ object TestRunner {
                                     flowName = "TODO",
                                     flowFile = flowFile,
                                 ),
-                                analyze = analyze
+                                analyze = analyze,
+                                apiKey = apiKey,
                             )
                         }.get()
                     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -98,7 +98,8 @@ class Orchestra(
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },
-    private val AIPredictionEngine: AIPredictionEngine? = CloudAIPredictionEngine(System.getenv("MAESTRO_CLOUD_API_KEY") ?: ""),
+    private val apiKey: String? = null,
+    private val AIPredictionEngine: AIPredictionEngine? = apiKey?.let { CloudAIPredictionEngine(it) },
 ) {
 
     private lateinit var jsEngine: JsEngine

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -35,6 +35,8 @@ import maestro.ai.Prediction
 import maestro.ai.anthropic.Claude
 import maestro.ai.cloud.Defect
 import maestro.ai.openai.OpenAI
+import maestro.ai.CloudAIPredictionEngine
+import maestro.ai.AIPredictionEngine
 import maestro.js.GraalJsEngine
 import maestro.js.JsEngine
 import maestro.js.RhinoJsEngine
@@ -96,6 +98,7 @@ class Orchestra(
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },
+    private val AIPredictionEngine: AIPredictionEngine? = CloudAIPredictionEngine(System.getenv("MAESTRO_CLOUD_API_KEY") ?: ""),
 ) {
 
     private lateinit var jsEngine: JsEngine
@@ -214,13 +217,16 @@ class Orchestra(
                         else throw e
                     }
                 } catch (ignored: CommandWarned) {
+                    logger.info("[Command execution] CommandWarned: ${ignored.message}")
                     // Swallow exception, but add a warning as an insight
                     insights.report(Insight(message = ignored.message, level = Insight.Level.WARNING))
                     onCommandWarned(index, command)
                 } catch (ignored: CommandSkipped) {
+                    logger.info("[Command execution] CommandSkipped: ${ignored.message}")
                     // Swallow exception
                     onCommandSkipped(index, command)
                 } catch (e: Throwable) {
+                    logger.error("[Command execution] CommandFailed: ${e.message}")
                     val errorResolution = onCommandFailed(index, command, e)
                     when (errorResolution) {
                         ErrorResolution.FAIL -> return false
@@ -255,6 +261,7 @@ class Orchestra(
     }
 
     private fun initAI(): AI? {
+        logger.info("[Orchestra] Initializing AI")
         val apiKey = System.getenv(AI_KEY_ENV_VAR) ?: return null
         val modelName: String? = System.getenv(AI.AI_MODEL_ENV_VAR)
 
@@ -370,17 +377,14 @@ class Orchestra(
     }
 
     private fun assertNoDefectsWithAICommand(command: AssertNoDefectsWithAICommand): Boolean = runBlocking {
-        // TODO(bartekpacia): make all of Orchestra suspending
-        val apiKey = System.getenv("MAESTRO_CLOUD_API_KEY")
-        if (apiKey.isNullOrEmpty()) {
+        if (AIPredictionEngine == null) {
             throw MaestroException.CloudApiKeyNotAvailable("`MAESTRO_CLOUD_API_KEY` is not available. Did you export MAESTRO_CLOUD_API_KEY?")
         }
 
         val imageData = Buffer()
         maestro.takeScreenshot(imageData, compressed = false)
 
-        val defects = Prediction.findDefects(
-            apiKey = apiKey,
+        val defects = AIPredictionEngine.findDefects(
             screen = imageData.copy().readByteArray(),
         )
 
@@ -402,19 +406,16 @@ class Orchestra(
     }
 
     private fun assertWithAICommand(command: AssertWithAICommand): Boolean = runBlocking {
-        // TODO(bartekpacia): make all of Orchestra suspending
-        val apiKey = System.getenv("MAESTRO_CLOUD_API_KEY")
-        if (apiKey.isNullOrEmpty()) {
+        if (AIPredictionEngine == null) {
             throw MaestroException.CloudApiKeyNotAvailable("`MAESTRO_CLOUD_API_KEY` is not available. Did you export MAESTRO_CLOUD_API_KEY?")
         }
 
         val imageData = Buffer()
         maestro.takeScreenshot(imageData, compressed = false)
 
-        val defect = Prediction.performAssertion(
-            apiKey = apiKey,
-            assertion = command.assertion,
+        val defect = AIPredictionEngine.performAssertion(
             screen = imageData.copy().readByteArray(),
+            assertion = command.assertion,
         )
 
         if (defect != null) {
@@ -432,17 +433,15 @@ class Orchestra(
     }
 
     private fun extractTextWithAICommand(command: ExtractTextWithAICommand): Boolean = runBlocking {
-        val apiKey = System.getenv("MAESTRO_CLOUD_API_KEY")
-        if (apiKey.isNullOrEmpty()) {
+        if (AIPredictionEngine == null) {
             throw MaestroException.CloudApiKeyNotAvailable("`MAESTRO_CLOUD_API_KEY` is not available. Did you export MAESTRO_CLOUD_API_KEY?")
         }
 
         val imageData = Buffer()
         maestro.takeScreenshot(imageData, compressed = false)
-        val text = Prediction.extractText(
-            apiKey = apiKey,
-            query = command.query,
+        val text = AIPredictionEngine.extractText(
             screen = imageData.copy().readByteArray(),
+            query = command.query,
         )
 
         jsEngine.putEnv(command.outputVariable, text)
@@ -766,11 +765,13 @@ class Orchestra(
                         }
                     } catch (ignored: CommandWarned) {
                         // Swallow exception, but add a warning as an insight
+                        logger.info("[Command execution subflow] CommandWarned: ${ignored.message}")
                         insights.report(Insight(message = ignored.message, level = Insight.Level.WARNING))
                         onCommandWarned(index, command)
                         false
                     } catch (ignored: CommandSkipped) {
                         // Swallow exception
+                        logger.info("[Command execution subflow] CommandSkipped: ${ignored.message}")
                         onCommandSkipped(index, command)
                         false
                     } catch (e: Throwable) {


### PR DESCRIPTION
## Proposed changes

Creating an interface for AIEnginePrediction. Using the CloudAIEnginePrediction implementation to call maestro's api to get the AI commands.

Pass the API Key from Run Tests - if present - to use in the API call

## Testing

Tested running a workflow with AI commands both before and after the changes, with and without setting the MAESTRO_CLOUD_API_KEY, and passing the --api-key param.

## Issues fixed

Allow for maestro.dev to use the AI commands