### PR TITLE
feat: Add timestamp to JUnit reports

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -612,6 +612,7 @@ data class UploadStatus(
     val status: Status,
     val completed: Boolean,
     val totalTime: Long?,
+    val startTime: Long?,
     val flows: List<FlowResult>
 ) {
 
@@ -619,6 +620,7 @@ data class UploadStatus(
         val name: String,
         val status: FlowStatus,
         val errors: List<String>,
+        val startTime: Long,
         val totalTime: Long? = null,
         val cancellationReason: CancellationReason? = null
     )

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -277,14 +277,16 @@ class CloudInteractor(
 
             if (upload.completed) {
                 val runningFlows = RunningFlows(
-                    upload.flows.map { flowResult ->
+                    flows = upload.flows.map { flowResult ->
                         RunningFlow(
                             flowResult.name,
                             flowResult.status,
-                            flowResult.totalTime?.milliseconds
+                            duration = flowResult.totalTime?.milliseconds,
+                            startTime = flowResult.startTime
                         )
                     },
-                    upload.totalTime?.milliseconds
+                    duration = upload.totalTime?.milliseconds,
+                    startTime = upload.startTime
                 )
                 return handleSyncUploadCompletion(
                     upload = upload,
@@ -409,15 +411,18 @@ class CloudInteractor(
             passed = passed,
             flows = upload.flows.map { uploadFlowResult ->
                 val failure = uploadFlowResult.errors.firstOrNull()
+                val currentRunningFlow = runningFlows.flows.find { it.name == uploadFlowResult.name }
                 TestExecutionSummary.FlowResult(
                     name = uploadFlowResult.name,
                     fileName = null,
                     status = uploadFlowResult.status,
                     failure = if (failure != null) TestExecutionSummary.Failure(failure) else null,
-                    duration = runningFlows.flows.find { it.name == uploadFlowResult.name }?.duration
+                    duration = currentRunningFlow?.duration,
+                    startTime = currentRunningFlow?.startTime
                 )
             },
-            duration = runningFlows.duration
+            duration = runningFlows.duration,
+            startTime = runningFlows.startTime
         )
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/model/RunningFlow.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/RunningFlow.kt
@@ -4,12 +4,14 @@ import kotlin.time.Duration
 
 data class RunningFlows(
     val flows: List<RunningFlow>,
-    val duration: Duration?
+    val duration: Duration?,
+    val startTime: Long?
 )
 
 data class RunningFlow(
     val name: String,
     val status: FlowStatus,
     val duration: Duration? = null,
+    val startTime: Long? = null,
     val reported: Boolean = false
 )

--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -15,6 +15,7 @@ data class TestExecutionSummary(
         val passed: Boolean,
         val flows: List<FlowResult>,
         val duration: Duration? = null,
+        val startTime: Long? = null,
         val deviceName: String? = null,
     )
 
@@ -24,6 +25,7 @@ data class TestExecutionSummary(
         val status: FlowStatus,
         val failure: Failure? = null,
         val duration: Duration? = null,
+        val startTime: Long? = null,
     )
 
     data class Failure(

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -5,10 +5,23 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
 import okio.Buffer
 import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 class JUnitTestSuiteReporterTest {
+
+    // Since timestamps we get from the server have milliseconds precision (specifically epoch millis)
+    // we need to truncate off nanoseconds (and any higher) precision.
+    val now = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS)
+
+    val nowPlus1 = now.plusSeconds(1)
+    val nowPlus2 = now.plusSeconds(2)
+
+    val nowAsIso = now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    val nowPlus1AsIso = nowPlus1.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    val nowPlus2AsIso = nowPlus2.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
 
     @Test
     fun `XML - Test passed`() {
@@ -26,16 +39,19 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
-                            duration = 421573.milliseconds
+                            duration = 421573.milliseconds,
+                            startTime = nowPlus1.toInstant().toEpochMilli()
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
                             fileName = "flow_b",
                             status = FlowStatus.WARNING,
-                            duration = 1494749.milliseconds
+                            duration = 1494749.milliseconds,
+                            startTime = nowPlus2.toInstant().toEpochMilli()
                         ),
                     ),
                     duration = 1915947.milliseconds,
+                    startTime = now.toInstant().toEpochMilli()
                 )
             )
         )
@@ -53,9 +69,9 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Test Suite" device="iPhone 15" tests="2" failures="0" time="1915.947">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" status="SUCCESS"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494.749" status="WARNING"/>
+                  <testsuite name="Test Suite" device="iPhone 15" tests="2" failures="0" time="1915.947" timestamp="$nowAsIso">
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494.749" timestamp="$nowPlus2AsIso" status="WARNING"/>
                   </testsuite>
                 </testsuites>
                 
@@ -78,17 +94,20 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
-                            duration = 421573.milliseconds
+                            duration = 421573.milliseconds,
+                            startTime = nowPlus1.toInstant().toEpochMilli()
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
                             fileName = "flow_b",
                             status = FlowStatus.ERROR,
                             failure = TestExecutionSummary.Failure("Error message"),
-                            duration = 131846.milliseconds
+                            duration = 131846.milliseconds,
+                            startTime = nowPlus2.toInstant().toEpochMilli()
                         ),
                     ),
                     duration = 552743.milliseconds,
+                    startTime = now.toInstant().toEpochMilli()
                 )
             )
         )
@@ -106,9 +125,9 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Test Suite" tests="2" failures="1" time="552.743">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" status="SUCCESS"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="131.846" status="ERROR">
+                  <testsuite name="Test Suite" tests="2" failures="1" time="552.743" timestamp="$nowAsIso">
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="131.846" timestamp="$nowPlus2AsIso" status="ERROR">
                       <failure>Error message</failure>
                     </testcase>
                   </testsuite>
@@ -133,16 +152,19 @@ class JUnitTestSuiteReporterTest {
                             name = "Flow A",
                             fileName = "flow_a",
                             status = FlowStatus.SUCCESS,
-                            duration = 421573.milliseconds
+                            duration = 421573.milliseconds,
+                            startTime = nowPlus1.toInstant().toEpochMilli()
                         ),
                         TestExecutionSummary.FlowResult(
                             name = "Flow B",
                             fileName = "flow_b",
                             status = FlowStatus.WARNING,
+                            startTime = nowPlus2.toInstant().toEpochMilli()
                         ),
                     ),
                     duration = 421573.milliseconds,
                     deviceName = "iPhone 14",
+                    startTime = now.toInstant().toEpochMilli()
                 )
             )
         )
@@ -160,9 +182,9 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0" time="421.573">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" status="SUCCESS"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" status="WARNING"/>
+                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0" time="421.573" timestamp="$nowAsIso">
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" timestamp="$nowPlus2AsIso" status="WARNING"/>
                   </testsuite>
                 </testsuites>
                 


### PR DESCRIPTION
## Proposed changes

This PR adds `timestamp` to the JUnit reports.

## Testing

Tests have been updated to confirm the behavior. Local testing has also been done, here is an example of what the final generate report looks like

```xml
<?xml version='1.0' encoding='UTF-8'?>
<testsuites>
  <testsuite name="Test Suite" tests="2" failures="0" time="69.395" timestamp="2025-08-21T11:50:27.371">
    <testcase id="ios-flow" name="ios-flow" classname="ios-flow" time="0.533" timestamp="2025-08-21T11:51:36.029" status="SUCCESS"/>
    <testcase id="ios-advanced-flow" name="ios-advanced-flow" classname="ios-advanced-flow" time="50.961" timestamp="2025-08-21T11:50:40.53" status="SUCCESS"/>
  </testsuite>
</testsuites>
```