### PR TITLE
feat: introducing TempFileHandler for iOS drivers

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -38,6 +38,7 @@ import maestro.drivers.AndroidDriver
 import maestro.drivers.IOSDriver
 import maestro.orchestra.WorkspaceConfig.PlatformConfiguration
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
+import maestro.utils.TempFileHandler
 import org.slf4j.LoggerFactory
 import util.IOSDeviceType
 import util.XCRunnerCLIUtils
@@ -379,6 +380,7 @@ object MaestroSessionManager {
              else -> throw UnsupportedOperationException("Unsupported device type $deviceType for iOS platform")
         }
 
+        val tempFileHandler = TempFileHandler()
         val deviceController = when (deviceType) {
             Device.DeviceType.REAL -> {
                 val device = util.LocalIOSDevice().listDeviceViaDeviceCtl(deviceId)
@@ -388,6 +390,7 @@ object MaestroSessionManager {
             Device.DeviceType.SIMULATOR -> {
                 val simctlIOSDevice = SimctlIOSDevice(
                     deviceId = deviceId,
+                    tempFileHandler = tempFileHandler
                 )
                 simctlIOSDevice
             }
@@ -401,7 +404,8 @@ object MaestroSessionManager {
             reinstallDriver = reinstallDriver,
             deviceType = iOSDeviceType,
             iOSDriverConfig = iOSDriverConfig,
-            deviceController = deviceController
+            deviceController = deviceController,
+            tempFileHandler = tempFileHandler
         )
 
         val xcTestDriverClient = XCTestDriverClient(
@@ -410,10 +414,11 @@ object MaestroSessionManager {
             reinstallDriver = reinstallDriver,
         )
 
+        val xcRunnerCLIUtils = XCRunnerCLIUtils(tempFileHandler = tempFileHandler)
         val xcTestDevice = XCTestIOSDevice(
             deviceId = deviceId,
             client = xcTestDriverClient,
-            getInstalledApps = { XCRunnerCLIUtils.listApps(deviceId) },
+            getInstalledApps = { xcRunnerCLIUtils.listApps(deviceId) },
         )
 
         val iosDriver = IOSDriver(

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -47,6 +47,7 @@ import maestro.utils.Metrics
 import maestro.utils.MetricsProvider
 import maestro.utils.NoopInsights
 import maestro.utils.ScreenshotUtils
+import maestro.utils.TempFileHandler
 import okio.Sink
 import okio.source
 import org.slf4j.LoggerFactory
@@ -65,6 +66,7 @@ class IOSDriver(
 
     private var appId: String? = null
     private var proxySet = false
+    private val xcRunnerCLIUtils = XCRunnerCLIUtils(tempFileHandler = TempFileHandler())
 
     override fun name(): String {
         return metrics.measured("name") {
@@ -458,13 +460,13 @@ class IOSDriver(
 
     override fun setProxy(host: String, port: Int) {
         metrics.measured("operation", mapOf("command" to "setProxy")) {
-            XCRunnerCLIUtils.setProxy(host, port)
+            xcRunnerCLIUtils.setProxy(host, port)
             proxySet = true
         }
     }
 
     override fun resetProxy() {
-        XCRunnerCLIUtils.resetProxy()
+        xcRunnerCLIUtils.resetProxy()
     }
 
     override fun isShutdown(): Boolean {

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/IOSBuildProductsExtractor.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/IOSBuildProductsExtractor.kt
@@ -1,5 +1,6 @@
 package xcuitest.installer
 
+import maestro.utils.TempFileHandler
 import org.rauschig.jarchivelib.ArchiverFactory
 import org.slf4j.LoggerFactory
 import util.IOSDeviceType
@@ -26,7 +27,7 @@ enum class Context {
 class IOSBuildProductsExtractor(
     private val target: Path,
     private val context: Context,
-    private val deviceType: IOSDeviceType
+    private val deviceType: IOSDeviceType,
 ) {
 
     companion object {

--- a/maestro-ios-driver/src/test/kotlin/IOSBuildProductsExtractorTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/IOSBuildProductsExtractorTest.kt
@@ -22,8 +22,8 @@ class IOSBuildProductsExtractorTest {
         // when
         IOSBuildProductsExtractor(
             target,
+            context = Context.CLI,
             deviceType = IOSDeviceType.SIMULATOR,
-            context = Context.CLI
         ).extract("driver-iphoneSimulator")
 
         // then

--- a/maestro-utils/src/main/kotlin/TempFileHandler.kt
+++ b/maestro-utils/src/main/kotlin/TempFileHandler.kt
@@ -1,0 +1,39 @@
+package maestro.utils
+
+import java.io.Closeable
+import java.io.File
+import java.nio.file.Files
+
+// creates temporary files and directories and makes sure they get disposed
+class TempFileHandler: Closeable {
+    val tempFiles = mutableListOf<File>()
+
+    fun createTempFile(prefix: String? = null, suffix: String? = null): File {
+        val file = Files.createTempFile(prefix, suffix).toFile()
+        file.deleteOnExit()
+        tempFiles.add(file)
+        return file
+    }
+
+    fun createTempDirectory(prefix: String? = null): File {
+        val file = Files.createTempDirectory(prefix).toFile()
+        file.deleteOnExit()
+        tempFiles.add(file)
+        return file
+    }
+
+    override fun close() {
+        tempFiles.forEach {
+            try {
+                // if it's a directory, recursively clean it up
+                it.deleteRecursively()
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    // add a file for deletion
+    fun addFile(logsFile: File) {
+        tempFiles.add(logsFile)
+    }
+}


### PR DESCRIPTION
## Proposed changes

When Maestro run iOS tests, it leaves behind lot of things:

- iOS driver derived data
- Driver binaries itself
- Test binaries while re-installing for clear state 

The problem here would be that this never cleans up and disk usage goes higher and higher over time.

This PR introduces a TempFileHandler that should now be used to create all such temp directories throughout project.

## Testing

- [x] Local 
- [x] Shard tests

## Issues fixed
