### PR TITLE
fix: timeouts creating errors in runtime 

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -28,6 +28,7 @@ class GraalJsEngine(
         name = "GraalJsEngine",
         readTimeout = 5.minutes,
         writeTimeout = 5.minutes,
+        callTimeout = 5.minutes,
         protocols = listOf(Protocol.HTTP_1_1)
     ),
     platform: String = "unknown"

--- a/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/RhinoJsEngine.kt
@@ -12,6 +12,7 @@ class RhinoJsEngine(
         name="RhinoJsEngine",
         readTimeout=5.minutes,
         writeTimeout=5.minutes,
+        callTimeout = 5.minutes,
         protocols=listOf(Protocol.HTTP_1_1)
     ),
     platform: String = "unknown"


### PR DESCRIPTION
## Proposed changes

Explicitly mention timeouts on JS engines because they get mangled after compilation and start giving NoSuchMethodError.

## Testing

- [x] Locally

## Issues fixed
