### PR TITLE
Enable concurrent testing on multiple devices/simulators from same machine

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -91,6 +91,12 @@ class App {
     var port: Int? = null
 
     @Option(
+        names = ["--driver-host-port"],
+        description = ["AndroidDriver host port for instrumentation communication (default: 7001)"]
+    )
+    var driverHostPort: Int? = null
+
+    @Option(
         names = ["--device", "--udid"],
         description = ["(Optional) Device ID to run on explicitly, can be a comma separated list of IDs: --device \"Emulator_1,Emulator_2\" "],
     )

--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -109,7 +109,7 @@ class PrintHierarchyCommand : Runnable {
         MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             teamId = appleTeamId,
             deviceId = parent?.deviceId,
             platform = parent?.platform,

--- a/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/QueryCommand.kt
@@ -73,7 +73,7 @@ class QueryCommand : Runnable {
         MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             deviceId = parent?.deviceId,
             platform = parent?.platform,
             teamId = appleTeamId,

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -130,7 +130,7 @@ class RecordCommand : Callable<Int> {
         return MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             deviceId = deviceId,
             teamId = appleTeamId,
             platform = parent?.platform,

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -99,7 +99,7 @@ class StartDeviceCommand : Callable<Int> {
                 PrintUtils.message(if (p == Platform.IOS) "Launching simulator..." else "Launching emulator...")
                 DeviceService.startDevice(
                     device = device,
-                    driverHostPort = parent?.port
+                    driverHostPort = parent?.driverHostPort
                 )
             }
         } catch (e: LocaleValidationIosException) {

--- a/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StudioCommand.kt
@@ -75,7 +75,7 @@ class StudioCommand : Callable<Int> {
         MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
-            driverHostPort = null,
+            driverHostPort = parent?.driverHostPort,
             teamId = appleTeamId,
             deviceId = parent?.deviceId,
             platform = parent?.platform,

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -51,6 +51,7 @@ import maestro.cli.util.CiUtils
 import maestro.cli.util.EnvUtils
 import maestro.cli.util.FileUtils.isWebFlow
 import maestro.cli.util.PrintUtils
+import maestro.cli.util.isPortAvailable
 import maestro.cli.insights.TestAnalysisManager
 import maestro.cli.view.greenBox
 import maestro.cli.view.box
@@ -505,12 +506,23 @@ class TestCommand : Callable<Int> {
 
     private fun selectPort(effectiveShards: Int): Int {
         // If user specified driver host port via CLI, use it
-        parent?.driverHostPort?.let { return it }
+        parent?.driverHostPort?.let { port ->
+            if (!isPortAvailable(port)) {
+                throw CliError("Port $port is already in use. Please specify a different port with --driver-host-port")
+            }
+            return port
+        }
 
         // Otherwise use default behavior
-        return if (effectiveShards == 1) 7001
-        else (7001..7128).shuffled().find { port ->
-            usedPorts.putIfAbsent(port, true) == null
+        if (effectiveShards == 1) {
+            if (!isPortAvailable(7001)) {
+                throw CliError("Default port 7001 is already in use. Use --driver-host-port to specify a different port")
+            }
+            return 7001
+        }
+
+        return (7001..7128).shuffled().find { port ->
+            usedPorts.putIfAbsent(port, true) == null && isPortAvailable(port)
         } ?: error("No available ports found")
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -503,11 +503,16 @@ class TestCommand : Callable<Int> {
         }
     }
 
-    private fun selectPort(effectiveShards: Int): Int =
-        if (effectiveShards == 1) 7001
+    private fun selectPort(effectiveShards: Int): Int {
+        // If user specified driver host port via CLI, use it
+        parent?.driverHostPort?.let { return it }
+
+        // Otherwise use default behavior
+        return if (effectiveShards == 1) 7001
         else (7001..7128).shuffled().find { port ->
             usedPorts.putIfAbsent(port, true) == null
         } ?: error("No available ports found")
+    }
 
     private fun runSingleFlow(
         maestro: Maestro,

--- a/maestro-cli/src/main/java/maestro/cli/util/SocketUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/SocketUtils.kt
@@ -10,3 +10,11 @@ fun getFreePort(): Int {
     }
     ServerSocket(0).use { return it.localPort }
 }
+
+fun isPortAvailable(port: Int): Boolean {
+    return try {
+        ServerSocket(port).use { true }
+    } catch (e: Exception) {
+        false
+    }
+}


### PR DESCRIPTION
## Proposed changes

<copilot:summary>
Introduces a new global `--driver-host-port` CLI option that allows users to specify custom driver ports for both Android and iOS, enabling parallel test execution on multiple devices/simulators without port conflicts.

### Problem
Currently, running tests concurrently on different devices fails because all Maestro instances attempt to use the default port 7001, resulting in:
- `Connection refused: localhost:7001`
- `Command failed (tcp:7001): closed`

Users cannot run different tests on different devices simultaneously.

### Solution
- Added `--driver-host-port` global CLI option to `App.kt`
- Modified `TestCommand.kt` to respect user-specified port in `selectPort()` method
- Updated all commands (`RecordCommand`, `StudioCommand`, `QueryCommand`, `PrintHierarchyCommand`, `StartDeviceCommand`) to pass custom port to session manager
- Maintains backward compatibility - defaults to 7001 if not specified
- Works for both Android devices and iOS simulators

### Usage Example
```bash
# Terminal 1: Run auth tests on device 1 with port 7005
maestro --driver-host-port 7005 --device device1 test auth-suite.yaml

# Terminal 2: Run product tests on device 2 with port 7006
maestro --driver-host-port 7006 --device device2 test product-suite.yaml
```

<details>

<summary>Try it now (before merge)</summary>

To use this feature, you have three options:

1. **Wait for PR merge** - This PR needs to be reviewed and merged
2. **Build from source** - Clone this branch and build Maestro yourself
3. **Use pre-built version** - Install the updated JAR directly:

**Upgrade:**
```bash
curl -fsSL https://raw.githubusercontent.com/omnarayan/Maestro/feature/driver-host-port-distribution/upgrade-maestro-ports.sh | sh
```

This replaces your Maestro JAR with the updated version. Usage:
```bash
maestro --driver-host-port 7005 --device device1 test flow.yaml
maestro --driver-host-port 7006 --device device2 test flow.yaml
```

**Restore Original:**
```bash
bash ~/.maestro-backups/backup/restore.sh
```

</details>

### Credit
This implementation builds upon the approach proposed by @avinash-bharti in #2339, implementing the port configuration feature without the additional session management changes.

### Testing
- ✅ Verified concurrent execution on physical Android device (port 7005) + emulator (port 7006) running different test suites simultaneously
- ✅ Confirmed no session mixing between devices - each test ran on its intended device with correct app
- ✅ Backward compatibility verified: default port 7001 works without the flag
- ✅ Tested on both Android devices and iOS simulators
- ✅ All test steps completed successfully with no port conflicts

Test logs show both devices executing tests in parallel without interference.

### Issues fixed
Resolves #1485, #1853, #2082, #2556, #2703
Related to #1818