### PR TITLE
fix: Failed test reporting in HtmlTestSuiteReporter

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -17,7 +17,9 @@ data class TestExecutionSummary(
         val duration: Duration? = null,
         val startTime: Long? = null,
         val deviceName: String? = null,
-    )
+    ) {
+        fun failures(): List<FlowResult> = flows.filter { it.status == FlowStatus.ERROR }
+    }
 
     data class FlowResult(
         val name: String,

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -24,7 +24,7 @@ class JUnitTestSuiteReporter(
     private fun suiteResultToTestSuite(suite: TestExecutionSummary.SuiteResult) = TestSuite(
         name = testSuiteName ?: "Test Suite",
         device = suite.deviceName,
-        failures = suite.flows.count { it.status == FlowStatus.ERROR },
+        failures = suite.failures().size,
         time = suite.duration?.toDouble(DurationUnit.SECONDS)?.toString(),
         timestamp = suite.startTime?.let { millisToCurrentLocalDateTime(it) },
         tests = suite.flows.size,

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/HtmlTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/HtmlTestSuiteReporterTest.kt
@@ -1,0 +1,166 @@
+package maestro.cli.report
+
+import com.google.common.truth.Truth.assertThat
+import okio.Buffer
+import org.junit.jupiter.api.Test
+
+class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
+
+    @Test
+    fun `HTML - Test passed`() {
+        // Given
+        val testee = HtmlTestSuiteReporter()
+        val sink = Buffer()
+
+        // When
+        testee.report(
+            summary = testSuccessWithWarning,
+            out = sink
+        )
+        val resultStr = sink.readUtf8()
+
+        // Then
+        assertThat(resultStr).isEqualTo(
+            """
+            <html>
+              <head>
+                <title>Maestro Test Report</title>
+                <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+              </head>
+              <body>
+                <div class="card mb-4">
+                  <div class="card-body">
+                    <h1 class="mt-5 text-center">Flow Execution Summary</h1>
+            <br>Test Result: PASSED<br>Duration: 31m 55.947s<br>Start Time: $nowAsIso<br><br>
+                    <div class="card-group mb-4">
+                      <div class="card">
+                        <div class="card-body">
+                          <h5 class="card-title text-center">Total number of Flows</h5>
+                          <h3 class="card-text text-center">2</h3>
+                        </div>
+                      </div>
+                      <div class="card text-white bg-danger">
+                        <div class="card-body">
+                          <h5 class="card-title text-center">Failed Flows</h5>
+                          <h3 class="card-text text-center">0</h3>
+                        </div>
+                      </div>
+                      <div class="card text-white bg-success">
+                        <div class="card-body">
+                          <h5 class="card-title text-center">Successful Flows</h5>
+                          <h3 class="card-text text-center">2</h3>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card mb-4">
+                      <div class="card-header">
+                        <h5 class="mb-0"><button class="btn btn-success" type="button" data-bs-toggle="collapse" data-bs-target="#Flow A" aria-expanded="false" aria-controls="Flow A">Flow A : SUCCESS</button></h5>
+                      </div>
+                      <div class="collapse" id="Flow A">
+                        <div class="card-body">
+                          <p class="card-text">Status: SUCCESS<br>Duration: 7m 1.573s<br>Start Time: $nowPlus1AsIso<br>File Name: flow_a</p>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card mb-4">
+                      <div class="card-header">
+                        <h5 class="mb-0"><button class="btn btn-success" type="button" data-bs-toggle="collapse" data-bs-target="#Flow B" aria-expanded="false" aria-controls="Flow B">Flow B : WARNING</button></h5>
+                      </div>
+                      <div class="collapse" id="Flow B">
+                        <div class="card-body">
+                          <p class="card-text">Status: WARNING<br>Duration: 24m 54.749s<br>Start Time: $nowPlus2AsIso<br>File Name: flow_b</p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
+                </div>
+              </body>
+            </html>
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `HTML - Test failed`() {
+        // Given
+        val testee = HtmlTestSuiteReporter()
+        val sink = Buffer()
+
+        // When
+        testee.report(
+            summary = testSuccessWithError,
+            out = sink
+        )
+        val resultStr = sink.readUtf8()
+
+        // Then
+        assertThat(resultStr).isEqualTo(
+            """
+            <html>
+              <head>
+                <title>Maestro Test Report</title>
+                <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+              </head>
+              <body>
+                <div class="card mb-4">
+                  <div class="card-body">
+                    <h1 class="mt-5 text-center">Flow Execution Summary</h1>
+            <br>Test Result: FAILED<br>Duration: 9m 12.743s<br>Start Time: $nowAsIso<br><br>
+                    <div class="card-group mb-4">
+                      <div class="card">
+                        <div class="card-body">
+                          <h5 class="card-title text-center">Total number of Flows</h5>
+                          <h3 class="card-text text-center">2</h3>
+                        </div>
+                      </div>
+                      <div class="card text-white bg-danger">
+                        <div class="card-body">
+                          <h5 class="card-title text-center">Failed Flows</h5>
+                          <h3 class="card-text text-center">1</h3>
+                        </div>
+                      </div>
+                      <div class="card text-white bg-success">
+                        <div class="card-body">
+                          <h5 class="card-title text-center">Successful Flows</h5>
+                          <h3 class="card-text text-center">1</h3>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card border-danger mb-3">
+                      <div class="card-body text-danger"><b>Failed Flow</b><br>
+                        <p class="card-text">Flow B<br></p>
+                      </div>
+                    </div>
+                    <div class="card mb-4">
+                      <div class="card-header">
+                        <h5 class="mb-0"><button class="btn btn-success" type="button" data-bs-toggle="collapse" data-bs-target="#Flow A" aria-expanded="false" aria-controls="Flow A">Flow A : SUCCESS</button></h5>
+                      </div>
+                      <div class="collapse" id="Flow A">
+                        <div class="card-body">
+                          <p class="card-text">Status: SUCCESS<br>Duration: 7m 1.573s<br>Start Time: $nowPlus1AsIso<br>File Name: flow_a</p>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card mb-4">
+                      <div class="card-header">
+                        <h5 class="mb-0"><button class="btn btn-danger" type="button" data-bs-toggle="collapse" data-bs-target="#Flow B" aria-expanded="false" aria-controls="Flow B">Flow B : ERROR</button></h5>
+                      </div>
+                      <div class="collapse" id="Flow B">
+                        <div class="card-body">
+                          <p class="card-text">Status: ERROR<br>Duration: 2m 11.846s<br>Start Time: $nowPlus2AsIso<br>File Name: flow_b</p>
+                          <p class="card-text text-danger">Error message</p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
+                </div>
+              </body>
+            </html>
+
+            """.trimIndent()
+        )
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -1,65 +1,20 @@
 package maestro.cli.report
 
 import com.google.common.truth.Truth.assertThat
-import maestro.cli.model.FlowStatus
-import maestro.cli.model.TestExecutionSummary
 import okio.Buffer
 import org.junit.jupiter.api.Test
-import java.time.OffsetDateTime
-import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoUnit
-import kotlin.time.Duration.Companion.milliseconds
 
-class JUnitTestSuiteReporterTest {
-
-    // Since timestamps we get from the server have milliseconds precision (specifically epoch millis)
-    // we need to truncate off nanoseconds (and any higher) precision.
-    val now = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS)
-
-    val nowPlus1 = now.plusSeconds(1)
-    val nowPlus2 = now.plusSeconds(2)
-
-    val nowAsIso = now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-    val nowPlus1AsIso = nowPlus1.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-    val nowPlus2AsIso = nowPlus2.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
 
     @Test
     fun `XML - Test passed`() {
         // Given
         val testee = JUnitTestSuiteReporter.xml()
-
-        val summary = TestExecutionSummary(
-            passed = true,
-            suites = listOf(
-                TestExecutionSummary.SuiteResult(
-                    passed = true,
-                    deviceName = "iPhone 15",
-                    flows = listOf(
-                        TestExecutionSummary.FlowResult(
-                            name = "Flow A",
-                            fileName = "flow_a",
-                            status = FlowStatus.SUCCESS,
-                            duration = 421573.milliseconds,
-                            startTime = nowPlus1.toInstant().toEpochMilli()
-                        ),
-                        TestExecutionSummary.FlowResult(
-                            name = "Flow B",
-                            fileName = "flow_b",
-                            status = FlowStatus.WARNING,
-                            duration = 1494749.milliseconds,
-                            startTime = nowPlus2.toInstant().toEpochMilli()
-                        ),
-                    ),
-                    duration = 1915947.milliseconds,
-                    startTime = now.toInstant().toEpochMilli()
-                )
-            )
-        )
         val sink = Buffer()
 
         // When
         testee.report(
-            summary = summary,
+            summary = testSuccessWithWarning,
             out = sink
         )
         val resultStr = sink.readUtf8()
@@ -83,39 +38,11 @@ class JUnitTestSuiteReporterTest {
     fun `XML - Test failed`() {
         // Given
         val testee = JUnitTestSuiteReporter.xml()
-
-        val summary = TestExecutionSummary(
-            passed = false,
-            suites = listOf(
-                TestExecutionSummary.SuiteResult(
-                    passed = false,
-                    flows = listOf(
-                        TestExecutionSummary.FlowResult(
-                            name = "Flow A",
-                            fileName = "flow_a",
-                            status = FlowStatus.SUCCESS,
-                            duration = 421573.milliseconds,
-                            startTime = nowPlus1.toInstant().toEpochMilli()
-                        ),
-                        TestExecutionSummary.FlowResult(
-                            name = "Flow B",
-                            fileName = "flow_b",
-                            status = FlowStatus.ERROR,
-                            failure = TestExecutionSummary.Failure("Error message"),
-                            duration = 131846.milliseconds,
-                            startTime = nowPlus2.toInstant().toEpochMilli()
-                        ),
-                    ),
-                    duration = 552743.milliseconds,
-                    startTime = now.toInstant().toEpochMilli()
-                )
-            )
-        )
         val sink = Buffer()
 
         // When
         testee.report(
-            summary = summary,
+            summary = testSuccessWithError,
             out = sink
         )
         val resultStr = sink.readUtf8()
@@ -141,38 +68,11 @@ class JUnitTestSuiteReporterTest {
     fun `XML - Custom test suite name is used when present`() {
         // Given
         val testee = JUnitTestSuiteReporter.xml("Custom test suite name")
-
-        val summary = TestExecutionSummary(
-            passed = true,
-            suites = listOf(
-                TestExecutionSummary.SuiteResult(
-                    passed = true,
-                    flows = listOf(
-                        TestExecutionSummary.FlowResult(
-                            name = "Flow A",
-                            fileName = "flow_a",
-                            status = FlowStatus.SUCCESS,
-                            duration = 421573.milliseconds,
-                            startTime = nowPlus1.toInstant().toEpochMilli()
-                        ),
-                        TestExecutionSummary.FlowResult(
-                            name = "Flow B",
-                            fileName = "flow_b",
-                            status = FlowStatus.WARNING,
-                            startTime = nowPlus2.toInstant().toEpochMilli()
-                        ),
-                    ),
-                    duration = 421573.milliseconds,
-                    deviceName = "iPhone 14",
-                    startTime = now.toInstant().toEpochMilli()
-                )
-            )
-        )
         val sink = Buffer()
 
         // When
         testee.report(
-            summary = summary,
+            summary = testSuccessWithWarning,
             out = sink
         )
         val resultStr = sink.readUtf8()
@@ -182,9 +82,9 @@ class JUnitTestSuiteReporterTest {
             """
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
-                  <testsuite name="Custom test suite name" device="iPhone 14" tests="2" failures="0" time="421.573" timestamp="$nowAsIso">
+                  <testsuite name="Custom test suite name" device="iPhone 15" tests="2" failures="0" time="1915.947" timestamp="$nowAsIso">
                     <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" timestamp="$nowPlus2AsIso" status="WARNING"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494.749" timestamp="$nowPlus2AsIso" status="WARNING"/>
                   </testsuite>
                 </testsuites>
                 

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
@@ -1,0 +1,78 @@
+package maestro.cli.report
+
+import maestro.cli.model.FlowStatus
+import maestro.cli.model.TestExecutionSummary
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import kotlin.time.Duration.Companion.milliseconds
+
+abstract class TestSuiteReporterTest {
+
+    // Since timestamps we get from the server have milliseconds precision (specifically epoch millis)
+    // we need to truncate off nanoseconds (and any higher) precision.
+    val now = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS)
+
+    val nowPlus1 = now.plusSeconds(1)
+    val nowPlus2 = now.plusSeconds(2)
+
+    val nowAsIso = now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    val nowPlus1AsIso = nowPlus1.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    val nowPlus2AsIso = nowPlus2.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+
+    val testSuccessWithWarning = TestExecutionSummary(
+        passed = true,
+        suites = listOf(
+            TestExecutionSummary.SuiteResult(
+                passed = true,
+                deviceName = "iPhone 15",
+                flows = listOf(
+                    TestExecutionSummary.FlowResult(
+                        name = "Flow A",
+                        fileName = "flow_a",
+                        status = FlowStatus.SUCCESS,
+                        duration = 421573.milliseconds,
+                        startTime = nowPlus1.toInstant().toEpochMilli()
+                    ),
+                    TestExecutionSummary.FlowResult(
+                        name = "Flow B",
+                        fileName = "flow_b",
+                        status = FlowStatus.WARNING,
+                        duration = 1494749.milliseconds,
+                        startTime = nowPlus2.toInstant().toEpochMilli()
+                    ),
+                ),
+                duration = 1915947.milliseconds,
+                startTime = now.toInstant().toEpochMilli()
+            )
+        )
+    )
+
+    val testSuccessWithError = TestExecutionSummary(
+        passed = false,
+        suites = listOf(
+            TestExecutionSummary.SuiteResult(
+                passed = false,
+                flows = listOf(
+                    TestExecutionSummary.FlowResult(
+                        name = "Flow A",
+                        fileName = "flow_a",
+                        status = FlowStatus.SUCCESS,
+                        duration = 421573.milliseconds,
+                        startTime = nowPlus1.toInstant().toEpochMilli()
+                    ),
+                    TestExecutionSummary.FlowResult(
+                        name = "Flow B",
+                        fileName = "flow_b",
+                        status = FlowStatus.ERROR,
+                        failure = TestExecutionSummary.Failure("Error message"),
+                        duration = 131846.milliseconds,
+                        startTime = nowPlus2.toInstant().toEpochMilli()
+                    ),
+                ),
+                duration = 552743.milliseconds,
+                startTime = now.toInstant().toEpochMilli()
+            )
+        )
+    )
+}


### PR DESCRIPTION
## Proposed changes

This PR fixes incorrect reporting of failures in `HtmlTestSuiteReporter`. The error appeared to be a simple one, due to the logic of calculating failures there was double counting of test failures. The logic of `getFailedTests` was simplified to just use a basic filter.

`failures` was also moved to a common function so that we don't get divergence in what constitutes a failure. Note that there are some other data structures which also represent test reports but that should be fixed in a future PR as its out of scope.

## Testing

Common testing logic was moved out of `JUnitTestSuiteReporterTest` into a `TestSuiteReporterTest` so that we could add newly added tests to `HtmlTestSuiteReporterTest` in order to verify that the failure count is working (amongst other things).

## Issues fixed

Resolves: https://github.com/mobile-dev-inc/Maestro/issues/2687#issuecomment-3246749465