### PR TITLE
MA-3547 Make Graal default JS engine

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -290,13 +290,19 @@ class Orchestra(
         if (this::jsEngine.isInitialized) {
             jsEngine.close()
         }
-        val shouldUseGraalJs =
-            config?.ext?.get("jsEngine") == "graaljs" || System.getenv("MAESTRO_USE_GRAALJS") == "true"
+        val isRhinoExplicitlyRequested = config?.ext?.get("jsEngine") == "rhino"
+        
+        // Warn users about deprecated Rhino JS engine
+        if (isRhinoExplicitlyRequested) {
+            logger.warn("⚠️  The Rhino JS engine (jsEngine: rhino) is deprecated and will be removed in a future version. Please migrate to GraalJS (the default) for better performance and compatibility.")
+        }
+        
         val platform = maestro.cachedDeviceInfo.platform.toString().lowercase()
-        jsEngine = if (shouldUseGraalJs) {
-            httpClient?.let { GraalJsEngine(it, platform) } ?: GraalJsEngine(platform = platform)
-        } else {
+        jsEngine = if (isRhinoExplicitlyRequested) {
             httpClient?.let { RhinoJsEngine(it, platform) } ?: RhinoJsEngine(platform = platform)
+        } else {
+            // Default to GraalJS for better performance and compatibility
+            httpClient?.let { GraalJsEngine(it, platform) } ?: GraalJsEngine(platform = platform)
         }
     }
 

--- a/maestro-orchestra/src/test/java/maestro/orchestra/CommandDescriptionTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/CommandDescriptionTest.kt
@@ -1,7 +1,7 @@
 package maestro.orchestra
 
 import com.google.common.truth.Truth.assertThat
-import maestro.js.RhinoJsEngine
+import maestro.js.GraalJsEngine
 import maestro.orchestra.yaml.junit.YamlFile
 import maestro.orchestra.yaml.junit.YamlCommandsExtension
 import org.junit.jupiter.api.Test
@@ -14,7 +14,7 @@ internal class CommandDescriptionTest {
     fun `original description contains raw command details`(
         @YamlFile("028_command_descriptions.yaml") commands: List<Command>
     ) {
-        val jsEngine = RhinoJsEngine(platform = "ios")
+        val jsEngine = GraalJsEngine(platform = "ios")
         jsEngine.putEnv("username", "Alice")
 
         // Tap command with label
@@ -44,7 +44,7 @@ internal class CommandDescriptionTest {
     fun `description uses label when available`(
         @YamlFile("028_command_descriptions.yaml") commands: List<Command>
     ) {
-        val jsEngine = RhinoJsEngine(platform = "ios")
+        val jsEngine = GraalJsEngine(platform = "ios")
         jsEngine.putEnv("username", "Bob")
 
         // Tap command with label
@@ -67,7 +67,7 @@ internal class CommandDescriptionTest {
     fun `description evaluates script variables`(
         @YamlFile("028_command_descriptions.yaml") commands: List<Command>
     ) {
-        val jsEngine = RhinoJsEngine(platform = "ios")
+        val jsEngine = GraalJsEngine(platform = "ios")
         jsEngine.putEnv("username", "Charlie")
 
         // Tap command with label (should be unchanged by evaluation)

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1830,7 +1830,7 @@ class IntegrationTest {
                 Event.InputText("1"),
                 Event.InputText("2"),
                 Event.InputText("12"),
-                Event.InputText("3.0"),
+                Event.InputText("3"),
                 Event.InputText("\${A} \${B} 1 2"),
             )
         )
@@ -2231,8 +2231,8 @@ class IntegrationTest {
         // Then
         driver.assertEvents(
             listOf(
-                Event.InputText("!@#\$&*()_+{}|:\"<>?[]\\;',./"),
-                Event.InputText("!@#\$&*()_+{}|:\"<>?[]\\;',./"),
+                Event.InputText("!@#\$&*()_+{}|:\"<>?[]\\\\;',./"),
+                Event.InputText("!@#\$&*()_+{}|:\"<>?[]\\\\;',./"),
             )
         )
     }

--- a/maestro-test/src/test/resources/077_env_special_characters.yaml
+++ b/maestro-test/src/test/resources/077_env_special_characters.yaml
@@ -1,6 +1,6 @@
 appId: com.example.app
 env:
-    INNER: |
+    INNER: |-
         !@#$&*()_+{}|:"<>?[]\\;',./
 ---
 - inputText: ${OUTER}

--- a/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
@@ -1,4 +1,5 @@
 appId: com.example.app
+jsEngine: rhino
 env:
   MY_VAR: 0
 ---
@@ -6,16 +7,15 @@ env:
     env:
       MY_VAR: 1
     commands:
-      - assertTrue: ${MY_VAR === '1'} 
+      - assertTrue: ${MY_VAR === '1'}
       - evalScript: ${if(MY_VAR !== '1') { throw Error } } # tests scoping for evalScript
-      - runFlow: 
+      - runFlow:
           env:
             MY_VAR: 2
           commands:
             - assertTrue: ${MY_VAR === '2'}
-      - assertTrue: ${MY_VAR === '1'} 
+      - assertTrue: ${MY_VAR === '1'}
 
-  
 # Second flow should NOT see first flow's variable
 - runFlow:
     commands:


### PR DESCRIPTION
Graal is now the default engine, but we allow rhino if specified via `jsEngine: rhino` in the test config.

There are subtle differences in the Graal implementation that _could_ affect users in edge case situations. Here are the ones I discovered while updating the tests:
- correctly resolves `${parseInt(3)}` to `3` (rhino would resolve to `3.0`)
- preserves newlines in ENV vars passed in via CLI or YAML (rhino would strip those out)
- correctly escapes double slashes (rhino would run two passes of escaping, reducing `////` to `/`)

## Testing

- ran all tests including with `./gradlew build`
- did not run e2e tests (assuming CI will do that)

## Issues fixed
MA-3547
https://github.com/mobile-dev-inc/maestro/issues/2049