### PR TITLE
Make CLI's integrationTest task part of the verification category

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -340,6 +340,7 @@ jreleaser {
 }
 
 tasks.register<Test>("integrationTest") {
+    group = "verification"
     useJUnitPlatform {
         includeTags("IntegrationTest")
     }


### PR DESCRIPTION
## Proposed changes

Entirely a developer experience change.

When I want to run the integrationTest task locally, I look in `verification`, see it's not there, then dig for it in `other`.

This fixes that, saving me _seconds_ every single week.

## Testing

Still runs.

## Issues fixed

n/a