### PR TITLE
Support negative indexes in element selectors

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -229,11 +229,14 @@ object Filters {
 
     fun index(idx: Int): ElementFilter {
         return { nodes ->
-            listOfNotNull(
-                nodes
-                    .sortedWith(INDEX_COMPARATOR)
-                    .getOrNull(idx)
-            )
+            val sortedNodes = nodes.sortedWith(INDEX_COMPARATOR)
+            val resolvedIndex = if (idx >= 0) idx else sortedNodes.size + idx
+
+            if (resolvedIndex < 0) {
+                emptyList()
+            } else {
+                listOfNotNull(sortedNodes.getOrNull(resolvedIndex))
+            }
         }
     }
 

--- a/maestro-client/src/test/java/maestro/FiltersTest.kt
+++ b/maestro-client/src/test/java/maestro/FiltersTest.kt
@@ -1,0 +1,60 @@
+package maestro
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class FiltersTest {
+
+    @Test
+    fun `index returns element at positive position`() {
+        val nodes = sampleNodes()
+
+        val result = Filters.index(1)(nodes)
+
+        assertThat(result).containsExactly(nodes[1])
+    }
+
+    @Test
+    fun `index supports negative values`() {
+        val nodes = sampleNodes()
+
+        val result = Filters.index(-1)(nodes)
+
+        assertThat(result).containsExactly(nodes.last())
+    }
+
+    @Test
+    fun `index supports negative value matching collection size`() {
+        val nodes = sampleNodes()
+
+        val result = Filters.index(-nodes.size)(nodes)
+
+        assertThat(result).containsExactly(nodes.first())
+    }
+
+    @Test
+    fun `index returns empty when negative value exceeds bounds`() {
+        val nodes = sampleNodes()
+
+        val result = Filters.index(-4)(nodes)
+
+        assertThat(result).isEmpty()
+    }
+
+    private fun sampleNodes(): List<TreeNode> {
+        return listOf(
+            node(bounds(0, 0)),
+            node(bounds(10, 10)),
+            node(bounds(20, 20)),
+        )
+    }
+
+    private fun node(bounds: String): TreeNode {
+        return TreeNode(attributes = mutableMapOf("bounds" to bounds))
+    }
+
+    private fun bounds(x: Int, y: Int): String {
+        val size = 5
+        return "[${x},${y}][${x + size},${y + size}]"
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds support for negative indexes in element selectors. Eg:

```yaml
- tapOn:
    text: row
    index: -2 # The second-to-last element with text "row"
```

## Testing

Added test for negative index

## Issues fixed

None