### PR TITLE
Only download apps as needed in CI

### DIFF
--- a/.github/workflows/ios-integration-tests.yaml
+++ b/.github/workflows/ios-integration-tests.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Download apps
         working-directory: ${{ github.workspace }}/e2e
-        run: ./download_apps
+        run: ./download_apps iOS
 
       - name: Install apps
         working-directory: ${{ github.workspace }}/e2e

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Download apps
         working-directory: ${{ github.workspace }}/e2e
-        run: ./download_apps
+        run: ./download_apps android
 
       - name: Install apps
         working-directory: ${{ github.workspace }}/e2e
@@ -237,7 +237,7 @@ jobs:
 
       - name: Download apps
         working-directory: ${{ github.workspace }}/e2e
-        run: ./download_apps
+        run: ./download_apps ios
 
       - name: Install apps
         working-directory: ${{ github.workspace }}/e2e

--- a/e2e/download_apps
+++ b/e2e/download_apps
@@ -10,12 +10,26 @@ set -eu
 
 command -v curl >/dev/null 2>&1 || { echo "curl is required" && exit 1; }
 
+platform="${1:-}" # android or ios or an empty string (no filter)
+platform="$(echo "$platform" | tr '[:upper:]' '[:lower:]')" # Normalize to lowercase
+
 mkdir -p ./apps
 while read -r url; do
-	echo "download $url"
-	app_file="$(curl -fsSL --output-dir ./apps --write-out "%{filename_effective}" -OJ "$url")"
-	extension="${app_file##*.}"
-	if [ "$extension" = "zip" ]; then
-		unzip -qq -o -d ./apps "$app_file" -x "__MACOSX/*"
-	fi
+  case "$platform" in
+    android)
+      echo "$url" | grep -qi '\.apk$' || continue # Skip if not an APK
+      ;;
+    ios)
+      echo "$url" | grep -qi '\.zip$' || continue # Skip if not a ZIP file
+      ;;
+    *)
+      # No filter
+      ;;
+  esac
+  echo "download $url"
+  app_file="$(curl -fsSL --output-dir ./apps --write-out "%{filename_effective}" -OJ "$url")"
+  extension="${app_file##*.}"
+  if [ "$extension" = "zip" ]; then
+    unzip -qq -o -d ./apps "$app_file" -x "__MACOSX/*"
+  fi
 done <manifest.txt


### PR DESCRIPTION
## Proposed changes

* Update download_apps to take an optional case insensitive parameter to specify platform.
* When platform is specified, skip apps belonging to other platforms
* When no platform is specified, download everything
* Update CI to use the parameter in the relevant places

This will save ~5 seconds on every run. You're welcome.

## Testing

```
./download_apps
./download_apps ios
./download_apps android
./download_apps iOS
./download_apps Android
```
