### PR TITLE
Don't print that analytics is enabled if it isn't

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
+++ b/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
@@ -55,8 +55,10 @@ object Analytics : AutoCloseable {
      */
     fun warnAndEnableAnalyticsIfNotDisable() {
         if (hasRunBefore) return
-        println("Anonymous analytics enabled. To opt out, set $DISABLE_ANALYTICS_ENV_VAR environment variable to any value before running Maestro.\n")
-        analyticsStateManager.saveInitialState(granted = !analyticsDisabledWithEnvVar, uuid = uuid)
+        val analyticsShouldBeEnabled = !analyticsDisabledWithEnvVar
+        if (analyticsShouldBeEnabled)
+            println("Anonymous analytics enabled. To opt out, set $DISABLE_ANALYTICS_ENV_VAR environment variable to any value before running Maestro.\n")
+        analyticsStateManager.saveInitialState(granted = analyticsShouldBeEnabled, uuid = uuid)
     }
 
     /**


### PR DESCRIPTION
## Proposed changes

Right now, CLI prints this when run:

> Anonymous analytics enabled. To opt out, set MAESTRO_CLI_NO_ANALYTICS environment variable to any value before running Maestro.

That happens regardless of whether the user has set that env var 😬 

## Testing

Setup

```
rm ~/.maestro/analytics.json
```

Before:
```
% export MAESTRO_CLI_NO_ANALYTICS=1
% maestro testo flow.yml
Anonymous analytics enabled. To opt out, set MAESTRO_CLI_NO_ANALYTICS environment variable to any value before running Maestro.
```
After
```
% maestro testo flow.yml
<normal flow things, no analytics console logging>
```

Checked analytics.json - shows `"enabled" : false`

## Issues fixed

Fixes #2796 