### PR TITLE
[Web] Adding support for <select> tag

### DIFF
--- a/maestro-client/src/main/java/maestro/ViewHierarchy.kt
+++ b/maestro-client/src/main/java/maestro/ViewHierarchy.kt
@@ -62,7 +62,7 @@ value class ViewHierarchy(val root: TreeNode) {
         return matches[0]
     }
 
-    private fun getElementAt(
+    fun getElementAt(
         node: TreeNode,
         x: Int,
         y: Int

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -5,10 +5,18 @@
         return INVALID_TAGS.has(node.tagName.toLowerCase())
     }
 
+    // Synthetic nodes do not truly have a visual representation in the DOM, but they are still visible to the user.
+    const isSynthetic = (node) => {
+        return node.tagName.toLowerCase() === 'option'
+    }
+
     const getNodeText = (node) => {
         switch (node.tagName.toLowerCase()) {
             case 'input':
                 return node.value || node.placeholder || node.ariaLabel || ''
+
+            case 'select':
+                return node.options && node.options.length > 0 ? node.options[node.selectedIndex].text : ''
 
             default:
                 const childNodes = [...(node.childNodes || [])].filter(node => node.nodeType === Node.TEXT_NODE)
@@ -16,7 +24,40 @@
         }
     }
 
+    const getIndexInParent = (node) => {
+        if (!node.parentElement) return -1;
+
+        const siblings = Array.from(node.parentElement.children);
+        return siblings.indexOf(node);
+    }
+
+    const getSyntheticNodeBounds = (node) => {
+        // If the node is synthetic, we return bounds in a special coordinate space that doesn't interfere
+        // with the rest of the DOM. We do this by adding 100000 offset to the x and y coordinates.
+
+        const idx = getIndexInParent(node);
+
+        const width = 100;
+        const height = 20;
+
+        const offset = 100000;
+
+        const x = offset;
+        const y = offset + (idx * height);
+
+        const l = x;
+        const t = y;
+        const r = x + width;
+        const b = y + height;
+
+        return `[${Math.round(l)},${Math.round(t)}][${Math.round(r)},${Math.round(b)}]`
+    }
+
     const getNodeBounds = (node) => {
+        if (isSynthetic(node)) {
+            return getSyntheticNodeBounds(node);
+        }
+
         const rect = node.getBoundingClientRect()
         const vpx = maestro.viewportX;
         const vpy = maestro.viewportY;
@@ -39,9 +80,15 @@
       if (!node || isInvalidTag(node)) return null
 
       const children = [...node.children || []].map(child => traverse(child)).filter(el => !!el)
+
       const attributes = {
           text: getNodeText(node),
           bounds: getNodeBounds(node),
+      }
+
+      // If this is an <option> element, we only want to include it if the parent <select> element is focused.
+      if (node.tagName.toLowerCase() === 'option' && !node.parentElement.matches(':focus-within')) {
+        return null;
       }
 
       if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
@@ -51,6 +98,15 @@
 
       if (node.tagName.toLowerCase() === 'body') {
         attributes['is-loading'] = isDocumentLoading()
+      }
+
+      if (node.selected) {
+        attributes['selected'] = true
+      }
+
+      if (isSynthetic(node)) {
+        attributes['synthetic'] = true
+        attributes['ignoreBoundsFiltering'] = true
       }
 
       return {
@@ -67,6 +123,35 @@
 
     maestro.getContentDescription = () => {
         return traverse(document.body)
+    }
+
+    maestro.tapOnSyntheticElement = (x, y) => {
+        // This function is used to tap on synthetic elements like <option> that do not have a visual representation.
+        // It will return the bounds of the synthetic element in a special coordinate space.
+
+        const syntheticElements = Array.from(document.querySelectorAll('option'));
+        if (syntheticElements.length === 0) {
+            throw new Error('No synthetic elements found');
+        }
+
+        for (const option of syntheticElements) {
+            const bounds = getSyntheticNodeBounds(option);
+            const [left, top] = bounds.match(/\d+/g).map(Number);
+            const [right, bottom] = bounds.match(/\d+/g).slice(2).map(Number);
+
+            if (x >= left && x <= right && y >= top && y <= bottom) {
+                const select = option.parentElement;
+                option.selected = true;
+
+                // Without this, browser will not update the select element's value.
+                select.dispatchEvent(new Event("change", { bubbles: true }));
+
+                // This is needed to hide the <select> dropdown after selection.
+                select.blur();
+
+                return;
+            }
+        }
     }
 
     // https://stackoverflow.com/a/5178132


### PR DESCRIPTION
`<select>` tags are handled differently than every other DOM element. For one - options are not rendered as part of the DOM but rather by the browser itself, so we do not get any `bounds` back.

<img width="333" alt="image" src="https://github.com/user-attachments/assets/5cd9e43c-5996-4135-8227-3d4710f8e0cf" />

To work around that, we pretend that there are visible `option` elements on the screen, just very far away (in what I call a "synthethic coordinate space"). If such element is clicked, we detect it and handle tap ourselves (without Selenium). That allows to keep the rest of the Maestro implementation untouched.

