### PR TITLE
[MA 3258] Introducing debug info on element not found exceptions

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -7,6 +7,7 @@ import com.github.michaelbull.result.get
 import com.github.michaelbull.result.getOr
 import com.github.michaelbull.result.onFailure
 import maestro.Maestro
+import maestro.MaestroException
 import maestro.device.Device
 import maestro.cli.report.FlowAIOutput
 import maestro.cli.report.FlowDebugOutput
@@ -91,7 +92,13 @@ object TestRunner {
             path = debugOutputPath,
         )
 
-        if (debugOutput.exception != null) PrintUtils.err("${debugOutput.exception?.message}")
+        val exception = debugOutput.exception
+        if (exception != null) {
+            PrintUtils.err(exception.message)
+            if (exception is MaestroException.AssertionFailure) {
+                PrintUtils.err(exception.debugMessage)
+            }
+        }
 
         return if (result.get() == true) 0 else 1
     }

--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -19,6 +19,10 @@
 
 package maestro
 
+data class DebugInfo (
+    val debugMessage: String
+)
+
 sealed class MaestroException(override val message: String) : RuntimeException(message) {
 
     class UnableToLaunchApp(message: String) : MaestroException(message)
@@ -32,12 +36,14 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
     open class AssertionFailure(
         message: String,
         val hierarchyRoot: TreeNode,
+        val debugInfo: DebugInfo,
     ) : MaestroException(message)
 
     class ElementNotFound(
         message: String,
         hierarchyRoot: TreeNode,
-    ) : AssertionFailure(message, hierarchyRoot)
+        debugInfo: DebugInfo,
+    ) : AssertionFailure(message, hierarchyRoot, debugInfo)
 
     class CloudApiKeyNotAvailable(message: String) : MaestroException(message)
 

--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -19,10 +19,6 @@
 
 package maestro
 
-data class DebugInfo (
-    val debugMessage: String
-)
-
 sealed class MaestroException(override val message: String) : RuntimeException(message) {
 
     class UnableToLaunchApp(message: String) : MaestroException(message)
@@ -36,14 +32,14 @@ sealed class MaestroException(override val message: String) : RuntimeException(m
     open class AssertionFailure(
         message: String,
         val hierarchyRoot: TreeNode,
-        val debugInfo: DebugInfo,
+        val debugMessage: String,
     ) : MaestroException(message)
 
     class ElementNotFound(
         message: String,
         hierarchyRoot: TreeNode,
-        debugInfo: DebugInfo,
-    ) : AssertionFailure(message, hierarchyRoot, debugInfo)
+        debugMessage: String,
+    ) : AssertionFailure(message, hierarchyRoot, debugMessage)
 
     class CloudApiKeyNotAvailable(message: String) : MaestroException(message)
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -410,37 +410,8 @@ class Maestro(
         }
     }
 
