### PR TITLE
Upgrade Jansi to fix warnings and errors

### DIFF
--- a/e2e/demo_app/.maestro/issues/issue2496.yaml
+++ b/e2e/demo_app/.maestro/issues/issue2496.yaml
@@ -1,0 +1,5 @@
+appId: com.notused
+env:
+  value: '#"k_reF`d`jVd@l@q@z@i@r@s@~@u@dAuAjBiAzAu@dA_@d@jBbCl@x@nBtC`AlAbAZf@Fb@P^Tn@f@p@r@nAzAd@l@h@r@`@^z@bApAlBf@x@d@v@f@z@b@z@f@|@p@rAj@fAh@fAr@rAj@x@\b@l@h@l@d@`@Tj@Xn@Vl@Pl@Jn@HtADj@At@Cb@Gp@I~@Oh@Mb@OlAg@d@Sl@W|@[xAMx@Cl@Bn@T^ZXh@Lh@J`A@l@AdAAl@C|@GhAOzBO`BOdBMlAMj@QrDG|BAfACnCEjHAp@?p@A`AG|CQt@Ij@In@KfAIt@Gr@ItAOfBOhBAr@@r@Ft@Dx@NvALzAFl@RxC@~@DzADxAD~A@l@@l@t@LfAE|AIv@Eb@CjDOvDQbI_@BdAP~GBjAx@VlAGzAG`BI~@EjBK`CKxBKt@CbDO"#'
+---
+- evalScript: ${console.log(value)}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,6 +103,7 @@ jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-d
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jansi = { module = "org.jline:jansi", version.ref = "jansi" }
+jansinative = { module = "org.jline:jline-native", version.ref = "jansi" }
 jarchivelib = { module = "org.rauschig:jarchivelib", version.ref = "jarchivelib" }
 jcodec = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 jcodec-awt = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ grpcKotlinStub = "1.4.1"
 imageComparison = "4.4.0"
 hiddenapibypass = "4.3"
 jackson = "2.17.1"
-jansi = "2.4.1"
+jansi = "3.30.6"
 jarchivelib = "1.2.0"
 jcodec = "0.2.5"
 junit = "5.10.2"
@@ -102,7 +102,7 @@ jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-da
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
-jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
+jansi = { module = "org.jline:jansi", version.ref = "jansi" }
 jarchivelib = { module = "org.rauschig:jarchivelib", version.ref = "jarchivelib" }
 jcodec = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 jcodec-awt = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,6 +104,7 @@ jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-d
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jansi = { module = "org.jline:jansi", version.ref = "jansi" }
+jansinative = { module = "org.jline:jline-native", version.ref = "jansi" }
 jarchivelib = { module = "org.rauschig:jarchivelib", version.ref = "jarchivelib" }
 jcodec = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 jcodec-awt = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ grpcKotlinStub = "1.4.1"
 imageComparison = "4.4.0"
 hiddenapibypass = "4.3"
 jackson = "2.17.1"
-jansi = "2.4.1"
+jansi = "3.30.6"
 jarchivelib = "1.2.0"
 jcodec = "0.2.5"
 junit = "5.10.2"
