### PR TITLE
Fix issue with select tag with multiple true

### DIFF
--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -16,7 +16,7 @@
                 return node.value || node.placeholder || node.ariaLabel || ''
 
             case 'select':
-                return node.options && node.options.length > 0 ? node.options[node.selectedIndex].text : ''
+                return Array.from(node.selectedOptions).map((option) => option.text).join(', ')
 
             default:
                 const childNodes = [...(node.childNodes || [])].filter(node => node.nodeType === Node.TEXT_NODE)


### PR DESCRIPTION
## Proposed changes

Fix js issue when getting text for select with multiple=true

## Testing

Tested using `maestro test` command:

- with select tag multiple=true having 0,1,2 selected options
- with normal select tag having 0,1 selected options

## Issues fixed

https://github.com/mobile-dev-inc/Maestro/issues/2889
