### PR TITLE
Add --skip-driver-app and --skip-server-app CLI flags

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -176,6 +176,18 @@ class TestCommand : Callable<Int> {
     @Option(names = ["--api-key"], description = ["[Beta] API key"])
     private var apiKey: String? = null
 
+    @Option(
+        names = ["--skip-driver-app"],
+        description = ["Skip installation and uninstallation of Maestro driver app"]
+    )
+    private var skipDriverApp: Boolean = false
+
+    @Option(
+        names = ["--skip-server-app"],
+        description = ["Skip installation and uninstallation of Maestro server app"]
+    )
+    private var skipServerApp: Boolean = false
+
     private val client: ApiClient = ApiClient(baseUrl = apiUrl)
     private val auth: Auth = Auth(client)
     private val authToken: String? = auth.getAuthToken(apiKey, triggerSignIn = false)
@@ -377,6 +389,8 @@ class TestCommand : Callable<Int> {
             platform = parent?.platform,
             isHeadless = headless,
             reinstallDriver = reinstallDriver,
+            skipDriverApp = skipDriverApp,
+            skipServerApp = skipServerApp,
             executionPlan = executionPlan
         ) { session ->
             val maestro = session.maestro

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -72,6 +72,8 @@ object MaestroSessionManager {
         isStudio: Boolean = false,
         isHeadless: Boolean = false,
         reinstallDriver: Boolean = true,
+        skipDriverApp: Boolean = false,
+        skipServerApp: Boolean = false,
         deviceIndex: Int? = null,
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan? = null,
         block: (MaestroSession) -> T,
@@ -115,6 +117,8 @@ object MaestroSessionManager {
             isHeadless = isHeadless,
             driverHostPort = driverHostPort,
             reinstallDriver = reinstallDriver,
+            skipDriverApp = skipDriverApp,
+            skipServerApp = skipServerApp,
             platformConfiguration = executionPlan?.workspaceConfig?.platform
         )
         Runtime.getRuntime().addShutdownHook(thread(start = false) {
@@ -194,6 +198,8 @@ object MaestroSessionManager {
         isStudio: Boolean,
         isHeadless: Boolean,
         reinstallDriver: Boolean,
+        skipDriverApp: Boolean,
+        skipServerApp: Boolean,
         driverHostPort: Int?,
         platformConfiguration: PlatformConfiguration? = null,
     ): MaestroSession {
@@ -204,6 +210,8 @@ object MaestroSessionManager {
                         selectedDevice.device.instanceId,
                         !connectToExistingSession,
                         driverHostPort,
+                        skipDriverApp,
+                        skipServerApp,
                     )
 
                     Platform.IOS -> createIOS(
@@ -226,6 +234,8 @@ object MaestroSessionManager {
                     selectedDevice.port,
                     driverHostPort,
                     !connectToExistingSession,
+                    skipDriverApp,
+                    skipServerApp,
                 ),
                 device = null,
             )
@@ -274,6 +284,8 @@ object MaestroSessionManager {
         port: Int?,
         driverHostPort: Int?,
         openDriver: Boolean,
+        skipDriverApp: Boolean,
+        skipServerApp: Boolean,
     ): Maestro {
         val dadb = if (port != null) {
             Dadb.create(host ?: defaultHost, port)
@@ -284,7 +296,7 @@ object MaestroSessionManager {
         }
 
         return Maestro.android(
-            driver = AndroidDriver(dadb, driverHostPort),
+            driver = AndroidDriver(dadb, driverHostPort, "", skipDriverApp, skipServerApp),
             openDriver = openDriver,
         )
     }
@@ -320,6 +332,8 @@ object MaestroSessionManager {
         instanceId: String,
         openDriver: Boolean,
         driverHostPort: Int?,
+        skipDriverApp: Boolean,
+        skipServerApp: Boolean,
     ): Maestro {
         val driver = AndroidDriver(
             dadb = Dadb
@@ -329,6 +343,8 @@ object MaestroSessionManager {
                 ?: error("Unable to find device with id $instanceId"),
             hostPort = driverHostPort,
             emulatorName = instanceId,
+            skipDriverApp = skipDriverApp,
+            skipServerApp = skipServerApp,
         )
 
         return Maestro.android(

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -65,6 +65,8 @@ class AndroidDriver(
     private val dadb: Dadb,
     hostPort: Int? = null,
     private var emulatorName: String = "",
+    private val skipDriverApp: Boolean = false,
+    private val skipServerApp: Boolean = false,
     private val metricsProvider: Metrics = MetricsProvider.getInstance(),
     ) : Driver {
     private var open = false
@@ -195,7 +197,12 @@ class AndroidDriver(
         LOGGER.info("[Done] Remove host port from port to allocation map")
 
         LOGGER.info("[Start] Uninstall driver from device")
-        uninstallMaestroApks()
+        if (!skipDriverApp) {
+            uninstallMaestroDriverApp()
+        }
+        if (!skipServerApp) {
+            uninstallMaestroServerApp()
+        }
         LOGGER.info("[Done] Uninstall driver from device")
 
         LOGGER.info("[Start] Close instrumentation session")
@@ -1105,7 +1112,11 @@ class AndroidDriver(
 
     fun installMaestroDriverApp() {
         metrics.measured("operation", mapOf("command" to "installMaestroDriverApp")) {
-            uninstallMaestroDriverApp()
+            if (!skipDriverApp) {
+                uninstallMaestroDriverApp()
+            } else if (isPackageInstalled("dev.mobile.maestro")) {
+                return@measured
+            }
 
             val maestroAppApk = File.createTempFile("maestro-app", ".apk")
 
@@ -1124,7 +1135,11 @@ class AndroidDriver(
     }
 
     private fun installMaestroServerApp() {
-        uninstallMaestroServerApp()
+        if (!skipServerApp) {
+            uninstallMaestroServerApp()
+        } else if (isPackageInstalled("dev.mobile.maestro.test")) {
+            return
+        }
 
         val maestroServerApk = File.createTempFile("maestro-server", ".apk")
 


### PR DESCRIPTION
Adds opt-in CLI flags to skip installation/uninstallation of Maestro driver and server Android apps.

- `--skip-driver-app`: Skips dev.mobile.maestro app install/uninstall  
- `--skip-server-app`: Skips dev.mobile.maestro.test app install/uninstall

## Proposed changes

copilot:summary

## Testing

Ran `maestro test` with and without the new flags

```bash
./maestro-cli/build/install/maestro/bin/maestro test twitter.yaml
./maestro-cli/build/install/maestro/bin/maestro test twitter.yaml --skip-driver-app --skip-server-app
```
When --skip-driver-app and --skip-server-app options are passed, the firstInstallTime of the packages don't change:
```
adb shell dumpsys package dev.mobile.maestro | grep 'firstInstallTime'
adb shell dumpsys package dev.mobile.maestro.test | grep 'firstInstallTime'
```
## Issues fixed

Fixes #2340 - helps avoid Android's app installation limits on real devices by preserving already installed driver and server apps between test runs.