@@ -103,7 +103,7 @@ jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-da
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
-jansi = { module = "org.fusesource.jansi:jansi", version.ref = "jansi" }
+jansi = { module = "org.jline:jansi", version.ref = "jansi" }
 jarchivelib = { module = "org.rauschig:jarchivelib", version.ref = "jarchivelib" }
 jcodec = { module = "org.jcodec:jcodec", version.ref = "jcodec" }
 jcodec-awt = { module = "org.jcodec:jcodec-javase", version.ref = "jcodec" }

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -168,6 +168,7 @@ dependencies {
     implementation(libs.jackson.dataformat.xml)
     implementation(libs.jackson.datatype.jsr310)
     implementation(libs.jansi)
+    implementation(libs.jansinative)
     implementation(libs.jcodec)
     implementation(libs.jcodec.awt)
     implementation(libs.square.okhttp)

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -20,7 +20,12 @@ val CLI_VERSION: String by project
 application {
     applicationName = "maestro"
     mainClass.set("maestro.cli.AppKt")
-    // Required for Jansi native library loading (System.load) under Java 17+ restricted access
+    // Suppresses the Java 24+ "restricted method" warning that Jansi/jline trip when loading
+    // their native library. Only takes effect for the generated bin/maestro launcher scripts
+    // (i.e. Homebrew, the install.sh distribution zip, and the documented Dockerfile that adds
+    // /opt/maestro/bin to PATH). Users invoking the shadow jar with `java -jar` directly will
+    // still see the warning on Java 24+ and need to pass --enable-native-access=ALL-UNNAMED
+    // themselves; behaviour is otherwise unaffected.
     applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
 }
 

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -20,6 +20,8 @@ val CLI_VERSION: String by project
 application {
     applicationName = "maestro"
     mainClass.set("maestro.cli.AppKt")
+    // Required for Jansi native library loading (System.load) under Java 17+ restricted access
+    applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
 }
 
 tasks.named<Jar>("jar") {

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -27,6 +27,8 @@ val CLI_VERSION: String by project
 application {
     applicationName = "maestro"
     mainClass.set("maestro.cli.AppKt")
+    // Required for Jansi native library loading (System.load) under Java 17+ restricted access
+    applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
 }
 
 tasks.named<Jar>("jar") {

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -27,7 +27,12 @@ val CLI_VERSION: String by project
 application {
     applicationName = "maestro"
     mainClass.set("maestro.cli.AppKt")
-    // Required for Jansi native library loading (System.load) under Java 17+ restricted access
+    // Suppresses the Java 24+ "restricted method" warning that Jansi/jline trip when loading
+    // their native library. Only takes effect for the generated bin/maestro launcher scripts
+    // (i.e. Homebrew, the install.sh distribution zip, and the documented Dockerfile that adds
+    // /opt/maestro/bin to PATH). Users invoking the shadow jar with `java -jar` directly will
+    // still see the warning on Java 24+ and need to pass --enable-native-access=ALL-UNNAMED
+    // themselves; behaviour is otherwise unaffected.
     applicationDefaultJvmArgs = listOf("--enable-native-access=ALL-UNNAMED")
 }
 

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -174,6 +174,7 @@ dependencies {
     implementation(libs.jackson.dataformat.xml)
     implementation(libs.jackson.datatype.jsr310)
     implementation(libs.jansi)
+    implementation(libs.jansinative)
     implementation(libs.jcodec)
     implementation(libs.jcodec.awt)
     implementation(libs.square.okhttp)

--- a/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
+++ b/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
@@ -1,8 +1,7 @@
 package maestro.cli
 
-import org.fusesource.jansi.Ansi
-import org.fusesource.jansi.AnsiConsole
-import org.fusesource.jansi.internal.CLibrary
+import org.jline.jansi.Ansi
+import org.jline.jansi.AnsiConsole
 import picocli.CommandLine
 
 class DisableAnsiMixin {
@@ -40,10 +39,7 @@ class DisableAnsiMixin {
             val parserWithANSIOption = findFirstParserWithMatchedParamLabel(parseResult, "<enableANSIOutput>")
             val mixin = parserWithANSIOption?.commandSpec()?.mixins()?.values?.firstNotNullOfOrNull { it.userObject() as? DisableAnsiMixin }
 
-            val stdoutIsTTY = CLibrary.isatty(CLibrary.STDOUT_FILENO) != 0
-            ansiEnabled = mixin?.enableANSIOutput // Use the param value if it was specified
-                ?: stdoutIsTTY // Otherwise fall back to checking if output is a tty
-
+            ansiEnabled = mixin?.enableANSIOutput ?: true // Use the param value if it was specified
             Ansi.setEnabled(ansiEnabled)
 
             if (ansiEnabled) {

--- a/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
+++ b/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
@@ -2,6 +2,7 @@ package maestro.cli
 
 import org.jline.jansi.Ansi
 import org.jline.jansi.AnsiConsole
+import org.jline.nativ.CLibrary
 import picocli.CommandLine
 
 class DisableAnsiMixin {
@@ -39,7 +40,8 @@ class DisableAnsiMixin {
             val parserWithANSIOption = findFirstParserWithMatchedParamLabel(parseResult, "<enableANSIOutput>")
             val mixin = parserWithANSIOption?.commandSpec()?.mixins()?.values?.firstNotNullOfOrNull { it.userObject() as? DisableAnsiMixin }
 
-            ansiEnabled = mixin?.enableANSIOutput ?: true // Use the param value if it was specified
+            val stdoutIsTTY = CLibrary.isatty(1 /* stdout */) != 0
+            ansiEnabled = mixin?.enableANSIOutput ?: stdoutIsTTY // Use the param value if it was specified
             Ansi.setEnabled(ansiEnabled)
 
             if (ansiEnabled) {

--- a/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
+++ b/maestro-cli/src/main/java/maestro/cli/DisableAnsiMixin.kt
@@ -3,7 +3,10 @@ package maestro.cli
 import org.jline.jansi.Ansi
 import org.jline.jansi.AnsiConsole
 import org.jline.nativ.CLibrary
+import org.jline.nativ.Kernel32
+import org.jline.terminal.TerminalBuilder
 import picocli.CommandLine
+import java.nio.charset.Charset
 
 class DisableAnsiMixin {
     @CommandLine.Option(
@@ -40,11 +43,36 @@ class DisableAnsiMixin {
             val parserWithANSIOption = findFirstParserWithMatchedParamLabel(parseResult, "<enableANSIOutput>")
             val mixin = parserWithANSIOption?.commandSpec()?.mixins()?.values?.firstNotNullOfOrNull { it.userObject() as? DisableAnsiMixin }
 
-            val stdoutIsTTY = CLibrary.isatty(1 /* stdout */) != 0
+            // CLibrary is POSIX-only; Windows uses Kernel32 instead.
+            val stdoutIsTTY = try {
+                if (System.getProperty("os.name").contains("Windows", ignoreCase = true)) {
+                    Kernel32.isatty(1) != 0
+                } else {
+                    CLibrary.isatty(1) != 0
+                }
+            } catch (_: Throwable) {
+                System.console() != null
+            }
             ansiEnabled = mixin?.enableANSIOutput ?: stdoutIsTTY // Use the param value if it was specified
             Ansi.setEnabled(ansiEnabled)
 
             if (ansiEnabled) {
+                // AnsiConsole creates an AnsiPrintStream using terminal.encoding() but its
+                // underlying WriterOutputStream uses terminal.outputEncoding() (from the JVM's
+                // stdout.encoding property, which on Windows is the OEM code page e.g. CP850).
+                // When these differ (e.g. UTF-8 vs CP850 on Java 18+), multi-byte Unicode
+                // characters like ║ (UTF-8: E2 95 91) are decoded as wrong CP850 glyphs.
+                // Build the terminal explicitly with matching encodings to avoid this.
+                val enc = Charset.defaultCharset()
+                AnsiConsole.setTerminal(
+                    TerminalBuilder.builder()
+                        .system(true)
+                        .name("jansi")
+                        .encoding(enc)
+                        .stdoutEncoding(enc)
+                        .stderrEncoding(enc)
+                        .build()
+                )
                 AnsiConsole.systemInstall()
             }
         }

--- a/maestro-cli/src/main/java/maestro/cli/command/ChatCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ChatCommand.kt
@@ -4,7 +4,7 @@ import maestro.auth.ApiKey
 import maestro.cli.api.ApiClient
 import maestro.cli.auth.Auth
 import maestro.cli.util.EnvUtils.BASE_API_URL
-import org.fusesource.jansi.Ansi.ansi
+import org.jline.jansi.Ansi.ansi
 import picocli.CommandLine
 import java.util.*
 import java.util.concurrent.Callable

--- a/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
@@ -4,13 +4,11 @@ import maestro.cli.DisableAnsiMixin
 import maestro.cli.ShowHelpMixin
 import maestro.cli.analytics.Analytics
 import maestro.cli.analytics.UserLoggedOutEvent
-import org.fusesource.jansi.Ansi
 import picocli.CommandLine
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.Callable
 import kotlin.io.path.deleteIfExists
-import maestro.cli.util.PrintUtils
 import maestro.cli.util.PrintUtils.message
 
 @CommandLine.Command(

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
@@ -5,7 +5,7 @@ import maestro.cli.util.PrintUtils
 import maestro.device.Device
 import maestro.device.DeviceSpec
 import maestro.device.Platform
-import org.fusesource.jansi.Ansi.ansi
+import org.jline.jansi.Ansi.ansi
 
 object PickDeviceView {
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -183,7 +183,7 @@ class AnsiResultView(
         commandState.logMessages.forEach {
             renderLineStart(indent + 2)
             render("   ")   // Space that a status symbol would normally occupy
-            render(it)
+            print(fgYellow().a(it).reset().toString()) // Carefully deal with potential for Jansi markdown in the log line
             render("\n")
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -33,7 +33,7 @@ import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointV2Command
 import maestro.utils.Insight
 import maestro.utils.chunkStringByWordCount
-import org.fusesource.jansi.Ansi
+import org.jline.jansi.Ansi
 
 class AnsiResultView(
     private val prompt: String? = null,

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -194,7 +194,7 @@ class AnsiResultView(
         commandState.logMessages.forEach {
             renderLineStart(indent + 2)
             render("   ")   // Space that a status symbol would normally occupy
-            fgYellow().a(it).reset()
+            a(it)           // Append literal text; bypasses Jansi @|...|@ markup parsing
             render("\n")
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -176,24 +176,13 @@ class AnsiResultView(
 
         var lastIndex = 0
         regex.findAll(description).forEach { match ->
-            // Literal text before the match (safe)
-            val literalSegment = description.substring(lastIndex, match.range.first)
-            print(a(literalSegment).toString())
-
-            // Highlighted match (safe ANSI, no markup parsing)
-            print(
-                fgCyan()          // color ON
-                    .a(match.value)
-                    .reset()       // color OFF
-                    .toString()
-            )
-
+            a(description.substring(lastIndex, match.range.first))
+            fgCyan().a(match.value).reset()
             lastIndex = match.range.last + 1
         }
 
-        // Final literal tail
         if (lastIndex < description.length) {
-            print(a(description.substring(lastIndex)).toString())
+            a(description.substring(lastIndex))
         }
     }
 
@@ -205,7 +194,7 @@ class AnsiResultView(
         commandState.logMessages.forEach {
             renderLineStart(indent + 2)
             render("   ")   // Space that a status symbol would normally occupy
-            print(fgYellow().a(it).reset().toString()) // Carefully deal with potential for Jansi markdown in the log line
+            fgYellow().a(it).reset()
             render("\n")
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -118,12 +118,8 @@ class AnsiResultView(
         renderLineStart(indent)
         render(statusSymbol)
         render(" ".repeat(2))
-        render(
-            commandState.command.description()
-                .replace("(?<!\\\\)\\\$\\{.*}".toRegex()) { match ->
-                    "@|cyan ${match.value}|@"
-                }
-        )
+
+        renderCommandDescriptionSafely(commandState.command.description())
 
         if (commandState.status == CommandStatus.SKIPPED) {
             render(" (skipped)")
@@ -172,6 +168,32 @@ class AnsiResultView(
                 render(" ║\n")
                 renderCommands(it)
             }
+        }
+    }
+
+    private fun Ansi.renderCommandDescriptionSafely(description: String) {
+        val regex = "(?<!\\\\)\\\$\\{.*?}".toRegex()
+
+        var lastIndex = 0
+        regex.findAll(description).forEach { match ->
+            // Literal text before the match (safe)
+            val literalSegment = description.substring(lastIndex, match.range.first)
+            print(a(literalSegment).toString())
+
+            // Highlighted match (safe ANSI, no markup parsing)
+            print(
+                fgCyan()          // color ON
+                    .a(match.value)
+                    .reset()       // color OFF
+                    .toString()
+            )
+
+            lastIndex = match.range.last + 1
+        }
+
+        // Final literal tail
+        if (lastIndex < description.length) {
+            print(a(description.substring(lastIndex)).toString())
         }
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/util/PrintUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/PrintUtils.kt
@@ -1,6 +1,6 @@
 package maestro.cli.util
 
-import org.fusesource.jansi.Ansi
+import org.jline.jansi.Ansi
 import java.io.IOException
 import kotlin.system.exitProcess
 

--- a/maestro-cli/src/main/java/maestro/cli/view/ProgressBar.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/ProgressBar.kt
@@ -1,7 +1,7 @@
 package maestro.cli.view
 
 import maestro.cli.DisableAnsiMixin
-import org.fusesource.jansi.Ansi
+import org.jline.jansi.Ansi
 
 class ProgressBar(private val width: Int) {
 

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -5,7 +5,7 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.util.PrintUtils
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel.FlowResult
 import maestro.cli.view.TestSuiteStatusView.uploadUrl
-import org.fusesource.jansi.Ansi
+import org.jline.jansi.Ansi
 import java.util.UUID
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds

--- a/maestro-cli/src/main/java/maestro/cli/view/ViewUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/ViewUtils.kt
@@ -1,6 +1,6 @@
 package maestro.cli.view
 
-import org.fusesource.jansi.Ansi
+import org.jline.jansi.Ansi
 
 fun String.magenta(): String {
     return "@|magenta $this|@".render()


### PR DESCRIPTION
## Proposed changes

Safely prints to the console strings containing `#` and other Jansi markup characters.

- Upgrades Jansi to a supported version
- Updates our output to use the Jansi-recommended usage
- Solves some Windows-specific console detection and output problems
- Avoids `Ansi.render(...)` on user input

## Testing

- Tested using the simple and original versions in the linked ticket (e2e test added)
- Tested on Windows and macOS

## Issues fixed

Fixes #2496 
Fixes #3258