### PR TITLE
feat: isolate environment variables between peer runFlow commands

### DIFF
--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -12,4 +12,7 @@ interface JsEngine : AutoCloseable {
         sourceName: String = "inline-script",
         runInSubScope: Boolean = false,
     ): Any?
+    
+    fun enterEnvScope()
+    fun leaveEnvScope()
 }

--- a/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
@@ -118,4 +118,16 @@ class RhinoJsEngine(
         )
     }
 
+    override fun enterEnvScope() {
+        // Create a new environment variable scope for flow isolation.
+        // For RhinoJS, we can use the existing JavaScript scope mechanism
+        // which automatically handles variable isolation and cleanup.
+        enterScope()
+    }
+
+    override fun leaveEnvScope() {
+        // For RhinoJS, we can use the existing scope mechanism
+        leaveScope()
+    }
+
 }

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -43,4 +43,27 @@ class GraalJsEngineTest : JsEngineTest() {
         val result = engine.evaluateScript("parseInt('1')").toString()
         assertThat(result).isEqualTo("1")
     }
+
+    @Test
+    fun `Environment variables are isolated between env scopes`() {
+        // Set a variable in the root scope
+        engine.putEnv("ROOT_VAR", "root_value")
+        
+        // Enter new env scope and set a variable
+        engine.enterEnvScope()
+        engine.putEnv("SCOPED_VAR", "scoped_value")
+        
+        // Both variables should be accessible in the child scope
+        assertThat(engine.evaluateScript("ROOT_VAR").toString()).isEqualTo("root_value")
+        assertThat(engine.evaluateScript("SCOPED_VAR").toString()).isEqualTo("scoped_value")
+        
+        // Leave the env scope
+        engine.leaveEnvScope()
+        
+        // Root variable should still be accessible
+        assertThat(engine.evaluateScript("ROOT_VAR").toString()).isEqualTo("root_value")
+        
+        // Scoped variable should no longer be accessible (undefined)
+        assertThat(engine.evaluateScript("SCOPED_VAR").toString()).contains("undefined")
+    }
 }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3870,6 +3870,34 @@ class IntegrationTest {
         driver.assertHasEvent(Event.SetOrientation(DeviceOrientation.LANDSCAPE_RIGHT))
         driver.assertHasEvent(Event.SetOrientation(DeviceOrientation.UPSIDE_DOWN))
     }
+
+    @Test
+    fun `Case 127 RhinoJS - Environment variables should be isolated between flows`() {
+        // Test that environment variables from one runFlow don't leak to peer runFlow commands
+        val commands = readCommands("127_env_vars_isolation_rhinojs")
+        val driver = driver {}
+
+        Maestro(driver).use {
+            runBlocking {
+                // Should succeed - uses positive assertions to verify isolation works
+                orchestra(it).runFlow(commands)
+            }
+        }
+    }
+
+    @Test
+    fun `Case 127 GraalJS - Environment variables should be isolated between flows`() {
+        // Test that environment variables are isolated between flows using GraalJS engine
+        val commands = readCommands("127_env_vars_isolation_graaljs")
+        val driver = driver {}
+
+        Maestro(driver).use {
+            runBlocking {
+                // Should succeed - uses positive assertions to verify isolation works
+                orchestra(it).runFlow(commands)
+            }
+        }
+    }
     
     private fun orchestra(
         maestro: Maestro,

--- a/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/RhinoJsEngineTest.kt
@@ -58,4 +58,27 @@ class RhinoJsEngineTest : JsEngineTest() {
         val result = engine.evaluateScript("parseInt('1')").toString()
         assertThat(result).isEqualTo("1.0")
     }
+
+    @Test
+    fun `Environment variables are isolated between env scopes`() {
+        // Set a variable in the root scope
+        engine.putEnv("ROOT_VAR", "root_value")
+        
+        // Enter new env scope and set a variable
+        engine.enterEnvScope()
+        engine.putEnv("SCOPED_VAR", "scoped_value")
+        
+        // Both variables should be accessible in the child scope
+        assertThat(engine.evaluateScript("ROOT_VAR")).isEqualTo("root_value")
+        assertThat(engine.evaluateScript("SCOPED_VAR")).isEqualTo("scoped_value")
+        
+        // Leave the env scope
+        engine.leaveEnvScope()
+        
+        // Root variable should still be accessible
+        assertThat(engine.evaluateScript("ROOT_VAR")).isEqualTo("root_value")
+        
+        // Scoped variable should no longer be accessible (null in RhinoJS due to scope mechanism)
+        assertThat(engine.evaluateScript("SCOPED_VAR")).isNull()
+    }
 }

--- a/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
@@ -1,0 +1,19 @@
+appId: com.example.app
+ext:
+  jsEngine: graaljs
+env:
+  GLOBAL_VAR: "available"
+---
+# First flow sets a local variable
+- runFlow:
+    commands:
+      - assertTrue: ${GLOBAL_VAR == "available"}  # Should work - global var accessible
+      - assertTrue: ${FLOW1_VAR == "set"}         # Should work - local var accessible
+    env:
+      FLOW1_VAR: "set"
+
+# Second flow should NOT see first flow's variable
+- runFlow:
+    commands:
+      - assertTrue: ${GLOBAL_VAR == "available"}      # Should work - global var still accessible  
+      - assertTrue: ${typeof FLOW1_VAR === 'undefined'}  # Should work - proves isolation

--- a/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
@@ -7,17 +7,17 @@ env:
     env:
       MY_VAR: 1
     commands:
-      - assertTrue: ${MY_VAR == 1} 
+      - assertTrue: ${MY_VAR === '1'} 
       - evalScript: ${if(MY_VAR !== '1') { throw Error } } # tests scoping for evalScript
       - runFlow: 
           env:
             MY_VAR: 2
           commands:
