### PR TITLE
Evaluate truthiness before visibility, to fail sooner if we can

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -784,6 +784,30 @@ class Orchestra(
             }
         }
 
+        condition.scriptCondition?.let { value ->
+            // Note that script should have been already evaluated by this point
+
+            if (value.isBlank()) {
+                return false
+            }
+
+            if (value.equals("false", ignoreCase = true)) {
+                return false
+            }
+
+            if (value == "undefined") {
+                return false
+            }
+
+            if (value == "null") {
+                return false
+            }
+
+            if (value.toDoubleOrNull() == 0.0) {
+                return false
+            }
+        }
+
         condition.visible?.let {
             try {
                 findElement(
@@ -816,30 +840,6 @@ class Orchestra(
 
             // Element was actually visible
             if (result != true) {
-                return false
-            }
-        }
-
-        condition.scriptCondition?.let { value ->
-            // Note that script should have been already evaluated by this point
-
-            if (value.isBlank()) {
-                return false
-            }
-
-            if (value.equals("false", ignoreCase = true)) {
-                return false
-            }
-
-            if (value == "undefined") {
-                return false
-            }
-
-            if (value == "null") {
-                return false
-            }
-
-            if (value.toDoubleOrNull() == 0.0) {
                 return false
             }
         }


### PR DESCRIPTION
## Proposed changes

When a Condition is evaluated, we test each provided test for failure else return true. These are evaluated sequentially.

When we have multiple conditions, it makes sense to test the quick ones first, so that if it's going to fail, it does so sooner.

Example:
```
- runFlow:
    when:
      true: ${output.foo > 3}
      visible: "bar"
    commands:
      - tapOn: "bar"
```

Before, it would test for the visibility of "bar", before testing the truthiness of the already evaluated condition, adding a ~5s pause to execution if "bar" isn't visible.

Assuming a truthiness check is 0s, and a check for visibility is 0.5s for visible, 5s for not visible:

| Foo | Bar       | Time before | Time after |
|-----|-----------|-------------|------------|
| 2   | Visible   | 0.5         | 0          |
| 4   | Visible   | 0.5         | 0.5        |
| 2   | Invisible | 5           | 0          |
| 4   | Invisible | 5           | 5          |

