### PR TITLE
MCP TakeScreenshotTool: add maxDimensions with 2000 default

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
@@ -9,10 +9,16 @@ import okio.Buffer
 import java.util.Base64
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.awt.RenderingHints
 import java.awt.image.BufferedImage
+import javax.imageio.IIOImage
 import javax.imageio.ImageIO
+import javax.imageio.ImageWriteParam
 
 object TakeScreenshotTool {
+    private const val DEFAULT_MAX_DIMENSIONS = 2000
+    private const val JPEG_QUALITY = 0.9f
+
     fun create(sessionManager: MaestroSessionManager): RegisteredTool {
         return RegisteredTool(
             Tool(
@@ -27,6 +33,7 @@ object TakeScreenshotTool {
                         putJsonObject("maxDimensions") {
                             put("type", "integer")
                             put("description", "Maximum size (in pixels) for the longest dimension of the screenshot. The image will be scaled down proportionally if either dimension exceeds this value. Defaults to 2000. Note: Claude works best with images below 2000 pixels.")
+                            put("minimum", 1)
                         }
                     },
                     required = listOf("device_id")
@@ -35,7 +42,6 @@ object TakeScreenshotTool {
         ) { request ->
             try {
                 val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
-                val maxDimensions = request.arguments?.get("maxDimensions")?.jsonPrimitive?.intOrNull ?: 2000
                 
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(
@@ -43,7 +49,10 @@ object TakeScreenshotTool {
                         isError = true
                     )
                 }
-                
+
+                val maxDimensions = (request.arguments?.get("maxDimensions")?.jsonPrimitive?.intOrNull
+                    ?: DEFAULT_MAX_DIMENSIONS).coerceAtLeast(1)
+
                 val result = sessionManager.newSession(
                     host = null,
                     port = null,
@@ -54,38 +63,46 @@ object TakeScreenshotTool {
                     val buffer = Buffer()
                     runBlocking { session.maestro.takeScreenshot(buffer, true) }
                     val pngBytes = buffer.readByteArray()
-                    
-                    // Convert PNG to JPEG
+
                     val pngImage = ImageIO.read(ByteArrayInputStream(pngBytes))
-                    val imageToEncode = if (maxOf(pngImage.width, pngImage.height) > maxDimensions) {
-                        val scale = maxDimensions.toDouble() / maxOf(pngImage.width, pngImage.height)
+                        ?: error("Failed to decode screenshot image")
+
+                    val longestSide = maxOf(pngImage.width, pngImage.height)
+                    val imageToEncode = if (longestSide > maxDimensions) {
+                        val scale = maxDimensions.toDouble() / longestSide
                         val newWidth = (pngImage.width * scale).toInt()
                         val newHeight = (pngImage.height * scale).toInt()
                         val scaled = BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB)
                         val g2d = scaled.createGraphics()
-                        g2d.drawImage(pngImage.getScaledInstance(newWidth, newHeight, java.awt.Image.SCALE_SMOOTH), 0, 0, null)
+                        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC)
+                        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+                        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                        g2d.drawImage(pngImage, 0, 0, newWidth, newHeight, null)
                         g2d.dispose()
                         scaled
                     } else {
                         pngImage
                     }
+
                     val jpegOutput = ByteArrayOutputStream()
-                    ImageIO.write(imageToEncode, "JPEG", jpegOutput)
-                    val jpegBytes = jpegOutput.toByteArray()
-                    
-                    val base64 = Base64.getEncoder().encodeToString(jpegBytes)
-                    base64
+                    val writer = ImageIO.getImageWritersByFormatName("JPEG").next()
+                    val params = writer.defaultWriteParam.apply {
+                        compressionMode = ImageWriteParam.MODE_EXPLICIT
+                        compressionQuality = JPEG_QUALITY
+                    }
+                    ImageIO.createImageOutputStream(jpegOutput).use { imageOutputStream ->
+                        writer.output = imageOutputStream
+                        writer.write(null, IIOImage(imageToEncode, null, null), params)
+                    }
+                    writer.dispose()
+
+                    Base64.getEncoder().encodeToString(jpegOutput.toByteArray())
                 }
-                
-                val imageContent = ImageContent(
-                    data = result,
-                    mimeType = "image/jpeg"
-                )
-                
-                CallToolResult(content = listOf(imageContent))
+
+                CallToolResult(content = listOf(ImageContent(data = result, mimeType = "image/jpeg")))
             } catch (e: Exception) {
                 CallToolResult(
-                    content = listOf(TextContent("Failed to take screenshot: ${e.message}")),
+                    content = listOf(TextContent("Failed to take screenshot: ${e::class.simpleName}: ${e.message}")),
                     isError = true
                 )
             }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
@@ -70,8 +70,8 @@ object TakeScreenshotTool {
                     val longestSide = maxOf(pngImage.width, pngImage.height)
                     val imageToEncode = if (longestSide > maxDimensions) {
                         val scale = maxDimensions.toDouble() / longestSide
-                        val newWidth = (pngImage.width * scale).toInt()
-                        val newHeight = (pngImage.height * scale).toInt()
+                        val newWidth = (pngImage.width * scale).toInt().coerceAtLeast(1)
+                        val newHeight = (pngImage.height * scale).toInt().coerceAtLeast(1)
                         val scaled = BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB)
                         val g2d = scaled.createGraphics()
                         g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC)

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
@@ -26,7 +26,7 @@ object TakeScreenshotTool {
                         }
                         putJsonObject("maxDimensions") {
                             put("type", "integer")
-                            put("description", "Maximum size (in pixels) for the longest dimension of the screenshot. The image will be scaled down proportionally if either dimension exceeds this value. Note: Claude works best with images below 2000 pixels.")
+                            put("description", "Maximum size (in pixels) for the longest dimension of the screenshot. The image will be scaled down proportionally if either dimension exceeds this value. Defaults to 2000. Note: Claude works best with images below 2000 pixels.")
                         }
                     },
                     required = listOf("device_id")
@@ -35,7 +35,7 @@ object TakeScreenshotTool {
         ) { request ->
             try {
                 val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
-                val maxDimensions = request.arguments?.get("maxDimensions")?.jsonPrimitive?.intOrNull
+                val maxDimensions = request.arguments?.get("maxDimensions")?.jsonPrimitive?.intOrNull ?: 2000
                 
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(
@@ -57,7 +57,7 @@ object TakeScreenshotTool {
                     
                     // Convert PNG to JPEG
                     val pngImage = ImageIO.read(ByteArrayInputStream(pngBytes))
-                    val imageToEncode = if (maxDimensions != null && maxOf(pngImage.width, pngImage.height) > maxDimensions) {
+                    val imageToEncode = if (maxOf(pngImage.width, pngImage.height) > maxDimensions) {
                         val scale = maxDimensions.toDouble() / maxOf(pngImage.width, pngImage.height)
                         val newWidth = (pngImage.width * scale).toInt()
                         val newHeight = (pngImage.height * scale).toInt()

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
@@ -9,6 +9,7 @@ import okio.Buffer
 import java.util.Base64
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.awt.image.BufferedImage
 import javax.imageio.ImageIO
 
 object TakeScreenshotTool {
@@ -23,6 +24,10 @@ object TakeScreenshotTool {
                             put("type", "string")
                             put("description", "The ID of the device to take a screenshot from")
                         }
+                        putJsonObject("maxDimensions") {
+                            put("type", "integer")
+                            put("description", "Maximum size (in pixels) for the longest dimension of the screenshot. The image will be scaled down proportionally if either dimension exceeds this value. Note: Claude works best with images below 2000 pixels.")
+                        }
                     },
                     required = listOf("device_id")
                 )
@@ -30,6 +35,7 @@ object TakeScreenshotTool {
         ) { request ->
             try {
                 val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val maxDimensions = request.arguments?.get("maxDimensions")?.jsonPrimitive?.intOrNull
                 
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(
@@ -51,8 +57,20 @@ object TakeScreenshotTool {
                     
                     // Convert PNG to JPEG
                     val pngImage = ImageIO.read(ByteArrayInputStream(pngBytes))
+                    val imageToEncode = if (maxDimensions != null && maxOf(pngImage.width, pngImage.height) > maxDimensions) {
+                        val scale = maxDimensions.toDouble() / maxOf(pngImage.width, pngImage.height)
+                        val newWidth = (pngImage.width * scale).toInt()
+                        val newHeight = (pngImage.height * scale).toInt()
+                        val scaled = BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB)
+                        val g2d = scaled.createGraphics()
+                        g2d.drawImage(pngImage.getScaledInstance(newWidth, newHeight, java.awt.Image.SCALE_SMOOTH), 0, 0, null)
+                        g2d.dispose()
+                        scaled
+                    } else {
+                        pngImage
+                    }
                     val jpegOutput = ByteArrayOutputStream()
-                    ImageIO.write(pngImage, "JPEG", jpegOutput)
+                    ImageIO.write(imageToEncode, "JPEG", jpegOutput)
                     val jpegBytes = jpegOutput.toByteArray()
                     
                     val base64 = Base64.getEncoder().encodeToString(jpegBytes)


### PR DESCRIPTION
## Summary

Improves the \`take_screenshot\` MCP tool to produce smaller, higher-quality images that work better with AI vision models like Claude.

- Add \`maxDimensions\` parameter: scales the screenshot down proportionally so the longest side does not exceed the given value. Defaults to 2000px (Claude's recommended max). Uses \`Graphics2D\` with bicubic rendering hints for quality downscaling.
- Add explicit JPEG quality control at 0.9 via \`ImageWriteParam\` instead of relying on the default.
- Guard against \`ImageIO.read\` returning \`null\` on corrupt/empty input.
- Include exception class name in error messages for easier debugging.
- Validate \`device_id\` before parsing other arguments.

## Screenshot comparison

<table>
  <thead>
    <tr>
      <th>Screenshot</th>
      <th>Dimensions</th>
      <th>Preview</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>System (v2.1.0, no param)</td>
      <td>1206 × 2622</td>
      <td><img src="https://github.com/user-attachments/assets/84e0f4cf-ea08-4560-a0c5-b75bc751faf7" width="300px" /></td>
    </tr>
    <tr>
      <td>New <code>take_screenshot</code> tool (no maxDimensions)</td>
      <td>919 × 2000</td>
      <td><img src="https://github.com/user-attachments/assets/e3dccad2-144d-4182-b968-a7233e793fa0" width="300px" /></td>
    </tr>
    <tr>
      <td>New <code>take_screenshot</code> tool (maxDimensions=800)</td>
      <td>367 × 800</td>
      <td><img src="https://github.com/user-attachments/assets/b1c0e269-9fc4-445f-9540-9385af980d2c" width="300px" /></td>
    </tr>
  </tbody>
</table>

## Test plan

- [x] Take a screenshot without \`maxDimensions\` — confirm image is scaled to ≤2000px on the longest side
- [x] Pass explicit \`maxDimensions\` and confirm scaling is applied correctly
- [x] Pass \`maxDimensions: 1\` — confirm it doesn't crash
- [x] Confirm JPEG output quality is visually acceptable

🤖 Generated with [Claude Code](https://claude.com/claude-code)