### PR TITLE
chore: Log MaestroException.ElementNotFound as a warn

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -624,7 +624,7 @@ class Orchestra(
                     return true
                 }
             } catch (ignored: MaestroException.ElementNotFound) {
-                logger.error("Error: $ignored")
+                logger.warn("Error: $ignored")
             }
             maestro.swipeFromCenter(
                 direction,
@@ -792,7 +792,7 @@ class Orchestra(
                     timeoutMs = adjustedToLatestInteraction(timeoutMs ?: optionalLookupTimeoutMs),
                     optional = commandOptional,
                 )
-            } catch (ignored: MaestroException.ElementNotFound) {
+            } catch (_: MaestroException.ElementNotFound) {
                 return false
             }
         }


### PR DESCRIPTION
## Proposed changes

We should log these as warn instead of errors to reduce log error pollution since this is a client/user problem
