### PR TITLE
Fix link in maestro bugreport command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/BugReportCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/BugReportCommand.kt
@@ -22,7 +22,7 @@ class BugReportCommand : Callable<Int> {
 
     override fun call(): Int {
         val message = """
-            Please open an issue on github: https://github.com/mobile-dev-inc/maestro/issues/new
+            Please open an issue on GitHub: https://github.com/mobile-dev-inc/Maestro/issues/new?template=bug_report.yaml
             Attach the files found in this folder ${DebugLogStore.logDirectory}
             """.trimIndent()
         println(message)


### PR DESCRIPTION
## Proposed changes

Link `maestro bugreport` to the bug report template in GitHub

## Testing

Tested using `./maestro` in the repo from a Linux machine:

```
dan@dan-thinkbook:~/git/maestro/maestro$ ./maestro bugreport
Please open an issue on GitHub: https://github.com/mobile-dev-inc/Maestro/issues/new?template=bug_report.yaml
Attach the files found in this folder /home/dan/.cache/maestro/logs
```

## Issues fixed

None.