### PR TITLE
Fix e2e test flake

### DIFF
--- a/e2e/workspaces/demo_app/commands/eraseText.yaml
+++ b/e2e/workspaces/demo_app/commands/eraseText.yaml
@@ -13,9 +13,13 @@ appId: com.example.example
     optional: true
 
 - inputText: 'testing'
-- assertVisible: 'testing'
+- assertVisible:
+    text: 'testing'
+    above: 'Login'
 - eraseText: 3
-- assertNotVisible: 'testing'
+- assertNotVisible:
+    text: 'testing'
+    above: 'Login' # In case there's a keyboard suggestion
 - assertVisible:
     text: 'test'
-    optional: true # FIXME: This still takes an extra character sometimes, even after #2123
+    above: 'Login'


### PR DESCRIPTION
## Proposed changes

The test:
```
- inputText: 'testing'
- assertVisible: 'testing'
- eraseText: 3
- assertNotVisible: 'testing'
```

The last line would flake due to keyboard suggestions

<img width="350" height="719" alt="image" src="https://github.com/user-attachments/assets/42e1f4d3-dcef-484e-8146-9218ec74d8a4" />

This introduces 'above' in the visibility selectors to avoid keyboard suggestions.

It also removes the optional keyword for the last assertion - we should find out if that last assertion is flaky.

