### PR TITLE
Consolidate Single enum for `Platform`

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -85,9 +85,9 @@ class StartDeviceCommand : Callable<Int> {
         val o = osVersion.toIntOrNull()
 
         val maestroPlatform = when(p) {
-            Platform.ANDROID -> maestro.Platform.ANDROID
-            Platform.IOS -> maestro.Platform.IOS
-            Platform.WEB -> maestro.Platform.WEB
+            Platform.ANDROID -> maestro.device.Platform.ANDROID
+            Platform.IOS -> maestro.device.Platform.IOS
+            Platform.WEB -> maestro.device.Platform.WEB
         }
 
         val locale = deviceLocale ?: "en_US"

--- a/maestro-client/src/main/java/maestro/DeviceInfo.kt
+++ b/maestro-client/src/main/java/maestro/DeviceInfo.kt
@@ -19,6 +19,8 @@
 
 package maestro
 
+import maestro.device.Platform
+
 data class DeviceInfo(
     val platform: Platform,
     val widthPixels: Int,

--- a/maestro-client/src/main/java/maestro/Platform.kt
+++ b/maestro-client/src/main/java/maestro/Platform.kt
@@ -1,5 +1,0 @@
-package maestro
-
-enum class Platform {
-    ANDROID, IOS, WEB
-}

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -35,6 +35,7 @@ import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.android.AndroidAppFiles
 import maestro.android.AndroidLaunchArguments.toAndroidLaunchArguments
 import maestro.android.chromedevtools.AndroidWebViewHierarchyClient
+import maestro.device.Platform
 import maestro.utils.BlockingStreamObserver
 import maestro.utils.MaestroTimer
 import maestro.utils.Metrics

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -10,7 +10,7 @@ import maestro.Driver
 import maestro.KeyCode
 import maestro.Maestro
 import maestro.OnDeviceElementQuery
-import maestro.Platform
+import maestro.device.Platform
 import maestro.Point
 import maestro.ScreenRecording
 import maestro.SwipeDirection

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -7,7 +7,7 @@ import maestro.Driver
 import maestro.KeyCode
 import maestro.Maestro
 import maestro.OnDeviceElementQuery
-import maestro.Platform
+import maestro.device.Platform
 import maestro.Point
 import maestro.ScreenRecording
 import maestro.SwipeDirection

--- a/maestro-client/src/main/java/maestro/utils/LocaleUtils.kt
+++ b/maestro-client/src/main/java/maestro/utils/LocaleUtils.kt
@@ -1,6 +1,6 @@
 package maestro.utils
 
-import maestro.Platform
+import maestro.device.Platform
 
 open class LocaleValidationException(message: String): Exception(message)
 

--- a/maestro-client/src/test/java/maestro/utils/LocaleUtilsTest.kt
+++ b/maestro-client/src/test/java/maestro/utils/LocaleUtilsTest.kt
@@ -1,6 +1,6 @@
 package maestro.utils
 
-import maestro.Platform
+import maestro.device.Platform
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import com.google.common.truth.Truth.assertThat

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
@@ -1,6 +1,6 @@
 package maestro.orchestra
 
-import maestro.Platform
+import maestro.device.Platform
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCondition.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCondition.kt
@@ -1,7 +1,7 @@
 package maestro.orchestra.yaml
 
 import com.fasterxml.jackson.annotation.JsonFormat
-import maestro.Platform
+import maestro.device.Platform
 
 data class YamlCondition(
     @JsonFormat(with = [JsonFormat.Feature.ACCEPT_CASE_INSENSITIVE_PROPERTIES])

--- a/maestro-studio/server/src/main/java/maestro/studio/Models.kt
+++ b/maestro-studio/server/src/main/java/maestro/studio/Models.kt
@@ -1,7 +1,7 @@
 package maestro.studio
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import maestro.Platform
+import maestro.device.Platform
 import java.util.UUID
 
 data class DeviceScreen(

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -28,7 +28,7 @@ import maestro.Driver
 import maestro.KeyCode
 import maestro.MaestroException
 import maestro.OnDeviceElementQuery
-import maestro.Platform
+import maestro.device.Platform
 import maestro.Point
 import maestro.ScreenRecording
 import maestro.SwipeDirection


### PR DESCRIPTION
## What?
I finally realized `maestro.Platform` and `maestro.device.Platform` were the same enums (except `maestro.device.Platform` was a superset).  So, now there is one canonical `Platform` enum.

## Why?
In my own codebase I was attempting to add an extension function on the `Platform` type and was getting weird compiler errors that didn't make sense.  