### PR TITLE
save anonymous analytics to posthog.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ micrometerCore = "1.13.4"
 mockk = "1.12.0"
 mozillaRhino = "1.7.14"
 picocli = "4.6.3"
+posthog = "1.2.0"
 selenium = "4.26.0"
 selenium-devtools = "4.26.0"
 skiko = "0.8.18"
@@ -118,6 +119,7 @@ mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mozilla-rhino = { module = "org.mozilla:rhino", version.ref = "mozillaRhino" }
 picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
 picocli-codegen = { module = "info.picocli:picocli-codegen", version.ref = "picocli" }
+posthog = { module = "com.posthog.java:posthog", version.ref = "posthog" }
 selenium = { module = "org.seleniumhq.selenium:selenium-java", version.ref = "selenium" }
 selenium-devtools = { module = "org.seleniumhq.selenium:selenium-devtools-v130", version.ref = "selenium-devtools" }
 skiko-macos-arm64 = { module = "org.jetbrains.skiko:skiko-awt-runtime-macos-arm64", version.ref = "skiko" }

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(project(":maestro-ios"))
     implementation(project(":maestro-ios-driver"))
     implementation(project(":maestro-studio:server"))
+    implementation(libs.posthog)
     implementation(libs.dadb)
     implementation(libs.picocli)
     implementation(libs.jackson.core.databind)

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -9,7 +9,6 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import maestro.cli.CliError
 import maestro.cli.analytics.Analytics
-import maestro.cli.analytics.AnalyticsReport
 import maestro.cli.insights.AnalysisDebugFiles
 import maestro.cli.model.FlowStatus
 import maestro.cli.runner.resultview.AnsiResultView
@@ -78,13 +77,6 @@ class ApiClient(
             body = mapOf(
                 "maxDepth" to maxDepth
             )
-        )
-    }
-
-    fun sendAnalyticsReport(analyticsReport: AnalyticsReport) {
-        post<Unit>(
-            path = "/maestro/analytics",
-            body = analyticsReport,
         )
     }
 


### PR DESCRIPTION
users can now opt-out any time by setting the `MAESTRO_CLI_NO_ANALYTICS` env variable (works on CI and local devices)
