### PR TITLE
feat: add onAllFlowsComplete hook

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -67,6 +67,12 @@ object MaestroCommandRunner {
         val config = YamlCommandReader.getConfig(commands)
         val onFlowComplete = config?.onFlowComplete
         val onFlowStart = config?.onFlowStart
+        
+        val allFlowsCompleteCommands =
+            collectAllFlowsCompleteCommands(onFlowStart?.commands ?: emptyList()) +
+            collectAllFlowsCompleteCommands(commands) +
+            collectAllFlowsCompleteCommands(onFlowComplete?.commands ?: emptyList()) +
+            (config?.onAllFlowsComplete?.commands ?: emptyList())
 
         val commandStatuses = IdentityHashMap<MaestroCommand, CommandStatus>()
         val commandMetadata = IdentityHashMap<MaestroCommand, Orchestra.CommandMetadata>()
@@ -83,6 +89,11 @@ object MaestroCommandRunner {
                     ),
                     onFlowCompleteCommands = toCommandStates(
                         onFlowComplete?.commands ?: emptyList(),
+                        commandStatuses,
+                        commandMetadata
+                    ),
+                    onAllFlowsCompleteCommands = toCommandStates(
+                        allFlowsCompleteCommands,
                         commandStatuses,
                         commandMetadata
                     ),
@@ -207,6 +218,16 @@ object MaestroCommandRunner {
         }        
 
         return flowSuccess
+    }
+
+    private fun collectAllFlowsCompleteCommands(commands: List<MaestroCommand>): List<MaestroCommand> {
+        val result = mutableListOf<MaestroCommand>()
+        for (command in commands) {
+            val composite = command.asCommand() as? CompositeCommand ?: continue
+            composite.config()?.onAllFlowsComplete?.commands?.let { result.addAll(it) }
+            result.addAll(collectAllFlowsCompleteCommands(composite.subCommands()))
+        }
+        return result
     }
 
     private fun toCommandStates(

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -91,6 +91,12 @@ class AnsiResultView(
             render(" ║\n")
             renderCommands(state.onFlowCompleteCommands)
         }
+        if (state.onAllFlowsCompleteCommands.isNotEmpty()) {
+            render(" ║\n")
+            render(" ║  > On All Flows Complete\n")
+            render(" ║\n")
+            renderCommands(state.onAllFlowsCompleteCommands)
+        }
         renderPrompt()
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
@@ -54,6 +54,11 @@ class PlainTextResultView: ResultView {
             printOnce("onFlowComplete") { println("  > On Flow Complete") }
             renderCommandsPlainText(state.onFlowCompleteCommands, prefix = "onFlowComplete")
         }
+
+        if (state.onAllFlowsCompleteCommands.isNotEmpty()) {
+            printOnce("onAllFlowsComplete") { println("  > On All Flows Complete") }
+            renderCommandsPlainText(state.onAllFlowsCompleteCommands, prefix = "onAllFlowsComplete")
+        }
     }
 
     private fun renderCommandsPlainText(commands: List<CommandState>, indent: Int = 0, prefix: String = "") {

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/UiState.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/UiState.kt
@@ -12,6 +12,7 @@ sealed class UiState {
         val device: Device? = null,
         val onFlowStartCommands: List<CommandState> = emptyList(),
         val onFlowCompleteCommands: List<CommandState> = emptyList(),
+        val onAllFlowsCompleteCommands: List<CommandState> = emptyList(),
         val commands: List<CommandState>,
     ) : UiState()
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -12,6 +12,7 @@ data class MaestroConfig(
     val ext: Map<String, Any?> = emptyMap(),
     val onFlowStart: MaestroOnFlowStart? = null,
     val onFlowComplete: MaestroOnFlowComplete? = null,
+    val onAllFlowsComplete: MaestroOnAllFlowsComplete? = null,
     val properties: Map<String, String> = emptyMap(),
 ) {
 
@@ -21,6 +22,7 @@ data class MaestroConfig(
             name = name?.evaluateScripts(jsEngine),
             onFlowComplete = onFlowComplete?.evaluateScripts(jsEngine),
             onFlowStart = onFlowStart?.evaluateScripts(jsEngine),
+            onAllFlowsComplete = onAllFlowsComplete?.evaluateScripts(jsEngine),
         )
     }
 
@@ -34,6 +36,12 @@ data class MaestroOnFlowComplete(val commands: List<MaestroCommand>) {
 
 data class MaestroOnFlowStart(val commands: List<MaestroCommand>) {
     fun evaluateScripts(jsEngine: JsEngine): MaestroOnFlowStart {
+        return this
+    }
+}
+
+data class MaestroOnAllFlowsComplete(val commands: List<MaestroCommand>) {
+    fun evaluateScripts(jsEngine: JsEngine): MaestroOnAllFlowsComplete {
         return this
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -152,8 +152,11 @@ class Orchestra(
 
     private val rawCommandToMetadata = mutableMapOf<MaestroCommand, CommandMetadata>()
 
+    private val allFlowsCompleteQueue = mutableListOf<MaestroCommand>()
+
     suspend fun runFlow(commands: List<MaestroCommand>): Boolean {
         timeMsOfLastInteraction = System.currentTimeMillis()
+        allFlowsCompleteQueue.clear()
 
         val config = YamlCommandReader.getConfig(commands)
 
@@ -198,9 +201,18 @@ class Orchestra(
                 )
             } ?: true
 
+            config?.onAllFlowsComplete?.commands?.let { allFlowsCompleteQueue.addAll(it) }
+            val allFlowsCompleteSuccess = if (allFlowsCompleteQueue.isNotEmpty()) {
+                executeCommands(
+                    commands = allFlowsCompleteQueue.toList(),
+                    config = config,
+                    shouldReinitJsEngine = false,
+                )
+            } else true
+
             exception?.let { throw it }
 
-            return onCompleteSuccess && flowSuccess
+            return onCompleteSuccess && allFlowsCompleteSuccess && flowSuccess
         }
     }
 
@@ -1041,6 +1053,8 @@ class Orchestra(
                 onCompleteSuccess = subflowConfig?.onFlowComplete?.commands?.let {
                     executeSubflowCommands(it, config)
                 } ?: true
+
+                subflowConfig?.onAllFlowsComplete?.commands?.let { allFlowsCompleteQueue.addAll(it) }
             }
             onCompleteSuccess && flowSuccess
         } finally {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.core.JsonLocation
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
+import maestro.orchestra.MaestroOnAllFlowsComplete
 import maestro.orchestra.MaestroOnFlowComplete
 import maestro.orchestra.MaestroOnFlowStart
 import java.nio.file.Path
@@ -25,6 +26,7 @@ data class YamlConfig(
     val env: Map<String, String> = emptyMap(),
     val onFlowStart: YamlOnFlowStart?,
     val onFlowComplete: YamlOnFlowComplete?,
+    val onAllFlowsComplete: YamlOnAllFlowsComplete?,
     val properties: Map<String, String> = emptyMap(),
     private val ext: MutableMap<String, Any?> = mutableMapOf<String, Any?>()
 ) {
@@ -53,6 +55,7 @@ data class YamlConfig(
             ext = ext.toMap(),
             onFlowStart = onFlowStart(flowPath),
             onFlowComplete = onFlowComplete(flowPath),
+            onAllFlowsComplete = onAllFlowsComplete(flowPath),
             properties = properties
         )
         return MaestroCommand(ApplyConfigurationCommand(config))
@@ -68,5 +71,11 @@ data class YamlConfig(
         if (onFlowStart == null) return null
 
         return MaestroOnFlowStart(onFlowStart.commands.flatMap { it.toCommands(flowPath, appId) })
+    }
+
+    private fun onAllFlowsComplete(flowPath: Path): MaestroOnAllFlowsComplete? {
+        if (onAllFlowsComplete == null) return null
+
+        return MaestroOnAllFlowsComplete(onAllFlowsComplete.commands.flatMap { it.toCommands(flowPath, appId) })
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOnAllFlowsComplete.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlOnAllFlowsComplete.kt
@@ -1,0 +1,13 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonCreator
+
+data class YamlOnAllFlowsComplete(val commands: List<YamlFluentCommand>) {
+    companion object {
+        @JvmStatic
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        fun parse(commands: List<YamlFluentCommand>) = YamlOnAllFlowsComplete(
+            commands = commands
+        )
+    }
+}

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -4262,6 +4262,53 @@ class IntegrationTest {
     }
 
     @Test
+    fun `Case 139 - onAllFlowsComplete in subflow runs after parent flow completes`() {
+        // Given
+        val commands = readCommands("139_on_all_flows_complete")
+        val driver = driver {}
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then - cleanup from subflow's onAllFlowsComplete runs after the main flow body
+        driver.assertEvents(
+            listOf(
+                Event.InputText("subflow"),
+                Event.InputText("main"),
+                Event.InputText("cleanup"),
+            )
+        )
+    }
+
+    @Test
+    fun `Case 140 - onAllFlowsComplete fires even if parent flow fails`() {
+        // Given
+        val commands = readCommands("140_on_all_flows_complete_flow_failed")
+        val driver = driver {}
+
+        // When & Then
+        assertThrows<MaestroException.AssertionFailure> {
+            Maestro(driver).use {
+                runBlocking {
+                    orchestra(it).runFlow(commands)
+                }
+            }
+        }
+
+        // Then - cleanup still runs despite the parent flow failing
+        driver.assertEvents(
+            listOf(
+                Event.InputText("subflow"),
+                Event.InputText("cleanup"),
+            )
+        )
+    }
+
+    @Test
     fun `Case 137 - Shard and device env vars`() {
         // Given
         // Use the proper API parameters (deviceId, shardIndex) instead of manually setting

--- a/maestro-test/src/test/resources/139_on_all_flows_complete.yaml
+++ b/maestro-test/src/test/resources/139_on_all_flows_complete.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- runFlow: "139_subflow.yaml"
+- inputText: "main"

--- a/maestro-test/src/test/resources/139_subflow.yaml
+++ b/maestro-test/src/test/resources/139_subflow.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+onAllFlowsComplete:
+  - inputText: "cleanup"
+---
+- inputText: "subflow"

--- a/maestro-test/src/test/resources/140_on_all_flows_complete_flow_failed.yaml
+++ b/maestro-test/src/test/resources/140_on_all_flows_complete_flow_failed.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- runFlow: "140_subflow.yaml"
+- assertVisible:
+    id: "nonexistent_element"

--- a/maestro-test/src/test/resources/140_subflow.yaml
+++ b/maestro-test/src/test/resources/140_subflow.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+onAllFlowsComplete:
+  - inputText: "cleanup"
+---
+- inputText: "subflow"


### PR DESCRIPTION
## Proposed changes

Our top level test flows start with a generic `runFlow: launch.yaml` command in the `onFlowStart` hook. In here we prepare the runner to start a test by for example setting the user permissions etc. But since our entire mobile app requires a user to be logged in we are moving the account creation step into this `launch.yaml` as well to make writing future tests simpler.

But this is where we run into a little "annoyance", since we can create new test accounts for a run right now we also want to be sure to delete said account afterwards. This now falls on the individual engineer to know the `launch.yaml` command expects the top level flow to add a `onFlowComplete` hook which deletes the account. Since the current `onFlowComplete` is run when the subflow itself finishes, not when the entire test finishes.

In here I want to propose adding a simple `onAllFlowsComplete` hook which lets us enqueue commands from any (sub)flow and lifts these commands up to the top level flow. This lets us write better helper flows and setup certain states, trusting that regardless of the call site it gets properly cleaned up afterwards.

## Testing

Added test flows for this case. But here is an example flow as well:

`main.yaml`
```yaml
appId: com.apple.Preferences
onFlowStart:
  - runFlow: ./launch.yaml
---
- assertVisible: "General"

- tapOn: "General"
- assertVisible: "About"
- tapOn: "About"
- assertVisible: "iOS Version"
```

`launch.yaml`
```yaml
appId: com.apple.Preferences
onAllFlowsComplete:
  - runFlow: ./close.yaml
---
- launchApp
```

`close.yaml`
```yaml
appId: com.apple.Preferences
---
- pressKey: "Home"
```

## Screen Recording

https://github.com/user-attachments/assets/b35c0279-c6a4-423f-9bbc-49af08537546

