### PR TITLE
Only persist context when maestro or output binding modified

### DIFF
--- a/maestro-client/src/main/java/maestro/js/JsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/JsEngine.kt
@@ -12,7 +12,7 @@ interface JsEngine : AutoCloseable {
         sourceName: String = "inline-script",
         runInSubScope: Boolean = false,
     ): Any?
-    
+
     fun enterEnvScope()
     fun leaveEnvScope()
 }

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -91,16 +91,107 @@ class GraalJsEngineTest : JsEngineTest() {
     fun `runInSubScope should isolate environment variables`() {
         // Set a base environment variable
         engine.putEnv("MY_VAR", "original")
-        
+
         // Verify original value is accessible
         assertThat(engine.evaluateScript("MY_VAR").toString()).isEqualTo("original")
-        
+
         // Execute script with runInSubScope=true and different env var
         val envVars = mapOf("MY_VAR" to "scoped")
         engine.evaluateScript("console.log('Log from runScript')", envVars, "test.js", runInSubScope = true)
-        
+
         // MY_VAR should still be original - the scoped value should not leak
         assertThat(engine.evaluateScript("MY_VAR").toString()).isEqualTo("original")
+    }
+
+    @Test
+    fun `contexts are automatically closed when shared bindings are not modified`() {
+        // This test simulates a repeat loop with a condition like:
+        //   - repeat:
+        //       while:
+        //         notVisible: '${MARKET}'
+        //       commands:
+        //         - swipe: ...
+        //
+        // The ${MARKET} expression is evaluated on every iteration.
+        //
+        // BEFORE FIX: Each evaluateScript() created a new GraalJS context that was
+        // never released until close() was called. This caused:
+        //   - 100 evaluations = 100 open contexts
+        //   - ~68 MB memory growth for just 100 simple evaluations (~0.68 MB each)
+        //   - OOM errors for flows with 1000+ iterations
+        //
+        // AFTER FIX: Contexts are automatically closed after evaluation when shared
+        // bindings (output, maestro) are not modified, keeping memory bounded.
+
+        val graalEngine = engine as GraalJsEngine
+        graalEngine.putEnv("MARKET", "some_value")
+
+        // Force GC and measure baseline memory
+        System.gc()
+        Thread.sleep(100)
+        val runtime = Runtime.getRuntime()
+        val baselineMemory = runtime.totalMemory() - runtime.freeMemory()
+
+        val iterations = 100
+        repeat(iterations) {
+            graalEngine.evaluateScript("MARKET")
+        }
+
+        // Measure memory after evaluations
+        System.gc()
+        Thread.sleep(100)
+        val finalMemory = runtime.totalMemory() - runtime.freeMemory()
+        val memoryGrowthMB = (finalMemory - baselineMemory) / (1024.0 * 1024.0)
+
+        val contextCount = graalEngine.openContextCount()
+
+        // Log the results for visibility
+        println(
+            "After $iterations evaluations (no binding modifications): $contextCount open contexts, " +
+            "memory growth: ${"%.2f".format(memoryGrowthMB)} MB " +
+            "(baseline: ${"%.2f".format(baselineMemory / (1024.0 * 1024.0))} MB, " +
+            "final: ${"%.2f".format(finalMemory / (1024.0 * 1024.0))} MB)"
+        )
+
+        // Contexts should be automatically closed since we didn't modify output/maestro
+        assertThat(contextCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `contexts are preserved when shared bindings are modified`() {
+        // When a script modifies shared bindings (output, maestro), the context must
+        // be kept alive because the stored values may be Value objects tied to that context.
+        // For example: output.list = [1, 2, 3] stores a JS array that remains valid
+        // only while its context is open.
+
+        val graalEngine = engine as GraalJsEngine
+
+        // This script modifies the output binding
+        graalEngine.evaluateScript("output.myValue = 'test'")
+
+        // Context should be preserved because output was modified
+        assertThat(graalEngine.openContextCount()).isEqualTo(1)
+
+        // The value should still be accessible in subsequent evaluations
+        val result = graalEngine.evaluateScript("output.myValue")
+        assertThat(result.toString()).isEqualTo("test")
+    }
+
+    @Test
+    fun `contexts are preserved when storing arrays in output`() {
+        // Arrays stored in output are Value objects tied to their context.
+        // The context must remain open for the array to be accessible.
+
+        val graalEngine = engine as GraalJsEngine
+
+        graalEngine.evaluateScript("output.list = [1, 2, 3]")
+
+        // Context preserved because output was modified
+        assertThat(graalEngine.openContextCount()).isEqualTo(1)
+
+        // Array length should be accessible
+        val length = graalEngine.evaluateScript("output.list.length")
+        assertThat(length.toString()).isEqualTo("3")
     }
 
 }


### PR DESCRIPTION
## Proposed changes

Graal JS contexts take almost a full 1MB of memory, and if we have a repeated loop of commands, we can easily hit 1000+ commands (with associated contexts). The contexts are only cleared when the full maestro flow is done executing, which means we can bloat our memory considerably.

However, if we close a context, then values that have been stored on our `output` or `maestro` objects will get wiped. So we need to keep those values around.

This PR immediately closes contexts _only_ when we detect that the the bindings have not been updated. Otherwise we keep the context around until the engine is closed.

## Testing

See test suite to understand how this was tested.

## NOTE

This fix relies on the fact that all callers of evaluateScript cast the result to a string. It would probably be safer to force the return type of this to `String` instead of `Any`; we have to do that because we need to copy the `Value` returned by the js engine to a kotlin type. There might be a better solution, but I didn't want to touch too much code around this.
