### PR TITLE
fix: Fix crash on empty args

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -150,7 +150,8 @@ fun main(args: Array<String>) {
             }
 
         // Track CLI run
-        Analytics.trackEvent(CliCommandRunEvent(command = args[0]))
+        if (args.isNotEmpty())
+            Analytics.trackEvent(CliCommandRunEvent(command = args[0]))
 
         val generateCompletionCommand = commandLine.subcommands["generate-completion"]
         generateCompletionCommand?.commandSpec?.usageMessage()?.hidden(true)


### PR DESCRIPTION
## Proposed changes

If you run maestro with empty cli args it crashes at this point since `args[0]` is not set

Resolves https://github.com/mobile-dev-inc/Maestro/issues/2726?