### PR TITLE
DriverBuilder: make the xcodebuild timeout configurable

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
+++ b/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
 
 class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderFactory = XcodeBuildProcessBuilderFactory()) {
-    private const val DEFAULT_XCODEBUILD_WAIT_TIME: Long = 120
     private val XCODEBUILD_WAIT_TIME: Long by lazy {
         System.getenv("XCODEBUILD_WAIT_TIME")?.toLongOrNull() ?: DEFAULT_XCODEBUILD_WAIT_TIME
     }
@@ -125,5 +124,9 @@ class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderF
             Paths.get(uri)
         }
         return path
+    }
+
+    companion object {
+        private const val DEFAULT_XCODEBUILD_WAIT_TIME: Long = 120
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
+++ b/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
 
 class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderFactory = XcodeBuildProcessBuilderFactory()) {
-    private val XCODEBUILD_WAIT_TIME: Long by lazy {
+    private val waitTime: Long by lazy {
         System.getenv("MAESTRO_XCODEBUILD_WAIT_TIME")?.toLongOrNull() ?: DEFAULT_XCODEBUILD_WAIT_TIME
     }
 
@@ -78,7 +78,7 @@ class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderF
                 ), workingDirectory = workingDirectory.toFile(), outputFile = outputFile
             )
 
-            process.waitFor(XCODEBUILD_WAIT_TIME, TimeUnit.SECONDS)
+            process.waitFor(waitTime, TimeUnit.SECONDS)
 
             if (process.exitValue() != 0) {
                 // copy the error log inside driver output

--- a/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
+++ b/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
@@ -9,7 +9,7 @@ import kotlin.io.path.pathString
 
 class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderFactory = XcodeBuildProcessBuilderFactory()) {
     private val XCODEBUILD_WAIT_TIME: Long by lazy {
-        System.getenv("XCODEBUILD_WAIT_TIME")?.toLongOrNull() ?: DEFAULT_XCODEBUILD_WAIT_TIME
+        System.getenv("MAESTRO_XCODEBUILD_WAIT_TIME")?.toLongOrNull() ?: DEFAULT_XCODEBUILD_WAIT_TIME
     }
 
     /**

--- a/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
+++ b/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
@@ -8,6 +8,8 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
 
 class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderFactory = XcodeBuildProcessBuilderFactory()) {
+    private const val DEFAULT_XCODEBUILD_WAIT_TIME: Int = 120
+    private val XCODEBUILD_WAIT_TIME: Int = System.getenv("XCODEBUILD_WAIT_TIME")?.toIntOrNull() ?: DEFAULT_XCODEBUILD_WAIT_TIME
 
     /**
      * Builds the iOS driver for real iOS devices by extracting the driver source, copying it to a temporary build
@@ -75,7 +77,7 @@ class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderF
                 ), workingDirectory = workingDirectory.toFile(), outputFile = outputFile
             )
 
-            process.waitFor(120, TimeUnit.SECONDS)
+            process.waitFor(XCODEBUILD_WAIT_TIME, TimeUnit.SECONDS)
 
             if (process.exitValue() != 0) {
                 // copy the error log inside driver output

--- a/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
+++ b/maestro-cli/src/main/java/maestro/cli/driver/DriverBuilder.kt
@@ -8,8 +8,10 @@ import java.util.concurrent.TimeUnit
 import kotlin.io.path.pathString
 
 class DriverBuilder(private val processBuilderFactory: XcodeBuildProcessBuilderFactory = XcodeBuildProcessBuilderFactory()) {
-    private const val DEFAULT_XCODEBUILD_WAIT_TIME: Int = 120
-    private val XCODEBUILD_WAIT_TIME: Int = System.getenv("XCODEBUILD_WAIT_TIME")?.toIntOrNull() ?: DEFAULT_XCODEBUILD_WAIT_TIME
+    private const val DEFAULT_XCODEBUILD_WAIT_TIME: Long = 120
+    private val XCODEBUILD_WAIT_TIME: Long by lazy {
+        System.getenv("XCODEBUILD_WAIT_TIME")?.toLongOrNull() ?: DEFAULT_XCODEBUILD_WAIT_TIME
+    }
 
     /**
      * Builds the iOS driver for real iOS devices by extracting the driver source, copying it to a temporary build


### PR DESCRIPTION
## Proposed changes

Instead of the hardocded `process.waitFor(120, TimeUnit.SECONDS)` we propose a way to set this with an environment variable (`MAESTRO_XCODEBUILD_WAIT_TIME`), which could help on slower host machines.

