### PR TITLE
chore: Put last error in device exception

### DIFF
--- a/maestro-client/src/main/java/maestro/device/DeviceError.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceError.kt
@@ -4,4 +4,4 @@ package maestro.device
  * Exception class specifically for device-related errors in the client module.
  * Functionally equivalent to CliError in maestro-cli.
  */
-class DeviceError(override val message: String) : RuntimeException(message)
+class DeviceError(override val message: String, override val cause: Throwable? = null) : RuntimeException(message, cause)

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -66,6 +66,8 @@ object DeviceService {
                     "full"
                 ).start().waitFor(10,TimeUnit.SECONDS)
 
+                var lastException: Exception? = null
+
                 val dadb = MaestroTimer.withTimeout(60000) {
                     try {
                         Dadb.list().lastOrNull{ dadb ->
@@ -73,9 +75,10 @@ object DeviceService {
                         }
                     } catch (ignored: Exception) {
                         Thread.sleep(100)
+                        lastException = ignored
                         null
                     }
-                } ?: throw DeviceError("Unable to start device: ${device.modelId}")
+                } ?: throw DeviceError("Unable to start device: ${device.modelId}", lastException)
 
                 PrintUtils.message("Waiting for emulator ( ${device.modelId} ) to boot...")
                 while (!bootComplete(dadb)) {


### PR DESCRIPTION
## Proposed changes

This should better help in debugging as it puts the last exception in the `DeviceError` exception allowing the cause to be shown properly
