### PR TITLE
fix: only connected devices for iOS devices

### DIFF
--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -11,6 +11,7 @@ import maestro.utils.MaestroTimer
 import okio.buffer
 import okio.source
 import org.slf4j.LoggerFactory
+import util.DeviceCtlResponse
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -261,7 +262,9 @@ object DeviceService {
     private fun listIOSConnectedDevices(): List<Device.Connected> {
         val connectedIphoneList = util.LocalIOSDevice().listDeviceViaDeviceCtl()
 
-        return connectedIphoneList.map {
+        return connectedIphoneList.filter {
+            it.connectionProperties.tunnelState == DeviceCtlResponse.ConnectionProperties.CONNECTED
+        }.map {
             val description = "${it.deviceProperties.name} - ${it.deviceProperties.osVersionNumber} - ${it.identifier}"
 
             Device.Connected(

--- a/maestro-ios-driver/src/main/kotlin/util/IOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/IOSDevice.kt
@@ -20,8 +20,18 @@ data class DeviceCtlResponse(
     data class Device(
         val identifier: String,
         val deviceProperties: DeviceProperties,
-        val hardwareProperties: HardwareProperties
+        val hardwareProperties: HardwareProperties,
+        val connectionProperties: ConnectionProperties,
     )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class ConnectionProperties(
+        val tunnelState: String,
+    ) {
+        companion object {
+            const val CONNECTED  = "connected"
+        }
+    }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class DeviceProperties(


### PR DESCRIPTION
## Proposed changes

Only filter connected devices. Since we observed not only connected but paired, unpaired and available are also visible on the devicectl list.

## Testing

- [x] Locally

## Issues fixed
