### PR TITLE
fix: sharding on iOS

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/IOSBuildProductsExtractor.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/IOSBuildProductsExtractor.kt
@@ -5,6 +5,9 @@ import org.slf4j.LoggerFactory
 import util.IOSDeviceType
 import java.io.File
 import java.io.FileNotFoundException
+import java.net.URI
+import java.nio.file.FileSystem
+import java.nio.file.FileSystemAlreadyExistsException
 import java.nio.file.FileSystemNotFoundException
 import java.nio.file.FileSystems
 import java.nio.file.Files
@@ -95,7 +98,7 @@ class IOSBuildProductsExtractor(
                     val fs = try {
                         FileSystems.getFileSystem(uri)
                     } catch (e: FileSystemNotFoundException) {
-                        FileSystems.newFileSystem(uri, emptyMap<String, Any>())
+                        uri.getOrCreateFileSystem()
                     }
                     fs.getPath(sourceDirectory)
                 }
@@ -112,6 +115,14 @@ class IOSBuildProductsExtractor(
                 Files.createDirectories(targetPath.parent)
                 Files.copy(file, targetPath, StandardCopyOption.REPLACE_EXISTING)
             }
+        }
+    }
+
+    private fun URI.getOrCreateFileSystem(): FileSystem {
+        return try {
+            FileSystems.newFileSystem(this, emptyMap<String, Any>())
+        } catch (e: FileSystemAlreadyExistsException) {
+            FileSystems.getFileSystem(this)
         }
     }
 }


### PR DESCRIPTION
## Proposed changes

When running the CLI with sharding > 1, this function can be executed by multiple threads concurrently. This leads to a race condition where multiple threads attempt to create the same file system for a given URI, resulting in a `FileSystemAlreadyExistsException`.

This PR adds logic to safely handle this case by attempting newFileSystem, and falling back to getFileSystem if it already exists ensuring the file system is reused instead of causing the thread to fail.

## Testing

- [x] Locally

## Issues fixed
https://github.com/mobile-dev-inc/Maestro/issues/2464