### PR TITLE
Store random inputs for future use

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -65,6 +65,10 @@ class GraalJsEngine(
         this.maestroBinding["copiedText"] = text
     }
 
+    override fun setRandomText(text: String?) {
+        this.maestroBinding["randomText"] = text
+    }
+
     override fun evaluateScript(
         script: String,
         env: Map<String, String>,

--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -6,6 +6,7 @@ interface JsEngine : AutoCloseable {
     fun leaveScope()
     fun putEnv(key: String, value: String)
     fun setCopiedText(text: String?)
+    fun setRandomText(text: String?)
     fun evaluateScript(
         script: String,
         env: Map<String, String> = emptyMap(),

--- a/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
@@ -81,6 +81,10 @@ class RhinoJsEngine(
         evaluateScript("maestro.copiedText = '${Js.sanitizeJs(text ?: "")}'")
     }
 
+    override fun setRandomText(text: String?) {
+        evaluateScript("maestro.randomText = '${Js.sanitizeJs(text ?: "")}'")
+    }
+
     override fun putEnv(key: String, value: String) {
         val cleanValue = Js.sanitizeJs(value)
         evaluateScript("var $key = '$cleanValue'")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -1044,7 +1044,9 @@ class Orchestra(
     }
 
     private fun inputTextRandomCommand(command: InputRandomCommand): Boolean {
-        inputTextCommand(InputTextCommand(text = command.genRandomString()))
+        val randomString = command.genRandomString()
+        inputTextCommand(InputTextCommand(text = randomString))
+        jsEngine.setRandomText(randomString)
 
         return true
     }

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -368,6 +368,10 @@ class FakeDriver : Driver {
         assertThat(currentText).isEqualTo(expected)
     }
 
+    fun assertCurrentTextInputMatches(regex: Regex) {
+        assertThat(currentText.matches(regex)).isTrue()
+    }
+
     private fun ensureOpen() {
         if (state != State.OPEN) {
             throw IllegalStateException("Driver is not opened yet")

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3898,6 +3898,52 @@ class IntegrationTest {
             }
         }
     }
+
+    @Test
+    fun `Case 128 - Random text into JS variable - Graal`() {
+        // Given
+        val commands = readCommands("128_randomText_jsVar_graaljs")
+
+        val driver = driver {}
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // No test failure
+        driver.assertAllEvent(condition = {
+            ((it as? Event.InputText?)?.text?.length ?: -1) >= 5
+        })
+
+        driver.assertCurrentTextInputMatches(Regex("(.+)\\1(.+)\\2(.+)\\3(.+)\\4(.+)\\5(.+)\\6")) // 6 pairs of repeated strings
+    }
+
+    @Test
+    fun `Case 128 - Random text into JS variable - Rhino`() {
+        // Given
+        val commands = readCommands("128_randomText_jsVar_rhinojs")
+
+        val driver = driver {}
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // No test failure
+        driver.assertAllEvent(condition = {
+            ((it as? Event.InputText?)?.text?.length ?: -1) >= 5
+        })
+
+        driver.assertCurrentTextInputMatches(Regex("(.+)\\1(.+)\\2(.+)\\3(.+)\\4(.+)\\5(.+)\\6")) // 6 pairs of repeated strings
+    }
     
     private fun orchestra(
         maestro: Maestro,

--- a/maestro-test/src/test/resources/128_randomText_jsVar_graaljs.yaml
+++ b/maestro-test/src/test/resources/128_randomText_jsVar_graaljs.yaml
@@ -1,0 +1,22 @@
+appId: com.example.app
+jsEngine: graaljs
+---
+- inputRandomPersonName
+- inputText: ${maestro.randomText}
+
+- inputRandomEmail
+- inputText: ${maestro.randomText}
+
+- inputRandomNumber
+- inputText: ${maestro.randomText}
+
+- inputRandomText
+- inputText: ${maestro.randomText}
+
+- inputRandomNumber:
+    length: 5
+- inputText: ${maestro.randomText}
+
+- inputRandomText:
+    length: 5
+- inputText: ${maestro.randomText}

--- a/maestro-test/src/test/resources/128_randomText_jsVar_rhinojs.yaml
+++ b/maestro-test/src/test/resources/128_randomText_jsVar_rhinojs.yaml
@@ -1,0 +1,22 @@
+appId: com.example.app
+jsEngine: rhinojs
+---
+- inputRandomPersonName
+- inputText: ${maestro.randomText}
+
+- inputRandomEmail
+- inputText: ${maestro.randomText}
+
+- inputRandomNumber
+- inputText: ${maestro.randomText}
+
+- inputRandomText
+- inputText: ${maestro.randomText}
+
+- inputRandomNumber:
+    length: 5
+- inputText: ${maestro.randomText}
+
+- inputRandomText:
+    length: 5
+- inputText: ${maestro.randomText}


### PR DESCRIPTION
## Proposed changes

This PR stores the strings used in random generating commands (e.g. `InputRandomEmail`) into a JS var of `maestro.randomText` (following the same pattern as CopyTextFrom).

This enables scenarios like creating a user on one screen and selecting them on a subsequent screen.

## Testing

Added tests
