### PR TITLE
Better detection of web flows

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
@@ -36,7 +36,7 @@ object FileUtils {
         }
 
         val config = YamlCommandReader.readConfig(toPath())
-        return Regex("https?://").containsMatchIn(config.appId)
+        return config.url != null
     }
 
 }

--- a/maestro-orchestra/src/test/resources/workspaces/e018_config_missing_appId/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e018_config_missing_appId/error.txt
@@ -1,4 +1,4 @@
-> Config Field Required: appId
+> Config Field Required
 
 /tmp/WorkspaceExecutionPlannerErrorsTest_workspace/workspace/Flow.yaml:2
 ╭────────────────────────────────────────────────────────────────────────╮
@@ -6,10 +6,18 @@
 │ 2 | ---                                                                │
 │     ^                                                                  │
 │ ╭────────────────────────────────────────────────────────────────────╮ │
-│ │ The config section is missing a required field: `appId`. Eg.       │ │
+│ │ Either 'url' or 'appId' must be specified in the config section.   │ │
 │ │                                                                    │ │
+│ │ For mobile apps, use:                                              │ │
 │ │ ```yaml                                                            │ │
 │ │ appId: com.example.app                                             │ │
+│ │ ---                                                                │ │
+│ │ - launchApp                                                        │ │
+│ │ ```                                                                │ │
+│ │                                                                    │ │
+│ │ For web apps, use:                                                 │ │
+│ │ ```yaml                                                            │ │
+│ │ url: https://example.com                                           │ │
 │ │ ---                                                                │ │
 │ │ - launchApp                                                        │ │
 │ │ ```                                                                │ │


### PR DESCRIPTION
We've used a string regex in the `File.isWebFlow` method to determine if a flow is a web flow, but this fails when flows use JS expressions since it hasn't evaluated expressions yet. This has led some people to do some [wacky stuff](https://github.com/mobile-dev-inc/Maestro/issues/2383). Instead of this working:

```
url: ${APP_ID}
---
- launchApp
```

They do this:
```
# Temporary until this bug is fixed:
# https://github.com/mobile-dev-inc/Maestro/issues/2383
appId: http://localhost:4000
jsEngine: graaljs
---
- launchApp: ${APP_ID} # This works around the above issue, couldn't tell you why
```

That `appId` line is just there to let the system know it's a web flow with the presence of "https:", but that's all it does. Then when `launchApp` is called, the JS expression is evaluated and pulls in the env's APP_ID. Fun!

To solve, this commit preserves the `url:` field in the YamlConfig, but then maps it to `appId` in the MaestroConfig. This allows the YamlConfig to more accurately reflect what's in the raw yaml, and allows us to just use the presence of the `url:` field to determine if a flow is a web flow.

The only downside I can see is if people are using "appId: https://example.com" (like in the hacky workaround above). This will no longer work, but I'm not sure if that's important since this is in beta. If we like this commit, we should also change this line in the documentation:

`For readability, you should specify url instead of an appId in your test file (but they're synonyms behind the scenes).`

If we DON'T like this approach, then anytime `File.isWebFlow` is called we'll need to have a JS engine available to use.

Fixes: https://github.com/mobile-dev-inc/Maestro/issues/2587
Fixes: https://linear.app/mobile-dev/issue/MAE-231/environment-variables-not-working-in-web-beta