### PR TITLE
fix: don't use prebuilt for cli on iOS 

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -96,7 +96,6 @@ class PrintHierarchyCommand : Runnable {
             deviceId = parent?.deviceId,
             platform = parent?.platform,
             reinstallDriver = reinstallDriver,
-            prebuiltIOSRunner = false,
         ) { session ->
             session.maestro.setAndroidChromeDevToolsEnabled(androidWebViewHierarchy == "devtools")
             val callback: (Insight) -> Unit = {

--- a/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
@@ -77,7 +77,6 @@ class QueryCommand : Runnable {
             deviceId = parent?.deviceId,
             platform = parent?.platform,
             teamId = appleTeamId,
-            prebuiltIOSRunner = false,
         ) { session ->
             val filters = mutableListOf<ElementFilter>()
 

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -118,7 +118,6 @@ class RecordCommand : Callable<Int> {
             deviceId = deviceId,
             platform = parent?.platform,
             teamId = appleTeamId,
-            prebuiltIOSRunner = true,
         ) { session ->
             val maestro = session.maestro
             val device = session.device

--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -70,7 +70,6 @@ class StudioCommand : Callable<Int> {
             deviceId = parent?.deviceId,
             platform = parent?.platform,
             isStudio = true,
-            prebuiltIOSRunner = false,
         ) { session ->
             session.maestro.setAndroidChromeDevToolsEnabled(androidWebViewHierarchy == "devtools")
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -347,7 +347,6 @@ class TestCommand : Callable<Int> {
             platform = parent?.platform,
             isHeadless = headless,
             reinstallDriver = reinstallDriver,
-            prebuiltIOSRunner = true,
         ) { session ->
             val maestro = session.maestro
             val device = session.device

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -70,7 +70,6 @@ object MaestroSessionManager {
         isStudio: Boolean = false,
         isHeadless: Boolean = isStudio,
         reinstallDriver: Boolean = true,
-        prebuiltIOSRunner: Boolean,
         block: (MaestroSession) -> T,
     ): T {
         val selectedDevice = selectDevice(
@@ -111,7 +110,7 @@ object MaestroSessionManager {
             isHeadless = isHeadless,
             driverHostPort = driverHostPort,
             reinstallDriver = reinstallDriver,
-            prebuiltIOSRunner = prebuiltIOSRunner
+            prebuiltIOSRunner = false
         )
         Runtime.getRuntime().addShutdownHook(thread(start = false) {
             heartbeatFuture.cancel(true)


### PR DESCRIPTION
## Proposed changes

This PR switches setting up iOS driver with xcodebuild. 

The problem on cli using prebuilt mode is that it always put the running app in background. 

## Testing

- [x] Locally

## Issues fixed
https://github.com/mobile-dev-inc/Maestro/issues/2456