### PR TITLE
[MAE 167] breaking deserialization

### DIFF
--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -265,7 +265,11 @@ object DeviceService {
         return connectedIphoneList.filter {
             it.connectionProperties.tunnelState == DeviceCtlResponse.ConnectionProperties.CONNECTED
         }.map {
-            val description = "${it.deviceProperties.name} - ${it.deviceProperties.osVersionNumber} - ${it.identifier}"
+            val description = listOfNotNull(
+                it.deviceProperties?.name,
+                it.deviceProperties?.osVersionNumber,
+                it.identifier
+            ).joinToString(" - ")
 
             Device.Connected(
                 instanceId = it.hardwareProperties.udid,

--- a/maestro-ios-driver/src/main/kotlin/util/IOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/IOSDevice.kt
@@ -19,7 +19,7 @@ data class DeviceCtlResponse(
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class Device(
         val identifier: String,
-        val deviceProperties: DeviceProperties,
+        val deviceProperties: DeviceProperties?,
         val hardwareProperties: HardwareProperties,
         val connectionProperties: ConnectionProperties,
     )
@@ -35,8 +35,8 @@ data class DeviceCtlResponse(
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class DeviceProperties(
-        val name: String,
-        val osVersionNumber: String,
+        val name: String?,
+        val osVersionNumber: String?,
     )
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
@@ -146,7 +146,6 @@ class DeviceCtlResponseTest {
                      "ddiServicesAvailable" : false,
                      "developerModeStatus" : "disabled",
                      "hasInternalOSBuild" : false,
-                     "name" : "S’s Apple's Watch",
                      "osBuildUpdate" : "22S560",
                      "osVersionNumber" : "11.3.1"
                    },

--- a/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
@@ -72,7 +72,6 @@ class DeviceCtlResponseTest {
                      "developerModeStatus" : "enabled",
                      "hasInternalOSBuild" : false,
                      "name" : "xx's iPhone ",
-                     "osVersionNumber" : "18.1.1",
                      "rootFileSystemIsWritable" : false
                    },
                    "hardwareProperties" : {


### PR DESCRIPTION
## Proposed changes

Made os version number and name in device properties nullable. We got 2 reports where we got to know that we might not have name and os number.

Updated the unit tests as well.

## Testing

- [x] Locally

## Issues fixed
