### PR TITLE
Revert "feat: Detect minimum JVM version"

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -41,69 +41,8 @@ tasks.named<JavaExec>("run") {
     workingDir = rootDir
 }
 
-/**
- * Logic adapted from https://stackoverflow.com/a/49688919
- */
-fun windowsMinimumJavaText(minimumJavaVersion: String): String = """
-rem Parses x out of 1.x; for example 8 out of java version 1.8.0_xx
-rem Otherwise, parses the major version; 9 out of java version 9-ea
-set JAVA_VERSION=0
-for /f "tokens=3" %%g in ('%JAVA_EXE% -Xms32M -Xmx32M -version 2^>^&1 ^| findstr /i "version"') do (
-  set JAVA_VERSION=%%g
-)
-set JAVA_VERSION=%JAVA_VERSION:"=%
-for /f "delims=.-_ tokens=1-2" %%v in ("%JAVA_VERSION%") do (
-  if /I "%%v" EQU "1" (
-    set JAVA_VERSION=%%w
-  ) else (
-    set JAVA_VERSION=%%v
-  )
-)
-
-if %JAVA_VERSION% LSS $minimumJavaVersion (
-  echo.
-  echo ERROR: Java $minimumJavaVersion or higher is required.
-  echo.
-  echo Please update Java, then try again.
-  echo To check your Java version, run: java -version
-  echo.
-  echo See https://maestro.dev/blog/what-s-new-inmaestro-2-0-0 for more details.
-  goto fail
-)
-""".trimIndent().replace("\n", "\r\n")
-
-/**
- * Logic adapted from https://stackoverflow.com/a/56243046
- */
-fun unixMinimumJavaText(minimumJavaVersion: String): String = """
-JAVA_VERSION=$( "${'$'}JAVACMD" -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^1\./s///' | cut -d'.' -f1 )
-if [ "${'$'}JAVA_VERSION" -lt $minimumJavaVersion ]; then
-  die "ERROR: Java $minimumJavaVersion or higher is required.
-
-Please update Java, then try again.
-To check your Java version, run: java -version
-
-See https://maestro.dev/blog/what-s-new-inmaestro-2-0-0 for more details."
-fi
-""".trimIndent()
-
 tasks.named<CreateStartScripts>("startScripts") {
     classpath = files("${layout.buildDirectory}/libs/*")
-    doLast {
-        val minimumJavaVersion = "17"
-        val unixExec = "exec \"\$JAVACMD\" \"\$@\""
-
-        val currentUnix = unixScript.readText()
-        val replacedUnix = currentUnix.replaceFirst(unixExec,
-            unixMinimumJavaText(minimumJavaVersion) + "\n\n" + unixExec)
-        unixScript.writeText(replacedUnix)
-
-        val currentWindows = windowsScript.readText()
-        val windowsExec = "@rem Execute maestro"
-        val replacedWindows = currentWindows.replaceFirst(windowsExec,
-            windowsMinimumJavaText(minimumJavaVersion) + "\r\n\r\n" + windowsExec)
-        windowsScript.writeText(replacedWindows)
-    }
 }
 
 dependencies {


### PR DESCRIPTION
This reverts commit 5998a726902e64f6b58cb210894fd46f29968246.

Reverts https://github.com/mobile-dev-inc/Maestro/pull/2635 since the output of `java -version` is not consistent amongst different producers of JDK (confirmed as not working with Eclipse Adoptium on Windows).