### PR TITLE
feat: add timeout property for conditions

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Condition.kt
@@ -9,6 +9,7 @@ data class Condition(
     val visible: ElementSelector? = null,
     val notVisible: ElementSelector? = null,
     val scriptCondition: String? = null,
+    val timeout: Long? = null,
     val label: String? = null,
 ) {
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -816,7 +816,7 @@ class Orchestra(
             try {
                 findElement(
                     selector = it,
-                    timeoutMs = adjustedToLatestInteraction(timeoutMs ?: optionalLookupTimeoutMs),
+                    timeoutMs = adjustedToLatestInteraction(condition.timeout ?: timeoutMs ?: optionalLookupTimeoutMs),
                     optional = commandOptional,
                 )
             } catch (_: MaestroException.ElementNotFound) {
@@ -825,7 +825,7 @@ class Orchestra(
         }
 
         condition.notVisible?.let {
-            val result = MaestroTimer.withTimeout(adjustedToLatestInteraction(timeoutMs ?: optionalLookupTimeoutMs)) {
+            val result = MaestroTimer.withTimeout(adjustedToLatestInteraction(condition.timeout ?: timeoutMs ?: optionalLookupTimeoutMs)) {
                 try {
                     findElement(
                         selector = it,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCondition.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCondition.kt
@@ -9,6 +9,7 @@ data class YamlCondition(
     val visible: YamlElementSelectorUnion? = null,
     val notVisible: YamlElementSelectorUnion? = null,
     val `true`: String? = null,
+    val timeout: Long? = null,
     val label: String? = null,
     val optional: Boolean = false,
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -967,6 +967,7 @@ data class YamlFluentCommand(
             visible = visible?.let { toElementSelector(it) },
             notVisible = notVisible?.let { toElementSelector(it) },
             scriptCondition = `true`?.trim(),
+            timeout = timeout,
             label = label
         )
     }

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -4015,6 +4015,51 @@ class IntegrationTest {
         // No test failure - if we reach this point, the test passed successfully
     }
 
+    @Test
+    fun `Case 131 - Repeat while with custom timeout`() {
+        // Given
+        val commands = readCommands("131_repeat_while_timeout")
+        val driver = driver {
+            var counter = 0
+
+            val counterView = element {
+                text = "Value 0"
+                bounds = Bounds(0, 100, 100, 100)
+            }
+
+            element {
+                text = "Always Visible Element"
+                bounds = Bounds(0, 100, 100, 100)
+            }
+
+            element {
+                text = "Button"
+                bounds = Bounds(0, 100, 100, 100)
+                onClick = {
+                    counter++
+                    counterView.text = "Value $counter"
+                }
+            }
+        }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // The "Always Visible Element" is always visible, so the while condition
+        // (notVisible: "Always Visible Element") should be false.
+        // With a 100ms timeout, it should check quickly and not run the loop.
+        // Button should never be tapped.
+        driver.assertEventCount(
+            Event.Tap(Point(50, 50)),
+            expectedCount = 0
+        )
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(

--- a/maestro-test/src/test/resources/131_repeat_while_timeout.yaml
+++ b/maestro-test/src/test/resources/131_repeat_while_timeout.yaml
@@ -1,0 +1,13 @@
+appId: com.other.app
+---
+- evalScript: ${output.counter = 0}
+- repeat:
+    while:
+      notVisible: "Always Visible Element"
+      timeout: 100
+    commands:
+      - evalScript: ${output.counter = output.counter + 1}
+      - tapOn: Button
+# The element is always visible, so with 100ms timeout the condition should
+# evaluate to false quickly and the loop should never run
+- assertVisible: "Value 0"


### PR DESCRIPTION
## Summary
This PR adds support for a timeout property on conditions used in `while` and `when` conditions for loops or conditional commands

## Motivation
Currently, conditions inherit timeout values from global configuration or command-level settings. I've been writing tests with Maestro, and tend to add these optional handling flows that can correct the app if it's in an unexpected state. For example:
```yaml
- runFlow:
    label: Login, if not already logged in
    when:
      visible: 'Login'
    commands:
      - tapOn: 'Login'
```
This is treated as an optional condition, which defaults to 7 seconds, so the test would wait for 7 seconds before continuing when the login screen is not presented. 

With these changes, we'll be able to specify a short timeout, because we already expect the app to be in a settled state when this condition is triggered:
```yaml
- runFlow:
    label: Login, if not already logged in
    when:
      visible: 'Login'
      timeout: 500
    commands:
      - tapOn: 'Login'
```

## Changes
- Added timeout: Long? property to Condition data class
- Updated YamlCondition to accept timeout parameter in YAML
- Modified Orchestra.evaluateCondition() to respect condition-level timeout with proper fallback chain
- Added integration test (Case 131) validating timeout behavior

## Tests
Added `131_repeat_while_timeout.yaml` test flow, as well as tests in our tests suite