### PR TITLE
Ensure recordings and screenshots create relative directories when specified

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -53,6 +53,7 @@ import maestro.utils.NoopInsights
 import maestro.utils.StringUtils.toRegexSafe
 import okhttp3.OkHttpClient
 import okio.Buffer
+import okio.BufferedSink
 import okio.Sink
 import okio.buffer
 import okio.sink
@@ -940,21 +941,15 @@ class Orchestra(
 
     private fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
         val pathStr = command.path + ".png"
-        val file = screenshotsDir
-            ?.let { it.resolve(pathStr).toFile() }
-            ?: File(pathStr)
-
-        maestro.takeScreenshot(file, false)
-
+        val fileSink = getFileSink(screenshotsDir, pathStr)
+        maestro.takeScreenshot(fileSink, false)
         return false
     }
 
     private fun startRecordingCommand(command: StartRecordingCommand): Boolean {
         val pathStr = command.path + ".mp4"
-        val file = screenshotsDir
-            ?.let { it.resolve(pathStr).toFile() }
-            ?: File(pathStr)
-        screenRecording = maestro.startScreenRecording(file.sink().buffer())
+        val fileSink = getFileSink(screenshotsDir, pathStr)
+        screenRecording = maestro.startScreenRecording(fileSink)
         return false
     }
 
@@ -1471,6 +1466,22 @@ class Orchestra(
     private fun pasteText(): Boolean {
         copiedText?.let { maestro.inputText(it) }
         return true
+    }
+
+    private fun getFileSink(parentPath: Path?, filePathStr: String): BufferedSink {
+        // Work out relative v absolute input
+        val resolvedFile = parentPath?.resolve(filePathStr)?.toFile() ?: File(filePathStr)
+        val absoluteFile = resolvedFile.absoluteFile
+
+        if(absoluteFile.parentFile.exists() || absoluteFile.parentFile.mkdirs()) {
+            return resolvedFile
+                .sink()
+                .buffer()
+        } else {
+            throw MaestroException.DestinationIsNotWritable(
+                "Unable to create directory for file: ${absoluteFile.parentFile.absolutePath}"
+            )
+        }
     }
 
     private suspend fun executeDefineVariablesCommands(commands: List<MaestroCommand>, config: MaestroConfig?) {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -58,6 +58,10 @@ class IntegrationTest {
     @AfterEach
     internal fun tearDown() {
         File("041_take_screenshot_with_filename.png").delete()
+        File("134_screenshots/filename.png").delete()
+        File("134_screenshots").delete()
+        File("135_recordings/filename.mp4").delete()
+        File("135_recordings").delete()
         File("099_screen_recording.mp4").delete()
         File("028_env.mp4").delete()
     }
@@ -4146,6 +4150,57 @@ class IntegrationTest {
                 Event.InputText("Hello, Maestro!"),
             )
         )
+    }
+
+    @Test
+    fun `Case 134 - Take screenshot with path`() {
+        // Given
+        val commands = readCommands("134_take_screenshot_with_path")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.TakeScreenshot,
+            )
+        )
+        assert(File("134_screenshots/filename.png").exists())
+    }
+
+    @Test
+    fun `Case 135 - Screen recording with path`() {
+        // Given
+        val commands = readCommands("135_screen_recording_with_path")
+
+        val driver = driver {
+        }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        // No test failure
+        driver.assertEvents(
+            listOf(
+                Event.StartRecording,
+                Event.StopRecording,
+            )
+        )
+        assert(File("135_recordings/filename.mp4").exists())
     }
 
     private fun orchestra(

--- a/maestro-test/src/test/resources/134_take_screenshot_with_path.yaml
+++ b/maestro-test/src/test/resources/134_take_screenshot_with_path.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- takeScreenshot: '134_screenshots/filename'

--- a/maestro-test/src/test/resources/135_screen_recording_with_path.yaml
+++ b/maestro-test/src/test/resources/135_screen_recording_with_path.yaml
@@ -1,0 +1,4 @@
+appId: com.other.app
+---
+- startRecording: '135_recordings/filename'
+- stopRecording


### PR DESCRIPTION
## Proposed changes

- Resolve and create directories for screenRecording
- Unify implementation with takeScreenshot
- Stop using deprecated takeScreenshot method

## Testing

New integration tests

## Issues fixed

Fixes #2483 