### PR TITLE
Add support for the --reinstall-driver option to AndroidDriver

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -62,7 +62,7 @@ class PrintHierarchyCommand : Runnable {
 
     @CommandLine.Option(
         names = ["--reinstall-driver"],
-        description = ["[Beta] Reinstalls xctestrunner driver before running the test. Set to false if the driver shouldn't be reinstalled"],
+        description = ["[Beta] Reinstalls iOS/Android driver before printing the hierarchy. Set to false if the driver shouldn't be reinstalled"],
         hidden = true
     )
     private var reinstallDriver: Boolean = true

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -176,7 +176,7 @@ class TestCommand : Callable<Int> {
 
     @Option(
         names = ["--reinstall-driver"],
-        description = ["[Beta] Reinstalls xctestrunner driver before running the test. Set to false if the driver shouldn't be reinstalled"],
+        description = ["[Beta] Reinstalls iOS/Android driver before running the test. Set to false if the driver shouldn't be reinstalled"],
         hidden = true
     )
     private var reinstallDriver: Boolean = true

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -198,9 +198,10 @@ object MaestroSessionManager {
             selectedDevice.device != null -> MaestroSession(
                 maestro = when (selectedDevice.device.platform) {
                     Platform.ANDROID -> createAndroid(
-                        selectedDevice.device.instanceId,
-                        !connectToExistingSession,
-                        driverHostPort,
+                        instanceId = selectedDevice.device.instanceId,
+                        reinstallDriver = reinstallDriver,
+                        openDriver = !connectToExistingSession,
+                        driverHostPort = driverHostPort,
                     )
 
                     Platform.IOS -> createIOS(
@@ -313,6 +314,7 @@ object MaestroSessionManager {
 
     private fun createAndroid(
         instanceId: String,
+        reinstallDriver: Boolean = true,
         openDriver: Boolean,
         driverHostPort: Int?,
     ): Maestro {
@@ -323,6 +325,7 @@ object MaestroSessionManager {
                 ?: Dadb.discover()
                 ?: error("Unable to find device with id $instanceId"),
             hostPort = driverHostPort,
+            reinstallDriver = reinstallDriver,
             emulatorName = instanceId,
         )
 


### PR DESCRIPTION
## Proposed changes

Add support for --reinstall-driver option to AndroidDriver. This allows forcing fresh driver installation instead of reusing existing sessions, improving debugging and testing workflows.

## Testing

- Functionality has been tested directly by invoking the CLI
- Tested by invoking it in a larger automated workflow

## Issues fixed

N/A - Enhancement to improve debugging workflow