### PR TITLE
Added the missing node text for the textarea in the view hierarchy

### DIFF
--- a/e2e/demo_app/.maestro/web_flows/textarea.yaml
+++ b/e2e/demo_app/.maestro/web_flows/textarea.yaml
@@ -1,0 +1,14 @@
+url: https://pastebin.com
+---
+- launchApp:
+    clearState: true
+
+- assertVisible: "We value your privacy"
+- tapOn: "AGREE"
+
+- assertVisible:
+    id: "postform-text"
+- tapOn:
+    id: "postform-text"
+- inputText: Potato
+- assertVisible: Potato

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -15,6 +15,9 @@
             case 'input':
                 return node.value || node.placeholder || node.ariaLabel || ''
 
+            case 'textarea':
+                return node.value || node.placeholder || node.ariaLabel || ''
+
             case 'select':
                 return Array.from(node.selectedOptions).map((option) => option.text).join(', ')
 


### PR DESCRIPTION
## Proposed changes

copilot:summary

## Testing
`text` attribute for the resource Id `"resource-id" : "APjFqb"` started getting displayed after the change.

**Before changes:** 

<img width="502" height="245" alt="image" src="https://github.com/user-attachments/assets/f6008ea6-54af-468a-8e2f-ee8b529dbe3d" />

**After changes:**

<img width="492" height="243" alt="image" src="https://github.com/user-attachments/assets/bd23398c-e132-407a-a084-46e5f7401fb0" />


## Issues fixed
https://github.com/mobile-dev-inc/Maestro/issues/2826 