-            - assertTrue: ${MY_VAR == 2}
-      - assertTrue: ${MY_VAR == 1} 
+            - assertTrue: ${MY_VAR === '2'}
+      - assertTrue: ${MY_VAR === '1'} 
 
   
 # Second flow should NOT see first flow's variable
 - runFlow:
     commands:
-      - assertTrue: ${MY_VAR == 0}
+      - assertTrue: ${MY_VAR === '0'}

--- a/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
@@ -1,19 +1,23 @@
 appId: com.example.app
-ext:
-  jsEngine: graaljs
+jsEngine: graaljs
 env:
-  GLOBAL_VAR: "available"
+  MY_VAR: 0
 ---
-# First flow sets a local variable
 - runFlow:
-    commands:
-      - assertTrue: ${GLOBAL_VAR == "available"}  # Should work - global var accessible
-      - assertTrue: ${FLOW1_VAR == "set"}         # Should work - local var accessible
     env:
-      FLOW1_VAR: "set"
+      MY_VAR: 1
+    commands:
+      - assertTrue: ${MY_VAR == 1} 
+      - evalScript: ${if(MY_VAR !== '1') { throw Error } } # tests scoping for evalScript
+      - runFlow: 
+          env:
+            MY_VAR: 2
+          commands:
+            - assertTrue: ${MY_VAR == 2}
+      - assertTrue: ${MY_VAR == 1} 
 
+  
 # Second flow should NOT see first flow's variable
 - runFlow:
     commands:
-      - assertTrue: ${GLOBAL_VAR == "available"}      # Should work - global var still accessible  
-      - assertTrue: ${typeof FLOW1_VAR === 'undefined'}  # Should work - proves isolation
+      - assertTrue: ${MY_VAR == 0}

--- a/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
@@ -1,17 +1,22 @@
 appId: com.example.app
 env:
-  GLOBAL_VAR: "available"
+  MY_VAR: 0
 ---
-# First flow sets a local variable
 - runFlow:
-    commands:
-      - assertTrue: ${GLOBAL_VAR == "available"}  # Should work - global var accessible
-      - assertTrue: ${FLOW1_VAR == "set"}         # Should work - local var accessible
     env:
-      FLOW1_VAR: "set"
+      MY_VAR: 1
+    commands:
+      - assertTrue: ${MY_VAR == 1} 
+      - evalScript: ${if(MY_VAR !== '1') { throw Error } } # tests scoping for evalScript
+      - runFlow: 
+          env:
+            MY_VAR: 2
+          commands:
+            - assertTrue: ${MY_VAR == 2}
+      - assertTrue: ${MY_VAR == 1} 
 
+  
 # Second flow should NOT see first flow's variable
 - runFlow:
     commands:
-      - assertTrue: ${GLOBAL_VAR == "available"}      # Should work - global var still accessible  
-      - assertTrue: ${typeof FLOW1_VAR === 'undefined'}  # Should work - proves isolation
+      - assertTrue: ${MY_VAR == 0}

--- a/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
@@ -1,0 +1,17 @@
+appId: com.example.app
+env:
+  GLOBAL_VAR: "available"
+---
+# First flow sets a local variable
+- runFlow:
+    commands:
+      - assertTrue: ${GLOBAL_VAR == "available"}  # Should work - global var accessible
+      - assertTrue: ${FLOW1_VAR == "set"}         # Should work - local var accessible
+    env:
+      FLOW1_VAR: "set"
+
+# Second flow should NOT see first flow's variable
+- runFlow:
+    commands:
+      - assertTrue: ${GLOBAL_VAR == "available"}      # Should work - global var still accessible  
+      - assertTrue: ${typeof FLOW1_VAR === 'undefined'}  # Should work - proves isolation

--- a/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
@@ -6,17 +6,17 @@ env:
     env:
       MY_VAR: 1
     commands:
-      - assertTrue: ${MY_VAR == 1} 
+      - assertTrue: ${MY_VAR === '1'} 
       - evalScript: ${if(MY_VAR !== '1') { throw Error } } # tests scoping for evalScript
       - runFlow: 
           env:
             MY_VAR: 2
           commands:
-            - assertTrue: ${MY_VAR == 2}
-      - assertTrue: ${MY_VAR == 1} 
+            - assertTrue: ${MY_VAR === '2'}
+      - assertTrue: ${MY_VAR === '1'} 
 
   
 # Second flow should NOT see first flow's variable
 - runFlow:
     commands:
-      - assertTrue: ${MY_VAR == 0}
+      - assertTrue: ${MY_VAR === '0'}


### PR DESCRIPTION
Environment variables from one runFlow command were persisting and being accessible to subsequent peer runFlow commands, violating expected scoping rules. This change ensures proper isolation while maintaining inheritance from parent flows to subflows.

Implementation:
- Add enterEnvScope/leaveEnvScope methods to JsEngine interface
- RhinoJS: leverage existing JavaScript scope mechanism
- GraalJS: implement manual stack-based environment management
- Orchestra: wrap runSubFlow execution with env scoping

Testing:
- Added a flow test for both graal and rhino engines to confirm the behavior works as expected (see the two yaml files; they demonstrate it clearly. Thanks to @Fishbowler for a good example repro in the ticket!)
- Added simple unit tests for the new behavior in the two engine implementations

Only concern: I don't know how much memory increase there is for the Rhino engine in this approach. If there are heavily nested subflows, this will add one new scope layer for each subflow (instead of just one new scope per subflow there will be two).

Fixes: [MA-3504](https://linear.app/mobile-dev/issue/MA-3504/env-variables-should-be-cleared-up-between-flow-runs)