### PR TITLE
Add origin to ScrollUntilVisible, to not always swipe from the centre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Core: support a screen-relative `fromPoint` on `scrollUntilVisible` to start the scroll swipe away from the screen center
+
 ## 2.8.0
 
 - Core: support element-relative `point` on `swipe` commands

--- a/e2e/demo_app/.maestro/commands/scrollUntilVisible.yaml
+++ b/e2e/demo_app/.maestro/commands/scrollUntilVisible.yaml
@@ -23,3 +23,9 @@ tags:
     optional: true
 - evalScript: ${maestro.endTime = new Date()}
 - assertTrue: ${maestro.endTime - maestro.startTime < 12000} # Far less than the 20000 default, but enough to allow for processing time
+
+- scrollUntilVisible:
+    element: Item 20
+    fromPoint: "50%, 25%"
+- assertVisible: Item 20
+- assertNotVisible: Item 1

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -172,7 +172,7 @@ class Maestro(
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
-    fun swipeFromPoint(point: Point, swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
+    suspend fun swipeFromPoint(point: Point, swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
         LOGGER.info("Swiping ${swipeDirection.name} from point $point")
         driver.swipe(point, swipeDirection, durationMs)
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -172,6 +172,12 @@ class Maestro(
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
+    fun swipeFromPoint(point: Point, swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
+        LOGGER.info("Swiping ${swipeDirection.name} from point $point")
+        driver.swipe(point, swipeDirection, durationMs)
+        waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
+    }
+
     suspend fun scrollVertical() {
         LOGGER.info("Scrolling vertically")
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -195,16 +195,6 @@ class Maestro(
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
-    suspend fun swipeFromCenter(swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
-        val deviceInfo = deviceInfo()
-
-        LOGGER.info("Swiping ${swipeDirection.name} from center")
-        val center = Point(x = deviceInfo.widthGrid / 2, y = deviceInfo.heightGrid / 2)
-        runInterruptible(Dispatchers.IO) { driver.swipe(center, swipeDirection, durationMs) }
-        recentScroll = true
-        waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
-    }
-
     suspend fun scrollVertical() {
         LOGGER.info("Scrolling vertically")
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -205,12 +205,6 @@ class Maestro(
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
-    suspend fun swipeFromPoint(point: Point, swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
-        LOGGER.info("Swiping ${swipeDirection.name} from point $point")
-        driver.swipe(point, swipeDirection, durationMs)
-        waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
-    }
-
     suspend fun scrollVertical() {
         LOGGER.info("Scrolling vertically")
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -205,6 +205,12 @@ class Maestro(
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
+    fun swipeFromPoint(point: Point, swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
+        LOGGER.info("Swiping ${swipeDirection.name} from point $point")
+        driver.swipe(point, swipeDirection, durationMs)
+        waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
+    }
+
     suspend fun scrollVertical() {
         LOGGER.info("Scrolling vertically")
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -205,7 +205,7 @@ class Maestro(
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
-    fun swipeFromPoint(point: Point, swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
+    suspend fun swipeFromPoint(point: Point, swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?) {
         LOGGER.info("Swiping ${swipeDirection.name} from point $point")
         driver.swipe(point, swipeDirection, durationMs)
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -109,7 +109,7 @@ data class ScrollUntilVisibleCommand(
     val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
     val originalSpeedValue: String? = scrollDuration,
-    val origin: String = DEFAULT_ORIGIN,
+    val fromPoint: String = DEFAULT_FROM_POINT,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -131,8 +131,8 @@ data class ScrollUntilVisibleCommand(
             } else {
                 additionalDescription.add("with centering disabled")
             }
-            if (origin != DEFAULT_ORIGIN) {
-                additionalDescription.add("from origin $origin")
+            if (fromPoint != DEFAULT_FROM_POINT) {
+                additionalDescription.add("from $fromPoint")
             }
             return "$baseDescription ${additionalDescription.joinToString(", ")}"
         }
@@ -156,7 +156,7 @@ data class ScrollUntilVisibleCommand(
             selector = selector.evaluateScripts(jsEngine),
             scrollDuration = scrollDuration.evaluateScripts(jsEngine).speedToDuration(),
             timeout = timeout.evaluateScripts(jsEngine).timeoutToMillis(),
-            origin = origin.evaluateScripts(jsEngine),
+            fromPoint = fromPoint.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -166,7 +166,7 @@ data class ScrollUntilVisibleCommand(
         const val DEFAULT_SCROLL_DURATION = "40"
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
         const val DEFAULT_CENTER_ELEMENT = false
-        const val DEFAULT_ORIGIN = "50%, 50%"
+        const val DEFAULT_FROM_POINT = "50%, 50%"
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -109,6 +109,7 @@ data class ScrollUntilVisibleCommand(
     val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
     val originalSpeedValue: String? = scrollDuration,
+    val origin: String = DEFAULT_ORIGIN,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -129,6 +130,9 @@ data class ScrollUntilVisibleCommand(
                 additionalDescription.add("with centering enabled")
             } else {
                 additionalDescription.add("with centering disabled")
+            }
+            if (origin != DEFAULT_ORIGIN) {
+                additionalDescription.add("from origin $origin")
             }
             return "$baseDescription ${additionalDescription.joinToString(", ")}"
         }
@@ -152,6 +156,7 @@ data class ScrollUntilVisibleCommand(
             selector = selector.evaluateScripts(jsEngine),
             scrollDuration = scrollDuration.evaluateScripts(jsEngine).speedToDuration(),
             timeout = timeout.evaluateScripts(jsEngine).timeoutToMillis(),
+            origin = origin.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -161,6 +166,7 @@ data class ScrollUntilVisibleCommand(
         const val DEFAULT_SCROLL_DURATION = "40"
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
         const val DEFAULT_CENTER_ELEMENT = false
+        const val DEFAULT_ORIGIN = "50%, 50%"
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -124,6 +124,7 @@ data class ScrollUntilVisibleCommand(
     val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
     val originalSpeedValue: String? = scrollDuration,
+    val origin: String = DEFAULT_ORIGIN,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -144,6 +145,9 @@ data class ScrollUntilVisibleCommand(
                 additionalDescription.add("with centering enabled")
             } else {
                 additionalDescription.add("with centering disabled")
+            }
+            if (origin != DEFAULT_ORIGIN) {
+                additionalDescription.add("from origin $origin")
             }
             return "$baseDescription ${additionalDescription.joinToString(", ")}"
         }
@@ -168,6 +172,7 @@ data class ScrollUntilVisibleCommand(
             selector = selector.evaluateScripts(jsEngine),
             scrollDuration = scrollDuration.evaluateScripts(jsEngine).speedToDuration(),
             timeout = timeout.evaluateScripts(jsEngine).timeoutToMillis(),
+            origin = origin.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -177,6 +182,7 @@ data class ScrollUntilVisibleCommand(
         const val DEFAULT_SCROLL_DURATION = "40"
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
         const val DEFAULT_CENTER_ELEMENT = false
+        const val DEFAULT_ORIGIN = "50%, 50%"
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -124,7 +124,7 @@ data class ScrollUntilVisibleCommand(
     val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
     val originalSpeedValue: String? = scrollDuration,
-    val fromPoint: String = DEFAULT_FROM_POINT,
+    val fromPoint: String? = null, // screen-relative start point for the scroll swipe
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -146,8 +146,8 @@ data class ScrollUntilVisibleCommand(
             } else {
                 additionalDescription.add("with centering disabled")
             }
-            if (fromPoint != DEFAULT_FROM_POINT) {
-                additionalDescription.add("from $fromPoint")
+            fromPoint?.let {
+                additionalDescription.add("from $it")
             }
             return "$baseDescription ${additionalDescription.joinToString(", ")}"
         }
@@ -172,7 +172,7 @@ data class ScrollUntilVisibleCommand(
             selector = selector.evaluateScripts(jsEngine),
             scrollDuration = scrollDuration.evaluateScripts(jsEngine).speedToDuration(),
             timeout = timeout.evaluateScripts(jsEngine).timeoutToMillis(),
-            fromPoint = fromPoint.evaluateScripts(jsEngine),
+            fromPoint = fromPoint?.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -182,7 +182,6 @@ data class ScrollUntilVisibleCommand(
         const val DEFAULT_SCROLL_DURATION = "40"
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
         const val DEFAULT_CENTER_ELEMENT = false
-        const val DEFAULT_FROM_POINT = "50%, 50%"
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -124,7 +124,7 @@ data class ScrollUntilVisibleCommand(
     val waitToSettleTimeoutMs: Int? = null,
     val centerElement: Boolean,
     val originalSpeedValue: String? = scrollDuration,
-    val origin: String = DEFAULT_ORIGIN,
+    val fromPoint: String = DEFAULT_FROM_POINT,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -146,8 +146,8 @@ data class ScrollUntilVisibleCommand(
             } else {
                 additionalDescription.add("with centering disabled")
             }
-            if (origin != DEFAULT_ORIGIN) {
-                additionalDescription.add("from origin $origin")
+            if (fromPoint != DEFAULT_FROM_POINT) {
+                additionalDescription.add("from $fromPoint")
             }
             return "$baseDescription ${additionalDescription.joinToString(", ")}"
         }
@@ -172,7 +172,7 @@ data class ScrollUntilVisibleCommand(
             selector = selector.evaluateScripts(jsEngine),
             scrollDuration = scrollDuration.evaluateScripts(jsEngine).speedToDuration(),
             timeout = timeout.evaluateScripts(jsEngine).timeoutToMillis(),
-            origin = origin.evaluateScripts(jsEngine),
+            fromPoint = fromPoint.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -182,7 +182,7 @@ data class ScrollUntilVisibleCommand(
         const val DEFAULT_SCROLL_DURATION = "40"
         const val DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE = 100
         const val DEFAULT_CENTER_ELEMENT = false
-        const val DEFAULT_ORIGIN = "50%, 50%"
+        const val DEFAULT_FROM_POINT = "50%, 50%"
     }
 }
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -129,6 +129,7 @@ data class ScrollUntilVisibleCommand(
     override val optional: Boolean = false,
 ) : Command {
 
+    @get:JsonIgnore
     val visibilityPercentageNormalized = (visibilityPercentage / 100).toDouble()
 
     override val originalDescription: String

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -739,7 +739,7 @@ class Orchestra(
             } catch (ignored: MaestroException.ElementNotFound) {
                 logger.warn("Error: $ignored")
             }
-            val swipeOrigin = resolveOrigin(command.origin, deviceInfo)
+            val swipeOrigin = resolveFromPoint(command.fromPoint, deviceInfo)
             maestro.swipeFromPoint(swipeOrigin, direction, command.scrollDuration.toLong(), command.waitToSettleTimeoutMs)
         } while (System.currentTimeMillis() < endTime)
 
@@ -780,15 +780,15 @@ class Orchestra(
         )
     }
 
-    private fun resolveOrigin(origin: String, deviceInfo: DeviceInfo): Point {
-        return if (origin.contains('%')) {
-            val (pctX, pctY) = origin.split(',').map { it.trim().trimEnd('%').toDouble() }
+    private fun resolveFromPoint(fromPoint: String, deviceInfo: DeviceInfo): Point {
+        return if (fromPoint.contains('%')) {
+            val (pctX, pctY) = fromPoint.split(',').map { it.trim().trimEnd('%').toDouble() }
             Point(
                 x = (deviceInfo.widthGrid * pctX / 100).toInt(),
                 y = (deviceInfo.heightGrid * pctY / 100).toInt(),
             )
         } else {
-            val (x, y) = origin.split(',').map { it.trim().toInt() }
+            val (x, y) = fromPoint.split(',').map { it.trim().toInt() }
             Point(x = x, y = y)
         }
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -739,11 +739,8 @@ class Orchestra(
             } catch (ignored: MaestroException.ElementNotFound) {
                 logger.warn("Error: $ignored")
             }
-            maestro.swipeFromCenter(
-                direction,
-                durationMs = command.scrollDuration.toLong(),
-                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
-            )
+            val swipeOrigin = resolveOrigin(command.origin, deviceInfo)
+            maestro.swipeFromPoint(swipeOrigin, direction, command.scrollDuration.toLong(), command.waitToSettleTimeoutMs)
         } while (System.currentTimeMillis() < endTime)
 
         val debugMessage = buildString {
@@ -781,6 +778,19 @@ class Orchestra(
             maestro.viewHierarchy().root,
             debugMessage = debugMessage
         )
+    }
+
+    private fun resolveOrigin(origin: String, deviceInfo: DeviceInfo): Point {
+        return if (origin.contains('%')) {
+            val (pctX, pctY) = origin.split(',').map { it.trim().trimEnd('%').toDouble() }
+            Point(
+                x = (deviceInfo.widthGrid * pctX / 100).toInt(),
+                y = (deviceInfo.heightGrid * pctY / 100).toInt(),
+            )
+        } else {
+            val (x, y) = origin.split(',').map { it.trim().toInt() }
+            Point(x = x, y = y)
+        }
     }
 
     private suspend fun hideKeyboardCommand(): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -762,8 +762,8 @@ class Orchestra(
         val endTime = System.currentTimeMillis() + command.timeout.toLong()
         val direction = command.direction.toSwipeDirection()
         val deviceInfo = maestro.deviceInfo()
-        val swipeOrigin = command.fromPoint
-            ?.let { calculateScreenRelativePoint(it, deviceInfo) }
+        // Resolve once; default to the screen centre when no explicit start point is given.
+        val swipeOrigin = calculateScreenRelativePoint(command.fromPoint ?: "50%, 50%", deviceInfo)
 
         var retryCenterCount = 0
         val maxRetryCenterCount = 4 // for when the list is no longer scrollable (last element) but the element is visible
@@ -791,20 +791,12 @@ class Orchestra(
             } catch (ignored: MaestroException.ElementNotFound) {
                 logger.warn("Error: $ignored")
             }
-            if (swipeOrigin != null) {
-                maestro.swipe(
-                    direction,
-                    swipeOrigin,
-                    command.scrollDuration.toLong(),
-                    waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
-                )
-            } else {
-                maestro.swipeFromCenter(
-                    direction,
-                    durationMs = command.scrollDuration.toLong(),
-                    waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
-                )
-            }
+            maestro.swipe(
+                direction,
+                swipeOrigin,
+                command.scrollDuration.toLong(),
+                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
+            )
         } while (System.currentTimeMillis() < endTime)
 
         val debugMessage = buildString {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -789,11 +789,8 @@ class Orchestra(
             } catch (ignored: MaestroException.ElementNotFound) {
                 logger.warn("Error: $ignored")
             }
-            maestro.swipeFromCenter(
-                direction,
-                durationMs = command.scrollDuration.toLong(),
-                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
-            )
+            val swipeOrigin = resolveOrigin(command.origin, deviceInfo)
+            maestro.swipeFromPoint(swipeOrigin, direction, command.scrollDuration.toLong(), command.waitToSettleTimeoutMs)
         } while (System.currentTimeMillis() < endTime)
 
         val debugMessage = buildString {
@@ -831,6 +828,19 @@ class Orchestra(
             maestro.viewHierarchy().root,
             debugMessage = debugMessage
         )
+    }
+
+    private fun resolveOrigin(origin: String, deviceInfo: DeviceInfo): Point {
+        return if (origin.contains('%')) {
+            val (pctX, pctY) = origin.split(',').map { it.trim().trimEnd('%').toDouble() }
+            Point(
+                x = (deviceInfo.widthGrid * pctX / 100).toInt(),
+                y = (deviceInfo.heightGrid * pctY / 100).toInt(),
+            )
+        } else {
+            val (x, y) = origin.split(',').map { it.trim().toInt() }
+            Point(x = x, y = y)
+        }
     }
 
     private suspend fun hideKeyboardCommand(): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -789,7 +789,7 @@ class Orchestra(
             } catch (ignored: MaestroException.ElementNotFound) {
                 logger.warn("Error: $ignored")
             }
-            val swipeOrigin = resolveOrigin(command.origin, deviceInfo)
+            val swipeOrigin = resolveFromPoint(command.fromPoint, deviceInfo)
             maestro.swipeFromPoint(swipeOrigin, direction, command.scrollDuration.toLong(), command.waitToSettleTimeoutMs)
         } while (System.currentTimeMillis() < endTime)
 
@@ -830,15 +830,15 @@ class Orchestra(
         )
     }
 
-    private fun resolveOrigin(origin: String, deviceInfo: DeviceInfo): Point {
-        return if (origin.contains('%')) {
-            val (pctX, pctY) = origin.split(',').map { it.trim().trimEnd('%').toDouble() }
+    private fun resolveFromPoint(fromPoint: String, deviceInfo: DeviceInfo): Point {
+        return if (fromPoint.contains('%')) {
+            val (pctX, pctY) = fromPoint.split(',').map { it.trim().trimEnd('%').toDouble() }
             Point(
                 x = (deviceInfo.widthGrid * pctX / 100).toInt(),
                 y = (deviceInfo.heightGrid * pctY / 100).toInt(),
             )
         } else {
-            val (x, y) = origin.split(',').map { it.trim().toInt() }
+            val (x, y) = fromPoint.split(',').map { it.trim().toInt() }
             Point(x = x, y = y)
         }
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -762,6 +762,8 @@ class Orchestra(
         val endTime = System.currentTimeMillis() + command.timeout.toLong()
         val direction = command.direction.toSwipeDirection()
         val deviceInfo = maestro.deviceInfo()
+        val swipeOrigin = command.fromPoint
+            ?.let { calculateScreenRelativePoint(it, deviceInfo) }
 
         var retryCenterCount = 0
         val maxRetryCenterCount = 4 // for when the list is no longer scrollable (last element) but the element is visible
@@ -789,8 +791,6 @@ class Orchestra(
             } catch (ignored: MaestroException.ElementNotFound) {
                 logger.warn("Error: $ignored")
             }
-            val swipeOrigin = command.fromPoint
-                ?.let { calculateScreenRelativePoint(it, deviceInfo) }
             if (swipeOrigin != null) {
                 maestro.swipe(
                     direction,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -33,7 +33,6 @@ import maestro.FindElementResult
 import maestro.Maestro
 import maestro.DeviceConnectionException
 import maestro.MaestroException
-import maestro.Point
 import maestro.ScreenRecording
 import maestro.UiElement
 import maestro.UiElement.Companion.toUiElementOrNull
@@ -55,6 +54,7 @@ import maestro.orchestra.filter.FilterWithDescription
 import maestro.orchestra.filter.TraitFilters
 import maestro.orchestra.geo.Traveller
 import maestro.orchestra.util.calculateElementRelativePoint
+import maestro.orchestra.util.calculateScreenRelativePoint
 import maestro.orchestra.util.Env.evaluateScripts
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.toSwipeDirection
@@ -789,8 +789,22 @@ class Orchestra(
             } catch (ignored: MaestroException.ElementNotFound) {
                 logger.warn("Error: $ignored")
             }
-            val swipeOrigin = resolveFromPoint(command.fromPoint, deviceInfo)
-            maestro.swipeFromPoint(swipeOrigin, direction, command.scrollDuration.toLong(), command.waitToSettleTimeoutMs)
+            val swipeOrigin = command.fromPoint
+                ?.let { calculateScreenRelativePoint(it, deviceInfo) }
+            if (swipeOrigin != null) {
+                maestro.swipe(
+                    direction,
+                    swipeOrigin,
+                    command.scrollDuration.toLong(),
+                    waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
+                )
+            } else {
+                maestro.swipeFromCenter(
+                    direction,
+                    durationMs = command.scrollDuration.toLong(),
+                    waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
+                )
+            }
         } while (System.currentTimeMillis() < endTime)
 
         val debugMessage = buildString {
@@ -828,19 +842,6 @@ class Orchestra(
             maestro.viewHierarchy().root,
             debugMessage = debugMessage
         )
-    }
-
-    private fun resolveFromPoint(fromPoint: String, deviceInfo: DeviceInfo): Point {
-        return if (fromPoint.contains('%')) {
-            val (pctX, pctY) = fromPoint.split(',').map { it.trim().trimEnd('%').toDouble() }
-            Point(
-                x = (deviceInfo.widthGrid * pctX / 100).toInt(),
-                y = (deviceInfo.heightGrid * pctY / 100).toInt(),
-            )
-        } else {
-            val (x, y) = fromPoint.split(',').map { it.trim().toInt() }
-            Point(x = x, y = y)
-        }
     }
 
     private suspend fun hideKeyboardCommand(): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/util/ElementCoordinateUtil.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/util/ElementCoordinateUtil.kt
@@ -1,12 +1,13 @@
 package maestro.orchestra.util
 
+import maestro.DeviceInfo
 import maestro.MaestroException
 import maestro.Point
 import maestro.UiElement
 
 /**
  * Calculates the absolute screen coordinates for a point relative to an element's bounds.
- * 
+ *
  * @param element The UI element to calculate coordinates relative to
  * @param point The relative point as a string (e.g., "50%, 90%" or "25, 40")
  * @return The absolute screen coordinates as a Point
@@ -14,30 +15,75 @@ import maestro.UiElement
  */
 internal fun calculateElementRelativePoint(element: UiElement, point: String): Point {
     val bounds = element.bounds
-    
+    return resolveRelativePoint(
+        point = point,
+        originX = bounds.x,
+        originY = bounds.y,
+        width = bounds.width,
+        height = bounds.height,
+        regionLabel = "element",
+    )
+}
+
+/**
+ * Calculates the absolute screen coordinates for a point relative to the device screen.
+ *
+ * @param point The point as a string (e.g., "50%, 90%" or "100, 400")
+ * @param deviceInfo The device info used to resolve percentage-based coordinates
+ * @return The absolute screen coordinates as a Point
+ * @throws MaestroException.InvalidCommand if the point is invalid
+ */
+internal fun calculateScreenRelativePoint(point: String, deviceInfo: DeviceInfo): Point {
+    return resolveRelativePoint(
+        point = point,
+        originX = 0,
+        originY = 0,
+        width = deviceInfo.widthGrid,
+        height = deviceInfo.heightGrid,
+        regionLabel = "screen",
+    )
+}
+
+/**
+ * Resolves a `"x%, y%"` (percentage) or `"x, y"` (absolute) point within a rectangular region
+ * to absolute screen coordinates. The region is defined by its top-left origin and its size;
+ * an element passes its bounds, the whole screen passes `(0, 0)` and the device dimensions.
+ *
+ * @param regionLabel Used in error messages to name the region (e.g. "element", "screen").
+ * @throws MaestroException.InvalidCommand if the point is out of range for the region.
+ */
+private fun resolveRelativePoint(
+    point: String,
+    originX: Int,
+    originY: Int,
+    width: Int,
+    height: Int,
+    regionLabel: String,
+): Point {
     return if (point.contains("%")) {
-        // Percentage-based coordinates within element bounds
+        // Percentage-based coordinates within the region
         val (percentX, percentY) = point
             .replace("%", "")
             .split(",")
             .map { it.trim().toInt() }
 
         if (percentX !in 0..100 || percentY !in 0..100) {
-            throw MaestroException.InvalidCommand("Invalid element-relative point: $point. Percentages must be between 0 and 100.")
+            throw MaestroException.InvalidCommand("Invalid $regionLabel-relative point: $point. Percentages must be between 0 and 100.")
         }
 
-        val x = bounds.x + (bounds.width * percentX / 100)
-        val y = bounds.y + (bounds.height * percentY / 100)
-        Point(x, y)
+        Point(
+            x = originX + (width * percentX / 100),
+            y = originY + (height * percentY / 100),
+        )
     } else {
-        // Absolute coordinates within element bounds
+        // Absolute coordinates within the region
         val (x, y) = point.split(",")
             .map { it.trim().toInt() }
 
-        if (x < 0 || y < 0 || x >= bounds.width || y >= bounds.height) {
-            throw MaestroException.InvalidCommand("Invalid element-relative point: $point. Coordinates must be within element bounds (0,0) to (${bounds.width-1},${bounds.height-1}).")
+        if (x < 0 || y < 0 || x >= width || y >= height) {
+            throw MaestroException.InvalidCommand("Invalid $regionLabel-relative point: $point. Coordinates must be within $regionLabel bounds (0,0) to (${width - 1},${height - 1}).")
         }
 
-        Point(bounds.x + x, bounds.y + y)
+        Point(originX + x, originY + y)
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -999,7 +999,7 @@ data class YamlFluentCommand(
                 optional = yaml.optional,
                 originalSpeedValue = yaml.speed,
                 waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs,
-                origin = yaml.origin,
+                fromPoint = yaml.fromPoint,
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -998,7 +998,8 @@ data class YamlFluentCommand(
                 label = yaml.label,
                 optional = yaml.optional,
                 originalSpeedValue = yaml.speed,
-                waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs
+                waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs,
+                origin = yaml.origin,
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -1001,7 +1001,8 @@ data class YamlFluentCommand(
                 label = yaml.label,
                 optional = yaml.optional,
                 originalSpeedValue = yaml.speed,
-                waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs
+                waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs,
+                origin = yaml.origin,
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -1002,7 +1002,7 @@ data class YamlFluentCommand(
                 optional = yaml.optional,
                 originalSpeedValue = yaml.speed,
                 waitToSettleTimeoutMs = yaml.waitToSettleTimeoutMs,
-                origin = yaml.origin,
+                fromPoint = yaml.fromPoint,
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -13,6 +13,7 @@ data class YamlScrollUntilVisible(
     val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE,
     val centerElement: Boolean = ScrollUntilVisibleCommand.DEFAULT_CENTER_ELEMENT,
     val waitToSettleTimeoutMs: Int? = null,
+    val origin: String = ScrollUntilVisibleCommand.DEFAULT_ORIGIN,
     val label: String? = null,
     val optional: Boolean = false,
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -13,7 +13,7 @@ data class YamlScrollUntilVisible(
     val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE,
     val centerElement: Boolean = ScrollUntilVisibleCommand.DEFAULT_CENTER_ELEMENT,
     val waitToSettleTimeoutMs: Int? = null,
-    val origin: String = ScrollUntilVisibleCommand.DEFAULT_ORIGIN,
+    val fromPoint: String = ScrollUntilVisibleCommand.DEFAULT_FROM_POINT,
     val label: String? = null,
     val optional: Boolean = false,
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlScrollUntilVisible.kt
@@ -13,7 +13,7 @@ data class YamlScrollUntilVisible(
     val visibilityPercentage: Int = ScrollUntilVisibleCommand.DEFAULT_ELEMENT_VISIBILITY_PERCENTAGE,
     val centerElement: Boolean = ScrollUntilVisibleCommand.DEFAULT_CENTER_ELEMENT,
     val waitToSettleTimeoutMs: Int? = null,
-    val fromPoint: String = ScrollUntilVisibleCommand.DEFAULT_FROM_POINT,
+    val fromPoint: String? = null,
     val label: String? = null,
     val optional: Boolean = false,
 )

--- a/maestro-orchestra/src/test/java/maestro/orchestra/CommandDescriptionTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/CommandDescriptionTest.kt
@@ -1,6 +1,7 @@
 package maestro.orchestra
 
 import com.google.common.truth.Truth.assertThat
+import maestro.ScrollDirection
 import maestro.js.GraalJsEngine
 import maestro.orchestra.yaml.junit.YamlFile
 import maestro.orchestra.yaml.junit.YamlCommandsExtension
@@ -207,6 +208,37 @@ internal class CommandDescriptionTest {
         assertThat(evaluatedAssert.originalDescription).isEqualTo("Assert that true is true")
 
         jsEngine.close()
+    }
+
+    @Test
+    fun `ScrollUntilVisibleCommand description includes fromPoint when provided`() {
+        val command = ScrollUntilVisibleCommand(
+            selector = ElementSelector(textRegex = "Item 20"),
+            direction = ScrollDirection.DOWN,
+            visibilityPercentage = 100,
+            centerElement = false,
+            fromPoint = "50%, 25%",
+        )
+
+        assertThat(command.originalDescription).isEqualTo(
+            "Scrolling DOWN until \"Item 20\" is visible with speed 40, " +
+                "visibility percentage 100%, timeout 20000 ms, with centering disabled, from 50%, 25%"
+        )
+    }
+
+    @Test
+    fun `ScrollUntilVisibleCommand description without fromPoint`() {
+        val command = ScrollUntilVisibleCommand(
+            selector = ElementSelector(textRegex = "Item 20"),
+            direction = ScrollDirection.DOWN,
+            visibilityPercentage = 100,
+            centerElement = false,
+        )
+
+        assertThat(command.originalDescription).isEqualTo(
+            "Scrolling DOWN until \"Item 20\" is visible with speed 40, " +
+                "visibility percentage 100%, timeout 20000 ms, with centering disabled"
+        )
     }
 
     @Test

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import maestro.device.DeviceOrientation
 import maestro.KeyCode
 import maestro.Point
+import maestro.ScrollDirection
 import maestro.SwipeDirection
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
@@ -723,6 +724,50 @@ internal class MaestroCommandSerializationTest {
               "setOrientationCommand" : {
                 "orientation" : "PORTRAIT",
                 "optional" : false
+              }
+            }
+          """.trimIndent()
+        assertThat(serializedCommandJson)
+            .isEqualTo(expectedJson)
+        assertThat(deserializedCommand)
+            .isEqualTo(command)
+    }
+
+    @Test
+    fun `serialize ScrollUntilVisibleCommand with fromPoint`() {
+        // given
+        val command = MaestroCommand(
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(textRegex = "Item 20"),
+                direction = ScrollDirection.DOWN,
+                visibilityPercentage = 100,
+                centerElement = false,
+                fromPoint = "30%, 60%",
+            )
+        )
+
+        // when
+        val serializedCommandJson = command.toJson()
+        val deserializedCommand = objectMapper.readValue(serializedCommandJson, MaestroCommand::class.java)
+
+        // then
+        @Language("json")
+        val expectedJson = """
+            {
+              "scrollUntilVisible" : {
+                "selector" : {
+                  "textRegex" : "Item 20",
+                  "optional" : false
+                },
+                "direction" : "DOWN",
+                "scrollDuration" : "40",
+                "visibilityPercentage" : 100,
+                "timeout" : "20000",
+                "centerElement" : false,
+                "originalSpeedValue" : "40",
+                "fromPoint" : "30%, 60%",
+                "optional" : false,
+                "visibilityPercentageNormalized" : 1.0
               }
             }
           """.trimIndent()

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -766,8 +766,7 @@ internal class MaestroCommandSerializationTest {
                 "centerElement" : false,
                 "originalSpeedValue" : "40",
                 "fromPoint" : "30%, 60%",
-                "optional" : false,
-                "visibilityPercentageNormalized" : 1.0
+                "optional" : false
               }
             }
           """.trimIndent()

--- a/maestro-orchestra/src/test/java/maestro/orchestra/util/ElementCoordinateUtilTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/util/ElementCoordinateUtilTest.kt
@@ -2,11 +2,15 @@ package maestro.orchestra.util
 
 import com.google.common.truth.Truth.assertThat
 import maestro.Bounds
+import maestro.DeviceInfo
+import maestro.MaestroException
 import maestro.TreeNode
 import maestro.UiElement
+import maestro.device.Platform
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.TapOnElementCommand
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * Unit tests for element coordinate calculation utility functions.
@@ -67,6 +71,47 @@ internal class ElementCoordinateUtilTest {
         assertThat(quarterPoint.x).isEqualTo(125) // 100 + (100 * 25 / 100) = 125
         assertThat(quarterPoint.y).isEqualTo(175) // 100 + (100 * 75 / 100) = 175
     }
+
+    @Test
+    fun `screen-relative point with percentage coordinates`() {
+        val point = calculateScreenRelativePoint("30%, 60%", testDeviceInfo())
+
+        assertThat(point.x).isEqualTo(300) // 1000 * 30 / 100
+        assertThat(point.y).isEqualTo(1200) // 2000 * 60 / 100
+    }
+
+    @Test
+    fun `screen-relative point with absolute coordinates`() {
+        val point = calculateScreenRelativePoint("100, 400", testDeviceInfo())
+
+        assertThat(point.x).isEqualTo(100)
+        assertThat(point.y).isEqualTo(400)
+    }
+
+    @Test
+    fun `screen-relative point rejects out-of-range percentage`() {
+        val exception = assertThrows<MaestroException.InvalidCommand> {
+            calculateScreenRelativePoint("150%, 60%", testDeviceInfo())
+        }
+        assertThat(exception.message).contains("Percentages must be between 0 and 100")
+    }
+
+    @Test
+    fun `screen-relative point rejects absolute coordinates outside the screen`() {
+        val exception = assertThrows<MaestroException.InvalidCommand> {
+            calculateScreenRelativePoint("1000, 400", testDeviceInfo()) // x == widthGrid, out of bounds
+        }
+        assertThat(exception.message).contains("Coordinates must be within screen bounds")
+    }
+
+    // Helper: a 1000x2000 grid so percentage math reads cleanly.
+    private fun testDeviceInfo(): DeviceInfo = DeviceInfo(
+        platform = Platform.ANDROID,
+        widthPixels = 1000,
+        heightPixels = 2000,
+        widthGrid = 1000,
+        heightGrid = 2000,
+    )
 
     // Helper function to create a test UiElement (same structure as real Maestro)
     private fun createTestUiElement(): UiElement {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -862,8 +862,8 @@ internal class YamlCommandReaderTest {
     }
 
     @Test
-    fun scrollUntilVisibleWithOrigin(
-        @YamlFile("031_scrollUntilVisible_origin.yaml") commands: List<Command>
+    fun scrollUntilVisibleWithFromPoint(
+        @YamlFile("031_scrollUntilVisible_fromPoint.yaml") commands: List<Command>
     ) {
         assertThat(commands).containsExactly(
             ApplyConfigurationCommand(MaestroConfig(
@@ -874,14 +874,14 @@ internal class YamlCommandReaderTest {
                 direction = ScrollDirection.DOWN,
                 centerElement = false,
                 visibilityPercentage = 100,
-                origin = "30%, 60%",
+                fromPoint = "30%, 60%",
             ),
             ScrollUntilVisibleCommand(
                 selector = ElementSelector(textRegex = "Target2"),
                 direction = ScrollDirection.UP,
                 centerElement = false,
                 visibilityPercentage = 100,
-                origin = "100, 400",
+                fromPoint = "100, 400",
             ),
             ScrollUntilVisibleCommand(
                 selector = ElementSelector(textRegex = "Target3"),

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -861,6 +861,37 @@ internal class YamlCommandReaderTest {
         assertThat(YamlCommandReader.findUnknownWorkspaceConfigKeys(config)).isNull()
     }
 
+    @Test
+    fun scrollUntilVisibleWithOrigin(
+        @YamlFile("031_scrollUntilVisible_origin.yaml") commands: List<Command>
+    ) {
+        assertThat(commands).containsExactly(
+            ApplyConfigurationCommand(MaestroConfig(
+                appId = "com.example.app"
+            )),
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(textRegex = "Target"),
+                direction = ScrollDirection.DOWN,
+                centerElement = false,
+                visibilityPercentage = 100,
+                origin = "30%, 60%",
+            ),
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(textRegex = "Target2"),
+                direction = ScrollDirection.UP,
+                centerElement = false,
+                visibilityPercentage = 100,
+                origin = "100, 400",
+            ),
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(textRegex = "Target3"),
+                direction = ScrollDirection.DOWN,
+                centerElement = false,
+                visibilityPercentage = 100,
+            ),
+        )
+    }
+
     private fun commands(vararg commands: Command): List<MaestroCommand> =
         commands.map(::MaestroCommand).toList()
 }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -923,8 +923,8 @@ internal class YamlCommandReaderTest {
     }
 
     @Test
-    fun scrollUntilVisibleWithOrigin(
-        @YamlFile("031_scrollUntilVisible_origin.yaml") commands: List<Command>
+    fun scrollUntilVisibleWithFromPoint(
+        @YamlFile("031_scrollUntilVisible_fromPoint.yaml") commands: List<Command>
     ) {
         assertThat(commands).containsExactly(
             ApplyConfigurationCommand(MaestroConfig(
@@ -935,14 +935,14 @@ internal class YamlCommandReaderTest {
                 direction = ScrollDirection.DOWN,
                 centerElement = false,
                 visibilityPercentage = 100,
-                origin = "30%, 60%",
+                fromPoint = "30%, 60%",
             ),
             ScrollUntilVisibleCommand(
                 selector = ElementSelector(textRegex = "Target2"),
                 direction = ScrollDirection.UP,
                 centerElement = false,
                 visibilityPercentage = 100,
-                origin = "100, 400",
+                fromPoint = "100, 400",
             ),
             ScrollUntilVisibleCommand(
                 selector = ElementSelector(textRegex = "Target3"),

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -922,6 +922,37 @@ internal class YamlCommandReaderTest {
         assertThat(YamlCommandReader.findUnknownWorkspaceConfigKeys(config)).isNull()
     }
 
+    @Test
+    fun scrollUntilVisibleWithOrigin(
+        @YamlFile("031_scrollUntilVisible_origin.yaml") commands: List<Command>
+    ) {
+        assertThat(commands).containsExactly(
+            ApplyConfigurationCommand(MaestroConfig(
+                appId = "com.example.app"
+            )),
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(textRegex = "Target"),
+                direction = ScrollDirection.DOWN,
+                centerElement = false,
+                visibilityPercentage = 100,
+                origin = "30%, 60%",
+            ),
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(textRegex = "Target2"),
+                direction = ScrollDirection.UP,
+                centerElement = false,
+                visibilityPercentage = 100,
+                origin = "100, 400",
+            ),
+            ScrollUntilVisibleCommand(
+                selector = ElementSelector(textRegex = "Target3"),
+                direction = ScrollDirection.DOWN,
+                centerElement = false,
+                visibilityPercentage = 100,
+            ),
+        )
+    }
+
     private fun commands(vararg commands: Command): List<MaestroCommand> =
         commands.map(::MaestroCommand).toList()
 }

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/031_scrollUntilVisible_fromPoint.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/031_scrollUntilVisible_fromPoint.yaml
@@ -4,12 +4,12 @@ appId: com.example.app
     element:
       text: "Target"
     direction: DOWN
-    origin: "30%, 60%"
+    fromPoint: "30%, 60%"
 - scrollUntilVisible:
     element:
       text: "Target2"
     direction: UP
-    origin: "100, 400"
+    fromPoint: "100, 400"
 - scrollUntilVisible:
     element:
       text: "Target3"

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/031_scrollUntilVisible_origin.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/031_scrollUntilVisible_origin.yaml
@@ -1,0 +1,16 @@
+appId: com.example.app
+---
+- scrollUntilVisible:
+    element:
+      text: "Target"
+    direction: DOWN
+    origin: "30%, 60%"
+- scrollUntilVisible:
+    element:
+      text: "Target2"
+    direction: UP
+    origin: "100, 400"
+- scrollUntilVisible:
+    element:
+      text: "Target3"
+    direction: DOWN

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -5327,6 +5327,34 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 152 - scrollUntilVisible starts the swipe from a screen-relative point`() {
+        // Screen is 540x960; 25%,25% → (135, 240), independent of the target element's position.
+        val commands = readCommands("152_scroll_until_visible_from_point")
+        val info = driver { }.deviceInfo()
+
+        val driver = driver {
+            element {
+                id = "maestro"
+                bounds = Bounds(0, 0 + info.heightGrid, 100, 100 + info.heightGrid)
+            }
+        }
+
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        driver.assertHasEvent(
+            Event.SwipeElementWithDirection(
+                Point(135, 240),
+                SwipeDirection.UP, // scrolling DOWN swipes the content UP
+                601
+            )
+        )
+    }
+
     private fun readCommands(
         caseName: String,
         deviceId: String? = null,

--- a/maestro-test/src/test/resources/152_scroll_until_visible_from_point.yaml
+++ b/maestro-test/src/test/resources/152_scroll_until_visible_from_point.yaml
@@ -1,0 +1,7 @@
+appId: com.example.app
+---
+- scrollUntilVisible:
+    element:
+      id: maestro
+    direction: DOWN
+    fromPoint: "25%, 25%"


### PR DESCRIPTION
## Proposed changes

Lots of folks have scrollable elements not in the centre (needing https://docs.maestro.dev/examples/recipes/custom-scrolling-for-screen-fragments) or have nested scrollable things, like a multiline text area in the centre spot.

This PR extends `scrollUntilVisible` to allow an `origin` that sets the point where the scroll starts.

## Testing

```
appId: com.android.settings
---
- launchApp
- scrollUntilVisible:
    element:
      text: 'About emulated device'
    origin: '10%, 90%'
```

I noticed that swiping from the bottom also gives a speed benefit 🤷 

## Issues fixed

None that I've found, although it possibly helps some folks who want #1651 