### PR TITLE
Reduce disk size for Android integration tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
         if: failure()
         with:
           name: maestro-unit-test-report
-          path: ./maestro-test/build/reports
+          path: ./**/build/reports/tests/test
           retention-days: 1
           include-hidden-files: true
 
@@ -69,7 +69,7 @@ jobs:
         if: failure()
         with:
           name: maestro-integration-test-report
-          path: ./maestro-cli/build/reports
+          path: ./**/build/reports/tests/integrationTest
           retention-days: 1
           include-hidden-files: true
 


### PR DESCRIPTION
This fixes CI failures due to Android Emulators not launching - failing due to disk size limitations on the ubuntu GH runner.

https://github.com/ReactiveCircus/android-emulator-runner/issues/455 led me onto API 33 requiring more disk space than others, so bumped to API 34. (I tried reducing the space needed using `disk-size` but it either didn't work, or it wouldn't go smaller than the minimum required).

Whilst I was there, I fixed up some test artifact storage.

## Proposed changes

copilot:summary

## Testing

<!--- Please describe how you tested your changes. -->

## Issues fixed
