### PR TITLE
Feat/support allure reporter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@
 # https://blog.gradle.org/best-practices-naming-version-catalog-entries
 
 [versions]
+allure = "2.32.0"
 androidPlugin = "8.13.2"
 androidxEspresso = "3.6.1"
 androidxTestJunit = "1.2.1"
@@ -63,6 +64,7 @@ gmsLocation = "21.3.0"
 mcpKotlinSdk = "steviec/kotlin-1.8"
 
 [libraries]
+allure-java-commons = { module = "io.qameta.allure:allure-java-commons", version.ref = "allure" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html", version.ref = "kotlinx-html" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -197,6 +197,7 @@ dependencies {
     implementation(libs.logging.layout.template)
     implementation(libs.log4j.core)
     implementation(libs.mordant)
+    implementation(libs.allure.java.commons)
 
     testImplementation(libs.junit.jupiter.api)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -141,7 +141,7 @@ class CloudCommand : Callable<Int> {
     @Option(
         order = 16,
         names = ["--output"],
-        description = ["File to write report into (default=report.xml)"],
+        description = ["Path to write report into. JUNIT/HTML: file (default=report.xml/report.html), ALLURE: directory (default=allure-results)"],
     )
     private var output: File? = null
 

--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -1,5 +1,6 @@
 package maestro.cli.model
 
+import java.io.File
 import kotlin.time.Duration
 
 // TODO: Some properties should be implemented as getters, but it's not possible.
@@ -31,15 +32,24 @@ data class TestExecutionSummary(
         val properties: Map<String, String>? = null,
         val tags: List<String>? = null,
         val steps: List<StepResult> = emptyList(),
+        val attachments: List<Attachment> = emptyList(),
+        val env: Map<String, String> = emptyMap(),
     )
 
     data class StepResult(
         val description: String,
         val status: String,
-        val duration: String,
+        val durationMs: Long? = null,
+        val startTime: Long? = null,
     )
 
     data class Failure(
         val message: String,
+    )
+
+    data class Attachment(
+        val file: File,
+        val label: String,
+        val mimeType: String,
     )
 }

--- a/maestro-cli/src/main/java/maestro/cli/report/AllureTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/AllureTestSuiteReporter.kt
@@ -63,7 +63,7 @@ class AllureTestSuiteReporter(
                 val testResult = TestResult()
                     .setUuid(uuid)
                     .setName(flow.name)
-                    .setFullName(buildFullName(suite, flow))
+                    .setFullName(buildFullName(flow))
                     .setHistoryId(buildHistoryId(flow))
                     .setStatus(mapFlowStatus(flow.status))
                     .setLabels(buildLabels(suite, flow))
@@ -120,11 +120,8 @@ class AllureTestSuiteReporter(
         }
     }
 
-    private fun buildFullName(
-        suite: TestExecutionSummary.SuiteResult,
-        flow: TestExecutionSummary.FlowResult,
-    ): String {
-        val suitePart = testSuiteName ?: suite.deviceName ?: "maestro"
+    private fun buildFullName(flow: TestExecutionSummary.FlowResult): String {
+        val suitePart = testSuiteName ?: "maestro"
         return "$suitePart#${flow.name}"
     }
 
@@ -141,7 +138,6 @@ class AllureTestSuiteReporter(
         val labels = mutableListOf<Label>()
 
         labels.add(Label().setName("framework").setValue("maestro"))
-
         if (testSuiteName != null) {
             labels.add(Label().setName("suite").setValue(testSuiteName))
         }

--- a/maestro-cli/src/main/java/maestro/cli/report/AllureTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/AllureTestSuiteReporter.kt
@@ -1,0 +1,188 @@
+package maestro.cli.report
+
+import io.qameta.allure.AllureLifecycle
+import io.qameta.allure.FileSystemResultsWriter
+import io.qameta.allure.model.Attachment
+import io.qameta.allure.model.Label
+import io.qameta.allure.model.Parameter
+import io.qameta.allure.model.Status
+import io.qameta.allure.model.StatusDetails
+import io.qameta.allure.model.StepResult
+import io.qameta.allure.model.TestResult
+import io.qameta.allure.util.ResultsUtils
+import maestro.cli.CliError
+import maestro.cli.model.FlowStatus
+import maestro.cli.model.TestExecutionSummary
+import java.io.File
+import java.nio.file.Files
+import java.util.UUID
+
+class AllureTestSuiteReporter(
+    private val outputDir: File,
+    private val testSuiteName: String?,
+) : TestSuiteReporter {
+
+    companion object {
+        fun from(output: File?, testSuiteName: String?): AllureTestSuiteReporter {
+            return AllureTestSuiteReporter(
+                outputDir = resolveOutputDir(output),
+                testSuiteName = testSuiteName,
+            )
+        }
+
+        private fun resolveOutputDir(output: File?): File {
+            val outputDir = output ?: error("ALLURE output directory is required")
+            if (outputDir.exists() && outputDir.isFile) {
+                throw CliError("ALLURE report output must be a directory: ${outputDir.path}")
+            }
+            return outputDir
+        }
+    }
+
+    override fun report(summary: TestExecutionSummary) {
+        reportToDirectory(summary)
+    }
+
+    private fun reportToDirectory(summary: TestExecutionSummary) {
+        outputDir.mkdirs()
+
+        val lifecycle = AllureLifecycle(FileSystemResultsWriter(outputDir.toPath()))
+
+        for (suite in summary.suites) {
+            for (flow in suite.flows) {
+                val uuid = UUID.randomUUID().toString()
+                val flowStart = flow.startTime ?: 0L
+
+                val steps = mapSteps(flow.steps, flowStart)
+                val stepsEnd = steps.lastOrNull()?.stop
+                val flowDurationEnd = flow.startTime?.let { start ->
+                    flow.duration?.let { duration -> start + duration.inWholeMilliseconds }
+                }
+                val flowStop = listOfNotNull(flowDurationEnd, stepsEnd).maxOrNull() ?: flowStart
+
+                val testResult = TestResult()
+                    .setUuid(uuid)
+                    .setName(flow.name)
+                    .setFullName(buildFullName(suite, flow))
+                    .setHistoryId(buildHistoryId(flow))
+                    .setStatus(mapFlowStatus(flow.status))
+                    .setLabels(buildLabels(suite, flow))
+                    .setParameters(buildParameters(flow.env))
+                    .setSteps(steps)
+                    .setStart(flowStart)
+                    .setStop(flowStop)
+
+                if (flow.failure != null) {
+                    testResult.setStatusDetails(
+                        StatusDetails().setMessage(flow.failure.message)
+                    )
+                }
+
+                val allureAttachments = copyAttachments(flow, outputDir)
+                testResult.setAttachments(allureAttachments)
+
+                lifecycle.scheduleTestCase(testResult)
+                lifecycle.writeTestCase(uuid)
+            }
+        }
+    }
+
+    private fun mapFlowStatus(status: FlowStatus): Status {
+        return when (status) {
+            FlowStatus.SUCCESS -> Status.PASSED
+            FlowStatus.ERROR -> Status.FAILED
+            FlowStatus.WARNING -> Status.BROKEN
+            FlowStatus.CANCELED, FlowStatus.STOPPED -> Status.SKIPPED
+            else -> Status.BROKEN
+        }
+    }
+
+    private fun mapStepStatus(status: String): Status {
+        return when (status.uppercase()) {
+            "COMPLETED" -> Status.PASSED
+            "FAILED" -> Status.FAILED
+            "WARNED" -> Status.BROKEN
+            "SKIPPED" -> Status.SKIPPED
+            else -> Status.BROKEN
+        }
+    }
+
+    private fun mapSteps(steps: List<TestExecutionSummary.StepResult>, flowStartTime: Long): List<StepResult> {
+        return steps.map { step ->
+            val start = step.startTime ?: flowStartTime
+            val durationMs = step.durationMs ?: 0L
+            val stop = start + durationMs
+            StepResult()
+                .setName(step.description)
+                .setStatus(mapStepStatus(step.status))
+                .setStart(start)
+                .setStop(stop)
+        }
+    }
+
+    private fun buildFullName(
+        suite: TestExecutionSummary.SuiteResult,
+        flow: TestExecutionSummary.FlowResult,
+    ): String {
+        val suitePart = testSuiteName ?: suite.deviceName ?: "maestro"
+        return "$suitePart#${flow.name}"
+    }
+
+    private fun buildHistoryId(flow: TestExecutionSummary.FlowResult): String {
+        val clazz = flow.fileName ?: "maestro.flow"
+        val method = flow.name
+        return ResultsUtils.generateMethodSignatureHash(clazz, method, emptyList())
+    }
+
+    private fun buildLabels(
+        suite: TestExecutionSummary.SuiteResult,
+        flow: TestExecutionSummary.FlowResult,
+    ): List<Label> {
+        val labels = mutableListOf<Label>()
+
+        labels.add(Label().setName("framework").setValue("maestro"))
+
+        if (testSuiteName != null) {
+            labels.add(Label().setName("suite").setValue(testSuiteName))
+        }
+
+        if (suite.deviceName != null) {
+            labels.add(Label().setName("host").setValue(suite.deviceName))
+        }
+
+        flow.tags?.forEach { tag ->
+            labels.add(Label().setName("tag").setValue(tag))
+        }
+
+        flow.properties?.forEach { (key, value) ->
+            labels.add(Label().setName(key).setValue(value))
+        }
+
+        return labels
+    }
+
+    private fun buildParameters(env: Map<String, String>): List<Parameter> {
+        return env.map { (key, value) ->
+            Parameter().setName(key).setValue(value)
+        }
+    }
+
+    private fun copyAttachments(flow: TestExecutionSummary.FlowResult, outputDir: File): List<Attachment> {
+        return flow.attachments.mapNotNull { attachment ->
+            if (!attachment.file.exists()) return@mapNotNull null
+
+            val extension = attachment.file.extension
+                .takeIf { it.isNotBlank() }
+                ?.let { ".$it" }
+                .orEmpty()
+            val destName = "${UUID.randomUUID()}-${attachment.label}${extension}"
+            val destFile = File(outputDir, destName)
+            Files.copy(attachment.file.toPath(), destFile.toPath())
+
+            Attachment()
+                .setName(attachment.label)
+                .setSource(destName)
+                .setType(attachment.mimeType)
+        }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/report/AllureTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/AllureTestSuiteReporter.kt
@@ -159,8 +159,21 @@ class AllureTestSuiteReporter(
 
     private fun buildParameters(env: Map<String, String>): List<Parameter> {
         return env.map { (key, value) ->
-            Parameter().setName(key).setValue(value)
+            Parameter().setName(key).setValue(maskSensitiveValue(key, value))
         }
+    }
+
+    private fun maskSensitiveValue(key: String, value: String): String {
+        val sensitiveKeywords = listOf(
+            "password", "pwd", "secret", "token", "key", "auth",
+            "credential", "apikey", "api_key", "private"
+        )
+
+        val isSensitive = sensitiveKeywords.any { keyword ->
+            key.lowercase().contains(keyword)
+        }
+
+        return if (isSensitive) "***MASKED***" else value
     }
 
     private fun copyAttachments(flow: TestExecutionSummary.FlowResult, outputDir: File): List<Attachment> {

--- a/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/HtmlTestSuiteReporter.kt
@@ -6,7 +6,10 @@ import maestro.cli.model.TestExecutionSummary
 import okio.Sink
 import okio.buffer
 
-class HtmlTestSuiteReporter(private val detailed: Boolean = false) : TestSuiteReporter {
+class HtmlTestSuiteReporter(
+    private val out: Sink,
+    private val detailed: Boolean = false,
+) : TestSuiteReporter {
 
     companion object {
         private fun loadPrettyCss(): String {
@@ -18,11 +21,19 @@ class HtmlTestSuiteReporter(private val detailed: Boolean = false) : TestSuiteRe
         }
     }
 
-    override fun report(summary: TestExecutionSummary, out: Sink) {
+    override fun report(summary: TestExecutionSummary) {
         val bufferedOut = out.buffer()
         val htmlContent = buildHtmlReport(summary)
         bufferedOut.writeUtf8(htmlContent)
         bufferedOut.close()
+    }
+
+    private fun formatStepDuration(durationMs: Long?): String {
+        return when {
+            durationMs == null -> "<1ms"
+            durationMs >= 1000L -> "%.1fs".format(durationMs / 1000.0)
+            else -> "${durationMs}ms"
+        }
     }
 
     private fun buildHtmlReport(summary: TestExecutionSummary): String {
@@ -184,7 +195,7 @@ class HtmlTestSuiteReporter(private val detailed: Boolean = false) : TestSuiteRe
                                                                     span(classes = "step-name") { +step.description }
                                                                 }
                                                                 span(classes = "badge bg-light text-dark") {
-                                                                    +step.duration
+                                                                    +formatStepDuration(step.durationMs)
                                                                 }
                                                             }
                                                         }

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -18,7 +18,8 @@ import kotlin.time.DurationUnit
 
 class JUnitTestSuiteReporter(
     private val mapper: ObjectMapper,
-    private val testSuiteName: String?
+    private val out: Sink,
+    private val testSuiteName: String?,
 ) : TestSuiteReporter {
 
     private fun suiteResultToTestSuite(suite: TestExecutionSummary.SuiteResult) = TestSuite(
@@ -61,10 +62,7 @@ class JUnitTestSuiteReporter(
     )
 
 
-    override fun report(
-        summary: TestExecutionSummary,
-        out: Sink
-    ) {
+    override fun report(summary: TestExecutionSummary) {
         mapper
             .writerWithDefaultPrettyPrinter()
             .writeValue(
@@ -121,12 +119,13 @@ class JUnitTestSuiteReporter(
 
     companion object {
 
-        fun xml(testSuiteName: String? = null) = JUnitTestSuiteReporter(
+        fun xml(sink: Sink, testSuiteName: String? = null) = JUnitTestSuiteReporter(
             mapper = XmlMapper().apply {
                 registerModule(KotlinModule.Builder().build())
                 setSerializationInclusion(JsonInclude.Include.NON_NULL)
                 configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
             },
+            out = sink,
             testSuiteName = testSuiteName
         )
 

--- a/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReportFormat.kt
@@ -3,14 +3,14 @@ package maestro.cli.report
 import picocli.CommandLine
 
 enum class ReportFormat(
-    val fileExtension: String?,
     private val displayName: String? = null
 ) {
 
-    JUNIT(".xml"),
-    HTML(".html"),
-    HTML_DETAILED(".html", "HTML-DETAILED"),
-    NOOP(null);
+    JUNIT,
+    HTML,
+    HTML_DETAILED("HTML-DETAILED"),
+    ALLURE,
+    NOOP;
 
     override fun toString(): String {
         return displayName ?: name

--- a/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/ReporterFactory.kt
@@ -1,16 +1,39 @@
 package maestro.cli.report
 
-import maestro.cli.model.TestExecutionSummary
-import okio.BufferedSink
+import okio.sink
+import java.io.File
 
 object ReporterFactory {
 
-    fun buildReporter(format: ReportFormat, testSuiteName: String?): TestSuiteReporter {
+    private const val DEFAULT_JUNIT_OUTPUT_FILE = "report.xml"
+    private const val DEFAULT_HTML_OUTPUT_FILE = "report.html"
+    private const val DEFAULT_ALLURE_OUTPUT_DIR = "allure-results"
+
+    fun buildReporter(
+        format: ReportFormat,
+        output: File?,
+        testSuiteName: String?,
+    ): TestSuiteReporter {
         return when (format) {
-            ReportFormat.JUNIT -> JUnitTestSuiteReporter.xml(testSuiteName)
+            ReportFormat.JUNIT -> JUnitTestSuiteReporter.xml(
+                sink = (output ?: File(DEFAULT_JUNIT_OUTPUT_FILE)).sink(),
+                testSuiteName = testSuiteName,
+            )
+
             ReportFormat.NOOP -> TestSuiteReporter.NOOP
-            ReportFormat.HTML -> HtmlTestSuiteReporter(detailed = false)
-            ReportFormat.HTML_DETAILED -> HtmlTestSuiteReporter(detailed = true)
+            ReportFormat.ALLURE -> AllureTestSuiteReporter.from(
+                output = output ?: File(DEFAULT_ALLURE_OUTPUT_DIR),
+                testSuiteName = testSuiteName,
+            )
+            ReportFormat.HTML -> HtmlTestSuiteReporter(
+                out = (output ?: File(DEFAULT_HTML_OUTPUT_FILE)).sink(),
+                detailed = false,
+            )
+
+            ReportFormat.HTML_DETAILED -> HtmlTestSuiteReporter(
+                out = (output ?: File(DEFAULT_HTML_OUTPUT_FILE)).sink(),
+                detailed = true,
+            )
         }
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestSuiteReporter.kt
@@ -1,7 +1,6 @@
 package maestro.cli.report
 
 import maestro.cli.model.TestExecutionSummary
-import okio.Sink
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -9,16 +8,15 @@ import java.time.format.DateTimeFormatter
 interface TestSuiteReporter {
 
     /**
-     * Writes the report for [summary] to [out] in the format specified by the implementation.
+     * Writes the report for [summary] in the format specified by the implementation.
      */
     fun report(
         summary: TestExecutionSummary,
-        out: Sink,
     )
 
     companion object {
         val NOOP: TestSuiteReporter = object : TestSuiteReporter {
-            override fun report(summary: TestExecutionSummary, out: Sink) {
+            override fun report(summary: TestExecutionSummary) {
                 // no-op
             }
         }

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -11,7 +11,6 @@ import maestro.cli.report.CommandDebugMetadata
 import maestro.cli.report.FlowAIOutput
 import maestro.cli.report.FlowDebugOutput
 import maestro.cli.report.TestDebugReporter
-import maestro.cli.report.TestSuiteReporter
 import maestro.cli.util.PrintUtils
 import maestro.cli.util.TimeUtils
 import maestro.cli.view.ErrorViewUtils
@@ -21,7 +20,6 @@ import maestro.orchestra.Orchestra
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.yaml.YamlCommandReader
-import okio.Sink
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Path
@@ -41,7 +39,6 @@ import maestro.orchestra.util.Env.withInjectedShellEnvVars
 class TestSuiteInteractor(
     private val maestro: Maestro,
     private val device: Device? = null,
-    private val reporter: TestSuiteReporter,
     private val shardIndex: Int? = null,
     private val captureSteps: Boolean = false,
 ) {
@@ -51,7 +48,6 @@ class TestSuiteInteractor(
 
     suspend fun runTestSuite(
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan,
-        reportOut: Sink?,
         env: Map<String, String>,
         debugOutputPath: Path,
         testOutputDir: Path? = null,
@@ -138,13 +134,6 @@ class TestSuiteInteractor(
             totalTests = flowResults.size
         )
 
-        if (reportOut != null) {
-            reporter.report(
-                summary,
-                reportOut,
-            )
-        }
-
         // TODO(bartekpacia): Should it also be saving to debugOutputPath?
         TestDebugReporter.saveSuggestions(aiOutputs, debugOutputPath)
 
@@ -179,6 +168,8 @@ class TestSuiteInteractor(
 
         logger.info("$shardPrefix Running flow $flowName")
 
+        val flowStartTime = System.currentTimeMillis()
+        var commandSequenceNumber = 0
         val flowTimeMillis = measureTimeMillis {
             try {
                 val orchestra = Orchestra(
@@ -188,8 +179,12 @@ class TestSuiteInteractor(
                         logger.info("${shardPrefix}${command.description()} RUNNING")
                         debugOutput.commands[command] = CommandDebugMetadata(
                             timestamp = System.currentTimeMillis(),
-                            status = CommandStatus.RUNNING
+                            status = CommandStatus.RUNNING,
+                            sequenceNumber = commandSequenceNumber++,
                         )
+                    },
+                    onCommandMetadataUpdate = { command, metadata ->
+                        debugOutput.commands[command]?.evaluatedCommand = metadata.evaluatedCommand
                     },
                     onCommandComplete = { _, command ->
                         logger.info("${shardPrefix}${command.description()} COMPLETED")
@@ -273,25 +268,25 @@ class TestSuiteInteractor(
             debugOutput.commands.entries
                 .sortedBy { it.value.sequenceNumber }
                 .mapIndexed { index, (command, metadata) ->
-                    val durationStr = when (val duration = metadata.duration) {
-                        null -> "<1ms"
-                        else -> if (duration >= 1000) {
-                            "%.1fs".format(duration / 1000.0)
-                        } else {
-                            "${duration}ms"
-                        }
-                    }
                     val status = metadata.status?.toString() ?: "UNKNOWN"
                     // Use evaluated command for interpolated labels, fallback to original
                     val displayCommand = metadata.evaluatedCommand ?: command
                     TestExecutionSummary.StepResult(
                         description = "${index + 1}. ${displayCommand.description()}",
                         status = status,
-                        duration = durationStr,
+                        durationMs = metadata.duration,
+                        startTime = metadata.timestamp,
                     )
                 }
         } else {
             emptyList()
+        }
+        val attachments = debugOutput.screenshots.map { screenshot ->
+            TestExecutionSummary.Attachment(
+                file = screenshot.screenshot,
+                label = "screenshot-${screenshot.timestamp}",
+                mimeType = "image/png",
+            )
         }
 
         return Pair(
@@ -305,9 +300,12 @@ class TestSuiteInteractor(
                     )
                 } else null,
                 duration = flowDuration,
+                startTime = flowStartTime,
                 properties = maestroConfig?.properties,
                 tags = maestroConfig?.tags,
                 steps = steps,
+                attachments = attachments,
+                env = env,
             ),
             second = aiOutput,
         )

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -28,7 +28,6 @@ import kotlin.time.Duration.Companion.seconds
 import maestro.cli.util.ScreenshotUtils
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
-import java.util.Locale
 
 /**
  * Similar to [TestRunner], but:

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/AllureTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/AllureTestSuiteReporterTest.kt
@@ -1,0 +1,365 @@
+package maestro.cli.report
+
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.google.common.truth.Truth.assertThat
+import io.qameta.allure.model.Status
+import io.qameta.allure.model.TestResult
+import io.qameta.allure.util.ResultsUtils
+import maestro.cli.model.FlowStatus
+import maestro.cli.model.TestExecutionSummary
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.time.Duration.Companion.milliseconds
+
+class AllureTestSuiteReporterTest : TestSuiteReporterTest() {
+
+    private val mapper = JsonMapper.builder()
+        .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+        .build()
+
+    @Test
+    fun `report writes JSON result files into output directory`(@TempDir outputDir: File) {
+        reporter(outputDir).report(testSuccessWithWarning)
+
+        assertThat(readResults(outputDir)).hasSize(2)
+    }
+
+    @Test
+    fun `result files contain correct flow names`(@TempDir outputDir: File) {
+        reporter(outputDir).report(testSuccessWithWarning)
+
+        val results = readResults(outputDir)
+        val names = results.mapNotNull { it.name }.toSet()
+
+        assertThat(names).containsExactly("Flow A", "Flow B")
+        results.forEach { assertThat(it.historyId).isNotEmpty() }
+    }
+
+    @Test
+    fun `result files contain framework host and suite labels`(@TempDir outputDir: File) {
+        reporter(outputDir).report(testSuccessWithWarning)
+
+        readResults(outputDir).forEach { result ->
+            assertThat(labelValues(result, "framework")).contains("maestro")
+            assertThat(labelValues(result, "host")).contains("iPhone 15")
+            assertThat(labelValues(result, "suite")).contains("Test Suite")
+        }
+    }
+
+    @Test
+    fun `result files contain tags and properties as labels`(@TempDir outputDir: File) {
+        reporter(outputDir).report(testWithTagsAndProperties)
+
+        val loginFlow = readResultByName(outputDir, "Login Flow")
+        val checkoutFlow = readResultByName(outputDir, "Checkout Flow")
+
+        assertThat(labelValues(loginFlow, "tag")).containsAtLeast("smoke", "critical", "auth")
+        assertThat(labelValues(loginFlow, "testCaseId")).contains("TC-001")
+        assertThat(labelValues(loginFlow, "priority")).contains("P0")
+
+        assertThat(labelValues(checkoutFlow, "tag")).containsAtLeast("regression", "e2e")
+        assertThat(labelValues(checkoutFlow, "testCaseId")).contains("TC-002")
+        assertThat(labelValues(checkoutFlow, "testrail-case-id")).contains("C456")
+    }
+
+    @Test
+    fun `steps are mapped with expected status and timestamps`(@TempDir outputDir: File) {
+        reporter(outputDir).report(testErrorWithSteps)
+
+        val result = readResultByName(outputDir, "Flow B")
+
+        assertThat(result.steps).hasSize(4)
+
+        val firstStep = result.steps[0]
+        assertThat(firstStep.name).isEqualTo("1. Launch app")
+        assertThat(firstStep.status).isEqualTo(Status.PASSED)
+
+        val warnedStep = result.steps[1]
+        assertThat(warnedStep.name).isEqualTo("2. Tap on optional element")
+        assertThat(warnedStep.status).isEqualTo(Status.BROKEN)
+        assertThat(warnedStep.stop).isEqualTo(warnedStep.start)
+
+        val failedStep = result.steps[2]
+        assertThat(failedStep.name).isEqualTo("3. Tap on button")
+        assertThat(failedStep.status).isEqualTo(Status.FAILED)
+
+        val skippedStep = result.steps[3]
+        assertThat(skippedStep.name).isEqualTo("4. Assert visible")
+        assertThat(skippedStep.status).isEqualTo(Status.SKIPPED)
+        assertThat(skippedStep.stop).isEqualTo(skippedStep.start)
+
+        assertThat(result.steps.mapNotNull { it.start }).isInStrictOrder()
+    }
+
+    @Test
+    fun `unknown step status maps to BROKEN`(@TempDir outputDir: File) {
+        val summary = TestExecutionSummary(
+            passed = true,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = true,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow With Unknown Step",
+                            fileName = "flow_unknown_step",
+                            status = FlowStatus.SUCCESS,
+                            duration = 1000.milliseconds,
+                            startTime = now.toInstant().toEpochMilli(),
+                            steps = listOf(
+                                TestExecutionSummary.StepResult(
+                                    description = "1. Unknown",
+                                    status = "SOMETHING_NEW",
+                                    durationMs = 1,
+                                    startTime = now.toInstant().toEpochMilli(),
+                                )
+                            ),
+                        ),
+                    ),
+                    duration = 1000.milliseconds,
+                    startTime = now.toInstant().toEpochMilli(),
+                )
+            )
+        )
+
+        reporter(outputDir).report(summary)
+
+        val result = readResultByName(outputDir, "Flow With Unknown Step")
+        assertThat(result.steps.single().status).isEqualTo(Status.BROKEN)
+    }
+
+    @Test
+    fun `flow status mapping covers skipped failed broken and default`(@TempDir outputDir: File) {
+        val summary = TestExecutionSummary(
+            passed = false,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = false,
+                    flows = listOf(
+                        flow(name = "Canceled", status = FlowStatus.CANCELED),
+                        flow(name = "Stopped", status = FlowStatus.STOPPED),
+                        flow(name = "Error", status = FlowStatus.ERROR),
+                        flow(name = "Warning", status = FlowStatus.WARNING),
+                        flow(name = "Running", status = FlowStatus.RUNNING),
+                    ),
+                    duration = 1000.milliseconds,
+                    startTime = now.toInstant().toEpochMilli(),
+                )
+            )
+        )
+
+        reporter(outputDir).report(summary)
+
+        assertThat(readResultByName(outputDir, "Canceled").status).isEqualTo(Status.SKIPPED)
+        assertThat(readResultByName(outputDir, "Stopped").status).isEqualTo(Status.SKIPPED)
+        assertThat(readResultByName(outputDir, "Error").status).isEqualTo(Status.FAILED)
+        assertThat(readResultByName(outputDir, "Warning").status).isEqualTo(Status.BROKEN)
+        assertThat(readResultByName(outputDir, "Running").status).isEqualTo(Status.BROKEN)
+    }
+
+    @Test
+    fun `attachments are copied and registered in result JSON`(@TempDir outputDir: File) {
+        val summaryWithAttachments = createSummaryWithAttachment()
+
+        reporter(outputDir).report(summaryWithAttachments)
+
+        val result = readResultByName(outputDir, "Flow With Attachment")
+
+        assertThat(result.attachments).hasSize(1)
+        val attachment = result.attachments.single()
+        assertThat(attachment.name).isEqualTo("screenshot")
+        assertThat(attachment.type).isEqualTo("image/png")
+        assertThat(attachment.source).endsWith(".png")
+        assertThat(File(outputDir, attachment.source).exists()).isTrue()
+    }
+
+    @Test
+    fun `missing attachments are skipped`(@TempDir outputDir: File) {
+        val missingFile = File(outputDir, "missing.png")
+        val summary = TestExecutionSummary(
+            passed = true,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = true,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow With Missing Attachment",
+                            fileName = "flow_missing_attachment",
+                            status = FlowStatus.SUCCESS,
+                            duration = 1000.milliseconds,
+                            startTime = now.toInstant().toEpochMilli(),
+                            attachments = listOf(
+                                TestExecutionSummary.Attachment(
+                                    file = missingFile,
+                                    label = "screenshot",
+                                    mimeType = "image/png",
+                                )
+                            ),
+                        ),
+                    ),
+                    duration = 1000.milliseconds,
+                    startTime = now.toInstant().toEpochMilli(),
+                )
+            )
+        )
+
+        reporter(outputDir).report(summary)
+
+        val result = readResultByName(outputDir, "Flow With Missing Attachment")
+        assertThat(result.attachments).isEmpty()
+    }
+
+    @Test
+    fun `null suite name uses device as full name and no suite label`(@TempDir outputDir: File) {
+        reporter(outputDir, null).report(testSuccessWithWarning)
+
+        val result = readResultByName(outputDir, "Flow A")
+        assertThat(result.fullName).isEqualTo("iPhone 15#Flow A")
+        assertThat(labelValues(result, "suite")).isEmpty()
+    }
+
+    @Test
+    fun `fallbacks are used for fullName and historyId when fields are missing`(@TempDir outputDir: File) {
+        val summary = TestExecutionSummary(
+            passed = true,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = true,
+                    deviceName = null,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow Without File",
+                            fileName = null,
+                            status = FlowStatus.SUCCESS,
+                            duration = 1000.milliseconds,
+                            startTime = now.toInstant().toEpochMilli(),
+                        )
+                    ),
+                    duration = 1000.milliseconds,
+                    startTime = now.toInstant().toEpochMilli(),
+                )
+            )
+        )
+
+        reporter(outputDir, null).report(summary)
+
+        val result = readResultByName(outputDir, "Flow Without File")
+        val expectedHistoryId = ResultsUtils.generateMethodSignatureHash("maestro.flow", "Flow Without File", emptyList())
+
+        assertThat(result.fullName).isEqualTo("maestro#Flow Without File")
+        assertThat(result.historyId).isEqualTo(expectedHistoryId)
+    }
+
+    @Test
+    fun `env variables are included as parameters`(@TempDir outputDir: File) {
+        val summaryWithEnv = TestExecutionSummary(
+            passed = true,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = true,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow With Env",
+                            fileName = "flow_env",
+                            status = FlowStatus.SUCCESS,
+                            duration = 1000.milliseconds,
+                            startTime = now.toInstant().toEpochMilli(),
+                            env = mapOf(
+                                "MAESTRO_FILENAME" to "flow_env",
+                                "MAESTRO_DEVICE_UDID" to "ABC-123",
+                                "MAESTRO_SHARD_ID" to "1",
+                                "API_URL" to "https://example.com",
+                            ),
+                        ),
+                    ),
+                    duration = 1000.milliseconds,
+                    startTime = now.toInstant().toEpochMilli(),
+                )
+            )
+        )
+
+        reporter(outputDir).report(summaryWithEnv)
+
+        val result = readResultByName(outputDir, "Flow With Env")
+        val parameters = result.parameters.associate { it.name to it.value }
+
+        assertThat(parameters).containsEntry("MAESTRO_FILENAME", "flow_env")
+        assertThat(parameters).containsEntry("MAESTRO_DEVICE_UDID", "ABC-123")
+        assertThat(parameters).containsEntry("MAESTRO_SHARD_ID", "1")
+        assertThat(parameters).containsEntry("API_URL", "https://example.com")
+    }
+
+    @Test
+    fun `failure message is included in status details`(@TempDir outputDir: File) {
+        reporter(outputDir).report(testSuccessWithError)
+
+        val failedResult = readResultByName(outputDir, "Flow B")
+
+        assertThat(failedResult.status).isEqualTo(Status.FAILED)
+        assertThat(failedResult.statusDetails?.message).isEqualTo("Error message")
+    }
+
+    private fun readResults(outputDir: File): List<TestResult> {
+        val files = outputDir.listFiles { _, name -> name.endsWith("-result.json") }.orEmpty()
+        return files.map { file -> mapper.readValue(file, TestResult::class.java) }
+    }
+
+    private fun readResultByName(outputDir: File, flowName: String): TestResult {
+        return readResults(outputDir).single { it.name == flowName }
+    }
+
+    private fun labelValues(result: TestResult, labelName: String): List<String?> {
+        return result.labels.filter { it.name == labelName }.map { it.value }
+    }
+
+    private fun createSummaryWithAttachment(): TestExecutionSummary {
+        val screenshotFile = File.createTempFile("screenshot", ".png")
+        screenshotFile.writeBytes(ByteArray(100))
+        screenshotFile.deleteOnExit()
+
+        return TestExecutionSummary(
+            passed = true,
+            suites = listOf(
+                TestExecutionSummary.SuiteResult(
+                    passed = true,
+                    flows = listOf(
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow With Attachment",
+                            fileName = "flow_attach",
+                            status = FlowStatus.SUCCESS,
+                            duration = 1000.milliseconds,
+                            startTime = now.toInstant().toEpochMilli(),
+                            attachments = listOf(
+                                TestExecutionSummary.Attachment(
+                                    file = screenshotFile,
+                                    label = "screenshot",
+                                    mimeType = "image/png",
+                                )
+                            ),
+                        ),
+                    ),
+                    duration = 1000.milliseconds,
+                    startTime = now.toInstant().toEpochMilli(),
+                )
+            )
+        )
+    }
+
+    private fun flow(name: String, status: FlowStatus): TestExecutionSummary.FlowResult {
+        return TestExecutionSummary.FlowResult(
+            name = name,
+            fileName = name.lowercase(),
+            status = status,
+            duration = 1000.milliseconds,
+            startTime = now.toInstant().toEpochMilli(),
+        )
+    }
+
+    private fun reporter(outputDir: File, testSuiteName: String? = "Test Suite"): AllureTestSuiteReporter {
+        return AllureTestSuiteReporter(
+            outputDir = outputDir,
+            testSuiteName = testSuiteName,
+        )
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/AllureTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/AllureTestSuiteReporterTest.kt
@@ -69,26 +69,31 @@ class AllureTestSuiteReporterTest : TestSuiteReporterTest() {
         reporter(outputDir).report(testErrorWithSteps)
 
         val result = readResultByName(outputDir, "Flow B")
+        val sourceSteps = testErrorWithSteps.suites.single().flows.single().steps
+        val (firstSourceStep, warnedSourceStep, failedSourceStep, skippedSourceStep) = sourceSteps
 
         assertThat(result.steps).hasSize(4)
+        assertThat(result.steps.map { it.start }).containsExactlyElementsIn(sourceSteps.map { it.startTime }).inOrder()
 
-        val firstStep = result.steps[0]
+        val (firstStep, warnedStep, failedStep, skippedStep) = result.steps
+
         assertThat(firstStep.name).isEqualTo("1. Launch app")
         assertThat(firstStep.status).isEqualTo(Status.PASSED)
+        assertThat(firstStep.stop).isEqualTo(firstSourceStep.startTime!! + firstSourceStep.durationMs!!)
 
-        val warnedStep = result.steps[1]
         assertThat(warnedStep.name).isEqualTo("2. Tap on optional element")
         assertThat(warnedStep.status).isEqualTo(Status.BROKEN)
         assertThat(warnedStep.stop).isEqualTo(warnedStep.start)
+        assertThat(warnedStep.start).isEqualTo(warnedSourceStep.startTime)
 
-        val failedStep = result.steps[2]
         assertThat(failedStep.name).isEqualTo("3. Tap on button")
         assertThat(failedStep.status).isEqualTo(Status.FAILED)
+        assertThat(failedStep.stop).isEqualTo(failedSourceStep.startTime!! + failedSourceStep.durationMs!!)
 
-        val skippedStep = result.steps[3]
         assertThat(skippedStep.name).isEqualTo("4. Assert visible")
         assertThat(skippedStep.status).isEqualTo(Status.SKIPPED)
         assertThat(skippedStep.stop).isEqualTo(skippedStep.start)
+        assertThat(skippedStep.start).isEqualTo(skippedSourceStep.startTime)
 
         assertThat(result.steps.mapNotNull { it.start }).isInStrictOrder()
     }

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/HtmlTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/HtmlTestSuiteReporterTest.kt
@@ -9,13 +9,12 @@ class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `HTML - Test passed`() {
         // Given
-        val testee = HtmlTestSuiteReporter()
         val sink = Buffer()
+        val testee = HtmlTestSuiteReporter(out = sink)
 
         // When
         testee.report(
             summary = testSuccessWithWarning,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -85,13 +84,12 @@ class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `HTML - Test failed`() {
         // Given
-        val testee = HtmlTestSuiteReporter()
         val sink = Buffer()
+        val testee = HtmlTestSuiteReporter(out = sink)
 
         // When
         testee.report(
             summary = testSuccessWithError,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -167,13 +165,12 @@ class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `HTML - Pretty mode with successful test and steps`() {
         // Given
-        val testee = HtmlTestSuiteReporter(detailed = true)
         val sink = Buffer()
+        val testee = HtmlTestSuiteReporter(out = sink, detailed = true)
 
         // When
         testee.report(
             summary = testSuccessWithSteps,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -201,13 +198,12 @@ class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `HTML - Pretty mode with failed test and steps with various statuses`() {
         // Given
-        val testee = HtmlTestSuiteReporter(detailed = true)
         val sink = Buffer()
+        val testee = HtmlTestSuiteReporter(out = sink, detailed = true)
 
         // When
         testee.report(
             summary = testErrorWithSteps,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -222,6 +218,8 @@ class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
         assertThat(resultStr).contains("2. Tap on optional element")
         assertThat(resultStr).contains("3. Tap on button")
         assertThat(resultStr).contains("4. Assert visible")
+        assertThat(resultStr).contains("&lt;1ms")
+        assertThat(resultStr).contains("0ms")
         assertThat(resultStr).contains("Element not found")
         assertThat(resultStr).contains(".step-item")
         assertThat(resultStr).contains(".step-header")
@@ -238,13 +236,12 @@ class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `HTML - Basic mode does not show steps even when present`() {
         // Given
-        val testee = HtmlTestSuiteReporter(detailed = false)
         val sink = Buffer()
+        val testee = HtmlTestSuiteReporter(out = sink, detailed = false)
 
         // When
         testee.report(
             summary = testSuccessWithSteps,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -264,13 +261,12 @@ class HtmlTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `HTML - Tags and properties are displayed`() {
         // Given
-        val testee = HtmlTestSuiteReporter(detailed = false)
         val sink = Buffer()
+        val testee = HtmlTestSuiteReporter(out = sink, detailed = false)
 
         // When
         testee.report(
             summary = testWithTagsAndProperties,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -9,13 +9,12 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `XML - Test passed`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml()
         val sink = Buffer()
+        val testee = JUnitTestSuiteReporter.xml(sink = sink)
 
         // When
         testee.report(
             summary = testSuccessWithWarning,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -37,13 +36,12 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `XML - Test failed`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml()
         val sink = Buffer()
+        val testee = JUnitTestSuiteReporter.xml(sink = sink)
 
         // When
         testee.report(
             summary = testSuccessWithError,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -67,13 +65,12 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `XML - Custom test suite name is used when present`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml("Custom test suite name")
         val sink = Buffer()
+        val testee = JUnitTestSuiteReporter.xml(sink = sink, "Custom test suite name")
 
         // When
         testee.report(
             summary = testSuccessWithWarning,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 
@@ -95,13 +92,12 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
     @Test
     fun `XML - Tags and properties are included in output`() {
         // Given
-        val testee = JUnitTestSuiteReporter.xml()
         val sink = Buffer()
+        val testee = JUnitTestSuiteReporter.xml(sink = sink)
 
         // When
         testee.report(
             summary = testWithTagsAndProperties,
-            out = sink
         )
         val resultStr = sink.readUtf8()
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/ReporterFactoryTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/ReporterFactoryTest.kt
@@ -1,0 +1,60 @@
+package maestro.cli.report
+
+import com.google.common.truth.Truth.assertThat
+import maestro.cli.CliError
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class ReporterFactoryTest : TestSuiteReporterTest() {
+
+    @Test
+    fun `JUNIT reporter writes to provided file`(@TempDir tempDir: File) {
+        val outputFile = File(tempDir, "junit.xml")
+
+        ReporterFactory
+            .buildReporter(ReportFormat.JUNIT, outputFile, testSuiteName = null)
+            .report(testSuccessWithWarning)
+
+        assertThat(outputFile.exists()).isTrue()
+        assertThat(outputFile.readText()).contains("<testsuites>")
+    }
+
+    @Test
+    fun `HTML reporter writes to provided file`(@TempDir tempDir: File) {
+        val outputFile = File(tempDir, "report.html")
+
+        ReporterFactory
+            .buildReporter(ReportFormat.HTML, outputFile, testSuiteName = null)
+            .report(testSuccessWithWarning)
+
+        assertThat(outputFile.exists()).isTrue()
+        assertThat(outputFile.readText()).contains("<html>")
+    }
+
+    @Test
+    fun `ALLURE reporter writes into provided directory`(@TempDir tempDir: File) {
+        val outputDir = File(tempDir, "allure-results")
+
+        ReporterFactory
+            .buildReporter(ReportFormat.ALLURE, outputDir, testSuiteName = "Suite")
+            .report(testSuccessWithWarning)
+
+        val jsonFiles = outputDir.listFiles { _, name -> name.endsWith("-result.json") }
+        assertThat(jsonFiles).isNotNull()
+        assertThat(jsonFiles!!.size).isEqualTo(2)
+    }
+
+    @Test
+    fun `ALLURE reporter rejects file output path`(@TempDir tempDir: File) {
+        val outputFile = File(tempDir, "allure-results")
+        outputFile.writeText("not-a-directory")
+
+        val error = assertThrows<CliError> {
+            ReporterFactory.buildReporter(ReportFormat.ALLURE, outputFile, testSuiteName = null)
+        }
+
+        assertThat(error).hasMessageThat().contains("must be a directory")
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
@@ -92,17 +92,20 @@ abstract class TestSuiteReporterTest {
                             TestExecutionSummary.StepResult(
                                 description = "1. Launch app",
                                 status = "COMPLETED",
-                                duration = "1.2s"
+                                durationMs = 1200,
+                                startTime = nowPlus1.toInstant().toEpochMilli(),
                             ),
                             TestExecutionSummary.StepResult(
                                 description = "2. Tap on button",
                                 status = "COMPLETED",
-                                duration = "500ms"
+                                durationMs = 500,
+                                startTime = nowPlus1.toInstant().toEpochMilli() + 1200,
                             ),
                             TestExecutionSummary.StepResult(
                                 description = "3. Assert visible",
                                 status = "COMPLETED",
-                                duration = "100ms"
+                                durationMs = 100,
+                                startTime = nowPlus1.toInstant().toEpochMilli() + 1700,
                             ),
                         )
                     ),
@@ -130,22 +133,26 @@ abstract class TestSuiteReporterTest {
                             TestExecutionSummary.StepResult(
                                 description = "1. Launch app",
                                 status = "COMPLETED",
-                                duration = "1.5s"
+                                durationMs = 1500,
+                                startTime = nowPlus1.toInstant().toEpochMilli(),
                             ),
                             TestExecutionSummary.StepResult(
                                 description = "2. Tap on optional element",
                                 status = "WARNED",
-                                duration = "<1ms"
+                                durationMs = null,
+                                startTime = nowPlus1.toInstant().toEpochMilli() + 1500,
                             ),
                             TestExecutionSummary.StepResult(
                                 description = "3. Tap on button",
                                 status = "FAILED",
-                                duration = "2.0s"
+                                durationMs = 2000,
+                                startTime = nowPlus1.toInstant().toEpochMilli() + 3500,
                             ),
                             TestExecutionSummary.StepResult(
                                 description = "4. Assert visible",
                                 status = "SKIPPED",
-                                duration = "0ms"
+                                durationMs = 0,
+                                startTime = nowPlus1.toInstant().toEpochMilli() + 5500,
                             ),
                         )
                     ),

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
@@ -122,40 +122,49 @@ abstract class TestSuiteReporterTest {
             TestExecutionSummary.SuiteResult(
                 passed = false,
                 flows = listOf(
-                    TestExecutionSummary.FlowResult(
-                        name = "Flow B",
-                        fileName = "flow_b",
-                        status = FlowStatus.ERROR,
-                        failure = TestExecutionSummary.Failure("Element not found"),
-                        duration = 3000.milliseconds,
-                        startTime = nowPlus1.toInstant().toEpochMilli(),
-                        steps = listOf(
-                            TestExecutionSummary.StepResult(
-                                description = "1. Launch app",
-                                status = "COMPLETED",
-                                durationMs = 1500,
-                                startTime = nowPlus1.toInstant().toEpochMilli(),
-                            ),
-                            TestExecutionSummary.StepResult(
-                                description = "2. Tap on optional element",
-                                status = "WARNED",
-                                durationMs = null,
-                                startTime = nowPlus1.toInstant().toEpochMilli() + 1500,
-                            ),
-                            TestExecutionSummary.StepResult(
-                                description = "3. Tap on button",
-                                status = "FAILED",
-                                durationMs = 2000,
-                                startTime = nowPlus1.toInstant().toEpochMilli() + 3500,
-                            ),
-                            TestExecutionSummary.StepResult(
-                                description = "4. Assert visible",
-                                status = "SKIPPED",
-                                durationMs = 0,
-                                startTime = nowPlus1.toInstant().toEpochMilli() + 5500,
-                            ),
+                    run {
+                        val flowStartMs = nowPlus1.toInstant().toEpochMilli()
+                        val launchStepStartMs = flowStartMs
+                        val warnedStepStartMs = launchStepStartMs + 1500L
+                        val warnedStepElapsedMs = 2000L // warned steps don't track duration, but time still passes
+                        val failedStepStartMs = warnedStepStartMs + warnedStepElapsedMs
+                        val skippedStepStartMs = failedStepStartMs + 2000L
+
+                        TestExecutionSummary.FlowResult(
+                            name = "Flow B",
+                            fileName = "flow_b",
+                            status = FlowStatus.ERROR,
+                            failure = TestExecutionSummary.Failure("Element not found"),
+                            duration = 3000.milliseconds,
+                            startTime = flowStartMs,
+                            steps = listOf(
+                                TestExecutionSummary.StepResult(
+                                    description = "1. Launch app",
+                                    status = "COMPLETED",
+                                    durationMs = 1500L,
+                                    startTime = launchStepStartMs,
+                                ),
+                                TestExecutionSummary.StepResult(
+                                    description = "2. Tap on optional element",
+                                    status = "WARNED",
+                                    durationMs = null,
+                                    startTime = warnedStepStartMs,
+                                ),
+                                TestExecutionSummary.StepResult(
+                                    description = "3. Tap on button",
+                                    status = "FAILED",
+                                    durationMs = 2000L,
+                                    startTime = failedStepStartMs,
+                                ),
+                                TestExecutionSummary.StepResult(
+                                    description = "4. Assert visible",
+                                    status = "SKIPPED",
+                                    durationMs = 0,
+                                    startTime = skippedStepStartMs,
+                                ),
+                            )
                         )
-                    ),
+                    },
                 ),
                 duration = 3000.milliseconds,
                 startTime = now.toInstant().toEpochMilli()


### PR DESCRIPTION
## Proposed changes

[Allure](https://allurereport.org/) is a widely used test reporting format, and this change adds support for generating Allure results in maestro:
- supports `--format allure` output
- exports artifacts as Allure attachments (`image/png`, `video/mp4`)
- includes screenshot diff artifact on visual mismatch
- maps Maestro metadata into Allure [labels](https://allurereport.org/docs/how-it-works-test-result-file/#labels) (`framework`, `suite`, `host`, `tag`, flow, properties)

## Testing

Tested locally on `e2e/workspaces/demo_app` by running `e2e/run_tests` with Allure output enabled (added Allure reporter flag in `e2e/run_tests` (`--format allure`))

  Repro steps:
  ```bash
  cd e2e
  ./run_tests android
  allure serve allure-results
```

Verified:
  - Allure result files are generated
  - attachments are present in report
  - image attachments are correct (regular screenshots + screenshot diff)
  - video attachment is present and playable (`video/mp4`)
  - labels are populated correctly in Allure
  - parallel execution is handled correctly, and test timelines are formed/rendered correctly in Allure
<img width="1721" height="807" alt="Screenshot 2026-02-15 at 18 39 10" src="https://github.com/user-attachments/assets/0022d4ab-c255-4cdb-9f5a-b21147b230b5" />
<img width="1718" height="939" alt="Screenshot 2026-02-15 at 18 32 22" src="https://github.com/user-attachments/assets/2ac61968-3625-497d-a1dd-3d3dc196340e" />
<img width="1714" height="946" alt="Screenshot 2026-02-15 at 18 32 59" src="https://github.com/user-attachments/assets/4c6e8f05-33b1-4cb1-ac19-3f6637417676" />
<img width="1709" height="569" alt="Screenshot 2026-02-15 at 18 33 15" src="https://github.com/user-attachments/assets/a3a4e6cc-d3e9-4543-b766-d521dadbb41d" />

  ## Allure docs

  - https://allurereport.org/docs/install/
  - https://allurereport.org/docs/v2/generate-report/
  - https://allurereport.org/docs/how-it-works-test-result-file/#labels

