### PR TITLE
fix: condition for checking web flows in case flows length is zero

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -201,12 +201,14 @@ class TestCommand : Callable<Int> {
     private val logger = LoggerFactory.getLogger(TestCommand::class.java)
 
     private fun executionPlanIncludesWebFlow(plan: ExecutionPlan): Boolean {
-        return plan.flowsToRun.any { it.toFile().isWebFlow() } || 
+        if(plan.flowsToRun.isEmpty()) return false
+        return plan.flowsToRun.any { it.toFile().isWebFlow() } ||
                plan.sequence.flows.any { it.toFile().isWebFlow() }
     }
 
     private fun allFlowsAreWebFlow(plan: ExecutionPlan): Boolean {
-      return plan.flowsToRun.all { it.toFile().isWebFlow() }
+        if(plan.flowsToRun.isEmpty()) return false
+        return plan.flowsToRun.all { it.toFile().isWebFlow() }
     }
   
     override fun call(): Int {
@@ -291,7 +293,7 @@ class TestCommand : Callable<Int> {
             }
             .ifEmpty { availableDevices }
             .toList()
-      
+
         val missingDevices = requestedShards - deviceIds.size
         if (missingDevices > 0) {
             PrintUtils.warn("Want to use ${deviceIds.size} devices, which is not enough to run $requestedShards shards. Missing $missingDevices device(s).")

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -201,14 +201,13 @@ class TestCommand : Callable<Int> {
     private val logger = LoggerFactory.getLogger(TestCommand::class.java)
 
     private fun executionPlanIncludesWebFlow(plan: ExecutionPlan): Boolean {
-        if(plan.flowsToRun.isEmpty()) return false
         return plan.flowsToRun.any { it.toFile().isWebFlow() } ||
                plan.sequence.flows.any { it.toFile().isWebFlow() }
     }
 
     private fun allFlowsAreWebFlow(plan: ExecutionPlan): Boolean {
-        if(plan.flowsToRun.isEmpty()) return false
-        return plan.flowsToRun.all { it.toFile().isWebFlow() }
+        if(plan.flowsToRun.isEmpty() && plan.sequence.flows.isEmpty()) return false
+        return (plan.flowsToRun.all { it.toFile().isWebFlow() } && plan.sequence.flows.all { it.toFile().isWebFlow() })
     }
   
     override fun call(): Int {

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -200,12 +200,12 @@ class TestCommand : Callable<Int> {
     private val usedPorts = ConcurrentHashMap<Int, Boolean>()
     private val logger = LoggerFactory.getLogger(TestCommand::class.java)
 
-    private fun executionPlanIncludesWebFlow(plan: ExecutionPlan): Boolean {
+    internal fun executionPlanIncludesWebFlow(plan: ExecutionPlan): Boolean {
         return plan.flowsToRun.any { it.toFile().isWebFlow() } ||
                plan.sequence.flows.any { it.toFile().isWebFlow() }
     }
 
-    private fun allFlowsAreWebFlow(plan: ExecutionPlan): Boolean {
+    internal fun allFlowsAreWebFlow(plan: ExecutionPlan): Boolean {
         if(plan.flowsToRun.isEmpty() && plan.sequence.flows.isEmpty()) return false
         return (plan.flowsToRun.all { it.toFile().isWebFlow() } && plan.sequence.flows.all { it.toFile().isWebFlow() })
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -87,8 +87,6 @@ class TestSuiteInteractor(
             }
         }
 
-      PrintUtils.message(executionPlan.sequence.toString())
-
         // proceed to run all other Flows
         executionPlan.flowsToRun.forEach { flow ->
             val flowFile = flow.toFile()

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -87,6 +87,8 @@ class TestSuiteInteractor(
             }
         }
 
+      PrintUtils.message(executionPlan.sequence.toString())
+
         // proceed to run all other Flows
         executionPlan.flowsToRun.forEach { flow ->
             val flowFile = flow.toFile()

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/TestCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/TestCommandTest.kt
@@ -1,0 +1,185 @@
+package maestro.cli.command
+
+import com.google.common.truth.Truth.assertThat
+import maestro.orchestra.workspace.WorkspaceExecutionPlanner
+import maestro.orchestra.WorkspaceConfig
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.BeforeEach
+import java.nio.file.Path
+
+class TestCommandTest {
+
+    private lateinit var testCommand: TestCommand
+
+    @BeforeEach
+    fun setUp() {
+        testCommand = TestCommand()
+    }
+
+    /*****************************************
+    *** executionPlanIncludesWebFlow Tests ***
+    ******************************************/
+    @Test
+    fun `executionPlanIncludesWebFlow should return false when both flowsToRun and sequence flows are empty`() {
+        val executionPlan = WorkspaceExecutionPlanner.ExecutionPlan(
+            flowsToRun = emptyList(),
+            sequence = WorkspaceExecutionPlanner.FlowSequence(emptyList(), true),
+            workspaceConfig = WorkspaceConfig()
+        )
+        val result = testCommand.executionPlanIncludesWebFlow(executionPlan)
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `executionPlanIncludesWebFlow should return true when flowsToRun contains both mobile & web flow`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/00_mixed_web_mobile_flow_tests")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val includesWebFlow = testCommand.executionPlanIncludesWebFlow(executionPlan)
+        assertThat(includesWebFlow).isTrue()
+    }
+
+    @Test
+    fun `executionPlanIncludesWebFlow should return true when sequence flows contains web flow only`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/01_web_only")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.executionPlanIncludesWebFlow(executionPlan)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `executionPlanIncludesWebFlow should return false when no web flows exist`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/02_mobile_only")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.executionPlanIncludesWebFlow(executionPlan)
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `executionPlanIncludesWebFlow should return true if after config mixed flows exist`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/03_mixed_with_config_execution_order")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.executionPlanIncludesWebFlow(executionPlan)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `executionPlanIncludesWebFlow should return false if after config no web flows exist`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/04_web_only_with_config_execution_order")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.executionPlanIncludesWebFlow(executionPlan)
+        assertThat(result).isFalse()
+    }
+
+    /*****************************************
+    ******** allFlowsAreWebFlow Tests ********
+    ******************************************/
+    @Test
+    fun `allFlowsAreWebFlow should return false when both flowsToRun and sequence flows are empty`() {
+        val executionPlan = WorkspaceExecutionPlanner.ExecutionPlan(
+            flowsToRun = emptyList(),
+            sequence = WorkspaceExecutionPlanner.FlowSequence(emptyList(), true),
+            workspaceConfig = WorkspaceConfig()
+        )
+        val result = testCommand.allFlowsAreWebFlow(executionPlan)
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `allFlowsAreWebFlow should return false when flowsToRun contains both mobile & web flow`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/00_mixed_web_mobile_flow_tests")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+       val result = testCommand.allFlowsAreWebFlow(executionPlan)
+       assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `allFlowsAreWebFlow should return true when sequence flows contains web flow only`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/01_web_only")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.allFlowsAreWebFlow(executionPlan)
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `allFlowsAreWebFlow should return false when no web flows exist`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/02_mobile_only")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.allFlowsAreWebFlow(executionPlan)
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `allFlowsAreWebFlow should return false if after config mixed flows exist`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/03_mixed_with_config_execution_order")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.allFlowsAreWebFlow(executionPlan)
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `allFlowsAreWebFlow should return false if after config no web flows exist`() {
+        val workspacePath = getTestResourcePath("workspaces/test_command_test/04_web_only_with_config_execution_order")
+        val executionPlan = WorkspaceExecutionPlanner.plan(
+            input = setOf(workspacePath),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            config = null
+        )
+        val result = testCommand.executionPlanIncludesWebFlow(executionPlan)
+        assertThat(result).isFalse()
+    }
+
+    /*****************************************
+    ************ Common Functions ************
+    ******************************************/
+    private fun getTestResourcePath(resourcePath: String): Path {
+        val resourceUrl = javaClass.classLoader.getResource(resourcePath)
+        requireNotNull(resourceUrl) { "Test resource not found: $resourcePath" }
+        return Path.of(resourceUrl.toURI())
+    }
+}

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/mobileflow.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/mobileflow.yaml
@@ -1,0 +1,4 @@
+appId: com.example.mobileapp
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/mobileflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/mobileflow2.yaml
@@ -1,0 +1,4 @@
+appId: com.example.mobileapp2
+---
+- launchApp
+- tapOn: 'Submit'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/webflow.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/webflow.yaml
@@ -1,0 +1,4 @@
+url: https://example.com
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/webflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/00_mixed_web_mobile_flow_tests/webflow2.yaml
@@ -1,0 +1,4 @@
+url: https://example2.com
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/01_web_only/webflow.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/01_web_only/webflow.yaml
@@ -1,0 +1,5 @@
+appId: com.example.webapp
+url: https://example.com
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/01_web_only/webflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/01_web_only/webflow2.yaml
@@ -1,0 +1,4 @@
+url: https://example2.com
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/02_mobile_only/mobileflow1.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/02_mobile_only/mobileflow1.yaml
@@ -1,0 +1,4 @@
+appId: com.example.mobileapp1
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/02_mobile_only/mobileflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/02_mobile_only/mobileflow2.yaml
@@ -1,0 +1,4 @@
+appId: com.example.mobileapp2
+---
+- launchApp
+- tapOn: 'Submit'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/config.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/config.yaml
@@ -1,0 +1,12 @@
+flows:
+  - 'subFolder/*'
+includeTags:
+  - tagNameToInclude
+excludeTags:
+  - tagNameToExclude
+executionOrder:
+  continueOnFailure: false
+  flowsOrder:
+    - mobileflow
+    - mobileflow2
+    - webflow

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/mobileflow.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/mobileflow.yaml
@@ -1,0 +1,7 @@
+appId: com.example.mobileapp
+name: mobileflow
+tags:
+  - tagNameToInclude
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/mobileflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/mobileflow2.yaml
@@ -1,0 +1,7 @@
+appId: com.example.mobileapp2
+name: mobileflow2
+tags:
+  - tagNameToInclude
+---
+- launchApp
+- tapOn: 'Submit'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/webflow.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/webflow.yaml
@@ -1,0 +1,7 @@
+url: https://example.com
+name: webflow
+tags:
+  - tagNameToInclude
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/webflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/03_mixed_with_config_execution_order/subFolder/webflow2.yaml
@@ -1,0 +1,7 @@
+url: https://example2.com
+name: webflow2
+tags:
+  - tagNameToExclude
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/config.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/config.yaml
@@ -1,0 +1,9 @@
+flows:
+  - 'subFolder/*'
+excludeTags:
+  - tagNameToExclude
+executionOrder:
+  continueOnFailure: false
+  flowsOrder:
+    - mobileflow
+    - mobileflow2

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/mobileflow.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/mobileflow.yaml
@@ -1,0 +1,7 @@
+appId: com.example.mobileapp
+name: mobileflow
+tags:
+  - tagNameToInclude
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/mobileflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/mobileflow2.yaml
@@ -1,0 +1,7 @@
+appId: com.example.mobileapp2
+name: mobileflow2
+tags:
+  - tagNameToInclude
+---
+- launchApp
+- tapOn: 'Submit'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/webflow.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/webflow.yaml
@@ -1,0 +1,7 @@
+url: https://example.com
+name: webflow
+tags:
+  - tagNameToExclude
+---
+- launchApp
+- tapOn: 'Button'

--- a/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/webflow2.yaml
+++ b/maestro-cli/src/test/resources/workspaces/test_command_test/04_web_only_with_config_execution_order/subFolder/webflow2.yaml
@@ -1,0 +1,7 @@
+url: https://example2.com
+name: webflow2
+tags:
+  - tagNameToExclude
+---
+- launchApp
+- tapOn: 'Button'


### PR DESCRIPTION
In case the `executionOrder` was there and it has wrong name, that means `flows` are `0`. Which caused `allFlowsAreWebFlow` to give true.

Added the check for empty flows as well as included the sequenceFlow as well.

Fixes #2674 