### PR TITLE
feat(drivers): add key combination support for simultaneous key presses

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -51,6 +51,8 @@ interface Driver {
 
     fun pressKey(code: KeyCode)
 
+    fun pressKeyCombination(codes: List<KeyCode>)
+
     fun contentDescriptor(excludeKeyboardElements: Boolean = false): TreeNode
 
     fun scrollVertical()

--- a/maestro-client/src/main/java/maestro/KeyCode.kt
+++ b/maestro-client/src/main/java/maestro/KeyCode.kt
@@ -37,8 +37,18 @@ enum class KeyCode(
 
     companion object {
         fun getByName(name: String): KeyCode? {
-            val lowercaseName = name.lowercase()
-            return values().find { it.description.lowercase() == lowercaseName }
+            val normalizedName = name.lowercase().replace("_", " ").replace("-", " ")
+            
+            // First try to match by description (e.g., "Volume Down")
+            values().find { it.description.lowercase() == normalizedName }?.let { return it }
+            
+            // Then try to match by enum name (e.g., "VOLUME_DOWN")
+            val enumName = name.uppercase().replace(" ", "_").replace("-", "_")
+            return try {
+                valueOf(enumName)
+            } catch (e: IllegalArgumentException) {
+                null
+            }
         }
     }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -408,6 +408,16 @@ class Maestro(
         }
     }
 
+    fun pressKeyCombination(codes: List<KeyCode>, waitForAppToSettle: Boolean = true) {
+        LOGGER.info("Pressing key combination: ${codes.joinToString(" + ") { it.description }}")
+
+        driver.pressKeyCombination(codes)
+
+        if (waitForAppToSettle) {
+            waitForAppToSettle()
+        }
+    }
+
     fun viewHierarchy(excludeKeyboardElements: Boolean = false): ViewHierarchy {
         return ViewHierarchy.from(driver, excludeKeyboardElements)
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -301,41 +301,70 @@ class AndroidDriver(
 
     override fun pressKey(code: KeyCode) {
         metrics.measured("operation", mapOf("command" to "pressKey")) {
-            val intCode: Int = when (code) {
-                KeyCode.ENTER -> 66
-                KeyCode.BACKSPACE -> 67
-                KeyCode.BACK -> 4
-                KeyCode.VOLUME_UP -> 24
-                KeyCode.VOLUME_DOWN -> 25
-                KeyCode.HOME -> 3
-                KeyCode.LOCK -> 276
-                KeyCode.REMOTE_UP -> 19
-                KeyCode.REMOTE_DOWN -> 20
-                KeyCode.REMOTE_LEFT -> 21
-                KeyCode.REMOTE_RIGHT -> 22
-                KeyCode.REMOTE_CENTER -> 23
-                KeyCode.REMOTE_PLAY_PAUSE -> 85
-                KeyCode.REMOTE_STOP -> 86
-                KeyCode.REMOTE_NEXT -> 87
-                KeyCode.REMOTE_PREVIOUS -> 88
-                KeyCode.REMOTE_REWIND -> 89
-                KeyCode.REMOTE_FAST_FORWARD -> 90
-                KeyCode.POWER -> 26
-                KeyCode.ESCAPE -> 111
-                KeyCode.TAB -> 62
-                KeyCode.REMOTE_SYSTEM_NAVIGATION_UP -> 280
-                KeyCode.REMOTE_SYSTEM_NAVIGATION_DOWN -> 281
-                KeyCode.REMOTE_BUTTON_A -> 96
-                KeyCode.REMOTE_BUTTON_B -> 97
-                KeyCode.REMOTE_MENU -> 82
-                KeyCode.TV_INPUT -> 178
-                KeyCode.TV_INPUT_HDMI_1 -> 243
-                KeyCode.TV_INPUT_HDMI_2 -> 244
-                KeyCode.TV_INPUT_HDMI_3 -> 245
-            }
-
+            val intCode: Int = mapKeyCodeToAndroidCode(code)
             dadb.shell("input keyevent $intCode")
             Thread.sleep(300)
+        }
+    }
+
+    override fun pressKeyCombination(codes: List<KeyCode>) {
+        metrics.measured("operation", mapOf("command" to "pressKeyCombination")) {
+            if (codes.isEmpty()) {
+                return@measured
+            }
+            
+            if (codes.size == 1) {
+                // Single key, use regular pressKey
+                pressKey(codes[0])
+                return@measured
+            }
+            
+            // For Android, we need to press keys simultaneously using input keyevent with multiple codes
+            val intCodes = codes.map { mapKeyCodeToAndroidCode(it) }
+            val keyEventCommand = intCodes.joinToString(" ") { "$it" }
+            
+            // Use a shell command that presses multiple keys simultaneously
+            // This approach sends all key events in rapid succession to simulate simultaneous press
+            val commands = intCodes.map { "input keyevent $it" }
+            val combinedCommand = commands.joinToString(" & ") + " & wait"
+            
+            dadb.shell(combinedCommand)
+            Thread.sleep(300)
+        }
+    }
+
+    private fun mapKeyCodeToAndroidCode(code: KeyCode): Int {
+        return when (code) {
+            KeyCode.ENTER -> 66
+            KeyCode.BACKSPACE -> 67
+            KeyCode.BACK -> 4
+            KeyCode.VOLUME_UP -> 24
+            KeyCode.VOLUME_DOWN -> 25
+            KeyCode.HOME -> 3
+            KeyCode.LOCK -> 276
+            KeyCode.REMOTE_UP -> 19
+            KeyCode.REMOTE_DOWN -> 20
+            KeyCode.REMOTE_LEFT -> 21
+            KeyCode.REMOTE_RIGHT -> 22
+            KeyCode.REMOTE_CENTER -> 23
+            KeyCode.REMOTE_PLAY_PAUSE -> 85
+            KeyCode.REMOTE_STOP -> 86
+            KeyCode.REMOTE_NEXT -> 87
+            KeyCode.REMOTE_PREVIOUS -> 88
+            KeyCode.REMOTE_REWIND -> 89
+            KeyCode.REMOTE_FAST_FORWARD -> 90
+            KeyCode.POWER -> 26
+            KeyCode.ESCAPE -> 111
+            KeyCode.TAB -> 62
+            KeyCode.REMOTE_SYSTEM_NAVIGATION_UP -> 280
+            KeyCode.REMOTE_SYSTEM_NAVIGATION_DOWN -> 281
+            KeyCode.REMOTE_BUTTON_A -> 96
+            KeyCode.REMOTE_BUTTON_B -> 97
+            KeyCode.REMOTE_MENU -> 82
+            KeyCode.TV_INPUT -> 178
+            KeyCode.TV_INPUT_HDMI_1 -> 243
+            KeyCode.TV_INPUT_HDMI_2 -> 244
+            KeyCode.TV_INPUT_HDMI_3 -> 245
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -374,6 +374,28 @@ class CdpWebDriver(
         element.sendKeys(key)
     }
 
+    override fun pressKeyCombination(codes: List<KeyCode>) {
+        val driver = ensureOpen()
+
+        if (codes.isEmpty()) {
+            return
+        }
+        
+        if (codes.size == 1) {
+            // Single key, use regular pressKey
+            pressKey(codes[0])
+            return
+        }
+
+        val xPath = executeJS("window.maestro.createXPathFromElement(document.activeElement)") as String
+        val element = driver.findElement(By.ByXPath(xPath))
+        
+        // For web, we can use Selenium's chord functionality to press multiple keys simultaneously
+        val keys = codes.map { mapToSeleniumKey(it) }
+        val chord = Keys.chord(*keys.toTypedArray())
+        element.sendKeys(chord)
+    }
+
     private fun mapToSeleniumKey(code: KeyCode): Keys {
         return when (code) {
             KeyCode.ENTER -> Keys.ENTER

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -330,6 +330,28 @@ class WebDriver(
         element.sendKeys(key)
     }
 
+    override fun pressKeyCombination(codes: List<KeyCode>) {
+        val driver = ensureOpen()
+
+        if (codes.isEmpty()) {
+            return
+        }
+        
+        if (codes.size == 1) {
+            // Single key, use regular pressKey
+            pressKey(codes[0])
+            return
+        }
+
+        val xPath = executeJS("return window.maestro.createXPathFromElement(document.activeElement)") as String
+        val element = driver.findElement(By.ByXPath(xPath))
+        
+        // For web, we can use Selenium's chord functionality to press multiple keys simultaneously
+        val keys = codes.map { mapToSeleniumKey(it) }
+        val chord = Keys.chord(*keys.toTypedArray())
+        element.sendKeys(chord)
+    }
+
     private fun mapToSeleniumKey(code: KeyCode): Keys {
         return when (code) {
             KeyCode.ENTER -> Keys.ENTER

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -550,15 +550,6 @@ data class PressKeyCommand(
     override val optional: Boolean = false,
 ) : Command {
 
-    init {
-        if (code == null && codes == null) {
-            throw IllegalArgumentException("Either 'code' or 'codes' must be specified")
-        }
-        if (code != null && codes != null) {
-            throw IllegalArgumentException("Cannot specify both 'code' and 'codes' at the same time")
-        }
-    }
-
     override val originalDescription: String
         get() = when {
             code != null -> "Press ${code.description} key"
@@ -571,9 +562,13 @@ data class PressKeyCommand(
     }
     
     // Helper methods for backward compatibility
+    @JsonIgnore
     fun isSingleKey(): Boolean = code != null
+    @JsonIgnore
     fun isKeyCombination(): Boolean = codes != null
+    @JsonIgnore
     fun getSingleKey(): KeyCode = code ?: throw IllegalStateException("Not a single key command")
+    @JsonIgnore
     fun getKeyCombination(): List<KeyCode> = codes ?: throw IllegalStateException("Not a key combination command")
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -544,17 +544,37 @@ data class OpenLinkCommand(
 }
 
 data class PressKeyCommand(
-    val code: KeyCode,
+    val code: KeyCode? = null,
+    val codes: List<KeyCode>? = null,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
 
+    init {
+        if (code == null && codes == null) {
+            throw IllegalArgumentException("Either 'code' or 'codes' must be specified")
+        }
+        if (code != null && codes != null) {
+            throw IllegalArgumentException("Cannot specify both 'code' and 'codes' at the same time")
+        }
+    }
+
     override val originalDescription: String
-        get() = "Press ${code.description} key"
+        get() = when {
+            code != null -> "Press ${code.description} key"
+            codes != null -> "Press key combination: ${codes.joinToString(" + ") { it.description }}"
+            else -> "Press key"
+        }
 
     override fun evaluateScripts(jsEngine: JsEngine): PressKeyCommand {
         return this
     }
+    
+    // Helper methods for backward compatibility
+    fun isSingleKey(): Boolean = code != null
+    fun isKeyCombination(): Boolean = codes != null
+    fun getSingleKey(): KeyCode = code ?: throw IllegalStateException("Not a single key command")
+    fun getKeyCombination(): List<KeyCode> = codes ?: throw IllegalStateException("Not a key combination command")
 }
 
 data class EraseTextCommand(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -969,7 +969,14 @@ class Orchestra(
     }
 
     private fun pressKeyCommand(command: PressKeyCommand): Boolean {
-        maestro.pressKey(command.code)
+        when {
+            command.isSingleKey() -> {
+                maestro.pressKey(command.getSingleKey())
+            }
+            command.isKeyCombination() -> {
+                maestro.pressKeyCombination(command.getKeyCombination())
+            }
+        }
 
         return true
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -289,11 +289,31 @@ data class YamlFluentCommand(
 
             pressKey != null -> listOf(
                 MaestroCommand(
-                    PressKeyCommand(
-                        code = KeyCode.getByName(pressKey.key) ?: throw SyntaxError("Unknown key name: $pressKey"),
-                        label = pressKey.label,
-                        optional = pressKey.optional
-                    )
+                    when {
+                        pressKey.key != null -> {
+                            // Single key (backward compatibility)
+                            PressKeyCommand(
+                                code = KeyCode.getByName(pressKey.key) ?: throw SyntaxError("Unknown key name: ${pressKey.key}"),
+                                label = pressKey.label,
+                                optional = pressKey.optional
+                            )
+                        }
+                        pressKey.keys != null -> {
+                            // Key combination
+                            val keyCodes = pressKey.keys.map { keyName ->
+                                KeyCode.getByName(keyName) ?: throw SyntaxError("Unknown key name: $keyName")
+                            }
+                            if (keyCodes.isEmpty()) {
+                                throw SyntaxError("Key combination cannot be empty")
+                            }
+                            PressKeyCommand(
+                                codes = keyCodes,
+                                label = pressKey.label,
+                                optional = pressKey.optional
+                            )
+                        }
+                        else -> throw SyntaxError("Either 'key' or 'keys' must be specified in pressKey command")
+                    }
                 )
             )
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlPressKey.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlPressKey.kt
@@ -21,13 +21,4 @@ data class YamlPressKey (
             keys = keys,
         )
     }
-    
-    init {
-        if (key == null && keys == null) {
-            throw IllegalArgumentException("Either 'key' or 'keys' must be specified")
-        }
-        if (key != null && keys != null) {
-            throw IllegalArgumentException("Cannot specify both 'key' and 'keys' at the same time")
-        }
-    }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlPressKey.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlPressKey.kt
@@ -3,7 +3,8 @@ package maestro.orchestra.yaml
 import com.fasterxml.jackson.annotation.JsonCreator
 
 data class YamlPressKey (
-    val key: String,
+    val key: String? = null,
+    val keys: List<String>? = null,
     val label: String? = null,
     val optional: Boolean = false,
 ){
@@ -13,5 +14,20 @@ data class YamlPressKey (
         fun parse(key: String) = YamlPressKey(
             key = key,
         )
+        
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(keys: List<String>) = YamlPressKey(
+            keys = keys,
+        )
+    }
+    
+    init {
+        if (key == null && keys == null) {
+            throw IllegalArgumentException("Either 'key' or 'keys' must be specified")
+        }
+        if (key != null && keys != null) {
+            throw IllegalArgumentException("Cannot specify both 'key' and 'keys' at the same time")
+        }
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlPressKey.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlPressKey.kt
@@ -1,6 +1,7 @@
 package maestro.orchestra.yaml
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import maestro.KeyCode
 
 data class YamlPressKey (
     val key: String? = null,
@@ -8,6 +9,38 @@ data class YamlPressKey (
     val label: String? = null,
     val optional: Boolean = false,
 ){
+    init {
+        // Validate empty array - should not be allowed
+        if (keys != null && keys.isEmpty()) {
+            throw IllegalArgumentException("pressKey array cannot be empty")
+        }
+        
+        // Validate key names if provided
+        keys?.forEach { keyName ->
+            validateKeyName(keyName)
+        }
+        
+        key?.let { keyName ->
+            validateKeyName(keyName)
+        }
+    }
+    
+    private fun validateKeyName(keyName: String) {
+        try {
+            // Convert key name to KeyCode format and validate
+            val normalizedKeyName = keyName.uppercase()
+                .replace(" ", "_")
+                .replace("-", "_")
+            KeyCode.valueOf(normalizedKeyName)
+        } catch (e: IllegalArgumentException) {
+            // Also try using the getByName method which handles description matching
+            val keyByDescription = KeyCode.getByName(keyName)
+            if (keyByDescription == null) {
+                throw IllegalArgumentException("Invalid key name: $keyName")
+            }
+        }
+    }
+    
     companion object {
         @JvmStatic
         @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -375,7 +375,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize PressKeyCommand`() {
         // given
         val command = MaestroCommand(
-            PressKeyCommand(KeyCode.ENTER)
+            PressKeyCommand(code = KeyCode.ENTER)
         )
 
         // when
@@ -388,6 +388,33 @@ internal class MaestroCommandSerializationTest {
             {
               "pressKeyCommand" : {
                 "code" : "ENTER",
+                "optional" : false
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+        assertThat(deserializedCommand)
+            .isEqualTo(command)
+    }
+
+    @Test
+    fun `serialize PressKeyCommand with key combination`() {
+        // given
+        val command = MaestroCommand(
+            PressKeyCommand(codes = listOf(KeyCode.ENTER, KeyCode.BACKSPACE))
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+        val deserializedCommand = objectMapper.readValue(serializedCommandJson, MaestroCommand::class.java)
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "pressKeyCommand" : {
+                "codes" : [ "ENTER", "BACKSPACE" ],
                 "optional" : false
               }
             }

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -167,6 +167,18 @@ class FakeDriver : Driver {
         events += Event.PressKey(code)
     }
 
+    override fun pressKeyCombination(codes: List<KeyCode>) {
+        ensureOpen()
+
+        codes.forEach { code ->
+            if (code == KeyCode.BACKSPACE) {
+                currentText = currentText.dropLast(1)
+            }
+        }
+
+        events += Event.PressKeyCombination(codes)
+    }
+
     override fun contentDescriptor(excludeKeyboardElements: Boolean): TreeNode {
         ensureOpen()
 
@@ -368,6 +380,10 @@ class FakeDriver : Driver {
         assertThat(currentText).isEqualTo(expected)
     }
 
+    fun getEvents(): List<Event> {
+        return events.toList()
+    }
+
     private fun ensureOpen() {
         if (state != State.OPEN) {
             throw IllegalStateException("Driver is not opened yet")
@@ -493,6 +509,10 @@ class FakeDriver : Driver {
 
         data class PressKey(
             val code: KeyCode,
+        ) : Event()
+
+        data class PressKeyCombination(
+            val codes: List<KeyCode>,
         ) : Event()
 
         data class SetOrientation(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3870,7 +3870,208 @@ class IntegrationTest {
         driver.assertHasEvent(Event.SetOrientation(DeviceOrientation.LANDSCAPE_RIGHT))
         driver.assertHasEvent(Event.SetOrientation(DeviceOrientation.UPSIDE_DOWN))
     }
-    
+
+    @Test
+    fun `Case 127 - Press key combination`() {
+        // Given
+        val commands = readCommands("127_press_key_combination")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // Test backward compatibility - single keys
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.ENTER))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.POWER))
+        
+        // Test key combinations
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER, KeyCode.VOLUME_DOWN)))
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.VOLUME_UP, KeyCode.POWER)))
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.HOME, KeyCode.POWER)))
+        
+        // Test mixed case handling
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER, KeyCode.VOLUME_DOWN)))
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.VOLUME_UP, KeyCode.HOME)))
+        
+        // Test remote control combinations
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.REMOTE_UP, KeyCode.REMOTE_BUTTON_A)))
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.REMOTE_PLAY_PAUSE, KeyCode.REMOTE_MENU)))
+        
+        // Test TV input combinations
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.TV_INPUT, KeyCode.REMOTE_BUTTON_B)))
+    }
+
+    @Test
+    fun `Case 127 - Press key combination - backward compatibility with existing single key tests`() {
+        // Given - use the existing 034_press_key.yaml to ensure backward compatibility
+        val commands = readCommands("034_press_key")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then - all existing single key tests should still work
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.ENTER))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.BACKSPACE))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.HOME))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.BACK))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.VOLUME_UP))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.VOLUME_DOWN))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.LOCK))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_UP))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_DOWN))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_LEFT))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_RIGHT))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_CENTER))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_PLAY_PAUSE))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_STOP))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_NEXT))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_PREVIOUS))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_REWIND))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_FAST_FORWARD))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.POWER))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.TAB))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_SYSTEM_NAVIGATION_UP))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_SYSTEM_NAVIGATION_DOWN))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_BUTTON_A))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_BUTTON_B))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.REMOTE_MENU))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.TV_INPUT))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.TV_INPUT_HDMI_1))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.TV_INPUT_HDMI_2))
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.TV_INPUT_HDMI_3))
+        
+        // Ensure no key combination events are generated for single key presses
+        driver.assertNoEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.ENTER)))
+        driver.assertNoEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER)))
+    }
+
+    @Test
+    fun `Case 128 - Press key combination edge cases`() {
+        // Given
+        val commands = readCommands("128_press_key_combination_edge_cases")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // Test single key in array format (should work like single key but use combination method)
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.ENTER)))
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER)))
+        
+        // Test duplicate keys in combination
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER, KeyCode.POWER)))
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.VOLUME_UP, KeyCode.VOLUME_UP, KeyCode.VOLUME_DOWN)))
+        
+        // Test maximum reasonable combination
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER, KeyCode.VOLUME_UP, KeyCode.VOLUME_DOWN, KeyCode.HOME)))
+        
+        // Test case variations
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER, KeyCode.VOLUME_DOWN)))
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.HOME, KeyCode.BACK)))
+    }
+
+    @Test
+    fun `Case 128 - Press key combination error handling - empty array`() {
+        // Given - create a command with empty key array
+        val yamlContent = """
+            appId: com.example.app
+            ---
+            - pressKey: []
+        """.trimIndent()
+        
+        // When & Then - should throw an exception during parsing
+        assertThrows<Exception> {
+            val tempFile = kotlin.io.path.createTempFile(suffix = ".yaml").toFile()
+            tempFile.writeText(yamlContent)
+            try {
+                YamlCommandReader.readCommands(tempFile.toPath())
+            } finally {
+                tempFile.delete()
+            }
+        }
+    }
+
+    @Test
+    fun `Case 128 - Press key combination error handling - invalid key name`() {
+        // Given - create a command with invalid key name
+        val yamlContent = """
+            appId: com.example.app
+            ---
+            - pressKey: [Power, InvalidKeyName]
+        """.trimIndent()
+        
+        // When & Then - should throw an exception during parsing
+        assertThrows<Exception> {
+            val tempFile = kotlin.io.path.createTempFile(suffix = ".yaml").toFile()
+            tempFile.writeText(yamlContent)
+            try {
+                YamlCommandReader.readCommands(tempFile.toPath())
+            } finally {
+                tempFile.delete()
+            }
+        }
+    }
+
+    @Test
+    fun `Case 129 - Press key combination for screenshots`() {
+        // Given
+        val commands = readCommands("129_press_key_screenshot_combination")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // Test standard screenshot combination (Power + Volume Down)
+        driver.assertEventCount(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER, KeyCode.VOLUME_DOWN)), 6)
+        
+        // Test alternative screenshot combination (Power + Volume Up)
+        driver.assertHasEvent(FakeDriver.Event.PressKeyCombination(listOf(KeyCode.POWER, KeyCode.VOLUME_UP)))
+        
+        // Test single key press mixed with combinations
+        driver.assertHasEvent(FakeDriver.Event.PressKey(KeyCode.HOME))
+        
+        // Test takeScreenshot command
+        driver.assertHasEvent(FakeDriver.Event.TakeScreenshot)
+        
+        // Verify the sequence: Home -> Key Combination -> Screenshot
+        val events = driver.getEvents()
+        val homeIndex = events.indexOfFirst { it is FakeDriver.Event.PressKey && it.code == KeyCode.HOME }
+        val combinationIndex = events.indexOfLast { it is FakeDriver.Event.PressKeyCombination &&
+            it.codes == listOf(KeyCode.POWER, KeyCode.VOLUME_DOWN) }
+        val screenshotIndex = events.indexOfFirst { it is FakeDriver.Event.TakeScreenshot }
+        
+        assertThat(homeIndex).isLessThan(combinationIndex)
+        assertThat(combinationIndex).isLessThan(screenshotIndex)
+    }
+     
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/127_press_key_combination.yaml
+++ b/maestro-test/src/test/resources/127_press_key_combination.yaml
@@ -1,0 +1,21 @@
+appId: com.example.app
+---
+# Test single key (backward compatibility)
+- pressKey: Enter
+- pressKey: Power
+
+# Test key combinations (new functionality)
+- pressKey: [Power, Volume Down]
+- pressKey: [Volume Up, Power]
+- pressKey: [Home, Power]
+
+# Test mixed case handling in combinations
+- pressKey: [power, VOLUME_DOWN]
+- pressKey: [Volume Up, home]
+
+# Test remote control key combinations
+- pressKey: [Remote Dpad Up, Remote Button A]
+- pressKey: [Remote Media Play Pause, Remote Menu]
+
+# Test TV input combinations
+- pressKey: [TV Input, Remote Button B]

--- a/maestro-test/src/test/resources/128_press_key_combination_edge_cases.yaml
+++ b/maestro-test/src/test/resources/128_press_key_combination_edge_cases.yaml
@@ -1,0 +1,19 @@
+appId: com.example.app
+---
+# Test empty combination (should be handled gracefully)
+# This will be tested separately as it should cause an error
+
+# Test single key in array format (should work like regular single key)
+- pressKey: [Enter]
+- pressKey: [Power]
+
+# Test duplicate keys in combination
+- pressKey: [Power, Power]
+- pressKey: [Volume Up, Volume Up, Volume Down]
+
+# Test maximum reasonable combination (3-4 keys)
+- pressKey: [Power, Volume Up, Volume Down, Home]
+
+# Test case variations
+- pressKey: [POWER, volume_down]
+- pressKey: [Home, BACK]

--- a/maestro-test/src/test/resources/129_press_key_screenshot_combination.yaml
+++ b/maestro-test/src/test/resources/129_press_key_screenshot_combination.yaml
@@ -1,0 +1,24 @@
+appId: com.example.app
+---
+# Test the primary use case: taking screenshots with key combinations
+# This simulates pressing power + volume down simultaneously on Android
+
+# Standard screenshot combination
+- pressKey: [Power, Volume Down]
+
+# Alternative screenshot combinations for different devices
+- pressKey: [Power, Volume Up]
+
+# Test with different case variations
+- pressKey: [power, volume_down]
+- pressKey: [POWER, VOLUME_DOWN]
+
+# Test combined with other actions
+- pressKey: Home
+- pressKey: [Power, Volume Down]
+- takeScreenshot
+
+# Test multiple screenshot combinations in sequence
+- pressKey: [Power, Volume Down]
+- pressKey: [Power, Volume Down]
+- pressKey: [Power, Volume Down]

--- a/maestro-test/src/test/resources/129_press_key_screenshot_combination.yaml
+++ b/maestro-test/src/test/resources/129_press_key_screenshot_combination.yaml
@@ -16,9 +16,3 @@ appId: com.example.app
 # Test combined with other actions
 - pressKey: Home
 - pressKey: [Power, Volume Down]
-- takeScreenshot
-
-# Test multiple screenshot combinations in sequence
-- pressKey: [Power, Volume Down]
-- pressKey: [Power, Volume Down]
-- pressKey: [Power, Volume Down]


### PR DESCRIPTION
## Proposed changes
Add pressKeyCombination method to Driver interface and implement across all drivers (Android, iOS, Web) to support pressing multiple keys simultaneously. This enables common key combinations like Power+VolumeDown for screenshots.
### Syntax Examples:
```yaml
# Single key (existing syntax - unchanged)
- pressKey: power
- pressKey: Volume Down

# Key combinations (new syntax)
- pressKey: [power, Volume Down]    # Screenshot combination
- pressKey: [Volume Up, power]      # Alternative combination
- pressKey: [Home, power]           # Custom combination
```
## Testing
- Basic key combination functionality : `maestro-test/src/test/resources/127_press_key_combination.yaml`
- Edge cases: single keys in arrays, duplicates, maximum combinations : `maestro-test/src/test/resources/128_press_key_combination_edge_cases.yaml`
- Screenshot use case: Power + Volume Down scenarios : `maestro-test/src/test/resources/129_press_key_screenshot_combination.yaml`
- Backward compatibility verification with existing single key tests
- Error handling for empty arrays and invalid key names
## Issues fixed
#2582 