### PR TITLE
[MA-3571] Cloud Upload Resolve Dependencies for Single Flow Upload

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
@@ -1,0 +1,116 @@
+package maestro.cli.util
+
+import maestro.orchestra.yaml.YamlCommandReader
+import maestro.orchestra.yaml.YamlFluentCommand
+import maestro.orchestra.yaml.MaestroFlowParser
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.exists
+
+object DependencyResolver {
+
+    fun discoverAllDependencies(flowFile: Path): List<Path> {
+        val discoveredFiles = mutableSetOf<Path>()
+        val filesToProcess = mutableListOf(flowFile)
+        
+        while (filesToProcess.isNotEmpty()) {
+            val currentFile = filesToProcess.removeFirst()
+            
+            // Skip if we've already processed this file (prevents circular references)
+            if (discoveredFiles.contains(currentFile)) continue
+            
+            // Add current file to discovered set
+            discoveredFiles.add(currentFile)
+            
+            try {
+                // Only process YAML files for dependency discovery
+                if (!currentFile.fileName.toString().endsWith(".yaml") && !currentFile.fileName.toString().endsWith(".yml")) {
+                    continue
+                }
+                
+                val flowContent = Files.readString(currentFile)
+                val commands = MaestroFlowParser.parseFlow(currentFile, flowContent)
+                
+                // Discover dependencies from each command
+                val dependencies = commands.flatMap { maestroCommand ->
+                    val commandDependencies = mutableListOf<Path>()
+
+                    // Check for runFlow commands
+                    maestroCommand.runFlowCommand?.let { runFlow ->
+                        val flowPath = resolvePath(currentFile, runFlow.sourceDescription ?: "")
+                        if (flowPath.exists()) {
+                            commandDependencies.add(flowPath)
+                        }
+                    }
+                    
+                    // Check for runScript commands
+                    maestroCommand.runScriptCommand?.let { runScript ->
+                        val scriptPath = resolvePath(currentFile, runScript.sourceDescription ?: "")
+                        if (scriptPath.exists()) {
+                            commandDependencies.add(scriptPath)
+                        }
+                    }
+                    
+                    // Check for addMedia commands
+                    maestroCommand.addMediaCommand?.let { addMedia ->
+                        addMedia.mediaPaths.forEach { mediaPath ->
+                            val mediaFile = currentFile.fileSystem.getPath(mediaPath)
+                            if (mediaFile.exists()) {
+                                commandDependencies.add(mediaFile)
+                            }
+                        }
+                    }
+                    
+                    commandDependencies
+                }
+                
+                val newDependencies = dependencies.filter { it.exists() && !discoveredFiles.contains(it) }
+                filesToProcess.addAll(newDependencies)
+                
+            } catch (e: Exception) {
+                println("Warning: Could not parse dependencies for ${currentFile.fileName}: ${e.message}")
+            }
+        }
+        
+        return discoveredFiles.toList()
+    }
+    
+    private fun resolvePath(flowPath: Path, requestedPath: String): Path {
+        val path = flowPath.fileSystem.getPath(requestedPath)
+        
+        return if (path.isAbsolute) {
+            path
+        } else {
+            flowPath.resolveSibling(path).toAbsolutePath()
+        }
+    }
+
+    fun getDependencySummary(flowFile: Path): String {
+        val dependencies = discoverAllDependencies(flowFile)
+        val mainFile = dependencies.firstOrNull { it == flowFile }
+        val subflows = dependencies.filter { it != flowFile && it.fileName.toString().substringAfterLast('.', "") in listOf("yaml", "yml") }
+        val scripts = dependencies.filter { it != flowFile && it.fileName.toString().substringAfterLast('.', "") == "js" }
+        val otherFiles = dependencies.filter { it != flowFile && it.fileName.toString().substringAfterLast('.', "") !in listOf("yaml", "yml", "js") }
+        
+        return buildString {
+            appendLine("Dependency discovery for: ${flowFile.fileName}")
+            appendLine("Total files: ${dependencies.size}")
+            if (subflows.isNotEmpty()) appendLine("Subflows: ${subflows.size}")
+            if (scripts.isNotEmpty()) appendLine("Scripts: ${scripts.size}")
+            if (otherFiles.isNotEmpty()) appendLine("Other files: ${otherFiles.size}")
+            
+            if (subflows.isNotEmpty()) {
+                appendLine("Subflow files:")
+                subflows.forEach { appendLine("  - ${it.fileName}") }
+            }
+            if (scripts.isNotEmpty()) {
+                appendLine("Script files:")
+                scripts.forEach { appendLine("  - ${it.fileName}") }
+            }
+            if (otherFiles.isNotEmpty()) {
+                appendLine("Other files:")
+                otherFiles.forEach { appendLine("  - ${it.fileName}") }
+            }
+        }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
@@ -54,7 +54,7 @@ object DependencyResolver {
                     // Check for addMedia commands
                     maestroCommand.addMediaCommand?.let { addMedia ->
                         addMedia.mediaPaths.forEach { mediaPath ->
-                            val mediaFile = currentFile.fileSystem.getPath(mediaPath)
+                            val mediaFile = resolvePath(currentFile, mediaPath)
                             if (mediaFile.exists()) {
                                 commandDependencies.add(mediaFile)
                             }

--- a/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
@@ -1,7 +1,5 @@
 package maestro.cli.util
 
-import maestro.orchestra.yaml.YamlCommandReader
-import maestro.orchestra.yaml.YamlFluentCommand
 import maestro.orchestra.yaml.MaestroFlowParser
 import java.nio.file.Files
 import java.nio.file.Path

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/DependencyResolverTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/DependencyResolverTest.kt
@@ -1,0 +1,141 @@
+package maestro.cli.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+class DependencyResolverTest {
+    
+    @Test
+    fun `test dependency discovery for single flow file`(@TempDir tempDir: Path) {
+        // Create a main flow file
+        val mainFlow = tempDir.resolve("main_flow.yaml")
+        mainFlow.writeText("""
+            appId: com.example.app
+            ---
+            - runFlow: subflow1.yaml
+            - runFlow: subflow2.yaml
+            - runScript: validation.js
+            - addMedia:
+              - "images/logo.png"
+        """.trimIndent())
+        
+        // Create subflow files
+        val subflow1 = tempDir.resolve("subflow1.yaml")
+        subflow1.writeText("""
+            appId: com.example.app
+            ---
+            - tapOn: "Button"
+        """.trimIndent())
+        
+        val subflow2 = tempDir.resolve("subflow2.yaml")
+        subflow2.writeText("""
+            appId: com.example.app
+            ---
+            - runFlow: nested_subflow.yaml
+        """.trimIndent())
+        
+        // Create nested subflow
+        val nestedSubflow = tempDir.resolve("nested_subflow.yaml")
+        nestedSubflow.writeText("""
+            appId: com.example.app
+            ---
+            - assertVisible: "Text"
+        """.trimIndent())
+        
+        // Create script file
+        val script = tempDir.resolve("validation.js")
+        script.writeText("console.log('validation script');")
+        
+        // Create media file
+        val mediaDir = tempDir.resolve("images")
+        mediaDir.toFile().mkdirs()
+        val mediaFile = mediaDir.resolve("logo.png")
+        mediaFile.writeText("fake png content")
+        
+        // Test dependency discovery
+        val dependencies = DependencyResolver.discoverAllDependencies(mainFlow)
+        
+        // Should include all files
+        assertThat(dependencies).hasSize(6)
+        assertThat(dependencies).contains(mainFlow)
+        assertThat(dependencies).contains(subflow1)
+        assertThat(dependencies).contains(subflow2)
+        assertThat(dependencies).contains(nestedSubflow)
+        assertThat(dependencies).contains(script)
+        assertThat(dependencies).contains(mediaFile)
+    }
+    
+    @Test
+    fun `test dependency summary generation`(@TempDir tempDir: Path) {
+        val mainFlow = tempDir.resolve("main_flow.yaml")
+        mainFlow.writeText("""
+            appId: com.example.app
+            ---
+            - runFlow: subflow.yaml
+            - runScript: script.js
+            - addMedia:
+              - "images/logo.png"
+        """.trimIndent())
+        
+        val subflow = tempDir.resolve("subflow.yaml")
+        subflow.writeText("""
+            appId: com.example.app
+            ---
+            - tapOn: "Button"
+        """.trimIndent())
+        
+        val script = tempDir.resolve("script.js")
+        script.writeText("console.log('test');")
+        
+        val mediaDir = tempDir.resolve("images")
+        mediaDir.toFile().mkdirs()
+        val mediaFile = mediaDir.resolve("logo.png")
+        mediaFile.writeText("fake png content")
+        
+        val summary = DependencyResolver.getDependencySummary(mainFlow)
+        
+        assertThat(summary).contains("Total files: 4")
+        assertThat(summary).contains("Subflows: 1")
+        assertThat(summary).contains("Scripts: 1")
+        assertThat(summary).contains("Other files: 1")
+    }
+    
+    @Test
+    fun `test enhanced dependency discovery finds all types`(@TempDir tempDir: Path) {
+        // Create a main flow file with runScript and addMedia
+        val mainFlow = tempDir.resolve("main_flow.yaml")
+        mainFlow.writeText("""
+            appId: com.example.app
+            ---
+            - runFlow: subflow.yaml
+            - runScript: script.js
+            - addMedia:
+              - "images/logo.png"
+        """.trimIndent())
+        
+        val subflow = tempDir.resolve("subflow.yaml")
+        subflow.writeText("""
+            appId: com.example.app
+            ---
+            - tapOn: "Button"
+        """.trimIndent())
+        
+        val script = tempDir.resolve("script.js")
+        script.writeText("console.log('test');")
+        
+        val mediaDir = tempDir.resolve("images")
+        mediaDir.toFile().mkdirs()
+        val mediaFile = mediaDir.resolve("logo.png")
+        mediaFile.writeText("fake png content")
+        
+        // Test enhanced discovery (should find all dependencies)
+        val enhancedDependencies = DependencyResolver.discoverAllDependencies(mainFlow)
+        assertThat(enhancedDependencies).hasSize(4)
+        assertThat(enhancedDependencies).contains(script)
+        assertThat(enhancedDependencies).contains(mediaFile)
+        assertThat(enhancedDependencies).contains(subflow)
+    }
+}


### PR DESCRIPTION
## Proposed Changes

**Enhance Cloud Upload with Automatic Dependency Discovery**

When uploading a single flow file to Maestro Cloud, the system now automatically discovers and includes all dependent files (subflows, scripts, and media) in the workspace ZIP. This eliminates the need for users to upload the workspace in order to run one flow that needs other files.

- **New `DependencyResolver` class**: Automatically discovers dependencies by parsing flow files for `runFlow`, `runScript`, and `addMedia` commands
- **Enhanced `WorkspaceUtils`**: Automatically detects single file uploads and includes dependencies, while maintaining existing directory upload behavior

### **User Experience Impact**
- **Before**: Users had to upload workspace in order to run one specific file with dependencies
- **After**: Users can upload a single flow file and all dependencies are automatically included

### **Example**
Uploading `android-advanced-flow.yaml` now works seamlessly, whereas before it would fail due to missing subflows, or scripts

## Testing
- Created comprehensive `DependencyResolverTest.kt` covering all dependency types
- Tests verify nested subflows, script dependencies, and media file discovery
- Tests include scenarios where subflows reference other subflows (nested dependencies)

## Maestro Studio

Changes will have the same effect there :) 

---

Error we get:

<img width="747" height="293" alt="image" src="https://github.com/user-attachments/assets/06114566-728b-4130-bc87-09be060c2969" />

With this PR:

<img width="717" height="296" alt="image" src="https://github.com/user-attachments/assets/c5f2b4c5-28d2-43aa-8bde-a86566f15d0d" />

