### PR TITLE
fix(recording): disable ANSI output when --no-ansi is set

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -147,7 +147,7 @@ class RecordCommand : Callable<Int> {
                     )
                 }
 
-                val resultView = AnsiResultView(useEmojis = DisableAnsiMixin.ansiEnabled && !EnvUtils.isWindows())
+                val resultView = AnsiResultView(useEmojis = !EnvUtils.isWindows())
                 val screenRecording = kotlin.io.path.createTempFile(suffix = ".mp4").toFile()
                 val exitCode = screenRecording.sink().use { out ->
                     maestro.startScreenRecording(out).use {

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -32,7 +32,6 @@ import maestro.cli.graphics.SkiaFrameRenderer
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.runner.TestRunner
 import maestro.cli.runner.resultview.AnsiResultView
-import maestro.cli.runner.resultview.PlainTextResultView
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.util.EnvUtils
 import maestro.cli.util.FileUtils.isWebFlow
@@ -148,11 +147,7 @@ class RecordCommand : Callable<Int> {
                     )
                 }
 
-                val resultView = if (DisableAnsiMixin.ansiEnabled) {
-                    AnsiResultView(useEmojis = !EnvUtils.isWindows())
-                } else {
-                    PlainTextResultView()
-                }
+                val resultView = AnsiResultView(useEmojis = DisableAnsiMixin.ansiEnabled && !EnvUtils.isWindows())
                 val screenRecording = kotlin.io.path.createTempFile(suffix = ".mp4").toFile()
                 val exitCode = screenRecording.sink().use { out ->
                     maestro.startScreenRecording(out).use {

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -32,7 +32,9 @@ import maestro.cli.graphics.SkiaFrameRenderer
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.runner.TestRunner
 import maestro.cli.runner.resultview.AnsiResultView
+import maestro.cli.runner.resultview.PlainTextResultView
 import maestro.cli.session.MaestroSessionManager
+import maestro.cli.util.EnvUtils
 import maestro.cli.util.FileUtils.isWebFlow
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import okio.sink
@@ -146,7 +148,11 @@ class RecordCommand : Callable<Int> {
                     )
                 }
 
-                val resultView = AnsiResultView()
+                val resultView = if (DisableAnsiMixin.ansiEnabled) {
+                    AnsiResultView(useEmojis = !EnvUtils.isWindows())
+                } else {
+                    PlainTextResultView()
+                }
                 val screenRecording = kotlin.io.path.createTempFile(suffix = ".mp4").toFile()
                 val exitCode = screenRecording.sink().use { out ->
                     maestro.startScreenRecording(out).use {


### PR DESCRIPTION
## Proposed changes
The record command was always creating an AnsiResultView() regardless of whether --no-ansi was passed, while the test command properly checked DisableAnsiMixin.ansiEnabled to decide between AnsiResultView and PlainTextResultView.

> While using maestro record, I noticed that it seems to ignore the --no-ansi option. When using maestro test, it works just fine

Added missing imports:
1. PlainTextResultView - for non-ANSI output
2. EnvUtils - to detect Windows (which disables emojis)

So in my changes, I have just replicated the exact same pattern used in TestCommand (line 550-553), ensuring consistent behavior.
```kotlin
val resultView = if (DisableAnsiMixin.ansiEnabled) {
    AnsiResultView(useEmojis = !EnvUtils.isWindows())
} else {
    PlainTextResultView()
}
```

What This Fixes
- maestro --no-ansi record {flow path} (strips ANSI codes)
- maestro --no-color record {flow path} (alias works too)

## Testing
I have tested my changes locally 

## Issues fixed
Resolved #1009 
