### PR TITLE
fix: cloud interactor for new status - PREPARING & INSTALLING

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -38,6 +38,7 @@ import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.absolute
+import kotlinx.html.PRE
 
 class CloudInteractor(
     private val client: ApiClient,
@@ -290,6 +291,12 @@ class CloudInteractor(
                     FlowStatus.PENDING -> { /* do nothing */
                     }
 
+                    FlowStatus.PREPARING -> { /* do nothing */
+                    }
+
+                    FlowStatus.INSTALLING -> { /* do nothing */
+                    }
+
                     FlowStatus.RUNNING -> {
                         if (runningFlow.startTime == null) {
                             runningFlow.startTime = System.currentTimeMillis()
@@ -364,6 +371,12 @@ class CloudInteractor(
         testSuiteName: String?,
         uploadUrl: String,
     ): Int {
+
+        PrintUtils.message("✅ Upload completed!")
+        PrintUtils.message("View the results of your upload below:")
+        PrintUtils.message(uploadUrl)
+        PrintUtils.message("App id: $appId")
+        
         TestSuiteStatusView.showSuiteResult(
             upload.toViewModel(
                 TestSuiteStatusView.TestSuiteViewModel.UploadDetails(

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -38,7 +38,6 @@ import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.absolute
-import kotlinx.html.PRE
 
 class CloudInteractor(
     private val client: ApiClient,
@@ -371,12 +370,6 @@ class CloudInteractor(
         testSuiteName: String?,
         uploadUrl: String,
     ): Int {
-
-        PrintUtils.message("✅ Upload completed!")
-        PrintUtils.message("View the results of your upload below:")
-        PrintUtils.message(uploadUrl)
-        PrintUtils.message("App id: $appId")
-        
         TestSuiteStatusView.showSuiteResult(
             upload.toViewModel(
                 TestSuiteStatusView.TestSuiteViewModel.UploadDetails(


### PR DESCRIPTION
With the last release of Maestro Studio we released the PREPARING and INSTALLING status of flow to maestro, but missed the do nothing part for these status in output. So when run change status from PENDING to PREPARING, results are shown, which shouldn't be the case.

Added do nothing condition for these status as well.