### PR TITLE
fix: infinite loop on maestro studio

### DIFF
--- a/maestro
+++ b/maestro
@@ -8,4 +8,4 @@ else
   input=$(cat -)
 fi
 
-./gradlew :maestro-cli:installDist -q && echo "$input" | ./maestro-cli/build/install/maestro/bin/maestro "$@"
+./gradlew :maestro-cli:installDist -q && ./maestro-cli/build/install/maestro/bin/maestro "$@"


### PR DESCRIPTION
## Proposed changes

When multiple devices are connected and Maestro is run locally, the CLI prompts the user to select a device. However, because we were previously piping input into the CLI (echo "$input" | maestro ...), it disconnected the TTY, which prevented any interactive input.

Removed the echo pipe so that the TTY remains connected, allowing the CLI to properly prompt the user for input when needed.

## Testing

Locally

## Issues fixed
