### PR TITLE
Fix cleanup of logs older than 14 days

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -119,10 +119,17 @@ object TestDebugReporter {
             val currentTime = Instant.now()
             val daysLimit = currentTime.minus(Duration.of(days, ChronoUnit.DAYS))
 
-            Files.walk(getDebugOutputPath()).filter {
+            val logParentDirectory = getDebugOutputPath().parent
+            logger.info("Performing purge of logs older than $days days from ${logParentDirectory.absolutePathString()}")
+
+            Files.walk(logParentDirectory).filter {
                 val fileTime = Files.getAttribute(it, "basic:lastModifiedTime") as FileTime
                 val isOlderThanLimit = fileTime.toInstant().isBefore(daysLimit)
-                Files.isDirectory(it) && isOlderThanLimit
+                val shouldBeDeleted = Files.isDirectory(it) && isOlderThanLimit
+                if (shouldBeDeleted) {
+                    logger.info("Deleting old directory: ${it.absolutePathString()}")
+                }
+                shouldBeDeleted
             }.sorted(Comparator.reverseOrder()).forEach { dir ->
                 Files.walk(dir).sorted(Comparator.reverseOrder()).forEach { file -> Files.delete(file) }
             }

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
@@ -1,0 +1,35 @@
+package maestro.cli.report
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.pathString
+
+
+class TestDebugReporterTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `will delete old files`() {
+        // Create directory structure, and an old test directory
+        val oldDir = Files.createDirectories(tempDir.resolve(".maestro/tests/old"))
+        Files.setLastModifiedTime(oldDir, java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis() - 1000 * 60 * 60 * 24 * 15))
+
+        // Initialise a new test reporter, which will create ./maestro/tests/<datestamp>
+        TestDebugReporter.install(tempDir.pathString, false,false)
+
+        // Run the deleteOldFiles method, which happens at the end of each test run
+        // This should delete the 'old' directory created above
+        TestDebugReporter.deleteOldFiles()
+        assertThat(Files.exists(oldDir)).isFalse() // Verify that the old directory was deleted
+        assertThat(TestDebugReporter.getDebugOutputPath().exists()).isTrue() // Verify that the logs from this run still exist
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

Fix a long-standing issue where the log cleanup has been broken, and accumulating cruft on disk.

https://maestro--dev.slack.com/archives/C041FU72T54/p1750333850096709

## Testing

Manually tested on a Mac. Added a test.

## Issues fixed

?? How can I not find this in the tracker ??