-    fun findElementByRegexp(regex: Regex, timeoutMs: Long): UiElement {
-        LOGGER.info("Looking for element by regex: ${regex.pattern} (timeout $timeoutMs)")
-
-        return findElementWithTimeout(timeoutMs, Filters.textMatches(regex))?.element
-            ?: throw MaestroException.ElementNotFound(
-                "No element that matches regex: $regex",
-                viewHierarchy().root
-            )
-    }
-
     fun viewHierarchy(excludeKeyboardElements: Boolean = false): ViewHierarchy {
         return ViewHierarchy.from(driver, excludeKeyboardElements)
-    }
-
-    fun findElementByIdRegex(regex: Regex, timeoutMs: Long): UiElement {
-        LOGGER.info("Looking for element by id regex: ${regex.pattern} (timeout $timeoutMs)")
-
-        return findElementWithTimeout(timeoutMs, Filters.idMatches(regex))?.element
-            ?: throw MaestroException.ElementNotFound(
-                "No element has id that matches regex $regex",
-                viewHierarchy().root
-            )
-    }
-
-    fun findElementBySize(width: Int?, height: Int?, tolerance: Int?, timeoutMs: Long): UiElement? {
-        LOGGER.info("Looking for element by size: $width x $height (tolerance $tolerance) (timeout $timeoutMs)")
-
-        return findElementWithTimeout(
-            timeoutMs,
-            Filters.sizeMatches(width, height, tolerance).asFilter()
-        )?.element
     }
 
     fun findElementWithTimeout(

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -110,7 +110,7 @@ data class ScrollUntilVisibleCommand(
     val timeout: String = DEFAULT_TIMEOUT_IN_MILLIS,
     val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
-    val originalSpeedValue: String? = null,
+    val originalSpeedValue: String? = scrollDuration,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -131,7 +131,21 @@ data class ScrollUntilVisibleCommand(
     }
 
     override fun description(): String {
-        return label ?: "Scrolling $direction until ${selector.description()} is visible."
+        val baseDescription = "Scrolling $direction until ${selector.description()} is visible"
+        val additionalDescription = mutableListOf<String>()
+        additionalDescription.add("with speed $originalSpeedValue")
+        additionalDescription.add("visibility percentage $visibilityPercentage%")
+        additionalDescription.add("timeout $timeout ms")
+        waitToSettleTimeoutMs?.let {
+            additionalDescription.add("wait to settle $it ms")
+        }
+        if (centerElement) {
+            additionalDescription.add("with centering enabled")
+        } else {
+            additionalDescription.add("with centering disabled")
+        }
+        val description = "$baseDescription ${additionalDescription.joinToString(", ")}"
+        return label ?: description
     }
 
     override fun evaluateScripts(jsEngine: JsEngine): ScrollUntilVisibleCommand {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -110,6 +110,7 @@ data class ScrollUntilVisibleCommand(
     val timeout: String = DEFAULT_TIMEOUT_IN_MILLIS,
     val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
+    val originalSpeedValue: String? = null,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -135,6 +136,7 @@ data class ScrollUntilVisibleCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): ScrollUntilVisibleCommand {
         return copy(
+            originalSpeedValue = scrollDuration,
             selector = selector.evaluateScripts(jsEngine),
             scrollDuration = scrollDuration.evaluateScripts(jsEngine).speedToDuration(),
             timeout = timeout.evaluateScripts(jsEngine).timeoutToMillis(),

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -27,11 +27,11 @@ import maestro.Filters.asFilter
 import maestro.FindElementResult
 import maestro.Maestro
 import maestro.MaestroException
+import maestro.DebugInfo
 import maestro.ScreenRecording
 import maestro.ViewHierarchy
 import maestro.ai.AI
 import maestro.ai.AI.Companion.AI_KEY_ENV_VAR
-import maestro.ai.Prediction
 import maestro.ai.anthropic.Claude
 import maestro.ai.cloud.Defect
 import maestro.ai.openai.OpenAI
@@ -371,6 +371,7 @@ class Orchestra(
             throw MaestroException.AssertionFailure(
                 message = "Assertion is false: ${command.condition.description()}",
                 hierarchyRoot = maestro.viewHierarchy().root,
+                debugInfo = DebugInfo("Assertion '${command.condition.description()}' failed. Check the UI hierarchy in debug artifacts to verify the element state and properties.")
             )
         }
 
@@ -406,6 +407,7 @@ class Orchestra(
                     |
                     """.trimMargin(),
                 hierarchyRoot = maestro.viewHierarchy().root,
+                debugInfo = DebugInfo("AI-powered visual defect detection failed. Check the UI and screenshots in debug artifacts to verify if there are actual visual issues that were missed or if the AI detection needs adjustment.")
             )
         }
 
@@ -437,6 +439,7 @@ class Orchestra(
                     |$reasoning
                     """.trimMargin(),
                 hierarchyRoot = maestro.viewHierarchy().root,
+                debugInfo = DebugInfo("AI-powered assertion failed. Check the UI and screenshots in debug artifacts to verify if there are actual visual issues that were missed or if the AI detection needs adjustment.")
             )
         }
 
@@ -598,8 +601,9 @@ class Orchestra(
             appendLine("- `centerElement`: current = ${command.centerElement} → $centerAdvice")
         }
         throw MaestroException.ElementNotFound(
-            debugMessage,
-            maestro.viewHierarchy().root
+            message = "No visible element found: ${command.selector.description()}",
+            maestro.viewHierarchy().root,
+            debugInfo = DebugInfo(debugMessage)
         )
     }
 
@@ -1075,6 +1079,7 @@ class Orchestra(
             ) ?: throw MaestroException.ElementNotFound(
                 "Element not found: $description",
                 parentViewHierarchy.root,
+                DebugInfo("Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.")
             )
         }
 
@@ -1085,6 +1090,7 @@ class Orchestra(
         ) ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             maestro.viewHierarchy().root,
+            DebugInfo("Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.")
         )
     }
 
