### PR TITLE
Fix iOS Simulator integration test

### DIFF
--- a/.github/scripts/boot_simulator.sh
+++ b/.github/scripts/boot_simulator.sh
@@ -2,7 +2,7 @@
 
 # Specify the device type and runtime as per your requirements
 DEVICE_TYPE="iPhone 15 Pro"
-RUNTIME="iOS17.5"
+RUNTIME="iOS18.5"
 
 # Create a unique identifier for the new simulator to avoid naming conflicts
 SIMULATOR_NAME="Simulator_$(uuidgen)"


### PR DESCRIPTION
The previous version attempted to boot iOS 17.5, which isn't included in the latest macos GHA runner, [as of August 11th](https://github.com/actions/runner-images/issues/12541).

## Proposed changes

Switch to iOS 18.5

## Testing

It's CI, so let's run it and see!

## Issues fixed
