### PR TITLE
fix: simplify cleanup because it leads leaking resources

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -88,8 +88,6 @@ class AndroidDriver(
     private var instrumentationSession: AdbShellStream? = null
     private var proxySet = false
 
-    var abruptClose = false
-
     private var isLocationMocked = false
     private var chromeDevToolsEnabled = false
 
@@ -170,7 +168,6 @@ class AndroidDriver(
     }
 
     override fun close() {
-        if (abruptClose) return
         if (proxySet) {
             resetProxy()
         }
@@ -376,13 +373,11 @@ class AndroidDriver(
             when (status.code) {
                 Status.Code.DEADLINE_EXCEEDED -> {
                     LOGGER.error("Timeout while fetching view hierarchy")
-                    abruptClose = true
-                    throw MaestroException.DriverTimeout("Android driver unreachable", cause = throwable)
+                    throw MaestroException.DriverTimeout("Android driver unreachable")
                 }
                 Status.Code.UNAVAILABLE -> {
                     if (throwable.cause is IOException || throwable.message?.contains("io exception", ignoreCase = true) == true) {
                         LOGGER.error("Not able to reach the gRPC server while fetching view hierarchy")
-                        abruptClose = true
                     } else {
                         LOGGER.error("Received UNAVAILABLE status with message: ${throwable.message}")
                     }
@@ -1242,13 +1237,11 @@ class AndroidDriver(
             when (status.code) {
                 Status.Code.DEADLINE_EXCEEDED -> {
                     LOGGER.error("Device call failed on android with $status", throwable)
-                    abruptClose = true
                     throw MaestroException.DriverTimeout("Android driver unreachable")
                 }
                 Status.Code.UNAVAILABLE -> {
                     if (throwable.cause is IOException || throwable.message?.contains("io exception", ignoreCase = true) == true) {
                         LOGGER.error("Not able to reach the gRPC server while doing android device call")
-                        abruptClose = true
                         throw throwable
                     } else {
                         LOGGER.error("Received UNAVAILABLE status with message: ${throwable.message} while doing android device call", throwable)


### PR DESCRIPTION
## What Happened

* abruptClose = true short-circuited close(), returning on the first line.
* This prevented tcp forwarder threads and other resources (instrumentation session, etc.) from being released.
* In production pods we observed:
    * Pods failing to shut down cleanly because the forwarder thread was still alive. 
    * lingering threads trying to make connection with dadb. The first evidence is in the stacktrace itself that has thread name:
```
 Exception in thread "pool-117-thread-7" java.net.SocketTimeoutException: Connect timed out                                                                                                                        │
│     at java.base/sun.nio.ch.NioSocketImpl.timedFinishConnect(NioSocketImpl.java:546)                                                                                                                              │
│     at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:597)                                                                                                                                         │
│     at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)                                                                                                                                       │
│     at java.base/java.net.Socket.connect(Socket.java:633)                                                                                                                                                         │
│     at dadb.DadbImpl.newConnection(DadbImpl.kt:84)                                                                                                                                                                │
│     at dadb.DadbImpl.connection(DadbImpl.kt:74)                                                                                                                                                                   │
│     at dadb.DadbImpl.open(DadbImpl.kt:54)                                                                                                                                                                         │
│     at dadb.forwarding.TcpForwarder.handleForwarding$lambda$1(TcpForwarder.kt:64)                                                                                                                                 │
│     at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)                                                                                                                  │
│     at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)                                                                                                                  │
│     at java.base/java.lang.Thread.run(Thread.java:833)    
```
  
## Why it was Added and Change?

Originally introduced to avoid hanging calls on dadb.shell.

Since then we’ve added multiple improvements: in form of recent migration and gRPC, dadb keep-alives. I don't want to overcomplicate this and try removing this and monitoring.

## Testing

- [ ] Locally

## Issues fixed
