### PR TITLE
Tidy up after screenshot test

### DIFF
--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -72,6 +72,7 @@ class IntegrationTest {
         File("135_recordings").delete()
         File("135_recordings/filename.mp4").delete()
         File("137_shard_device_env_vars_test-device_shard1_idx0.png").delete()
+        File("138_take_cropped_screenshot_with_filename.png").delete()
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Running tests locally left a test artifact in the workspace from a recently added integration test. This fixes that.

## Testing

Had a file leftover before. Didn't afterwards. Git said so.

## Issues fixed
