### PR TITLE
Unify api key calls

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
+++ b/maestro-cli/src/main/java/maestro/cli/auth/Auth.kt
@@ -1,31 +1,21 @@
 package maestro.cli.auth
 
-import io.ktor.http.ContentType
-import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
-import io.ktor.server.response.respondText
-import io.ktor.server.routing.get
-import io.ktor.server.routing.routing
-import java.awt.Desktop
-import java.net.URI
-import java.nio.file.Paths
-import kotlin.io.path.createDirectories
-import kotlin.io.path.deleteIfExists
-import kotlin.io.path.exists
-import kotlin.io.path.isDirectory
-import kotlin.io.path.readText
-import kotlin.io.path.writeText
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
+import maestro.auth.ApiKey
 import maestro.cli.api.ApiClient
 import maestro.cli.util.PrintUtils.err
 import maestro.cli.util.PrintUtils.info
-import maestro.cli.util.PrintUtils.message
 import maestro.cli.util.PrintUtils.success
 import maestro.cli.util.getFreePort
-import maestro.cli.util.EnvUtils
+import java.awt.Desktop
+import java.net.URI
 
 private const val SUCCESS_HTML = """
     <!DOCTYPE html>
@@ -76,28 +66,13 @@ class Auth(
     fun getAuthToken(apiKey: String?, triggerSignIn: Boolean = true): String? {
         if (triggerSignIn) {
             return apiKey // Check for API key
-                ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
-                ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
+                ?: ApiKey.getToken()
                 ?: triggerSignInFlow() // Otherwise, trigger the sign-in flow
         }
         return apiKey // Check for API key
-            ?: getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
-            ?: EnvUtils.maestroCloudApiKey() // Resolve API key from shell if set
+            ?: ApiKey.getToken()
     }
 
-    fun getCachedAuthToken(): String? {
-        if (!cachedAuthTokenFile.exists()) return null
-        if (cachedAuthTokenFile.isDirectory()) return null
-        val cachedAuthToken = cachedAuthTokenFile.readText()
-        return cachedAuthToken
-//        return if (apiClient.isAuthTokenValid(cachedAuthToken)) {
-//            cachedAuthToken
-//        } else {
-//            message("Existing Authentication token is invalid or expired")
-//            cachedAuthTokenFile.deleteIfExists()
-//            null
-//        }
-    }
 
     fun triggerSignInFlow(): String {
         val deferredToken = CompletableDeferred<String>()
@@ -125,7 +100,7 @@ class Auth(
             deferredToken.await()
         }
         server.stop(0, 0)
-        setCachedAuthToken(token)
+        ApiKey.setToken(token)
         success("Authentication completed.")
         return token
     }
@@ -142,27 +117,6 @@ class Auth(
 
         call.respondText(SUCCESS_HTML, ContentType.Text.Html)
         deferredToken.complete(newApiKey)
-    }
-
-    private fun setCachedAuthToken(token: String?) {
-        cachedAuthTokenFile.parent.createDirectories()
-        if (token == null) {
-            cachedAuthTokenFile.deleteIfExists()
-        } else {
-            cachedAuthTokenFile.writeText(token)
-        }
-    }
-
-    companion object {
-
-        private val cachedAuthTokenFile by lazy {
-            Paths.get(
-                System.getProperty("user.home"),
-                ".mobiledev",
-                "authtoken"
-            )
-        }
-
     }
 
 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheatSheetTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheatSheetTool.kt
@@ -3,6 +3,7 @@ package maestro.cli.mcp.tools
 import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
+import maestro.auth.ApiKey
 import maestro.utils.HttpClient
 import okhttp3.Request
 import kotlin.time.Duration.Companion.minutes
@@ -21,10 +22,10 @@ object CheatSheetTool {
             )
         ) { _ ->
             try {
-                val apiKey = System.getenv("MAESTRO_API_KEY")
+                val apiKey = ApiKey.getToken()
                 if (apiKey.isNullOrBlank()) {
                     return@RegisteredTool CallToolResult(
-                        content = listOf(TextContent("MAESTRO_API_KEY environment variable is required")),
+                        content = listOf(TextContent("MAESTRO_CLOUD_API_KEY environment variable is required")),
                         isError = true
                     )
                 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/QueryDocsTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/QueryDocsTool.kt
@@ -3,6 +3,7 @@ package maestro.cli.mcp.tools
 import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
+import maestro.auth.ApiKey
 import maestro.utils.HttpClient
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
@@ -37,10 +38,10 @@ object QueryDocsTool {
                     )
                 }
                 
-                val apiKey = System.getenv("MAESTRO_API_KEY")
+                val apiKey = ApiKey.getToken()
                 if (apiKey.isNullOrBlank()) {
                     return@RegisteredTool CallToolResult(
-                        content = listOf(TextContent("MAESTRO_API_KEY environment variable is required")),
+                        content = listOf(TextContent("MAESTRO_CLOUD_API_KEY environment variable is required")),
                         isError = true
                     )
                 }

--- a/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/EnvUtils.kt
@@ -48,10 +48,6 @@ object EnvUtils {
         return Paths.get(System.getProperty("user.home"), ".maestro")
     }
 
-    fun maestroCloudApiKey(): String? {
-        return System.getenv("MAESTRO_CLOUD_API_KEY")
-    }
-
     /**
      * @return true, if we're executing from Windows Linux shell (WSL)
      */

--- a/maestro-client/src/main/java/maestro/auth/ApiKey.kt
+++ b/maestro-client/src/main/java/maestro/auth/ApiKey.kt
@@ -1,0 +1,44 @@
+package maestro.auth
+
+import java.nio.file.Paths
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.exists
+import kotlin.io.path.isDirectory
+import kotlin.io.path.readText
+
+class ApiKey {
+    companion object {
+        private val cachedAuthTokenFile by lazy {
+            Paths.get(
+                System.getProperty("user.home"),
+                ".mobiledev",
+                "authtoken"
+            )
+        }
+
+        private fun maestroCloudApiKey(): String? {
+            return System.getenv("MAESTRO_CLOUD_API_KEY")
+        }
+
+        private fun getCachedAuthToken(): String? {
+            if (!cachedAuthTokenFile.exists()) return null
+            if (cachedAuthTokenFile.isDirectory()) return null
+            val cachedAuthToken = cachedAuthTokenFile.readText()
+            return cachedAuthToken
+        }
+
+        fun getToken(): String? {
+            return maestroCloudApiKey() ?: // Resolve API key from shell if set
+            getCachedAuthToken() // Otherwise, if the user has already logged in, use the cached auth token
+        }
+
+        fun setToken(token: String?) {
+            cachedAuthTokenFile.parent.toFile().mkdirs()
+            if (token == null) {
+                cachedAuthTokenFile.deleteIfExists()
+                return
+            }
+            cachedAuthTokenFile.toFile().writeText(token)
+        }
+    }
+}

--- a/maestro-client/src/main/java/maestro/mockserver/MockInteractor.kt
+++ b/maestro-client/src/main/java/maestro/mockserver/MockInteractor.kt
@@ -2,16 +2,12 @@ package maestro.mockserver
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import maestro.auth.ApiKey
 import maestro.utils.HttpClient
 import okhttp3.Protocol
 import okhttp3.Request
 import java.nio.file.Paths
-import java.util.UUID
-import java.util.concurrent.TimeUnit
-import kotlin.io.path.exists
-import kotlin.io.path.isDirectory
-import kotlin.io.path.readText
-import kotlin.math.max
+import java.util.*
 import kotlin.time.Duration.Companion.minutes
 
 data class Auth(
@@ -47,15 +43,8 @@ class MockInteractor {
         protocols = listOf(Protocol.HTTP_1_1)
     )
 
-    fun getCachedAuthToken(): String? {
-        if (!System.getProperty("MAESTRO_CLOUD_API_KEY").isNullOrEmpty()) return System.getProperty("MAESTRO_CLOUD_API_KEY")
-        if (!cachedAuthTokenFile.exists()) return null
-        if (cachedAuthTokenFile.isDirectory()) return null
-        return cachedAuthTokenFile.readText()
-    }
-
     fun getProjectId(): UUID? {
-        val authToken = getCachedAuthToken() ?: return null
+        val authToken = ApiKey.getToken()
 
         val request = try {
             Request.Builder()
@@ -86,7 +75,7 @@ class MockInteractor {
     }
 
     fun getMockEvents(): List<MockEvent> {
-        val authToken = getCachedAuthToken()
+        val authToken = ApiKey.getToken()
 
         val request = try {
             Request.Builder()

--- a/maestro-studio/server/src/main/java/maestro/studio/AuthService.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/AuthService.kt
@@ -5,6 +5,7 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import maestro.auth.ApiKey
 import java.io.IOException
 import java.nio.file.Paths
 import kotlin.io.path.createDirectories
@@ -25,12 +26,11 @@ data class AuthResponse(
 object AuthService {
 
     private val mobileDevDir = Paths.get(System.getProperty("user.home"), ".mobiledev")
-    private val authTokenFile = mobileDevDir.resolve("authtoken")
     private val openAiTokenFile = mobileDevDir.resolve("openaitoken")
 
     fun routes(routing: Routing) {
         routing.get("/api/auth-token") {
-            val authToken = getAuthToken()
+            val authToken = ApiKey.getToken()
             if (authToken == null) {
                 call.respond(HttpStatusCode.NotFound, "No auth token found")
             } else {
@@ -38,7 +38,7 @@ object AuthService {
             }
         }
         routing.get("/api/auth") {
-            val authToken = getAuthToken()
+            val authToken = ApiKey.getToken()
             val openAiToken = getOpenAiToken()
             val response = AuthResponse(authToken, openAiToken)
             val responseString = jacksonObjectMapper().writeValueAsString(response)
@@ -61,12 +61,6 @@ object AuthService {
                 call.respond(HttpStatusCode.BadRequest, "Failed to delete OpenAI token: ${e.message}")
             }
         }
-    }
-
-    private fun getAuthToken(): String? {
-        System.getProperty("MAESTRO_CLOUD_API_KEY")?.let { if (it.isNotEmpty()) return it }
-        if (!authTokenFile.isRegularFile()) return null
-        return authTokenFile.readText()
     }
 
     private fun getOpenAiToken(): String? {


### PR DESCRIPTION
api keys are supported via an env var or a file cached in disk. This unifies that whole thing in one place