### PR TITLE
Use device info when retrying cloud uploads

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -337,6 +337,8 @@ class ApiClient(
                 disableNotifications = disableNotifications,
                 deviceLocale = deviceLocale,
                 projectId = projectId,
+                deviceModel = deviceModel,
+                deviceOs = deviceOs,
             )
         }
 
@@ -399,7 +401,9 @@ class ApiClient(
                                 appBinaryId = appBinaryId,
                                 disableNotifications = disableNotifications,
                                 deviceLocale = deviceLocale,
-                                projectId = projectId
+                                projectId = projectId,
+                                deviceModel = deviceModel,
+                                deviceOs = deviceOs,
                             )
                         } else {
                             println("\u001B[31;1m[ERROR]\u001B[0m Failed to start trial. Please check your details and try again.")


### PR DESCRIPTION
## Proposed changes

Device info wasn't preserved when doing retries
This led to weird errors when doing `maestro cloud --device-model iPhone-16-Pro --device-os iOS-18-2 ....` 

```
Evaluating flow(s)...

Uploading Flow(s)...
....................
Upload failed due to socket exception, retrying (1/3)...
....................
Upload request failed (404): App minimum deployment target version 16.4 too high, set minimum version to 16.2 to run on iOS 16.
```

This PR adds the missing device properties to the retry requests.