### PR TITLE
fix: web flow check & mix sharding

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -291,9 +291,7 @@ class TestCommand : Callable<Int> {
             }
             .ifEmpty { availableDevices }
             .toList()
-
-      println(availableDevices)
-
+      
         val missingDevices = requestedShards - deviceIds.size
         if (missingDevices > 0) {
             PrintUtils.warn("Want to use ${deviceIds.size} devices, which is not enough to run $requestedShards shards. Missing $missingDevices device(s).")

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -488,16 +488,20 @@ class TestCommand : Callable<Int> {
     }
 
     private fun getPassedOptionsDeviceIds(plan: ExecutionPlan): List<String> {
-        if (executionPlanIncludesWebFlow(plan)) {
-            PrintUtils.warn("Web support is in Beta. We would appreciate your feedback!\n")
-        }
-        
-        val deviceIds = parent?.deviceId
+        val userDeviceIds = parent?.deviceId
             .orEmpty()
             .split(",")
             .map { it.trim() }
             .filter { it.isNotBlank() }
-        return deviceIds
+        
+        return if (executionPlanIncludesWebFlow(plan)) {
+            PrintUtils.warn("Web support is in Beta. We would appreciate your feedback!\n")
+            // Always include chromium for web flows, plus any user-specified devices
+            val devicesWithChromium = (userDeviceIds + "chromium").distinct()
+            devicesWithChromium
+        } else {
+            userDeviceIds
+        }
     }
 
     private fun printExitDebugMessage() {


### PR DESCRIPTION
Fixed issues with web flow test related to this [PR](https://github.com/mobile-dev-inc/Maestro/commit/be97bc657a671577de110c8ee77cd4ad71989f1a) which cause some issues with `test` and `sharding`.

**Issue 1:**
No web flow in config, yet it stills open the web flow. Reason was we were checking all the files and if any of them included web flow we were adding that device. 

https://github.com/user-attachments/assets/c1a2a36a-2626-44de-99ec-4cc63a29414d

**Fix: Updated the function to check files that need to be executed.**

**Issue 2:**
Opened android and tried to do sharding between 2 devices. Workspace has both android and web flows. But it errors out saying only one device present. 

https://github.com/user-attachments/assets/ced42a6d-d690-4eba-8af9-a9bc9f7c7657

**Fix: In case web flow is present, add chromium to the device Id list** (we were just replacing the list with chromium)