### PR TITLE
feat: Add passingPercentage to JUnit report

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -52,7 +52,12 @@ class JUnitTestSuiteReporter(
                                             time = flow.duration?.inWholeSeconds?.toString(),
                                             status = flow.status
                                         )
-                                    }
+                                    },
+                                passingPercentage =
+                                    if(suite.flows.isEmpty())
+                                        0.0
+                                    else
+                                        (suite.flows.count { it.status == FlowStatus.SUCCESS || it.status == FlowStatus.WARNING }.toDouble()) / suite.flows.size.toDouble() * 100.0
                             )
                         }
                 )
@@ -73,6 +78,7 @@ class JUnitTestSuiteReporter(
         @JacksonXmlProperty(isAttribute = true) val tests: Int,
         @JacksonXmlProperty(isAttribute = true) val failures: Int,
         @JacksonXmlProperty(isAttribute = true) val time: String? = null,
+        @JacksonXmlProperty(isAttribute = true) val passingPercentage: Double,
         @JacksonXmlElementWrapper(useWrapping = false)
         @JsonProperty("testcase")
         val testCases: List<TestCase>,

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -52,7 +52,7 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Test Suite" device="iPhone 15" tests="2" failures="0" time="1915">
+                  <testsuite name="Test Suite" device="iPhone 15" tests="2" failures="0" time="1915" passingPercentage="100.0">
                     <testcase id="Flow A" name="Flow A" classname="Flow A" time="421" status="SUCCESS"/>
                     <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494" status="WARNING"/>
                   </testsuite>
@@ -105,7 +105,7 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Test Suite" tests="2" failures="1" time="552">
+                  <testsuite name="Test Suite" tests="2" failures="1" time="552" passingPercentage="50.0">
                     <testcase id="Flow A" name="Flow A" classname="Flow A" time="421" status="SUCCESS"/>
                     <testcase id="Flow B" name="Flow B" classname="Flow B" time="131" status="ERROR">
                       <failure>Error message</failure>
@@ -159,7 +159,7 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0" time="421">
+                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0" time="421" passingPercentage="100.0">
                     <testcase id="Flow A" name="Flow A" classname="Flow A" time="421" status="SUCCESS"/>
                     <testcase id="Flow B" name="Flow B" classname="Flow B" status="WARNING"/>
                   </testsuite>


### PR DESCRIPTION
## Proposed changes

This PR adds a `passingPercentage` to the XML JUnit report. Currently the logic is that only tests that have `FlowStatus.SUCCESS` count as passed although it can be argued that `FlowStatus.WARNING` should also be included

## Testing

Tests have been updated to reflect changes

## Other considerations

It could be argued that to be consistent with the other XML attributes we should have `passed` as an int rather than `passingPercentage` and then its easy to calculate the percentage from that. Similarly it can also be argued that since we are already calculating `passingPercentage` we should add a `passed` int attribute as well.
