### PR TITLE
chore: Put root cause in MaestroException.DriverTimeout

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -388,7 +388,7 @@ class AndroidDriver(
                 Status.Code.DEADLINE_EXCEEDED -> {
                     LOGGER.error("Timeout while fetching view hierarchy")
                     abruptClose = true
-                    throw MaestroException.DriverTimeout("Android driver unreachable")
+                    throw MaestroException.DriverTimeout("Android driver unreachable", cause = throwable)
                 }
                 Status.Code.UNAVAILABLE -> {
                     if (throwable.cause is IOException || throwable.message?.contains("io exception", ignoreCase = true) == true) {


### PR DESCRIPTION
## Proposed changes

This can better help in diagnosing AndroidDriver issues as well as being able to catch `StatusRuntimeException` as a root cause
