### PR TITLE
fix: studio mode should not foreground running app

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -96,6 +96,7 @@ class PrintHierarchyCommand : Runnable {
             deviceId = parent?.deviceId,
             platform = parent?.platform,
             reinstallDriver = reinstallDriver,
+            prebuiltIOSRunner = false,
         ) { session ->
             session.maestro.setAndroidChromeDevToolsEnabled(androidWebViewHierarchy == "devtools")
             val callback: (Insight) -> Unit = {

--- a/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
@@ -77,6 +77,7 @@ class QueryCommand : Runnable {
             deviceId = parent?.deviceId,
             platform = parent?.platform,
             teamId = appleTeamId,
+            prebuiltIOSRunner = false,
         ) { session ->
             val filters = mutableListOf<ElementFilter>()
 

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -118,6 +118,7 @@ class RecordCommand : Callable<Int> {
             deviceId = deviceId,
             platform = parent?.platform,
             teamId = appleTeamId,
+            prebuiltIOSRunner = true,
         ) { session ->
             val maestro = session.maestro
             val device = session.device

--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -69,7 +69,8 @@ class StudioCommand : Callable<Int> {
             teamId = appleTeamId,
             deviceId = parent?.deviceId,
             platform = parent?.platform,
-            isStudio = true
+            isStudio = true,
+            prebuiltIOSRunner = false,
         ) { session ->
             session.maestro.setAndroidChromeDevToolsEnabled(androidWebViewHierarchy == "devtools")
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -347,6 +347,7 @@ class TestCommand : Callable<Int> {
             platform = parent?.platform,
             isHeadless = headless,
             reinstallDriver = reinstallDriver,
+            prebuiltIOSRunner = true,
         ) { session ->
             val maestro = session.maestro
             val device = session.device

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -70,6 +70,7 @@ object MaestroSessionManager {
         isStudio: Boolean = false,
         isHeadless: Boolean = isStudio,
         reinstallDriver: Boolean = true,
+        prebuiltIOSRunner: Boolean,
         block: (MaestroSession) -> T,
     ): T {
         val selectedDevice = selectDevice(
@@ -110,6 +111,7 @@ object MaestroSessionManager {
             isHeadless = isHeadless,
             driverHostPort = driverHostPort,
             reinstallDriver = reinstallDriver,
+            prebuiltIOSRunner = prebuiltIOSRunner
         )
         Runtime.getRuntime().addShutdownHook(thread(start = false) {
             heartbeatFuture.cancel(true)
@@ -187,6 +189,7 @@ object MaestroSessionManager {
         isStudio: Boolean,
         isHeadless: Boolean,
         reinstallDriver: Boolean,
+        prebuiltIOSRunner: Boolean,
         driverHostPort: Int?,
     ): MaestroSession {
         return when {
@@ -203,7 +206,8 @@ object MaestroSessionManager {
                         !connectToExistingSession,
                         driverHostPort,
                         reinstallDriver,
-                        selectedDevice.device.deviceType
+                        deviceType = selectedDevice.device.deviceType,
+                        prebuiltRunner = prebuiltIOSRunner
                     )
 
                     Platform.WEB -> pickWebDevice(isStudio, isHeadless)
@@ -227,6 +231,7 @@ object MaestroSessionManager {
                     openDriver = !connectToExistingSession,
                     driverHostPort = driverHostPort ?: defaultXcTestPort,
                     reinstallDriver = reinstallDriver,
+                    isStudio = isStudio
                 ),
                 device = null,
             )
@@ -291,6 +296,7 @@ object MaestroSessionManager {
         openDriver: Boolean,
         driverHostPort: Int,
         reinstallDriver: Boolean,
+        isStudio: Boolean
     ): Maestro {
         val device = PickDeviceInteractor.pickDevice(deviceId, driverHostPort)
         return createIOS(
@@ -298,7 +304,8 @@ object MaestroSessionManager {
             openDriver,
             driverHostPort,
             reinstallDriver,
-            device.deviceType
+            deviceType = device.deviceType,
+            prebuiltRunner = isStudio
         )
     }
 
@@ -328,6 +335,7 @@ object MaestroSessionManager {
         openDriver: Boolean,
         driverHostPort: Int?,
         reinstallDriver: Boolean,
+        prebuiltRunner: Boolean,
         deviceType: Device.DeviceType,
     ): Maestro {
 
@@ -351,7 +359,7 @@ object MaestroSessionManager {
             }
             Device.DeviceType.SIMULATOR -> {
                 IOSDriverConfig(
-                    prebuiltRunner = true,
+                    prebuiltRunner = prebuiltRunner,
                     sourceDirectory =  "driver-iPhoneSimulator",
                     context = Context.CLI
                 )


### PR DESCRIPTION
## Proposed changes

We introduced prebuilt mode on iOS to make driver setup faster and more consistent. While it's working as expected, it caused a regression in the Maestro Studio flow by sending the foreground app to the background.

This PR fixes that by:
1. **Avoiding backgrounding the app**: We switch back to using xcodebuild for flows where keeping the app in the foreground is necessary (e.g., Maestro Studio).
2. **Fixing infinite loop in device detection**: The recent changes for iOS physical device detection logic causes an infinite loop during local installation because user input isn't possible in the current setup. This PR disables that behavior in local mode.

## Testing

Locally

## Issues fixed
