### PR TITLE
Allow evaluation of JS expressions in waitForAnimationToEnd timeout

### DIFF
--- a/e2e/demo_app/.maestro/commands/waitForAnimationToEnd.yaml
+++ b/e2e/demo_app/.maestro/commands/waitForAnimationToEnd.yaml
@@ -6,6 +6,7 @@ tags:
 
 - tapOn: "Animation Test"
 
+# Test no blocking when no animation occurs
 - evalScript: ${maestro.startTime = new Date()}
 - waitForAnimationToEnd
 - evalScript: ${maestro.endTime = new Date()}
@@ -15,6 +16,7 @@ tags:
     text: "Animate (30s)"
     waitToSettleTimeoutMs: 100
 
+# Test small timeouts are honoured
 - evalScript: ${maestro.startTime = new Date()}
 - waitForAnimationToEnd:
     timeout: 1000
@@ -22,7 +24,16 @@ tags:
 - assertTrue: ${maestro.endTime - maestro.startTime > 1000}
 - assertTrue: ${maestro.endTime - maestro.startTime < 4000} # Some allowance for slow runners
 
+# Test variables are honoured
+- evalScript: ${output.myTimeout = 1000}
+- evalScript: ${maestro.startTime = new Date()}
+- waitForAnimationToEnd:
+    timeout: ${output.myTimeout}
+- evalScript: ${maestro.endTime = new Date()}
+- assertTrue: ${maestro.endTime - maestro.startTime > 1000}
+- assertTrue: ${maestro.endTime - maestro.startTime < 4000} # Some allowance for slow runners
 
+# Test defaults are honoured
 - evalScript: ${maestro.startTime = new Date()}
 - waitForAnimationToEnd
 - evalScript: ${maestro.endTime = new Date()}

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -628,9 +628,9 @@ class Maestro(
         driver.eraseText(charactersToErase)
     }
 
-    suspend fun waitForAnimationToEnd(timeout: Long?) = runInterruptible(Dispatchers.IO) {
+    suspend fun waitForAnimationToEnd(timeout: String?) = runInterruptible(Dispatchers.IO) {
         @Suppress("NAME_SHADOWING")
-        val timeout = timeout ?: ANIMATION_TIMEOUT_MS
+        val timeout = timeout?.toLong() ?: ANIMATION_TIMEOUT_MS
         LOGGER.info("Waiting for animation to end with timeout $timeout")
 
         ScreenshotUtils.waitUntilScreenIsStatic(timeout, SCREENSHOT_DIFF_THRESHOLD, driver)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -1023,16 +1023,29 @@ data class RunScriptCommand(
 }
 
 data class WaitForAnimationToEndCommand(
-    val timeout: Long?,
+    val timeout: String?,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
 
     override val originalDescription: String
-        get() = "Wait for animation to end"
+        get() {
+            var description = "Wait for animation to end"
+            timeout?.let {
+                description += " within $it ms"
+            }
+            return description
+        }
 
+    private fun String.timeoutToMillis(): String? {
+        return if (this.toLong() < 0) {
+            null
+        } else this
+    }
     override fun evaluateScripts(jsEngine: JsEngine): Command {
-        return this
+        return copy(
+            timeout = timeout?.evaluateScripts(jsEngine)?.timeoutToMillis()
+        )
     }
 }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlWaitForAnimationToEndCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlWaitForAnimationToEndCommand.kt
@@ -1,7 +1,7 @@
 package maestro.orchestra.yaml
 
 data class YamlWaitForAnimationToEndCommand(
-    val timeout: Long?,
+    val timeout: String? = null,
     val label: String? = null,
     val optional: Boolean = false,
 )

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -647,7 +647,7 @@ internal class MaestroCommandSerializationTest {
     fun `serialize WaitForAnimationToEndCommand`() {
         // given
         val command = MaestroCommand(
-            WaitForAnimationToEndCommand(timeout = 9)
+            WaitForAnimationToEndCommand(timeout = "9")
         )
 
         // when
@@ -659,7 +659,7 @@ internal class MaestroCommandSerializationTest {
         val expectedJson = """
             {
               "waitForAnimationToEndCommand" : {
-                "timeout" : 9,
+                "timeout" : "9",
                 "optional" : false
               }
             }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -418,7 +418,7 @@ internal class YamlCommandReaderTest {
                 label = "Run around the north pole"
             ),
             WaitForAnimationToEndCommand(
-                timeout = 4000,
+                timeout = "4000",
                 label = "Wait for the thing to stop spinning"
             ),
             SwipeCommand(


### PR DESCRIPTION
## Proposed changes

Allows JS expressions in the `timeout` field of `waitForAnimationToEnd`

## Testing

```
appId: com.nonexistent.app
---
- evalScript: ${output.customTimeout = 1234}
- waitForAnimationToEnd:
    timeout: ${output.customTimeout}
```

<img width="454" height="116" alt="image" src="https://github.com/user-attachments/assets/8d6dcf05-a6bc-45f0-aeb1-1746cdb90392" />

Unsure if there's a sensible place in the existing tests (or if there's value) for yet another JS evaluation test.

## Issues fixed

Fixes #2734 