### PR TITLE
fix: iOS call timeout being 60 seconds

### DIFF
--- a/maestro-utils/src/main/kotlin/HttpClient.kt
+++ b/maestro-utils/src/main/kotlin/HttpClient.kt
@@ -65,6 +65,7 @@ object HttpClient {
         connectTimeout: Duration = 10.seconds,
         readTimeout: Duration = 10.seconds,
         writeTimeout: Duration = 10.seconds,
+        callTimeout: Duration = 60.seconds,
         interceptors: List<Interceptor> = emptyList(),
         networkInterceptors: List<Interceptor> = emptyList(),
         protocols: List<Protocol> = listOf(Protocol.HTTP_1_1),
@@ -75,6 +76,7 @@ object HttpClient {
             .connectTimeout(connectTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .readTimeout(readTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .writeTimeout(writeTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            .callTimeout(callTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .addNetworkInterceptor(Interceptor { chain ->
                 val start = System.currentTimeMillis()
                 val response = chain.proceed(chain.request())


### PR DESCRIPTION
## Proposed changes

iOS driver HTTP client doesn't configure a call timeout right now. This is a huge problem because this can leave the calls hanging on our XCUITest server. 

Read and write timeout are just small part of HTTP transaction. With this we have a complete timeout defined for each call to server.


## Testing

- [x] Locally.
- [x] Unit test that verifies thread doesn't block forever like before. 

## Issues fixed
