### PR TITLE
Add shard index option to StartDeviceCommand

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -64,6 +64,13 @@ class StartDeviceCommand : Callable<Int> {
     )
     private var forceCreate: Boolean = false
 
+    @CommandLine.Option(
+        order = 5,
+        names = ["--shard-index"],
+        description = ["Shard index to use for the device"],
+    )
+    private var shardIndex: Int? = null
+
     override fun call(): Int {
         TestDebugReporter.install(null, printToConsole = parent?.verbose == true)
 
@@ -95,7 +102,7 @@ class StartDeviceCommand : Callable<Int> {
         try {
             val (deviceLanguage, deviceCountry) = LocaleUtils.parseLocaleParams(locale, maestroPlatform)
 
-            DeviceCreateUtil.getOrCreateDevice(p, o, deviceLanguage, deviceCountry, forceCreate).let { device ->
+            DeviceCreateUtil.getOrCreateDevice(p, o, deviceLanguage, deviceCountry, forceCreate, shardIndex).let { device ->
                 PrintUtils.message(if (p == Platform.IOS) "Launching simulator..." else "Launching emulator...")
                 DeviceService.startDevice(
                     device = device,


### PR DESCRIPTION
This update introduces a new command line option `--shard-index` to the StartDeviceCommand, allowing users to specify a shard index for device creation, enabling the user to start multiple emulators via the maestro cli. 

The cli appeared to already support this internally so this PR simply exposes this to the end user.

## Proposed changes

copilot:summary

## Testing

Usage example:

```bash
for ((i=0; i<$MAX_EMULATORS; i++)); do
  echo "Starting emulator $((i+1))/$MAX_EMULATORS with shard-index=$i"
  maestro start-device --platform=android --shard-index="$i"
done
```
## Issues fixed
