### PR TITLE
fix: add mergeServiceFiles() to shadow jar to fix gRPC crash on Windows

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -258,6 +258,7 @@ tasks.named<Tar>("distTar") {
 
 tasks.shadowJar {
     setProperty("zip64", true)
+    mergeServiceFiles()
 }
 
 mavenPublishing {


### PR DESCRIPTION
﻿Hey! Full disclosure  I honestly have no idea how anything related to Java works. I was trying to use Maestro CLI on Windows and kept getting a `ClassCastException` crash. I asked Claude Opus 4.6 (via GitHub Copilot) to download the source code, diagnose the issue, and fix it. If you think this makes the PR invalid, feel free to close it  no hard feelings. It works for me now so I'm happy with the results either way.

Everything below this point was generated by AI:

---

## Environment

- **Maestro CLI:** 2.2.0
- **OS:** Windows 11
- **Java:** OpenJDK 17.0.18 (Microsoft build)
- **Gradle:** 8.13
- **Android Emulator:** API 36 (Pixel 9)
- **Shadow Plugin:** version from `libs.plugins.shadow` in the project

## Problem

Maestro CLI crashes on Windows when trying to communicate with the Android device via gRPC. The error occurs during `launchApp`, `deviceInfo`, and any other command that uses the `AndroidDriver` gRPC channel:

```
SEVERE: [Channel<1>: (localhost:7001)] Uncaught exception in the SynchronizationContext. Panic!
java.lang.ClassCastException: class io.netty.channel.unix.DomainSocketAddress
  cannot be cast to class java.net.InetSocketAddress
    at io.grpc.okhttp.OkHttpChannelBuilder$OkHttpTransportFactory.newClientTransport(OkHttpChannelBuilder.java:842)
```

This affects Windows users using the shadow jar distribution (including the CLI installed via the standard install script).

## Root Cause

The `shadowJar` Gradle task in `maestro-cli/build.gradle.kts` does not call `mergeServiceFiles()`. When the Shadow plugin packages multiple JARs into a single fat JAR, it encounters duplicate `META-INF/services/` files from different gRPC dependencies. Without merging, the last file wins and overwrites earlier ones.

Specifically, `META-INF/services/io.grpc.NameResolverProvider` ends up containing only:

```
io.grpc.netty.UdsNameResolverProvider
```

The standard DNS name resolver (`io.grpc.internal.DnsNameResolverProvider` from `grpc-core`) is silently dropped.

As a result, when `AndroidDriver` creates a gRPC channel via `ManagedChannelBuilder.forAddress("localhost", 7001)`, the only available name resolver is `UdsNameResolverProvider`, which resolves the address to a `DomainSocketAddress` (Unix domain socket). The channel's transport factory (OkHttp, selected via service provider priority) then receives this `DomainSocketAddress` and throws `ClassCastException` because it expects `InetSocketAddress`.

This issue does not manifest on macOS/Linux because Unix domain sockets are natively supported there  the Netty UDS transport can handle `DomainSocketAddress`. On Windows, the OkHttp transport is selected but cannot handle the UDS-resolved address, surfacing the cast exception.

### Before fix  shadow jar contents:
```
# META-INF/services/io.grpc.NameResolverProvider
io.grpc.netty.UdsNameResolverProvider          # only UDS resolver, DNS resolver lost
```

### After fix  shadow jar contents:
```
# META-INF/services/io.grpc.NameResolverProvider
io.grpc.netty.UdsNameResolverProvider
io.grpc.internal.DnsNameResolverProvider        # now properly included (higher priority)
```

## Fix

Add `mergeServiceFiles()` to the `shadowJar` task. This is the [standard Shadow plugin approach](https://gradleup.com/shadow/configuration/merging/#merging-service-descriptor-files) for handling Java SPI `META-INF/services/` files  it concatenates entries from all JARs instead of overwriting.

```diff
 tasks.shadowJar {
     setProperty("zip64", true)
+    mergeServiceFiles()
 }
```

## Testing

1. Built the shadow jar with the fix
2. Inspected `META-INF/services/io.grpc.NameResolverProvider`  confirms both resolvers are now present
3. Ran Maestro E2E tests on Windows with Android emulator (API 36)  `launchApp`, `deviceInfo`, and full test flows all work correctly
4. The gRPC `ClassCastException` is completely resolved
