### PR TITLE
Add error handling for devicectl execution

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/LocalIOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalIOSDevice.kt
@@ -5,11 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import java.io.File
 
-object DeviceCtlProcess {
-
-    val devicectlDevicesOutput: File? by lazy {
-        devicectlDevicesOutput()
-    }
+class DeviceCtlProcess {
 
     /**
      * Executes `xcrun devicectl list devices` (lists Apple devices visible to Xcode)
@@ -17,7 +13,7 @@ object DeviceCtlProcess {
      *
      * @return temp JSON file on success, or null if the command fails.
      */
-    private fun devicectlDevicesOutput(): File? {
+    fun devicectlDevicesOutput(): File? {
         val tempOutput = File.createTempFile("devicectl_response", ".json")
 
         val process = ProcessBuilder(
@@ -41,7 +37,7 @@ object DeviceCtlProcess {
     }
 }
 
-class LocalIOSDevice(private val deviceCtlProcess: DeviceCtlProcess = DeviceCtlProcess) {
+class LocalIOSDevice(private val deviceCtlProcess: DeviceCtlProcess = DeviceCtlProcess()) {
 
     fun uninstall(deviceId: String, bundleIdentifier: String) {
         CommandLineUtils.runCommand(
@@ -59,7 +55,7 @@ class LocalIOSDevice(private val deviceCtlProcess: DeviceCtlProcess = DeviceCtlP
     }
 
     fun listDeviceViaDeviceCtl(deviceId: String): DeviceCtlResponse.Device {
-        val tempOutput = deviceCtlProcess.devicectlDevicesOutput
+        val tempOutput = deviceCtlProcess.devicectlDevicesOutput()
             ?: throw java.lang.IllegalArgumentException("Unable retrieve device list")
         try {
             val bytes = tempOutput.readBytes()
@@ -77,7 +73,7 @@ class LocalIOSDevice(private val deviceCtlProcess: DeviceCtlProcess = DeviceCtlP
     }
 
     fun listDeviceViaDeviceCtl(): List<DeviceCtlResponse.Device> {
-        val tempOutput = deviceCtlProcess.devicectlDevicesOutput ?: return emptyList()
+        val tempOutput = deviceCtlProcess.devicectlDevicesOutput() ?: return emptyList()
 
         try {
             val bytes = tempOutput.readBytes()

--- a/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
@@ -18,7 +18,7 @@ class DeviceCtlResponseTest {
             writeText(deviceCtlOutput)
         }
         val deviceCtlProcess = mockk<DeviceCtlProcess>()
-        every { deviceCtlProcess.devicectlDevicesOutput } returns deviceOutput.toFile()
+        every { deviceCtlProcess.devicectlDevicesOutput() } returns deviceOutput.toFile()
 
         // when
         val connectedDevices = LocalIOSDevice(deviceCtlProcess).listDeviceViaDeviceCtl()


### PR DESCRIPTION
## Proposed changes

Fix device detection crash
- Added error handling for devicectl call
- Improve logging for process execution
- Refactor device list parsing 
- Remove unused temp file


copilot:summary

## Description
Issue happens when `xcrun devicectl` command fails
For me it was failing because of `.zshenv` caused by cargo
```
. "$HOME/.cargo/env"
# ... other things
```

which causes `xcrun devicectl` command to fail with 
```
Error: 2 unexpected arguments: 'PATH ...
```

That leads `devicectl_response.json` to be empty which afterwards crashes during the deserialization.

```
com.fasterxml.jackson.databind.exc.MismatchedInputException: No content to map due to end-of-input
...
```

## Testing

Tested with:

`./maestro-cli/build/install/maestro/bin/maestro test android-test.yaml`

With `xcrun devicectl` is failing

<img width="1033" height="417" alt="image" src="https://github.com/user-attachments/assets/89d54f09-c7b6-47d0-9e46-6b8e7aa6a3b9" />
 
With normal `xcrun devicectl` execution

<img width="993" height="192" alt="image" src="https://github.com/user-attachments/assets/7f6a48ca-9799-4c68-84c4-03fb43c76777" />


Run test using `./gradlew :maestro-cli:test`

<img width="1086" height="273" alt="image" src="https://github.com/user-attachments/assets/3a7cba4b-d63d-47a4-9633-b67b4b474c29" />

## Reasoning

The command-line output should give the user enough information to understand and fix this issue, since it is caused by a local environment problem. If the user is only running an Android flow, a failure in xcrun devicectl should not block them from proceeding.
 

## Issues fixed

linked issue https://github.com/mobile-dev-inc/maestro/issues/2811