### PR TITLE
Update wikipedia sample test to cater for Year In Review

### DIFF
--- a/e2e/workspaces/wikipedia/ios-advanced-flow.yaml
+++ b/e2e/workspaces/wikipedia/ios-advanced-flow.yaml
@@ -6,13 +6,22 @@ tags:
 ---
 - runFlow: subflows/onboarding-ios.yaml
 
-# Dismiss the auth modal if visible
+- runFlow:
+    when:
+      visible:
+        text: Explore your Wikipedia Year in Review
+    commands:
+      - tapOn: Done
+    label: Dismiss Year In Review popup, if visible
+
 - runFlow:
     when:
       visible: "You have been logged out"
     commands:
       - tapOn:
           text: "Continue without logging in"
+    label: Dismiss the auth modal if visible
+
 - tapOn:
     text: "Non existent view"
     optional: true


### PR DESCRIPTION
## Proposed changes

The latest version of Wikipedia has a Year In Review popup after onboarding. This updates the test to cater for it, but doesn't fail if it never appears. 

## Testing

Tested on the existing Wikipedia app in the Maestro samples (~9 months old) and the current Wikipedia app (3 weeks old), on iOS 18 and 26.1 respectively.

## Issues fixed
