### PR TITLE
feat: add ability to switch and assert themes on iOS and Android: setDarkMode, toggleDarkMode, assertDarkMode & assertLightMode

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -112,6 +112,10 @@ interface Driver {
 
     fun setAirplaneMode(enabled: Boolean)
 
+    fun isDarkModeEnabled(): Boolean
+
+    fun setDarkMode(enabled: Boolean)
+
     fun setAndroidChromeDevToolsEnabled(enabled: Boolean) = Unit
 
     fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -764,6 +764,14 @@ class Maestro(
         driver.setAirplaneMode(enabled)
     }
 
+    suspend fun isDarkModeEnabled(): Boolean = runInterruptible(Dispatchers.IO) {
+        driver.isDarkModeEnabled()
+    }
+
+    suspend fun setDarkModeState(enabled: Boolean) = runInterruptible(Dispatchers.IO) {
+        driver.setDarkMode(enabled)
+    }
+
     suspend fun setAndroidChromeDevToolsEnabled(enabled: Boolean) = runInterruptible(Dispatchers.IO) {
         driver.setAndroidChromeDevToolsEnabled(enabled)
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -826,6 +826,23 @@ class AndroidDriver(
         }
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        return metrics.measured("operation", mapOf("command" to "isDarkModeEnabled")) {
+            when (val result = shell("cmd uimode night").trim()) {
+                "Night mode: no" -> false
+                "Night mode: yes" -> true
+                else -> throw IllegalStateException("Received invalid response while trying to read dark mode state: $result")
+            }
+        }
+    }
+
+    override fun setDarkMode(enabled: Boolean) {
+        metrics.measured("operation", mapOf("command" to "setDarkMode", "enabled" to enabled.toString())) {
+            val value = if (enabled) "yes" else "no"
+            shell("cmd uimode night $value")
+        }
+    }
+
     private fun broadcastAirplaneMode(enabled: Boolean) {
         val command = "am broadcast -a android.intent.action.AIRPLANE_MODE --ez state $enabled"
         try {

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -655,6 +655,14 @@ class CdpWebDriver(
         // Do nothing
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        return false
+    }
+
+    override fun setDarkMode(enabled: Boolean) {
+        // Do nothing
+    }
+
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {
         return when (query) {
             is OnDeviceElementQuery.Css -> queryCss(query)

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -34,6 +34,7 @@ import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.chromium.ChromiumDriverLogLevel
 import org.openqa.selenium.devtools.HasDevTools
 import org.openqa.selenium.devtools.v147.emulation.Emulation
+import org.openqa.selenium.devtools.v147.emulation.model.MediaFeature
 import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.interactions.PointerInput
 import org.openqa.selenium.interactions.Sequence
@@ -656,11 +657,20 @@ class CdpWebDriver(
     }
 
     override fun isDarkModeEnabled(): Boolean {
-        return false
+        return executeJS("window.matchMedia('(prefers-color-scheme: dark)').matches") as? Boolean ?: false
     }
 
     override fun setDarkMode(enabled: Boolean) {
-        // Do nothing
+        val driver = ensureOpen() as HasDevTools
+
+        driver.devTools.createSessionIfThereIsNotOne()
+
+        driver.devTools.send(
+            Emulation.setEmulatedMedia(
+                Optional.empty(),
+                Optional.of(listOf(MediaFeature("prefers-color-scheme", if (enabled) "dark" else "light")))
+            )
+        )
     }
 
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -535,6 +535,18 @@ class IOSDriver(
         LOGGER.warn("Airplane mode is not available on iOS simulators")
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        return metrics.measured("operation", mapOf("command" to "isDarkModeEnabled")) {
+            runDeviceCall("isDarkModeEnabled") { iosDevice.isDarkModeEnabled() }
+        }
+    }
+
+    override fun setDarkMode(enabled: Boolean) {
+        metrics.measured("operation", mapOf("command" to "setDarkMode")) {
+            runDeviceCall("setDarkMode") { iosDevice.setAppearance(if (enabled) "dark" else "light") }
+        }
+    }
+
     private fun addMediaToDevice(mediaFile: File) {
         metrics.measured("operation", mapOf("command" to "addMediaToDevice")) {
             val namedSource = NamedSource(

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -625,6 +625,14 @@ class WebDriver(
         // Do nothing
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        return false
+    }
+
+    override fun setDarkMode(enabled: Boolean) {
+        // Do nothing
+    }
+
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {
         return when (query) {
             is OnDeviceElementQuery.Css -> queryCss(query)

--- a/maestro-ios-driver/src/main/kotlin/device/IOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/device/IOSDevice.kt
@@ -136,6 +136,18 @@ interface IOSDevice : AutoCloseable {
     fun setOrientation(orientation: String)
 
     /**
+     * @return true if the device's appearance is currently set to dark mode
+     */
+    fun isDarkModeEnabled(): Boolean
+
+    /**
+     * Sets the device's appearance.
+     *
+     * @param appearance - "dark" or "light"
+     */
+    fun setAppearance(appearance: String)
+
+    /**
      * @return true if the connection to the device (not device itself) is shut down
      */
     fun isShutdown(): Boolean

--- a/maestro-ios-driver/src/main/kotlin/device/SimctlIOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/device/SimctlIOSDevice.kt
@@ -155,6 +155,14 @@ class SimctlIOSDevice(
         TODO("Not yet implemented")
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAppearance(appearance: String) {
+        TODO("Not yet implemented")
+    }
+
     override fun isShutdown(): Boolean {
         TODO("Not yet implemented")
     }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -190,6 +190,15 @@ class XCTestDriverClient(
         executeJsonRequest("setOrientation", SetOrientationRequest(orientation))
     }
 
+    fun setAppearance(appearance: String) {
+        executeJsonRequest("setAppearance", SetAppearanceRequest(appearance))
+    }
+
+    fun getAppearance(httpUrl: HttpUrl = client.xctestAPIBuilder("appearance").build()): AppearanceResponse {
+        val response = executeJsonRequest(httpUrl, Unit)
+        return mapper.readValue(response, AppearanceResponse::class.java)
+    }
+
     fun pressKey(name: String) {
         executeJsonRequest("pressKey", PressKeyRequest(name))
     }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/api/AppearanceResponse.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/api/AppearanceResponse.kt
@@ -1,0 +1,3 @@
+package xcuitest.api
+
+data class AppearanceResponse(val appearance: String)

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/api/SetAppearanceRequest.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/api/SetAppearanceRequest.kt
@@ -1,0 +1,3 @@
+package xcuitest.api
+
+data class SetAppearanceRequest(val appearance: String)

--- a/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/project.pbxproj
+++ b/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/project.pbxproj
@@ -62,6 +62,10 @@
 		52F33A942AE6823100692902 /* StatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52F33A932AE6823100692902 /* StatusResponse.swift */; };
 		5B8E0ABC2CD562D000E9D439 /* SetOrientationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8E0ABB2CD562D000E9D439 /* SetOrientationHandler.swift */; };
 		5B8E0ABE2CD562F200E9D439 /* SetOrientationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B8E0ABD2CD562F200E9D439 /* SetOrientationRequest.swift */; };
+		B989DC7F4F55F4EBD9FD10C9 /* SetAppearanceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA3B2307F723A0C1C707C50 /* SetAppearanceRequest.swift */; };
+		989F5A5E9E97797870C83F35 /* AppearanceResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A89F24DF7C8AD254B7EFE8B /* AppearanceResponse.swift */; };
+		986F4E9268A487A7FC35B4CA /* SetAppearanceHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BCFA7B93536729D3DF6160 /* SetAppearanceHandler.swift */; };
+		5BC221F6806E37052BF2BB63 /* AppearanceHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4020AE5DE27FE7FDCA8C2617 /* AppearanceHandler.swift */; };
 		610D58F92A45B5DA00B4BBEB /* ViewHierarchyHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610D58F82A45B5DA00B4BBEB /* ViewHierarchyHandler.swift */; };
 		610D58FB2A49E3CA00B4BBEB /* AXClientSwizzler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610D58FA2A49E3CA00B4BBEB /* AXClientSwizzler.swift */; };
 		6124329C2A4B368100F5F619 /* ViewHierarchyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6124329B2A4B368100F5F619 /* ViewHierarchyRequest.swift */; };
@@ -308,6 +312,10 @@
 		52F33A932AE6823100692902 /* StatusResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusResponse.swift; sourceTree = "<group>"; };
 		566C6ED5A08D754A03395D84 /* maestro-driver-iosTests-Bridging-Header.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "maestro-driver-iosTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		5B8E0ABB2CD562D000E9D439 /* SetOrientationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOrientationHandler.swift; sourceTree = "<group>"; };
+		DFA3B2307F723A0C1C707C50 /* SetAppearanceRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAppearanceRequest.swift; sourceTree = "<group>"; };
+		4A89F24DF7C8AD254B7EFE8B /* AppearanceResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceResponse.swift; sourceTree = "<group>"; };
+		F5BCFA7B93536729D3DF6160 /* SetAppearanceHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetAppearanceHandler.swift; sourceTree = "<group>"; };
+		4020AE5DE27FE7FDCA8C2617 /* AppearanceHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceHandler.swift; sourceTree = "<group>"; };
 		5B8E0ABD2CD562F200E9D439 /* SetOrientationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetOrientationRequest.swift; sourceTree = "<group>"; };
 		5D711D048386CB50800447DD /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		610D58F82A45B5DA00B4BBEB /* ViewHierarchyHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyHandler.swift; sourceTree = "<group>"; };
@@ -658,6 +666,8 @@
 				32ECCB252980449200A1A0A0 /* TouchRequest.swift */,
 				61C0AFE429C7AAB3005D1FC5 /* PressKeyRequest.swift */,
 				5B8E0ABD2CD562F200E9D439 /* SetOrientationRequest.swift */,
+				DFA3B2307F723A0C1C707C50 /* SetAppearanceRequest.swift */,
+				4A89F24DF7C8AD254B7EFE8B /* AppearanceResponse.swift */,
 				61C0AFE829C86378005D1FC5 /* PressButtonRequest.swift */,
 				61C0AFEE29C8961F005D1FC5 /* EraseTextRequest.swift */,
 				61C0AFF229C8C040005D1FC5 /* DeviceInfoResponse.swift */,
@@ -703,6 +713,8 @@
 				61C0AFEC29C88926005D1FC5 /* EraseTextHandler.swift */,
 				61C0AFF029C8C01F005D1FC5 /* DeviceInfoHandler.swift */,
 				5B8E0ABB2CD562D000E9D439 /* SetOrientationHandler.swift */,
+				F5BCFA7B93536729D3DF6160 /* SetAppearanceHandler.swift */,
+				4020AE5DE27FE7FDCA8C2617 /* AppearanceHandler.swift */,
 				945DD44C29D6F73B004D8ECF /* SetPermissionsHandler.swift */,
 				52047F772A7A638E00BF982D /* StatusHandler.swift */,
 				52F0B1B02B3C25BC00C6471A /* KeyboardRouteHandler.swift */,
@@ -1016,6 +1028,10 @@
 				610D58FB2A49E3CA00B4BBEB /* AXClientSwizzler.swift in Sources */,
 				F328D3E62A2A98E7000546D3 /* StringExtensions.swift in Sources */,
 				5B8E0ABC2CD562D000E9D439 /* SetOrientationHandler.swift in Sources */,
+				B989DC7F4F55F4EBD9FD10C9 /* SetAppearanceRequest.swift in Sources */,
+				989F5A5E9E97797870C83F35 /* AppearanceResponse.swift in Sources */,
+				986F4E9268A487A7FC35B4CA /* SetAppearanceHandler.swift in Sources */,
+				5BC221F6806E37052BF2BB63 /* AppearanceHandler.swift in Sources */,
 				61C0AFEF29C8961F005D1FC5 /* EraseTextRequest.swift in Sources */,
 				521C1F102D8051FC0024EE42 /* XCTestDaemonsProxy.m in Sources */,
 				61A79B9729DF0B8A00C38882 /* SwipeRouteHandlerV2.swift in Sources */,

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/AppearanceHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/AppearanceHandler.swift
@@ -1,0 +1,29 @@
+import Foundation
+import FlyingFox
+import os
+import XCTest
+
+@MainActor
+struct AppearanceHandler: HTTPHandler {
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: Self.self)
+    )
+
+    func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard #available(iOS 15.0, *) else {
+            return AppError(type: .precondition, message: "setDarkMode requires iOS 15+").httpResponse
+        }
+
+        let appearance: String
+        switch XCUIDevice.shared.appearance {
+        case .dark:
+            appearance = "dark"
+        default:
+            appearance = "light"
+        }
+
+        let responseBody = try JSONEncoder().encode(AppearanceResponse(appearance: appearance))
+        return HTTPResponse(statusCode: .ok, body: responseBody)
+    }
+}

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SetAppearanceHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SetAppearanceHandler.swift
@@ -1,0 +1,33 @@
+import Foundation
+import FlyingFox
+import os
+import XCTest
+
+@MainActor
+struct SetAppearanceHandler: HTTPHandler {
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier!,
+        category: String(describing: Self.self)
+    )
+
+    func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let requestBody = try? await JSONDecoder().decode(SetAppearanceRequest.self, from: request.bodyData) else {
+            return AppError(type: .precondition, message: "incorrect request body provided for set appearance").httpResponse
+        }
+
+        guard #available(iOS 15.0, *) else {
+            return AppError(type: .precondition, message: "setDarkMode requires iOS 15+").httpResponse
+        }
+
+        switch requestBody.appearance.lowercased() {
+        case "dark":
+            XCUIDevice.shared.appearance = .dark
+        case "light":
+            XCUIDevice.shared.appearance = .light
+        default:
+            return AppError(type: .precondition, message: "Invalid appearance value. Use 'dark' or 'light'").httpResponse
+        }
+
+        return HTTPResponse(statusCode: .ok)
+    }
+}

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Models/AppearanceResponse.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Models/AppearanceResponse.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct AppearanceResponse: Codable {
+    let appearance: String
+}

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Models/SetAppearanceRequest.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Models/SetAppearanceRequest.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct SetAppearanceRequest: Codable {
+    let appearance: String
+}

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/RouteHandlerFactory.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/RouteHandlerFactory.swift
@@ -28,6 +28,10 @@ class RouteHandlerFactory {
             return DeviceInfoHandler()
         case .setOrientation:
             return SetOrientationHandler()
+        case .setAppearance:
+            return SetAppearanceHandler()
+        case .appearance:
+            return AppearanceHandler()
         case .setPermissions:
             return SetPermissionsHandler()
         case .viewHierarchy:

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTestHTTPServer.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTestHTTPServer.swift
@@ -14,6 +14,8 @@ enum Route: String, CaseIterable {
     case eraseText
     case deviceInfo
     case setOrientation
+    case setAppearance
+    case appearance
     case setPermissions
     case viewHierarchy
     case status

--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -135,6 +135,14 @@ class LocalIOSDevice(
         return xcTestDevice.setOrientation(orientation)
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        return xcTestDevice.isDarkModeEnabled()
+    }
+
+    override fun setAppearance(appearance: String) {
+        return xcTestDevice.setAppearance(appearance)
+    }
+
     override fun isShutdown(): Boolean {
         return xcTestDevice.isShutdown()
     }

--- a/maestro-ios/src/main/java/ios/devicectl/DeviceControlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/devicectl/DeviceControlIOSDevice.kt
@@ -95,6 +95,14 @@ class DeviceControlIOSDevice(override val deviceId: String) : IOSDevice {
         TODO("Not yet implemented")
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAppearance(appearance: String) {
+        TODO("Not yet implemented")
+    }
+
     override fun isShutdown(): Boolean {
         TODO("Not yet implemented")
     }

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -181,6 +181,14 @@ class XCTestIOSDevice(
         execute { client.setOrientation(orientation) }
     }
 
+    override fun isDarkModeEnabled(): Boolean {
+        return execute { client.getAppearance().appearance == "dark" }
+    }
+
+    override fun setAppearance(appearance: String) {
+        execute { client.setAppearance(appearance) }
+    }
+
     override fun isShutdown(): Boolean {
         return !client.isChannelAlive()
     }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -1243,6 +1243,30 @@ data class ToggleDarkModeCommand(
     }
 }
 
+data class AssertDarkModeCommand(
+    override val label: String? = null,
+    override val optional: Boolean = false,
+) : Command {
+    override val originalDescription: String
+        get() = "Assert dark mode is enabled"
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+}
+
+data class AssertLightModeCommand(
+    override val label: String? = null,
+    override val optional: Boolean = false,
+) : Command {
+    override val originalDescription: String
+        get() = "Assert dark mode is disabled"
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+}
+
 internal fun tapOnDescription(isLongPress: Boolean?, repeat: TapRepeat?): String {
     return if (isLongPress == true) "Long press"
     else if (repeat != null) {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -1210,6 +1210,39 @@ data class ToggleAirplaneModeCommand(
     }
 }
 
+enum class DarkModeValue {
+    Enable,
+    Disable,
+}
+
+data class SetDarkModeCommand(
+    val value: DarkModeValue,
+    override val label: String? = null,
+    override val optional: Boolean = false,
+) : Command {
+    override val originalDescription: String
+        get() = when (value) {
+            DarkModeValue.Enable -> "Enable dark mode"
+            DarkModeValue.Disable -> "Disable dark mode"
+        }
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+}
+
+data class ToggleDarkModeCommand(
+    override val label: String? = null,
+    override val optional: Boolean = false,
+) : Command {
+    override val originalDescription: String
+        get() = "Toggle dark mode"
+
+    override fun evaluateScripts(jsEngine: JsEngine): Command {
+        return this
+    }
+}
+
 internal fun tapOnDescription(isLongPress: Boolean?, repeat: TapRepeat?): String {
     return if (isLongPress == true) "Long press"
     else if (repeat != null) {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -75,6 +75,8 @@ data class MaestroCommand(
     val toggleAirplaneModeCommand: ToggleAirplaneModeCommand? = null,
     val setDarkModeCommand: SetDarkModeCommand? = null,
     val toggleDarkModeCommand: ToggleDarkModeCommand? = null,
+    val assertDarkModeCommand: AssertDarkModeCommand? = null,
+    val assertLightModeCommand: AssertLightModeCommand? = null,
     val retryCommand: RetryCommand? = null,
     // @JsonIgnore: serializing would duplicate the full origin YAML on every command in the DB.
     @JsonIgnore val sourceInfo: SourceInfo? = null,
@@ -127,6 +129,8 @@ data class MaestroCommand(
         toggleAirplaneModeCommand = command as? ToggleAirplaneModeCommand,
         setDarkModeCommand = command as? SetDarkModeCommand,
         toggleDarkModeCommand = command as? ToggleDarkModeCommand,
+        assertDarkModeCommand = command as? AssertDarkModeCommand,
+        assertLightModeCommand = command as? AssertLightModeCommand,
         retryCommand = command as? RetryCommand
     )
 
@@ -177,6 +181,8 @@ data class MaestroCommand(
         toggleAirplaneModeCommand != null -> toggleAirplaneModeCommand
         setDarkModeCommand != null -> setDarkModeCommand
         toggleDarkModeCommand != null -> toggleDarkModeCommand
+        assertDarkModeCommand != null -> assertDarkModeCommand
+        assertLightModeCommand != null -> assertLightModeCommand
         retryCommand != null -> retryCommand
         else -> null
     }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroCommand.kt
@@ -73,6 +73,8 @@ data class MaestroCommand(
     val addMediaCommand: AddMediaCommand? = null,
     val setAirplaneModeCommand: SetAirplaneModeCommand? = null,
     val toggleAirplaneModeCommand: ToggleAirplaneModeCommand? = null,
+    val setDarkModeCommand: SetDarkModeCommand? = null,
+    val toggleDarkModeCommand: ToggleDarkModeCommand? = null,
     val retryCommand: RetryCommand? = null,
     // @JsonIgnore: serializing would duplicate the full origin YAML on every command in the DB.
     @JsonIgnore val sourceInfo: SourceInfo? = null,
@@ -123,6 +125,8 @@ data class MaestroCommand(
         addMediaCommand = command as? AddMediaCommand,
         setAirplaneModeCommand = command as? SetAirplaneModeCommand,
         toggleAirplaneModeCommand = command as? ToggleAirplaneModeCommand,
+        setDarkModeCommand = command as? SetDarkModeCommand,
+        toggleDarkModeCommand = command as? ToggleDarkModeCommand,
         retryCommand = command as? RetryCommand
     )
 
@@ -171,6 +175,8 @@ data class MaestroCommand(
         addMediaCommand != null -> addMediaCommand
         setAirplaneModeCommand != null -> setAirplaneModeCommand
         toggleAirplaneModeCommand != null -> toggleAirplaneModeCommand
+        setDarkModeCommand != null -> setDarkModeCommand
+        toggleDarkModeCommand != null -> toggleDarkModeCommand
         retryCommand != null -> retryCommand
         else -> null
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -441,8 +441,8 @@ class Orchestra(
             is ToggleAirplaneModeCommand -> toggleAirplaneMode()
             is SetDarkModeCommand -> setDarkMode(command)
             is ToggleDarkModeCommand -> toggleDarkMode()
-            is AssertDarkModeCommand -> assertDarkModeCommand()
-            is AssertLightModeCommand -> assertLightModeCommand()
+            is AssertDarkModeCommand -> assertDarkMode(expected = true)
+            is AssertLightModeCommand -> assertDarkMode(expected = false)
             is RetryCommand -> retryCommand(command, config)
             else -> true
         }.also { mutating ->
@@ -480,24 +480,15 @@ class Orchestra(
         return true
     }
 
-    private suspend fun assertDarkModeCommand(): Boolean {
-        if (!maestro.isDarkModeEnabled()) {
+    private suspend fun assertDarkMode(expected: Boolean): Boolean {
+        val actual = maestro.isDarkModeEnabled()
+        if (actual != expected) {
+            val expectedState = if (expected) "enabled" else "disabled"
+            val actualState = if (actual) "dark mode" else "light mode"
             throw MaestroException.AssertionFailure(
-                message = "Assertion failed: expected dark mode to be enabled, but it was disabled",
+                message = "Assertion failed: expected dark mode to be $expectedState, but it was ${if (actual) "enabled" else "disabled"}",
                 hierarchyRoot = maestro.viewHierarchy().root,
-                debugMessage = "The device's system-wide appearance is currently light mode. Use setDarkMode or toggleDarkMode to change it before this assertion."
-            )
-        }
-
-        return false
-    }
-
-    private suspend fun assertLightModeCommand(): Boolean {
-        if (maestro.isDarkModeEnabled()) {
-            throw MaestroException.AssertionFailure(
-                message = "Assertion failed: expected dark mode to be disabled, but it was enabled",
-                hierarchyRoot = maestro.viewHierarchy().root,
-                debugMessage = "The device's system-wide appearance is currently dark mode. Use setDarkMode or toggleDarkMode to change it before this assertion."
+                debugMessage = "The device's system-wide appearance is currently $actualState. Use setDarkMode or toggleDarkMode to change it before this assertion."
             )
         }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -441,6 +441,8 @@ class Orchestra(
             is ToggleAirplaneModeCommand -> toggleAirplaneMode()
             is SetDarkModeCommand -> setDarkMode(command)
             is ToggleDarkModeCommand -> toggleDarkMode()
+            is AssertDarkModeCommand -> assertDarkModeCommand()
+            is AssertLightModeCommand -> assertLightModeCommand()
             is RetryCommand -> retryCommand(command, config)
             else -> true
         }.also { mutating ->
@@ -476,6 +478,30 @@ class Orchestra(
     private suspend fun toggleDarkMode(): Boolean {
         maestro.setDarkModeState(!maestro.isDarkModeEnabled())
         return true
+    }
+
+    private suspend fun assertDarkModeCommand(): Boolean {
+        if (!maestro.isDarkModeEnabled()) {
+            throw MaestroException.AssertionFailure(
+                message = "Assertion failed: expected dark mode to be enabled, but it was disabled",
+                hierarchyRoot = maestro.viewHierarchy().root,
+                debugMessage = "The device's system-wide appearance is currently light mode. Use setDarkMode or toggleDarkMode to change it before this assertion."
+            )
+        }
+
+        return false
+    }
+
+    private suspend fun assertLightModeCommand(): Boolean {
+        if (maestro.isDarkModeEnabled()) {
+            throw MaestroException.AssertionFailure(
+                message = "Assertion failed: expected dark mode to be disabled, but it was enabled",
+                hierarchyRoot = maestro.viewHierarchy().root,
+                debugMessage = "The device's system-wide appearance is currently dark mode. Use setDarkMode or toggleDarkMode to change it before this assertion."
+            )
+        }
+
+        return false
     }
 
     private suspend fun travelCommand(command: TravelCommand): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -439,6 +439,8 @@ class Orchestra(
             is AddMediaCommand -> addMediaCommand(command.mediaPaths)
             is SetAirplaneModeCommand -> setAirplaneMode(command)
             is ToggleAirplaneModeCommand -> toggleAirplaneMode()
+            is SetDarkModeCommand -> setDarkMode(command)
+            is ToggleDarkModeCommand -> toggleDarkMode()
             is RetryCommand -> retryCommand(command, config)
             else -> true
         }.also { mutating ->
@@ -459,6 +461,20 @@ class Orchestra(
 
     private suspend fun toggleAirplaneMode(): Boolean {
         maestro.setAirplaneModeState(!maestro.isAirplaneModeEnabled())
+        return true
+    }
+
+    private suspend fun setDarkMode(command: SetDarkModeCommand): Boolean {
+        when (command.value) {
+            DarkModeValue.Enable -> maestro.setDarkModeState(true)
+            DarkModeValue.Disable -> maestro.setDarkModeState(false)
+        }
+
+        return true
+    }
+
+    private suspend fun toggleDarkMode(): Boolean {
+        maestro.setDarkModeState(!maestro.isDarkModeEnabled())
         return true
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
@@ -166,6 +166,7 @@ private val stringCommands = mapOf<String, (YamlFluentCommand) -> YamlFluentComm
     "waitForAnimationToEnd" to { it.copy(waitForAnimationToEnd = YamlWaitForAnimationToEndCommand(timeout = null)) },
     "stopRecording" to { it.copy(stopRecording = YamlStopRecording()) },
     "toggleAirplaneMode" to { it.copy(toggleAirplaneMode = YamlToggleAirplaneMode()) },
+    "toggleDarkMode" to { it.copy(toggleDarkMode = YamlToggleDarkMode()) },
     "assertNoDefectsWithAI" to { it.copy(assertNoDefectsWithAI = YamlAssertNoDefectsWithAI()) },
 )
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
@@ -167,6 +167,8 @@ private val stringCommands = mapOf<String, (YamlFluentCommand) -> YamlFluentComm
     "stopRecording" to { it.copy(stopRecording = YamlStopRecording()) },
     "toggleAirplaneMode" to { it.copy(toggleAirplaneMode = YamlToggleAirplaneMode()) },
     "toggleDarkMode" to { it.copy(toggleDarkMode = YamlToggleDarkMode()) },
+    "assertDarkMode" to { it.copy(assertDarkMode = YamlAssertDarkMode()) },
+    "assertLightMode" to { it.copy(assertLightMode = YamlAssertLightMode()) },
     "assertNoDefectsWithAI" to { it.copy(assertNoDefectsWithAI = YamlAssertNoDefectsWithAI()) },
 )
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertDarkMode.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertDarkMode.kt
@@ -1,0 +1,6 @@
+package maestro.orchestra.yaml
+
+data class YamlAssertDarkMode(
+    val label: String? = null,
+    val optional: Boolean = false,
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertLightMode.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertLightMode.kt
@@ -1,0 +1,6 @@
+package maestro.orchestra.yaml
+
+data class YamlAssertLightMode(
+    val label: String? = null,
+    val optional: Boolean = false,
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -26,6 +26,8 @@ import maestro.Point
 import maestro.TapRepeat
 import maestro.orchestra.AddMediaCommand
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.AssertDarkModeCommand
+import maestro.orchestra.AssertLightModeCommand
 import maestro.orchestra.AssertNoDefectsWithAICommand
 import maestro.orchestra.AssertScreenshotCommand
 import maestro.orchestra.AssertWithAICommand
@@ -144,6 +146,8 @@ data class YamlFluentCommand(
     val toggleAirplaneMode: YamlToggleAirplaneMode? = null,
     val setDarkMode: YamlSetDarkMode? = null,
     val toggleDarkMode: YamlToggleDarkMode? = null,
+    val assertDarkMode: YamlAssertDarkMode? = null,
+    val assertLightMode: YamlAssertLightMode? = null,
     val retry: YamlRetryCommand? = null,
     @JsonIgnore val _sourceInfo: SourceInfo,
 ) {
@@ -502,6 +506,24 @@ data class YamlFluentCommand(
                     ToggleDarkModeCommand(
                         toggleDarkMode.label,
                         toggleDarkMode.optional
+                    )
+                )
+            )
+
+            assertDarkMode != null -> listOf(
+                MaestroCommand(
+                    AssertDarkModeCommand(
+                        assertDarkMode.label,
+                        assertDarkMode.optional
+                    )
+                )
+            )
+
+            assertLightMode != null -> listOf(
+                MaestroCommand(
+                    AssertLightModeCommand(
+                        assertLightMode.label,
+                        assertLightMode.optional
                     )
                 )
             )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -58,6 +58,7 @@ import maestro.orchestra.RunScriptCommand
 import maestro.orchestra.ScrollCommand
 import maestro.orchestra.ScrollUntilVisibleCommand
 import maestro.orchestra.SetAirplaneModeCommand
+import maestro.orchestra.SetDarkModeCommand
 import maestro.orchestra.SetLocationCommand
 import maestro.orchestra.SetOrientationCommand
 import maestro.orchestra.SetPermissionsCommand
@@ -70,6 +71,7 @@ import maestro.orchestra.TakeScreenshotCommand
 import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointV2Command
 import maestro.orchestra.ToggleAirplaneModeCommand
+import maestro.orchestra.ToggleDarkModeCommand
 import maestro.orchestra.TravelCommand
 import maestro.orchestra.WaitForAnimationToEndCommand
 import maestro.orchestra.error.InvalidFlowFile
@@ -140,6 +142,8 @@ data class YamlFluentCommand(
     val addMedia: YamlAddMedia? = null,
     val setAirplaneMode: YamlSetAirplaneMode? = null,
     val toggleAirplaneMode: YamlToggleAirplaneMode? = null,
+    val setDarkMode: YamlSetDarkMode? = null,
+    val toggleDarkMode: YamlToggleDarkMode? = null,
     val retry: YamlRetryCommand? = null,
     @JsonIgnore val _sourceInfo: SourceInfo,
 ) {
@@ -479,6 +483,25 @@ data class YamlFluentCommand(
                     ToggleAirplaneModeCommand(
                         toggleAirplaneMode.label,
                         toggleAirplaneMode.optional
+                    )
+                )
+            )
+
+            setDarkMode != null -> listOf(
+                MaestroCommand(
+                    SetDarkModeCommand(
+                        setDarkMode.value,
+                        setDarkMode.label,
+                        setDarkMode.optional
+                    )
+                )
+            )
+
+            toggleDarkMode != null -> listOf(
+                MaestroCommand(
+                    ToggleDarkModeCommand(
+                        toggleDarkMode.label,
+                        toggleDarkMode.optional
                     )
                 )
             )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSetDarkMode.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlSetDarkMode.kt
@@ -1,0 +1,73 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.TreeNode
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import maestro.orchestra.DarkModeValue
+
+@JsonDeserialize(using = YamlSetDarkModeDeserializer::class)
+data class YamlSetDarkMode(
+    val value: DarkModeValue,
+    val label: String? = null,
+    val optional: Boolean = false,
+) {
+    companion object {
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(value: DarkModeValue): YamlSetDarkMode {
+            return YamlSetDarkMode(value)
+        }
+    }
+}
+
+class YamlSetDarkModeDeserializer : JsonDeserializer<YamlSetDarkMode>() {
+
+    override fun deserialize(parser: JsonParser, ctxt: DeserializationContext): YamlSetDarkMode {
+        val mapper = (parser.codec as ObjectMapper)
+        val root: TreeNode = mapper.readTree(parser)
+        val input = root.fieldNames().asSequence().toList()
+        val label = getLabel(root)
+        when {
+            input.contains("value") -> {
+                val parsedValue = root.get("value").toString().replace("\"", "")
+                val returnValue = when (parsedValue) {
+                    "enabled" -> DarkModeValue.Enable
+                    "disabled" -> DarkModeValue.Disable
+                    else -> throwInvalidInputException(input)
+                }
+                return YamlSetDarkMode(returnValue, label)
+            }
+            (root.isValueNode && root.toString().contains("enabled")) -> {
+                return YamlSetDarkMode(DarkModeValue.Enable, label)
+            }
+            (root.isValueNode && root.toString().contains("disabled")) -> {
+                return YamlSetDarkMode(DarkModeValue.Disable, label)
+            }
+            else -> throwInvalidInputException(input)
+        }
+    }
+
+    private fun throwInvalidInputException(input: List<String>): Nothing {
+        throw IllegalArgumentException(
+            "setDarkMode command takes one of the following formats:\n" +
+                    "\t- setDarkMode: enabled\n" +
+                    "\t- setDarkMode:\n" +
+                    "\t    value: enabled\n" +
+                    "\t    label: \"Optional label\"\n" +
+                    "It seems you provided invalid input with: $input"
+        )
+    }
+
+    private fun getLabel(root: TreeNode): String? {
+        return if (root.path("label").isMissingNode) {
+            null
+        } else {
+            root.path("label").toString().replace("\"", "")
+        }
+    }
+
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlToggleDarkMode.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlToggleDarkMode.kt
@@ -1,0 +1,6 @@
+package maestro.orchestra.yaml
+
+data class YamlToggleDarkMode(
+    val label: String? = null,
+    val optional: Boolean = false,
+)

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -11,6 +11,8 @@ import maestro.orchestra.AddMediaCommand
 import maestro.orchestra.AirplaneValue
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.AssertDarkModeCommand
+import maestro.orchestra.AssertLightModeCommand
 import maestro.orchestra.AssertScreenshotCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
@@ -469,6 +471,12 @@ internal class YamlCommandReaderTest {
             ),
             ToggleDarkModeCommand(
                 label = "Toggle dark mode for testing"
+            ),
+            AssertDarkModeCommand(
+                label = "Assert dark mode is enabled"
+            ),
+            AssertLightModeCommand(
+                label = "Assert dark mode is disabled"
             ),
             RepeatCommand(
                 condition = Condition(visible = ElementSelector(textRegex = "Some important text")),

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -18,6 +18,7 @@ import maestro.orchestra.ClearStateCommand
 import maestro.orchestra.Command
 import maestro.orchestra.Condition
 import maestro.orchestra.CopyTextFromCommand
+import maestro.orchestra.DarkModeValue
 import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.EraseTextCommand
@@ -41,6 +42,7 @@ import maestro.orchestra.RunScriptCommand
 import maestro.orchestra.ScrollCommand
 import maestro.orchestra.ScrollUntilVisibleCommand
 import maestro.orchestra.SetAirplaneModeCommand
+import maestro.orchestra.SetDarkModeCommand
 import maestro.orchestra.SetLocationCommand
 import maestro.orchestra.SetOrientationCommand
 import maestro.orchestra.SetPermissionsCommand
@@ -52,6 +54,7 @@ import maestro.orchestra.TakeScreenshotCommand
 import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointV2Command
 import maestro.orchestra.ToggleAirplaneModeCommand
+import maestro.orchestra.ToggleDarkModeCommand
 import maestro.orchestra.TravelCommand
 import maestro.orchestra.WaitForAnimationToEndCommand
 import maestro.orchestra.yaml.junit.YamlCommandsExtension
@@ -459,6 +462,13 @@ internal class YamlCommandReaderTest {
             ),
             ToggleAirplaneModeCommand(
                 label = "Toggle airplane mode for testing"
+            ),
+            SetDarkModeCommand(
+                value = DarkModeValue.Enable,
+                label = "Turn on dark mode for testing"
+            ),
+            ToggleDarkModeCommand(
+                label = "Toggle dark mode for testing"
             ),
             RepeatCommand(
                 condition = Condition(visible = ElementSelector(textRegex = "Some important text")),

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/023_labels.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/023_labels.yaml
@@ -127,6 +127,11 @@ appId: com.example.app
       label: "Turn on airplane mode for testing"
 - toggleAirplaneMode:
       label: "Toggle airplane mode for testing"
+- setDarkMode:
+      value: enabled
+      label: "Turn on dark mode for testing"
+- toggleDarkMode:
+      label: "Toggle dark mode for testing"
 
 # Repeats
 - repeat:

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/023_labels.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/023_labels.yaml
@@ -132,6 +132,10 @@ appId: com.example.app
       label: "Turn on dark mode for testing"
 - toggleDarkMode:
       label: "Toggle dark mode for testing"
+- assertDarkMode:
+      label: "Assert dark mode is enabled"
+- assertLightMode:
+      label: "Assert dark mode is disabled"
 
 # Repeats
 - repeat:

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -55,6 +55,8 @@ open class FakeDriver : Driver {
 
     private var airplaneMode: Boolean = false
 
+    private var darkMode: Boolean = false
+
     // If true, keyboard will remain visible even after hideKeyboard() is called.
     var keyboardRemainsVisible: Boolean = false
 
@@ -417,6 +419,14 @@ open class FakeDriver : Driver {
 
     override fun setAirplaneMode(enabled: Boolean) {
         this.airplaneMode = enabled
+    }
+
+    override fun isDarkModeEnabled(): Boolean {
+        return this.darkMode
+    }
+
+    override fun setDarkMode(enabled: Boolean) {
+        this.darkMode = enabled
     }
 
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -24,6 +24,7 @@ import maestro.Point
 import maestro.SwipeDirection
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.AssertDarkModeCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.Condition
 import maestro.orchestra.DefineVariablesCommand
@@ -5341,6 +5342,61 @@ class IntegrationTest {
         // Then
         // enabled -> disabled -> toggled = enabled
         assertThat(driver.isDarkModeEnabled()).isTrue()
+    }
+
+    @Test
+    fun `Case 153 - assertDarkMode and assertLightMode pass when state matches`() {
+        val commands = readCommands("153_assert_dark_light_mode_pass")
+        val driver = driver { }
+
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+    }
+
+    @Test
+    fun `Case 154 - assertDarkMode fails when device is in light mode`() {
+        val commands = readCommands("154_assert_dark_mode_fail")
+        val driver = driver { } // darkMode defaults to false
+
+        assertThrows<MaestroException.AssertionFailure> {
+            Maestro(driver).use {
+                runBlocking {
+                    orchestra(it).runFlow(commands)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `optional assertDarkMode is warned, not failed`() {
+        val driver = driver { } // darkMode defaults to false
+        val commands = listOf(
+            MaestroCommand(AssertDarkModeCommand(optional = true))
+        )
+
+        var onCommandWarnedCalled = false
+        var onCommandFailedCalled = false
+
+        Maestro(driver).use { maestro ->
+            val result = runBlocking {
+                Orchestra(
+                    maestro,
+                    lookupTimeoutMs = 0L,
+                    optionalLookupTimeoutMs = 0L,
+                    onCommandWarned = { _, _ -> onCommandWarnedCalled = true },
+                    onCommandFailed = { _, _, _ ->
+                        onCommandFailedCalled = true
+                        Orchestra.ErrorResolution.FAIL
+                    },
+                ).runFlow(commands)
+            }
+            assertThat(result.success).isTrue()
+        }
+        assertThat(onCommandWarnedCalled).isTrue()
+        assertThat(onCommandFailedCalled).isFalse()
     }
 
     private fun readCommands(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -5327,6 +5327,22 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 152 - dark mode`() {
+        val commands = readCommands("152_dark_mode")
+        val driver = driver { }
+
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // enabled -> disabled -> toggled = enabled
+        assertThat(driver.isDarkModeEnabled()).isTrue()
+    }
+
     private fun readCommands(
         caseName: String,
         deviceId: String? = null,

--- a/maestro-test/src/test/resources/152_dark_mode.yaml
+++ b/maestro-test/src/test/resources/152_dark_mode.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- setDarkMode: enabled
+- setDarkMode: disabled
+- toggleDarkMode

--- a/maestro-test/src/test/resources/153_assert_dark_light_mode_pass.yaml
+++ b/maestro-test/src/test/resources/153_assert_dark_light_mode_pass.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+---
+- setDarkMode: enabled
+- assertDarkMode
+- setDarkMode: disabled
+- assertLightMode
+- toggleDarkMode
+- assertDarkMode

--- a/maestro-test/src/test/resources/154_assert_dark_mode_fail.yaml
+++ b/maestro-test/src/test/resources/154_assert_dark_mode_fail.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- assertDarkMode


### PR DESCRIPTION
## Proposed changes

This is a new feature that adds the ability to set the `light`/`dark` mode on iOS and Android platforms.

It adds the following new functionality:

- `setDarkMode` - possible values: `enabled` / `disabled`
- `toggleDarkMode` - swaps between light/dark mode
- `assertDarkMode` - fails the flow if dark mode is not currently enabled
- `assertLightMode` - fails the flow if dark mode is currently enabled

It achieves this by running commands for iOS/Android:

|   | iOS | Android |
|--------|--------|--------|
| `setDarkMode: enabled` | `XCUIDevice.shared.appearance = .dark` (via a new `setAppearance` endpoint on the XCUITest runner) | `adb shell 'cmd uimode night yes'` |
| `setDarkMode: disabled` | `XCUIDevice.shared.appearance = .light` (via the same endpoint) | `adb shell 'cmd uimode night no'` | 

iOS requires iOS 15+ (`XCUIDevice.appearance` isn't available below that); the endpoint returns a precondition error on older runtimes.

Web (`CdpWebDriver`) is a no-op for now — `isDarkModeEnabled`/`setDarkMode` are stubbed out since there's no dark-mode signal to drive on a headless/CDP-controlled browser yet.

## Testing

`./gradlew :maestro-test:test && ./gradlew test` passes 🟢 

I then "ignited" an app that [has a default maestro test in it called `FavoritePodcast.yaml`](https://github.com/infinitered/ignite/blob/master/boilerplate/.maestro/flows/FavoritePodcast.yaml) and replaced the contents with the following, adding calls to `setDarkMode`, `toggleDarkMode`, `assertDarkMode`, and `assertLightMode`

```yaml
# flow: run the login flow and then navigate to the demo podcast list screen, favorite a podcast, and then switch the list to only be favorites.

appId: ${MAESTRO_APP_ID}
env:
  FAVORITES_TEXT: "Switch on to only show favorites" # en.demoPodcastListScreen.accessibility.switch
onFlowStart:
  - runFlow: ../shared/_OnFlowStart.yaml
---
- runFlow: ../shared/_Login.yaml
- setDarkMode: disabled
- assertLightMode
- toggleDarkMode
- toggleDarkMode
- assertLightMode
- tapOn: "Podcast"
- assertVisible: "React Native Radio episodes"
- tapOn:
    text: ${FAVORITES_TEXT}
- setDarkMode: disabled
- assertVisible: "This looks a bit empty"
- tapOn:
    text: ${FAVORITES_TEXT}
    # https://maestro.mobile.dev/troubleshooting/known-issues#android-accidental-double-tap
    retryTapIfNoChange: false
- toggleDarkMode
- assertDarkMode
- repeat:
    times: 2
    commands:
      - scroll
- copyTextFrom:
    text: "RNR .*" # assumes all podcast titles start with RNR
    index: 2 # grab the third one, others might not be fully visible
- toggleDarkMode
- longPressOn: ${maestro.copiedText}
- scrollUntilVisible:
    element:
      text: ${FAVORITES_TEXT}
    direction: UP
    timeout: 50000
    speed: 90
    visibilityPercentage: 100
- tapOn:
    text: ${FAVORITES_TEXT}
- assertVisible: ${maestro.copiedText}
```

Then to test this, i ran the associated application on the iOS simulator and from this projects' directory i ran:

```bash
./maestro record -e MAESTRO_APP_ID=com.foo ../Foo/.maestro/flows/FavoritePodcast.yaml
```

Here is the resulting video showing the interface swapping back and forth from light to dark:


https://github.com/user-attachments/assets/d52da13c-9a39-48d9-8be7-ccfe37745b6f

## Issues fixed

n/a

