### PR TITLE
[MA-3574] Argument --test-output-dir fix for when directory not existent

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -175,8 +175,8 @@ object TestDebugReporter {
 
     fun updateTestOutputDir(testOutputDir: Path?) {
         this.testOutputDir = testOutputDir
-        // set debug output path to match the test output directory
-        debugOutputPath = testOutputDir
+        // Reset debugOutputPath so getDebugOutputPath() will properly handle directory creation
+        debugOutputPath = null
     }
 
     fun getDebugOutputPath(): Path {


### PR DESCRIPTION
## Proposed changes

Fix `--test-output-dir` parameter causing FileNotFoundException by ensuring proper directory creation. 

The issue was that `updateTestOutputDir()` was setting `debugOutputPath` directly to the user-provided directory without creating it, bypassing the directory creation logic in `getDebugOutputPath()`. This fix resets `debugOutputPath` to `null`, forcing the proper initialization flow that creates the directory structure.

## Testing

Tested with:
```bash
./maestro test flow.yaml --test-output-dir=./test_output
```

Before: `FileNotFoundException: /test_output/commands-(...).json (No such file or directory)`
After: Successfully creates directory and writes test artifacts

## Issues fixed

Fixes FileNotFoundException when using `--test-output-dir` parameter due to missing directory creation.