@@ -1104,6 +1110,7 @@ class Orchestra(
         )?.hierarchy ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             parentViewHierarchy.root,
+            DebugInfo("Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.")
         )
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -27,7 +27,6 @@ import maestro.Filters.asFilter
 import maestro.FindElementResult
 import maestro.Maestro
 import maestro.MaestroException
-import maestro.DebugInfo
 import maestro.ScreenRecording
 import maestro.ViewHierarchy
 import maestro.ai.AI
@@ -371,7 +370,7 @@ class Orchestra(
             throw MaestroException.AssertionFailure(
                 message = "Assertion is false: ${command.condition.description()}",
                 hierarchyRoot = maestro.viewHierarchy().root,
-                debugInfo = DebugInfo("Assertion '${command.condition.description()}' failed. Check the UI hierarchy in debug artifacts to verify the element state and properties.")
+                debugMessage = "Assertion '${command.condition.description()}' failed. Check the UI hierarchy in debug artifacts to verify the element state and properties."
             )
         }
 
@@ -407,7 +406,7 @@ class Orchestra(
                     |
                     """.trimMargin(),
                 hierarchyRoot = maestro.viewHierarchy().root,
-                debugInfo = DebugInfo("AI-powered visual defect detection failed. Check the UI and screenshots in debug artifacts to verify if there are actual visual issues that were missed or if the AI detection needs adjustment.")
+                debugMessage = "AI-powered visual defect detection failed. Check the UI and screenshots in debug artifacts to verify if there are actual visual issues that were missed or if the AI detection needs adjustment."
             )
         }
 
@@ -439,7 +438,7 @@ class Orchestra(
                     |$reasoning
                     """.trimMargin(),
                 hierarchyRoot = maestro.viewHierarchy().root,
-                debugInfo = DebugInfo("AI-powered assertion failed. Check the UI and screenshots in debug artifacts to verify if there are actual visual issues that were missed or if the AI detection needs adjustment.")
+                debugMessage = "AI-powered assertion failed. Check the UI and screenshots in debug artifacts to verify if there are actual visual issues that were missed or if the AI detection needs adjustment."
             )
         }
 
@@ -603,7 +602,7 @@ class Orchestra(
         throw MaestroException.ElementNotFound(
             message = "No visible element found: ${command.selector.description()}",
             maestro.viewHierarchy().root,
-            debugInfo = DebugInfo(debugMessage)
+            debugMessage = debugMessage
         )
     }
 
@@ -1079,7 +1078,7 @@ class Orchestra(
             ) ?: throw MaestroException.ElementNotFound(
                 "Element not found: $description",
                 parentViewHierarchy.root,
-                DebugInfo("Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.")
+                debugMessage = "Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists."
             )
         }
 
@@ -1090,7 +1089,7 @@ class Orchestra(
         ) ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             maestro.viewHierarchy().root,
-            DebugInfo("Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.")
+            debugMessage = "Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists."
         )
     }
 
@@ -1110,7 +1109,7 @@ class Orchestra(
         )?.hierarchy ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             parentViewHierarchy.root,
