### PR TITLE
Add assertScreenshot paths to DependencyResolver

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/DependencyResolver.kt
@@ -69,6 +69,11 @@ object DependencyResolver {
             resolveDependencyFile(currentFile, retry.sourceDescription)?.let { commandDependencies.add(it) }
         }
         
+        // Check for assertScreenshot commands and add the reference image as a dependency
+        maestroCommand.assertScreenshotCommand?.let { assertScreenshot ->
+            resolveDependencyFile(currentFile, assertScreenshot.path)?.let { commandDependencies.add(it) }
+        }
+
         // Check for addMedia commands and add the dependency if it exists (mediaPaths is not null)
         maestroCommand.addMediaCommand?.let { addMedia ->
             addMedia.mediaPaths.forEach { mediaPath ->

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/DependencyResolverTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/DependencyResolverTest.kt
@@ -645,6 +645,47 @@ class DependencyResolverTest {
     }
 
     @Test
+    fun `test assertScreenshot reference image is discovered as a dependency`(@TempDir tempDir: Path) {
+        val referenceImage = tempDir.resolve("reference.png")
+        referenceImage.writeText("fake png content")
+
+        val mainFlow = tempDir.resolve("main_flow.yaml")
+        mainFlow.writeText("""
+            appId: com.example.app
+            ---
+            - assertScreenshot: reference.png
+        """.trimIndent())
+
+        val dependencies = DependencyResolver.discoverAllDependencies(mainFlow)
+
+        assertThat(dependencies).hasSize(2)
+        assertThat(dependencies).contains(mainFlow)
+        assertThat(dependencies).contains(referenceImage)
+    }
+
+    @Test
+    fun `test assertScreenshot inside repeat block is discovered as a dependency`(@TempDir tempDir: Path) {
+        val referenceImage = tempDir.resolve("reference.png")
+        referenceImage.writeText("fake png content")
+
+        val mainFlow = tempDir.resolve("main_flow.yaml")
+        mainFlow.writeText("""
+            appId: com.example.app
+            ---
+            - repeat:
+                times: 3
+                commands:
+                  - assertScreenshot: reference.png
+        """.trimIndent())
+
+        val dependencies = DependencyResolver.discoverAllDependencies(mainFlow)
+
+        assertThat(dependencies).hasSize(2)
+        assertThat(dependencies).contains(mainFlow)
+        assertThat(dependencies).contains(referenceImage)
+    }
+
+    @Test
     fun `treats files with same name but different real paths as different dependencies`(@TempDir tempDir: Path) {
         // Directory layout:
         // tempDir/


### PR DESCRIPTION
## Proposed changes

When running a single flow from CLI or Studio that contains an assertScreenshot command, DependencyResolver needs to include a reference to this file else it won't be included in the upload. This already happens for runScript, runFlow, addMedia, etc.

## Testing

New unit tests added

## Issues fixed

Spotted in [Slack](https://maestro--dev.slack.com/archives/C01A2QJL51T/p1772620435024889?thread_ts=1771594322.914399&cid=C01A2QJL51T)