### PR TITLE
Using subscope for runScript execution in Graal engine

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -76,9 +76,24 @@ class GraalJsEngine(
         sourceName: String,
         runInSubScope: Boolean,
     ): Value {
-        envBinding.putAll(env)
-        val source = Source.newBuilder("js", script, sourceName).build()
-        return createContext().eval(source)
+        if (runInSubScope) {
+            // Save current environment state
+            enterEnvScope()
+            try {
+                // Add the new env vars on top of the current scope
+                envBinding.putAll(env)
+                val source = Source.newBuilder("js", script, sourceName).build()
+                return createContext().eval(source)
+            } finally {
+                // Restore previous environment state
+                leaveEnvScope()
+            }
+        } else {
+            // Original behavior - directly add to envBinding
+            envBinding.putAll(env)
+            val source = Source.newBuilder("js", script, sourceName).build()
+            return createContext().eval(source)
+        }
     }
 
     val hostAccess = HostAccess.newBuilder()

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -87,4 +87,20 @@ class GraalJsEngineTest : JsEngineTest() {
         assertThat(result).matches("^[A-Za-z]+ [A-Za-z']+$")
     }
 
+    @Test
+    fun `runInSubScope should isolate environment variables`() {
+        // Set a base environment variable
+        engine.putEnv("MY_VAR", "original")
+        
+        // Verify original value is accessible
+        assertThat(engine.evaluateScript("MY_VAR").toString()).isEqualTo("original")
+        
+        // Execute script with runInSubScope=true and different env var
+        val envVars = mapOf("MY_VAR" to "scoped")
+        engine.evaluateScript("console.log('Log from runScript')", envVars, "test.js", runInSubScope = true)
+        
+        // MY_VAR should still be original - the scoped value should not leak
+        assertThat(engine.evaluateScript("MY_VAR").toString()).isEqualTo("original")
+    }
+
 }

--- a/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_graaljs.yaml
@@ -9,6 +9,10 @@ env:
     commands:
       - assertTrue: ${MY_VAR === '1'} 
       - evalScript: ${if(MY_VAR !== '1') { throw Error } } # tests scoping for evalScript
+      - runScript:
+          file: 127_script.js
+          env:
+            MY_VAR: 3
       - runFlow: 
           env:
             MY_VAR: 2
@@ -17,7 +21,8 @@ env:
       - assertTrue: ${MY_VAR === '1'} 
 
   
-# Second flow should NOT see first flow's variable
+# Second flow should NOT see first flow's variable or script variable
 - runFlow:
     commands:
       - assertTrue: ${MY_VAR === '0'}
+      - assertTrue: ${MY_VAR === '0'} # MY_VAR from runScript should not leak

--- a/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
+++ b/maestro-test/src/test/resources/127_env_vars_isolation_rhinojs.yaml
@@ -9,6 +9,10 @@ env:
     commands:
       - assertTrue: ${MY_VAR === '1'}
       - evalScript: ${if(MY_VAR !== '1') { throw Error } } # tests scoping for evalScript
+      - runScript:
+          file: 127_script.js
+          env:
+            MY_VAR: 3
       - runFlow:
           env:
             MY_VAR: 2
@@ -16,7 +20,8 @@ env:
             - assertTrue: ${MY_VAR === '2'}
       - assertTrue: ${MY_VAR === '1'}
 
-# Second flow should NOT see first flow's variable
+# Second flow should NOT see first flow's variable or script variable
 - runFlow:
     commands:
       - assertTrue: ${MY_VAR === '0'}
+      - assertTrue: ${MY_VAR === '0'} # MY_VAR from runScript should not leak

--- a/maestro-test/src/test/resources/127_script.js
+++ b/maestro-test/src/test/resources/127_script.js
@@ -1,0 +1,1 @@
+console.log('Log from runScript')


### PR DESCRIPTION
The graal engine implementation ignored the `runInSubScope` boolean flag. So even though it would correctly isolate env scopes set by commands, it didn't do it for `runScript`, which is a "special" command that calls `evaluateScript` directly.

I added integration and graal engine tests, they all failed, then I fixed them to confirm this is working as expected.

Fixes MAE-270 / #2694 