### PR TITLE
Rhino deprecation warning in CLI

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -198,7 +198,7 @@ object MaestroCommandRunner {
         // Warn users about deprecated Rhino JS engine
         val isRhinoExplicitlyRequested = config?.ext?.get("jsEngine") == "rhino"
         if (isRhinoExplicitlyRequested) {
-          PrintUtils.warn("⚠️ The Rhino JS engine (jsEngine: rhino) is deprecated and will be removed in a future version. Please migrate to GraalJS (the default) for better performance and compatibility. This warning will be removed in a future version.")
+          PrintUtils.warn("⚠️  The Rhino JS engine (jsEngine: rhino) is deprecated and will be removed in a future version. Please migrate to GraalJS (the default) for better performance and compatibility. This warning will be removed in a future version.")
         }        
 
         return flowSuccess

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -28,10 +28,12 @@ import maestro.cli.report.FlowAIOutput
 import maestro.cli.report.FlowDebugOutput
 import maestro.cli.runner.resultview.ResultView
 import maestro.cli.runner.resultview.UiState
+import maestro.cli.util.PrintUtils
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.CompositeCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
+
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.utils.CliInsights
 import org.slf4j.LoggerFactory
@@ -94,6 +96,7 @@ object MaestroCommandRunner {
         }
 
         refreshUi()
+        
         if (analyze) {
             ScreenshotUtils.takeDebugScreenshotByCommand(maestro, debugOutput, CommandStatus.PENDING)
         }
@@ -191,6 +194,13 @@ object MaestroCommandRunner {
         )
 
         val flowSuccess = orchestra.runFlow(commands)
+
+        // Warn users about deprecated Rhino JS engine
+        val isRhinoExplicitlyRequested = config?.ext?.get("jsEngine") == "rhino"
+        if (isRhinoExplicitlyRequested) {
+          PrintUtils.warn("⚠️ The Rhino JS engine (jsEngine: rhino) is deprecated and will be removed in a future version. Please migrate to GraalJS (the default) for better performance and compatibility. This warning will be removed in a future version.")
+        }        
+
         return flowSuccess
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -285,12 +285,7 @@ class Orchestra(
             jsEngine.close()
         }
         val isRhinoExplicitlyRequested = config?.ext?.get("jsEngine") == "rhino"
-        
-        // Warn users about deprecated Rhino JS engine
-        if (isRhinoExplicitlyRequested) {
-            logger.warn("⚠️  The Rhino JS engine (jsEngine: rhino) is deprecated and will be removed in a future version. Please migrate to GraalJS (the default) for better performance and compatibility.")
-        }
-        
+                
         val platform = maestro.cachedDeviceInfo.platform.toString().lowercase()
         jsEngine = if (isRhinoExplicitlyRequested) {
             httpClient?.let { RhinoJsEngine(it, platform) } ?: RhinoJsEngine(platform = platform)


### PR DESCRIPTION
This logs a simple warning at the end of execution warning people about the rhino deprecation. It looks like this:
```
Running on Medium_Phone                   
                                          
 ║                                        
 ║  > Flow: android-flow                  
 ║                                        
 ║    ✅   Launch app "org.wikipedia"     
 ║                                        
                                          
⚠️  The Rhino JS engine (jsEngine: rhino) is deprecated and will be removed in a future version. Please migrate to GraalJS (the default) for better performance and compatibility. This warning will be removed in a future version.
```

Logging directly using `PrintUtils` is pretty gross. I think the "correct" way to do this would be to add flow-level reporting information that could be processed by our various `ResultView` classes, but that's a fairly big change for this use case. Happy to take any feedback!

Fixes https://linear.app/mobile-dev/issue/MA-3577/add-warning-for-rhino-deprecation-in-cli-and-cloud 