-            DebugInfo("Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.")
+            debugMessage = "Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists."
         )
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -366,11 +366,19 @@ class Orchestra(
 
     private fun assertConditionCommand(command: AssertConditionCommand): Boolean {
         val timeout = (command.timeoutMs() ?: lookupTimeoutMs)
+        val debugMessage = """
+            Assertion '${command.condition.description()}' failed. Check the UI hierarchy in debug artifacts to verify the element state and properties.
+            
+            Possible causes:
+            - Element selector may be incorrect - check if there are similar elements with slightly different names/properties.
+            - Element may be temporarily unavailable due to loading state
+            - This could be a real regression that needs to be addressed
+        """.trimIndent()
         if (!evaluateCondition(command.condition, timeoutMs = timeout, commandOptional = command.optional)) {
             throw MaestroException.AssertionFailure(
                 message = "Assertion is false: ${command.condition.description()}",
                 hierarchyRoot = maestro.viewHierarchy().root,
-                debugMessage = "Assertion '${command.condition.description()}' failed. Check the UI hierarchy in debug artifacts to verify the element state and properties."
+                debugMessage = debugMessage
             )
         }
 
@@ -1066,6 +1074,14 @@ class Orchestra(
             )
 
         val (description, filterFunc) = buildFilter(selector = selector)
+        val debugMessage = """
+            Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.
+            
+            Possible causes:
+            - Element selector may be incorrect - check if there are similar elements with slightly different names/properties.
+            - Element may be temporarily unavailable due to loading state.
+            - This could be a real regression that needs to be addressed.
+        """.trimIndent()
         if (selector.childOf != null) {
             val parentViewHierarchy = findElementViewHierarchy(
                 selector.childOf,
@@ -1078,18 +1094,26 @@ class Orchestra(
             ) ?: throw MaestroException.ElementNotFound(
                 "Element not found: $description",
                 parentViewHierarchy.root,
-                debugMessage = "Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists."
+                debugMessage = debugMessage
             )
         }
 
 
+        val exceptionDebugMessage = """
+            Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.
+            
+            Possible causes:
+            - Element selector may be incorrect - check if there are similar elements with slightly different names/properties.
+            - Element may be temporarily unavailable due to loading state.
+            - This could be a real regression that needs to be addressed.
+        """.trimIndent()
         return maestro.findElementWithTimeout(
             timeoutMs = timeout,
             filter = filterFunc
         ) ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             maestro.viewHierarchy().root,
-            debugMessage = "Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists."
+            debugMessage = exceptionDebugMessage
         )
     }
 
@@ -1102,6 +1126,14 @@ class Orchestra(
         }
         val parentViewHierarchy = findElementViewHierarchy(selector.childOf, timeout)
         val (description, filterFunc) = buildFilter(selector = selector)
+        val debugMessage = """
+            Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists.
+            
+            Possible causes:
+            - Element selector may be incorrect - check if there are similar elements with slightly different names/properties.
+            - Element may be temporarily unavailable due to loading state.
+            - This could be a real regression that needs to be addressed.
+        """.trimIndent()
         return maestro.findElementWithTimeout(
             timeout,
             filterFunc,
@@ -1109,7 +1141,7 @@ class Orchestra(
         )?.hierarchy ?: throw MaestroException.ElementNotFound(
             "Element not found: $description",
             parentViewHierarchy.root,
-            debugMessage = "Element with $description not found. Check the UI hierarchy in debug artifacts to verify if the element exists."
+            debugMessage = debugMessage
         )
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -940,6 +940,7 @@ data class YamlFluentCommand(
                 centerElement = yaml.centerElement,
                 label = yaml.label,
                 optional = yaml.optional,
+                originalSpeedValue = yaml.speed,
                 waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs
             )
         )


### PR DESCRIPTION
## Proposed changes

1. Introduce a debug info on maestro errors to send debug messages on failures. This is to help users guide how they show be changing commands if something errors out on assertions specifically scrollUntilVisible.
2. scrollUntilVisible command also doesn't show other attributes like speed, timeout which are even there by default. This PR includes them in description

<img width="983" alt="Screenshot 2025-05-15 at 3 28 36 PM" src="https://github.com/user-attachments/assets/db881559-f513-4b4a-b53c-fd4f2255c94c" />



## Testing

- [x] Locally

## Issues fixed
