### PR TITLE
Mute ktor logs for better web logs

### DIFF
--- a/maestro-client/src/main/java/maestro/debuglog/LogConfig.kt
+++ b/maestro-client/src/main/java/maestro/debuglog/LogConfig.kt
@@ -1,8 +1,5 @@
 package maestro.debuglog
 
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.core.LoggerContext
-import org.apache.logging.log4j.core.appender.ConsoleAppender
 import org.apache.logging.log4j.core.appender.FileAppender
 import org.apache.logging.log4j.core.config.Configurator
 import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder
@@ -21,6 +18,12 @@ object LogConfig {
         val builder = ConfigurationBuilderFactory.newConfigurationBuilder()
         builder.setStatusLevel(org.apache.logging.log4j.Level.ERROR)
         builder.setConfigurationName("MaestroConfig")
+
+        // Disable ktor logging completely
+        builder.add(
+            builder.newLogger("io.ktor", org.apache.logging.log4j.Level.OFF)
+                .addAttribute("additivity", false)
+        )
 
         val rootLogger = builder.newRootLogger(org.apache.logging.log4j.Level.ALL)
 


### PR DESCRIPTION
## Proposed changes

Logs for web runs are currently _incredibly_ noisy with ktor debug logging.
This mutes everything from ktor, to give a sane log. A quick run showed that ktor was 80-90% of the maestro.log, none of which I could discern any usefulness from.

[Here's a recent e2e action](https://github.com/mobile-dev-inc/Maestro/actions/runs/20916116183/job/60090855085)

## Testing

Tests still run locally, but without as much nonsense.

## Issues fixed
