### PR TITLE
fix: remove the unused variable leading to memory leak

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -30,14 +30,6 @@ class XCTestDriverClient(
         this.client = client
     }
 
-    private var isShuttingDown = false
-
-    init {
-        Runtime.getRuntime().addShutdownHook(Thread {
-            isShuttingDown = true
-        })
-    }
-
     fun restartXCTestRunner() {
         if(reinstallDriver) {
             logger.trace("Restarting XCTest Runner (uninstalling, installing and starting)")


### PR DESCRIPTION
## Investigation

While profiling memory usage during Maestro Cloud test execution, we noticed that `XCTestDriverClient` instances were never getting garbage collected, leading to gradual memory bloat over time.

This PR resolves one of the leaks we found there.

JVM shutdown hook that unintentionally holds a strong reference to the XCTestDriverClient instance.

Inside XCTestDriverClient, we register a shutdown hook like this:

```
Runtime.getRuntime().addShutdownHook(Thread(XCTestDriverClient::_init_$lambda$0));
```

This looks fine in Kotlin, but once compiled and decompiled (via IntelliJ → Tools → Kotlin → Show Bytecode → Decompile), you’ll see why its strong reference:

```
public final class XCTestDriverClient {
     Runtime.getRuntime().addShutdownHook(new Thread(XCTestDriverClient::_init_$lambda$0));
     .
     .
     .
     private static final void _init_$lambda$0(XCTestDriverClient this$0) {
        this$0.isShuttingDown = true;
     }
}
```

The `_init_$lambda$0` method, implicitly captures this$0, which is the enclosing XCTestDriverClient instance — held strongly by the shutdown thread.

And since all shutdown hooks are stored in a static list in ApplicationShutdownHooks, the thread — and therefore the XCTestDriverClient — stays alive until the JVM exits. This causes a memory leak in long-running or heavily parallelized test environments.

### Leak trace

In this example the array has almost 100s of MB which would grow over time the more ios tests get executed

<img width="774" height="828" alt="473784064-79c75e1f-c84f-4c4c-96f5-4a53eb43be9c" src="https://github.com/user-attachments/assets/38776a32-b181-44ec-8b54-6b5553cc5b0b" />


## Fix

Well fix is to just remove it, we don't even use this anymore 😅 

## Validation

The plan is to ship this and verify dumping memory again to see if the above threads with XCTestDriverClient not leak anymore.

## Issues fixed
