### PR TITLE
Quieter permissions logging when setting permissions

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -934,9 +934,13 @@ class AndroidDriver(
         try {
             shell("pm $permissionValue $appId $permission")
         } catch (exception: Exception) {
-            // We don't need to be loud about this. IOExceptions were caught in shell. Remaining issues are likely due
-            // to "all" containing permissions that the app doesn't support.
-            logger.debug("Failed to set permission $permission for app $appId: ${exception.message}")
+            // Ignore if it's something that the user doesn't have control over (e.g. you can't grant / deny INTERNET)
+            if (exception.message?.contains("is not a changeable permission type") == false) {
+                // Debug level is fine.
+                // We don't need to be loud about this. IOExceptions were already caught in shell(..)
+                // Remaining issues are likely due to "all" containing permissions that the app doesn't support.
+                logger.debug("Failed to set permission $permission for app $appId: ${exception.message}")
+            }
         }
     }
 


### PR DESCRIPTION
## Proposed changes

In #2775, some debug logging was added for failures to set permissions. That's actually still really noisy when, by default, we set 'all'.

Example from our e2e tests:

```
==> [demo_app] [passing] => disableAnsi=false([ INFO]) Launch app "com.example.example" RUNNING
==> [demo_app] [passing] => disableAnsi=false([DEBUG]) Failed to set permission android.permission.INTERNET for app com.example.example: pm grant com.example.example android.permission.INTERNET: 
==> [demo_app] [passing] => Exception occurred while executing 'grant':
==> [demo_app] [passing] => java.lang.SecurityException: Permission android.permission.INTERNET requested by com.example.example is not a changeable permission type
==> [demo_app] [passing] => 	at com.android.server.pm.permission.PermissionManagerService.grantRuntimePermissionInternal(PermissionManagerService.java:1508)
```

This filters out the permissions that error because they're not settable.

## Testing

<!--- Please describe how you tested your changes. -->

## Issues fixed
