### PR TITLE
Fix: make assertScreenshot work without specifying the extension

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -535,8 +535,13 @@ class Orchestra(
         return false
     }
 
+    private fun normalizeScreenshotPath(path: String): String {
+        val imageExtensions = listOf(".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".wbmp")
+        return if (imageExtensions.any { path.endsWith(it, ignoreCase = true) }) path else "$path.png"
+    }
+
     private suspend fun assertScreenshotCommand(command: AssertScreenshotCommand): Boolean {
-        val path = command.path
+        val path = normalizeScreenshotPath(command.path)
         val thresholdDifferencePercentage = (100 - command.thresholdPercentage)
 
         val expectedFile = if (screenshotsDir != null) {


### PR DESCRIPTION
## Proposed changes
This PR makes assertScreenshot work without specifying the extension, so it behaves more like takeScreenshot.
copilot:summary

## Testing
1. assertScreenshot on a file without a specified extension.

## Issues fixed
