### PR TITLE
Detect broken xcode-select path

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
@@ -68,6 +68,14 @@ object DeviceCreateUtil {
                     * https://developer.apple.com/documentation/xcode/installing-additional-simulator-runtimes
                 """.trimIndent()
                 throw CliError(msg)
+            } else if (error.contains("xcrun: error: unable to find utility \"simctl\"")) {
+                val msg = """
+                    The xcode-select CLI tools are not installed, install with xcode-select --install
+                    
+                    If the xcode-select CLI tools are already installed, the path may be broken. Try
+                    running sudo xcode-select -r to repair the path and re-run this command
+                """.trimIndent()
+                throw CliError(msg)
             } else if (error.contains("Invalid device type")) {
                 throw CliError("Device type $device is either not supported or not found.")
             } else {


### PR DESCRIPTION
## Proposed changes

Its possible for a user on macOS to have a broken xcode-select path (this was the case for my machine). This PR detects if this is the case by catching the following error

```
$ maestro start-device --platform=ios --os-version=16 --device-locale=en_US

Attempting to create iOS simulator: Maestro_iPhone11_16

xcrun: error: unable to find utility "simctl", not a developer tool or in PATH
```

## Testing

Unfortunately I couldn't test these changes because my xcode path is now fixed! But the PR is trivial enough that it shouldn't need an explicit test

## Issues fixed
