### PR TITLE
feat: Add start time to HTML report

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
@@ -45,6 +45,8 @@ class HtmlTestSuiteReporter : TestSuiteReporter {
                 br{}
                 +"Duration: ${suite.duration}"
                 br{}
+                +"Start Time: ${suite.startTime?.let { millisToCurrentLocalDateTime(it) } }"
+                br{}
                 br{}
                 div(classes = "card-group mb-4") {
                   div(classes = "card") {
@@ -102,6 +104,8 @@ class HtmlTestSuiteReporter : TestSuiteReporter {
                           +"Status: ${flow.status}"
                           br{}
                           +"Duration: ${flow.duration}"
+                          br{}
+                          +"Start Time: ${flow.startTime?.let{ millisToCurrentLocalDateTime(it) } }"
                           br{}
                           +"File Name: ${flow.fileName}"
                         }

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -14,28 +14,12 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.model.TestExecutionSummary
 import okio.Sink
 import okio.buffer
-import java.time.Instant
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 import kotlin.time.DurationUnit
 
 class JUnitTestSuiteReporter(
     private val mapper: ObjectMapper,
     private val testSuiteName: String?
 ) : TestSuiteReporter {
-
-    /**
-     * Judging from https://github.com/testmoapp/junitxml?tab=readme-ov-file#complete-junit-xml-example,
-     * the output of timestamp needs to be an ISO 8601 local date time instead of an ISO 8601 offset date
-     * time (it would be ideal to use ISO 8601 offset date time it needs to be confirmed if it's valid)
-     *
-     * Due to having to use LocalDateTime, we need to get the offset from the client (i.e. the machine running
-     * maestro-cli) using ZoneId.systemDefault() so we can display the time relative to the client machine
-     */
-    private fun millisToCurrentLocalDateTime(milliseconds: Long): String {
-        val localDateTime = Instant.ofEpochMilli(milliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime()
-        return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-    }
 
     private fun suiteResultToTestSuite(suite: TestExecutionSummary.SuiteResult) = TestSuite(
         name = testSuiteName ?: "Test Suite",

--- a/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
@@ -2,6 +2,9 @@ package maestro.cli.report
 
 import maestro.cli.model.TestExecutionSummary
 import okio.Sink
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 interface TestSuiteReporter {
 
@@ -19,5 +22,19 @@ interface TestSuiteReporter {
                 // no-op
             }
         }
+    }
+
+
+    /**
+     * Judging from https://github.com/testmoapp/junitxml?tab=readme-ov-file#complete-junit-xml-example,
+     * the output of timestamp needs to be an ISO 8601 local date time instead of an ISO 8601 offset date
+     * time (it would be ideal to use ISO 8601 offset date time it needs to be confirmed if it's valid)
+     *
+     * Due to having to use LocalDateTime, we need to get the offset from the client (i.e. the machine running
+     * maestro-cli) using ZoneId.systemDefault() so we can display the time relative to the client machine
+     */
+    fun millisToCurrentLocalDateTime(milliseconds: Long): String {
+        val localDateTime = Instant.ofEpochMilli(milliseconds).atZone(ZoneId.systemDefault()).toLocalDateTime()
+        return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
     }
 }


### PR DESCRIPTION
## Proposed changes

Adds the start time to HTML generate test report

## Testing

There aren't any existing tests however this is what the result looks like locally

<img width="2544" height="1456" alt="image" src="https://github.com/user-attachments/assets/94f874b4-7030-4c5f-be1e-b78857e19f62" />

## Issues fixed

Resolves: https://github.com/mobile-dev-inc/Maestro/issues/2554