### PR TITLE
fix: hardware udid can be missing

### DIFF
--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -262,17 +262,20 @@ object DeviceService {
     private fun listIOSConnectedDevices(): List<Device.Connected> {
         val connectedIphoneList = util.LocalIOSDevice().listDeviceViaDeviceCtl()
 
-        return connectedIphoneList.filter {
-            it.connectionProperties.tunnelState == DeviceCtlResponse.ConnectionProperties.CONNECTED
-        }.map {
+        return connectedIphoneList.mapNotNull { device ->
+            val udid = device.hardwareProperties?.udid
+            if (device.connectionProperties.tunnelState != DeviceCtlResponse.ConnectionProperties.CONNECTED || udid == null) {
+                return@mapNotNull null
+            }
+
             val description = listOfNotNull(
-                it.deviceProperties?.name,
-                it.deviceProperties?.osVersionNumber,
-                it.identifier
+                device.deviceProperties?.name,
+                device.deviceProperties?.osVersionNumber,
+                device.identifier
             ).joinToString(" - ")
 
             Device.Connected(
-                instanceId = it.hardwareProperties.udid,
+                instanceId = udid,
                 description = description,
                 platform = Platform.IOS,
                 deviceType = Device.DeviceType.REAL

--- a/maestro-ios-driver/src/main/kotlin/util/IOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/IOSDevice.kt
@@ -20,7 +20,7 @@ data class DeviceCtlResponse(
     data class Device(
         val identifier: String,
         val deviceProperties: DeviceProperties?,
-        val hardwareProperties: HardwareProperties,
+        val hardwareProperties: HardwareProperties?,
         val connectionProperties: ConnectionProperties,
     )
 
@@ -41,6 +41,6 @@ data class DeviceCtlResponse(
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     data class HardwareProperties(
-        val udid: String
+        val udid: String?
     )
 }

--- a/maestro-ios-driver/src/main/kotlin/util/LocalIOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalIOSDevice.kt
@@ -51,7 +51,7 @@ class LocalIOSDevice(private val deviceCtlProcess: DeviceCtlProcess = DeviceCtlP
             jacksonObjectMapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
             val deviceCtlResponse = jacksonObjectMapper.readValue<DeviceCtlResponse>(response)
             return deviceCtlResponse.result.devices.find {
-                it.hardwareProperties.udid == deviceId
+                it.hardwareProperties?.udid == deviceId
             } ?: throw IllegalArgumentException("iOS device with identifier $deviceId not connected or available")
         } finally {
             tempOutput.delete()

--- a/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
@@ -27,7 +27,7 @@ class DeviceCtlResponseTest {
         assertThat(connectedDevices).isNotEmpty()
     }
 
-    fun getDeviceCtlOutput(): String {
+    private fun getDeviceCtlOutput(): String {
        return """
            {
              "info" : {


### PR DESCRIPTION
## Proposed changes

Hardware udid which is later used as destination id in xcodebuild commands in case of physical devices, could be missing. This PR handles that case on new model we added.

## Testing

- [x] Locally

## Issues fixed
