### PR TITLE
Allow forwarding to fail to allow studio and flow to be active at the same time

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -148,10 +148,14 @@ class AndroidDriver(
     private fun allocateForwarder() {
         portForwarder?.close()
 
-        portForwarder = dadb.tcpForward(
-            hostPort,
-            hostPort
-        )
+        try {
+            portForwarder = dadb.tcpForward(
+                hostPort,
+                hostPort
+            )
+        } catch (e: Throwable) {
+            LOGGER.warn("Unable to forward $hostPort, assume another instance of maestro is active")
+        }
     }
 
     private fun awaitLaunch() {


### PR DESCRIPTION
This is a bit of a workaround, both studio and flow forwards the driver-host-port (default 7001) for the android driver session.  The forwarding fails for the second instance as the port is already open. But it doesn't really matter which driver-host is used, so let forwarding silently fail and let the android driver session continue.

## Proposed changes

copilot:summary

## Testing

Launched maestro studio and while it was still running, launched a test flow with maestro test.
Also ran integration and unit tests.

## Issues fixed

Fixes #2188