### PR TITLE
Add a 250ms buffer between withTimeout retries

### DIFF
--- a/maestro-utils/build.gradle.kts
+++ b/maestro-utils/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(libs.square.okhttp)
     implementation(libs.micrometer.core)
     implementation(libs.micrometer.observation)
+    implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.mockk)
     testImplementation(libs.junit.jupiter.api)

--- a/maestro-utils/src/main/kotlin/MaestroTimer.kt
+++ b/maestro-utils/src/main/kotlin/MaestroTimer.kt
@@ -1,5 +1,7 @@
 package maestro.utils
 
+import kotlinx.coroutines.*
+
 object MaestroTimer {
 
     var sleep: (Reason, Long) -> Unit = { _, ms -> Thread.sleep(ms) }
@@ -18,6 +20,8 @@ object MaestroTimer {
             if (result != null) {
                 return result
             }
+            
+            sleep(Reason.BUFFER, 250)
         } while (System.currentTimeMillis() < endTime)
 
         return null


### PR DESCRIPTION
## Proposed changes

Right now, MaestroTimer.withTimeout is a dumb do/while loop. But it's used for things like assertVisible checks, which means it's really quite intensive on the device. Whilst this slows checks by a quarter of a second, it's likely to speed up a number of tests by not slowing the device or saturating the device link.

A later PR should make this (and other timeouts) configurable via config.yaml

## Testing

Wikipedia flows look good locally. Excited to see what happens in CI...

## Issues fixed
