### PR TITLE
Make the iOS Webview e2e test more resilient

### DIFF
--- a/e2e/workspaces/simple_web_view/webview.yaml
+++ b/e2e/workspaces/simple_web_view/webview.yaml
@@ -8,6 +8,9 @@ tags:
 
 - tapOn: Open Login Page
 
-- assertVisible: Login
+- extendedWaitUntil:
+    visible: Login
+    timeout: 30000
+    label: Wait for Login page to load
 - assertVisible: Sign In
 - assertVisible: Forgot your password?


### PR DESCRIPTION
## Proposed changes

Saw a failure [here](https://github.com/mobile-dev-inc/Maestro/actions/runs/20851694517/job/59909283710) related to slow loading of the webview. This is an optimistic fix.

## Testing

Ran it locally, five times.

## Issues fixed
