### PR TITLE
feat: Accurately use durations from server

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -611,13 +611,15 @@ data class UploadStatus(
     val uploadId: String,
     val status: Status,
     val completed: Boolean,
-    val flows: List<FlowResult>,
+    val totalTime: Long?,
+    val flows: List<FlowResult>
 ) {
 
     data class FlowResult(
         val name: String,
         val status: FlowStatus,
         val errors: List<String>,
+        val totalTime: Long? = null,
         val cancellationReason: CancellationReason? = null
     )
 

--- a/maestro-cli/src/main/java/maestro/cli/model/RunningFlow.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/RunningFlow.kt
@@ -1,17 +1,15 @@
 package maestro.cli.model
 
-import maestro.cli.api.UploadStatus
 import kotlin.time.Duration
 
 data class RunningFlows(
-    val flows: MutableSet<RunningFlow> = mutableSetOf(),
-    var duration: Duration? = null
+    val flows: List<RunningFlow>,
+    val duration: Duration?
 )
 
 data class RunningFlow(
     val name: String,
-    var status: FlowStatus? = null,
-    var startTime: Long? = null,
-    var duration: Duration? = null,
-    var reported: Boolean = false
+    val status: FlowStatus,
+    val duration: Duration? = null,
+    val reported: Boolean = false
 )


### PR DESCRIPTION
## Proposed changes

With recent changes that have been deployed to maestro server, this PR allows accurate reporting of `time` values which are used in generated JUnit reports. Rather than inaccurately calculating the durations on client side (i.e. maestro-cli) we instead get the durations from the flow status on the server.

PR also fixes a bug where its possible that the time duration would incorrectly be zero. This would happen in the case where the poll duration is longer than flow status changes from the server, causing the currently existing logic to fail as it relies on detecting a state transition to `RUNNING` in order to calculate the durations.

There is an additional change to be wary of, previously if the duration field was `null` then this would get reported in JUnit as `time="0"`. Now the `time` attribute will be missing entirely to indicate that if for whatever reason the total time cannot be calculated, we will not be misleadingly represent it as 0. This is important considering that the timeunit for `time` is seconds, and so for a very short successful run (i.e. < 0.5 seconds) this would get shown as `0` which is different to not having a `totalTime` time at all.

Also note that the `totalTime` for the main parent flow is now calculated differently, its not the total duration of all of the subflows but rather the total time inclusive of other steps that are not part of subflows (such as the initialization of the device). Its up to discussion whether this is a better or worse change but in any case it can always be updated later.

In terms of implementation of this PR, polling is still used but its only to figure out if the flow has finished and not to get the status changes while the flow is running. So while there is still polling, its not going to mess with the accuracy of the reported durations. The only remaining effect of using polling now is that the `maestro-cli` execution time might be slightly longer, but thats not a big deal.

## Testing

This has been tested locally (with the changes from the server) and confirmed as working.

## Issues fixed

Resolves: https://github.com/mobile-dev-inc/Maestro/issues/827