### PR TITLE
Fix jreleaser minimum jvm version homebrew

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -328,7 +328,7 @@ jreleaser {
             }
 
             dependencies {
-                dependency("openjdk")
+                dependency("openjdk", "17+")
             }
         }
     }


### PR DESCRIPTION
## Proposed changes

This PR fixes jreleaser not producing the minimum JVM version check. This minimum JVM version check was introduced at https://github.com/mobile-dev-inc/homebrew-tap/pull/7 but it would get overridden every single time a new jreleaser release is made

## Testing

To test this locally do

```
export JRELEASER_GITHUB_TOKEN=not used
./gradlew :maestro-cli:jreleaserPrepare --no-daemon --no-parallel
```

Then go into `/maestro-cli/build/jreleaser/prepare/maestro/brew/Formula` and you can see the generated ruby formula, on my system its

```ruby
# Generated with JReleaser 1.13.1 at 2025-08-29T17:37:25.291347+02:00

class Maestro < Formula
  desc "The easiest way to automate UI testing for your mobile app"
  homepage "https://maestro.mobile.dev"
  url "https://github.com/mobile-dev-inc/maestro/releases/download/cli-2.0.1/maestro.zip"
  version "2.0.1"
  sha256 "2180201f1e67afb3169fb00d22d2f6559207ec300341b83c286410a12ce15364"
  license "Apache-2.0"

  depends_on "openjdk" => "17+"

  def install
    libexec.install Dir["*"]
    bin.install_symlink "#{libexec}/bin/maestro" => "maestro"
  end

  test do
    output = shell_output("#{bin}/maestro --version")
    assert_match "2.0.1", output
  end
end
```