### PR TITLE
feat: add 'maestro doctor' command for environment diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -123,8 +123,20 @@ body:
         - I'm on M1 MacBook Air, with macOS 14.5 Sonoma and Xcode 15.4.
   - type: textarea
     attributes:
+      label: Maestro Environment
+      description: |
+        Please run `maestro doctor` and paste the output below. This helps us understand your environment.
+      placeholder: |
+        ```
+        $ maestro doctor
+        [Paste output here]
+        ```
+    validations:
+      required: true
+  - type: textarea
+    attributes:
       label: Logs
-      description: >
+      description: |
         Include the full logs of the command you're running. The zip files
         created with `maestro bugreport` can be uploaded here as well.
 

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -37,6 +37,7 @@ import maestro.cli.command.StartDeviceCommand
 import maestro.cli.command.StudioCommand
 import maestro.cli.command.TestCommand
 import maestro.cli.command.UploadCommand
+import maestro.cli.command.DoctorCommand
 import maestro.cli.insights.TestAnalysisManager
 import maestro.cli.update.Updates
 import maestro.cli.util.ChangeLogUtils
@@ -70,6 +71,7 @@ import kotlin.system.exitProcess
         CheckSyntaxCommand::class,
         DriverCommand::class,
         McpCommand::class,
+        DoctorCommand::class,
     ]
 )
 class App {

--- a/maestro-cli/src/main/java/maestro/cli/command/DoctorCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/DoctorCommand.kt
@@ -56,12 +56,19 @@ class DoctorCommand : Callable<Int> {
         )
 
         private fun detectInstallMethod(): Pair<String, String> {
-            val path = getMaestroCliPath()
+            val path = getMaestroCliPath().replace('\\', '/').lowercase()
             return when {
-                path.contains("/brew/") || path.contains("/Homebrew/") -> 
-                    InstallInfo("Homebrew", "installed with Homebrew")
+                path.contains("/brew/") || path.contains("/homebrew/") -> 
+                    InstallInfo("homebrew", "installed via Homebrew")
+                    
+                path.contains("/.maestro/bin") -> 
+                    InstallInfo("script", "installed via install script")
+                    
+                path.contains("maestro/bin") -> 
+                    InstallInfo("windows", "installed via zip archive")
+                    
                 else -> 
-                    InstallInfo("script", "installed via curl script")
+                    InstallInfo("custom", "custom installation")
             }.let { it.method to it.displayText }
         }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/DoctorCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/DoctorCommand.kt
@@ -1,0 +1,77 @@
+package maestro.cli.command
+
+import picocli.CommandLine
+import java.io.PrintWriter
+import java.util.concurrent.Callable
+import maestro.cli.util.EnvUtils
+import maestro.cli.util.IOSEnvUtils
+
+@CommandLine.Command(
+    name = "doctor",
+    description = ["Show information about the local environment for debugging and issue reporting."]
+)
+class DoctorCommand : Callable<Int> {
+    @CommandLine.Option(names = ["-v", "--verbose"], description = ["Show verbose output."])
+    var verbose: Boolean = false
+
+    override fun call(): Int {
+        val out = PrintWriter(System.out, true)
+        printDoctorSummary(out, verbose)
+        return 0
+    }
+
+    companion object {
+        fun printDoctorSummary(out: PrintWriter, verbose: Boolean) {
+            val cliVersion = EnvUtils.CLI_VERSION?.toString() ?: "Unknown"
+            val osName = EnvUtils.OS_NAME
+            val osVersion = EnvUtils.OS_VERSION
+            val osArch = EnvUtils.OS_ARCH
+            val javaVersion = System.getProperty("java.version") ?: "Unknown"
+            val javaVendor = System.getProperty("java.vendor") ?: "Unknown"
+            
+            val (installMethod, installSource) = detectInstallMethod()
+
+            out.println("Doctor summary (to see all details, run maestro doctor -v):")
+            out.println("• Maestro CLI v$cliVersion [$installSource]")
+            out.println("• $osName $osVersion ($osArch)")
+            out.println("• $javaVendor (Java $javaVersion)")
+            
+            if (osName.contains("Mac", ignoreCase = true)) {
+                val xcodeVersion = IOSEnvUtils.xcodeVersion ?: "Not installed"
+                out.println("• Xcode $xcodeVersion")
+            }
+
+            if (verbose) {
+                out.println("\nVerbose details:")
+                out.println("- Java home: ${System.getProperty("java.home")}")
+                out.println("- Java vendor: $javaVendor")
+                out.println("- User locale: ${System.getProperty("user.language")}-${System.getProperty("user.country")}")
+                out.println("- Maestro CLI path: ${getMaestroCliPath()}")
+            }
+        }
+
+        private data class InstallInfo(
+            val method: String,
+            val displayText: String
+        )
+
+        private fun detectInstallMethod(): Pair<String, String> {
+            val path = getMaestroCliPath()
+            return when {
+                path.contains("/brew/") || path.contains("/Homebrew/") -> 
+                    InstallInfo("Homebrew", "installed with Homebrew")
+                else -> 
+                    InstallInfo("script", "installed via curl script")
+            }.let { it.method to it.displayText }
+        }
+
+        private fun getMaestroCliPath(): String {
+            return try {
+                val codeSource = DoctorCommand::class.java.protectionDomain.codeSource
+                codeSource?.location?.path ?: "Unknown"
+            } catch (e: Exception) {
+                "Unknown"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR introduces a new `maestro doctor` command inspired by `flutter doctor` to help users quickly gather environment information for debugging and issue triage. Related to [this issue](https://github.com/mobile-dev-inc/Maestro/issues/1785)

<img width="1259" height="410" alt="Capture d’écran 2025-08-11 à 17 15 33" src="https://github.com/user-attachments/assets/c84a9e15-5bb1-4ab2-b44d-bb36f854870f" />


### Key Features:
- Displays essential environment details:
  - Maestro CLI version
  - Installation method (Homebrew or curl script)
  - OS name, version, and architecture
  - Java vendor and version
  - Xcode version (on macOS)
- Supports verbose mode (`-v` flag) for additional debugging information
- Consistent and clean output format similar to `flutter doctor`

### Implementation Details:
- Added new [DoctorCommand](cci:2://file:///Users/user/personal_workspace/github.com/maestro/Maestro/maestro-cli/src/main/java/maestro/cli/command/DoctorCommand.kt:8:0-76:1) class implementing the command
- Integrated with existing environment utilities
- Added platform-specific detection for Xcode on macOS
- Implemented simple but reliable installation method detection

## Testing

### Tested on:
- [x] macOS (Homebrew installation)
- [x] macOS (curl script installation)
- [ ] Linux (need community testing)
- [ ] WSL (need community testing)

### Test Cases:
1. Basic command: `maestro doctor`
   - [x] Displays basic environment info
   - [x] Shows correct installation method
   - [x] Shows Xcode version on macOS

2. Verbose mode: `maestro doctor -v`
   - [x] Shows additional debug information
   - [x] Includes Java home path
   - [x] Shows full Maestro CLI path

3. Error cases:
   - [x] Handles missing Xcode gracefully
   - [x] Handles unknown installation methods gracefully

## Issues Fixed

- N/A (New feature)

## Next Steps

- [ ] Update documentation to include the new command
- [ ] Add integration tests for different installation methods?