### PR TITLE
Do no retry taps by default

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -174,7 +174,7 @@ class Maestro(
     fun tap(
         element: UiElement,
         initialHierarchy: ViewHierarchy,
-        retryIfNoChange: Boolean = true,
+        retryIfNoChange: Boolean = false,
         waitUntilVisible: Boolean = false,
         longPress: Boolean = false,
         appId: String? = null,
@@ -228,7 +228,7 @@ class Maestro(
     fun tapOnRelative(
         percentX: Int,
         percentY: Int,
-        retryIfNoChange: Boolean = true,
+        retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         tapRepeat: TapRepeat? = null,
         waitToSettleTimeoutMs: Int? = null
@@ -249,7 +249,7 @@ class Maestro(
     fun tap(
         x: Int,
         y: Int,
-        retryIfNoChange: Boolean = true,
+        retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         tapRepeat: TapRepeat? = null,
         waitToSettleTimeoutMs: Int? = null
@@ -271,7 +271,7 @@ class Maestro(
     private fun performTap(
         x: Int,
         y: Int,
-        retryIfNoChange: Boolean = true,
+        retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
         tapRepeat: TapRepeat? = null,
@@ -289,7 +289,7 @@ class Maestro(
     private fun screenshotBasedTap(
         x: Int,
         y: Int,
-        retryIfNoChange: Boolean = true,
+        retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
         tapRepeat: TapRepeat? = null,
@@ -325,7 +325,7 @@ class Maestro(
     private fun hierarchyBasedTap(
         x: Int,
         y: Int,
-        retryIfNoChange: Boolean = true,
+        retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
         tapRepeat: TapRepeat? = null,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -281,13 +281,13 @@ class Orchestra(
             is TapOnElementCommand -> {
                 tapOnElement(
                     command = command,
-                    retryIfNoChange = command.retryIfNoChange ?: true,
+                    retryIfNoChange = command.retryIfNoChange ?: false,
                     waitUntilVisible = command.waitUntilVisible ?: false,
                     config = config
                 )
             }
 
-            is TapOnPointCommand -> tapOnPoint(command, command.retryIfNoChange ?: true)
+            is TapOnPointCommand -> tapOnPoint(command, command.retryIfNoChange ?: false)
             is TapOnPointV2Command -> tapOnPointV2Command(command)
             is BackPressCommand -> backPressCommand()
             is HideKeyboardCommand -> hideKeyboardCommand()
@@ -1038,7 +1038,7 @@ class Orchestra(
             maestro.tapOnRelative(
                 percentX = percentX,
                 percentY = percentY,
-                retryIfNoChange = command.retryIfNoChange ?: true,
+                retryIfNoChange = command.retryIfNoChange ?: false,
                 longPress = command.longPress ?: false,
                 tapRepeat = command.repeat,
                 waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
@@ -1052,7 +1052,7 @@ class Orchestra(
             maestro.tap(
                 x = x,
                 y = y,
-                retryIfNoChange = command.retryIfNoChange ?: true,
+                retryIfNoChange = command.retryIfNoChange ?: false,
                 longPress = command.longPress ?: false,
                 tapRepeat = command.repeat,
                 waitToSettleTimeoutMs = command.waitToSettleTimeoutMs

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -737,7 +737,7 @@ data class YamlFluentCommand(
         longPress: Boolean = false,
         tapRepeat: TapRepeat? = null
     ): MaestroCommand {
-        val retryIfNoChange = (tapOn as? YamlElementSelector)?.retryTapIfNoChange ?: true
+        val retryIfNoChange = (tapOn as? YamlElementSelector)?.retryTapIfNoChange ?: false
         val waitUntilVisible = (tapOn as? YamlElementSelector)?.waitUntilVisible ?: false
         val point = (tapOn as? YamlElementSelector)?.point
         val label = (tapOn as? YamlElementSelector)?.label

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -228,14 +228,14 @@ internal class YamlCommandReaderTest {
             // Taps
             TapOnElementCommand(
                 selector = ElementSelector(idRegex = "foo"),
-                retryIfNoChange = true,
+                retryIfNoChange = false,
                 waitUntilVisible = false,
                 longPress = false,
                 label = "Tap on the important button"
             ),
             TapOnElementCommand(
                 selector = ElementSelector(idRegex = "foo"),
-                retryIfNoChange = true,
+                retryIfNoChange = false,
                 waitUntilVisible = false,
                 longPress = false,
                 repeat = TapRepeat(
@@ -246,14 +246,14 @@ internal class YamlCommandReaderTest {
             ),
             TapOnElementCommand(
                 selector = ElementSelector(idRegex = "foo"),
-                retryIfNoChange = true,
+                retryIfNoChange = false,
                 waitUntilVisible = false,
                 longPress = true,
                 label = "Press and hold the important button"
             ),
             TapOnPointV2Command(
                 point = "50%,50%",
-                retryIfNoChange = true,
+                retryIfNoChange = false,
                 longPress = false,
                 label = "Tap on the middle of the screen"
             ),
@@ -431,7 +431,7 @@ internal class YamlCommandReaderTest {
                     MaestroCommand(
                         command = TapOnElementCommand(
                             selector = ElementSelector(idRegex = "foo"),
-                            retryIfNoChange = true,
+                            retryIfNoChange = false,
                             waitUntilVisible = false,
                             longPress = false,
                             label = "Tap on the important button"
@@ -440,7 +440,7 @@ internal class YamlCommandReaderTest {
                     MaestroCommand(
                         command = TapOnElementCommand(
                             selector = ElementSelector(idRegex = "bar"),
-                            retryIfNoChange = true,
+                            retryIfNoChange = false,
                             waitUntilVisible = false,
                             longPress = false,
                             label = "Tap on the other important button"
@@ -490,21 +490,21 @@ internal class YamlCommandReaderTest {
                 ElementSelector(
                     textRegex = "Hello",
                 ),
-                retryIfNoChange = true,
+                retryIfNoChange = false,
                 waitUntilVisible = false,
                 longPress = false
             ),
             TapOnElementCommand(
                 selector = ElementSelector(textRegex = "Hello"),
                 repeat = TapRepeat(2, TapOnElementCommand.DEFAULT_REPEAT_DELAY),
-                retryIfNoChange = true,
+                retryIfNoChange = false,
                 waitUntilVisible = false,
                 longPress = false
             ),
             TapOnElementCommand(
                 selector = ElementSelector(textRegex = "Hello"),
                 longPress = true,
-                retryIfNoChange = true,
+                retryIfNoChange = false,
                 waitUntilVisible = false
             ),
             AssertConditionCommand(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -197,7 +197,7 @@ class IntegrationTest {
     }
 
     @Test
-    fun `Case 008 - Tap on element - Retry if no UI change`() {
+    fun `Case 008 - Tap on element - Do not retry by default if no UI change`() {
         // Given
         val commands = readCommands("008_tap_on_element")
 
@@ -215,7 +215,7 @@ class IntegrationTest {
 
         // Then
         // No test failure
-        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 2)
+        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 1)
     }
 
     @Test
@@ -3216,6 +3216,28 @@ class IntegrationTest {
                 Event.Scroll,
             )
         )
+    }
+
+    @Test
+    fun `Case 120 - Tap on element - Retry if no UI change opt-in`() {
+        // Given
+        val commands = readCommands("120_tap_on_element_retryTapIfNoChange")
+
+        val driver = driver {
+            element {
+                text = "Primary button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            orchestra(it).runFlow(commands)
+        }
+
+        // Then
+        // No test failure
+        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 2)
     }
 
     private fun orchestra(

--- a/maestro-test/src/test/resources/120_tap_on_element_retryTapIfNoChange.yaml
+++ b/maestro-test/src/test/resources/120_tap_on_element_retryTapIfNoChange.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- tapOn:
+    text: ".*button.*"
+    retryTapIfNoChange: true


### PR DESCRIPTION
**WARNING:** This is a breaking change for flows that are benefitting from the previous default behavior of retrying taps when Maestro determines the UI has not changed.

It's very difficult to know whether the previous behavior was actually benefitting anyone, but there are certainly lots of complaints of the default behavior causing problems.

I propose ripping the bandaid off with this PR and changing this behavior to an opt-in.

Resolves #1202 