### PR TITLE
fix: don't treat grpc connection issue as MaestroException

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -373,7 +373,7 @@ class AndroidDriver(
             when (status.code) {
                 Status.Code.DEADLINE_EXCEEDED -> {
                     LOGGER.error("Timeout while fetching view hierarchy")
-                    throw MaestroException.DriverTimeout("Android driver unreachable")
+                    throw throwable
                 }
                 Status.Code.UNAVAILABLE -> {
                     if (throwable.cause is IOException || throwable.message?.contains("io exception", ignoreCase = true) == true) {
@@ -1237,7 +1237,7 @@ class AndroidDriver(
             when (status.code) {
                 Status.Code.DEADLINE_EXCEEDED -> {
                     LOGGER.error("Device call failed on android with $status", throwable)
-                    throw MaestroException.DriverTimeout("Android driver unreachable")
+                    throw throwable
                 }
                 Status.Code.UNAVAILABLE -> {
                     if (throwable.cause is IOException || throwable.message?.contains("io exception", ignoreCase = true) == true) {


### PR DESCRIPTION
## Proposed changes

Maestro exceptions are the app issues we should not treat them as exceptions that are caused by internal device disconnection issues.

## Testing

- [x] E2E 

## Issues fixed
