### PR TITLE
feat: added list device command

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -28,6 +28,7 @@ import maestro.cli.command.CheckSyntaxCommand
 import maestro.cli.command.CloudCommand
 import maestro.cli.command.DownloadSamplesCommand
 import maestro.cli.command.DriverCommand
+import maestro.cli.command.ListCloudDevicesCommand
 import maestro.cli.command.ListDevicesCommand
 import maestro.cli.command.LoginCommand
 import maestro.cli.command.LogoutCommand
@@ -66,6 +67,7 @@ import kotlin.system.exitProcess
         StudioCommand::class,
         StartDeviceCommand::class,
         ListDevicesCommand::class,
+        ListCloudDevicesCommand::class,
         GenerateCompletion::class,
         ChatCommand::class,
         CheckSyntaxCommand::class,

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -28,6 +28,7 @@ import maestro.cli.command.CheckSyntaxCommand
 import maestro.cli.command.CloudCommand
 import maestro.cli.command.DownloadSamplesCommand
 import maestro.cli.command.DriverCommand
+import maestro.cli.command.ListDevicesCommand
 import maestro.cli.command.LoginCommand
 import maestro.cli.command.LogoutCommand
 import maestro.cli.command.McpCommand
@@ -64,6 +65,7 @@ import kotlin.system.exitProcess
         BugReportCommand::class,
         StudioCommand::class,
         StartDeviceCommand::class,
+        ListDevicesCommand::class,
         GenerateCompletion::class,
         ChatCommand::class,
         CheckSyntaxCommand::class,

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -564,6 +564,25 @@ class ApiClient(
         }
     }
 
+    fun listCloudDevices(authToken: String): Map<String, Map<String, List<String>>> {
+        val request = Request.Builder()
+            .header("Authorization", "Bearer $authToken")
+            .url("$baseUrl/v2/device/list")
+            .get()
+            .build()
+
+        val response = try {
+            client.newCall(request).execute()
+        } catch (e: IOException) {
+            throw ApiException(statusCode = null)
+        }
+
+        response.use {
+            if (!response.isSuccessful) throw ApiException(statusCode = response.code)
+            return JSON.readValue(response.body?.bytes(), object : TypeReference<Map<String, Map<String, List<String>>>>() {})
+        }
+    }
+
     fun botMessage(question: String, sessionId: String, authToken: String): List<MessageContent> {
         val body = JSON.writeValueAsString(
             MessageRequest(

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -564,9 +564,8 @@ class ApiClient(
         }
     }
 
-    fun listCloudDevices(authToken: String): Map<String, Map<String, List<String>>> {
+    fun listCloudDevices(): Map<String, Map<String, List<String>>> {
         val request = Request.Builder()
-            .header("Authorization", "Bearer $authToken")
             .url("$baseUrl/v2/device/list")
             .get()
             .build()

--- a/maestro-cli/src/main/java/maestro/cli/command/ListCloudDevicesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListCloudDevicesCommand.kt
@@ -14,7 +14,7 @@ import picocli.CommandLine
 import java.util.concurrent.Callable
 
 @CommandLine.Command(
-    name = "list-cloud-device",
+    name = "list-cloud-devices",
     description = ["List devices available on Maestro Cloud, grouped by platform"],
 )
 class ListCloudDevicesCommand : Callable<Int> {

--- a/maestro-cli/src/main/java/maestro/cli/command/ListCloudDevicesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListCloudDevicesCommand.kt
@@ -3,22 +3,21 @@ package maestro.cli.command
 import maestro.cli.App
 import maestro.cli.CliError
 import maestro.cli.ShowHelpMixin
+import maestro.cli.api.ApiClient
 import maestro.cli.report.TestDebugReporter
+import maestro.cli.util.EnvUtils
 import maestro.cli.util.PrintUtils
 import maestro.cli.view.bold
 import maestro.cli.view.cyan
-import maestro.cli.view.faint
-import maestro.device.Device
-import maestro.device.DeviceService
 import maestro.device.Platform
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
 @CommandLine.Command(
-    name = "list-device",
-    description = ["List local devices available, grouped by platform"],
+    name = "list-cloud-device",
+    description = ["List devices available on Maestro Cloud, grouped by platform"],
 )
-class ListDevicesCommand : Callable<Int> {
+class ListCloudDevicesCommand : Callable<Int> {
 
     @CommandLine.Mixin
     var showHelpMixin: ShowHelpMixin? = null
@@ -41,19 +40,31 @@ class ListDevicesCommand : Callable<Int> {
             )
         }
 
-        println("Showing local devices. Use 'maestro list-cloud-device' to list devices available on Maestro Cloud.".faint())
-        println()
+        val apiClient = ApiClient(EnvUtils.BASE_API_URL)
 
-        PrintUtils.info("Local Devices", bold = true)
+        println()
+        PrintUtils.info("Cloud Devices", bold = true)
         println("─".repeat(SEPARATOR_WIDTH))
 
-        val devices = DeviceService.listDevices(includeWeb = true)
-        val platforms = if (platformFilter != null) listOf(platformFilter) else Platform.entries
-        val sections = platforms.map { p -> p to devices.filter { it.platform == p }.groupedByModel() }
-            .filter { it.second.isNotEmpty() }
+        val cloudDevices = try {
+            apiClient.listCloudDevices()
+        } catch (e: ApiClient.ApiException) {
+            if (e.statusCode == null) PrintUtils.err("Unable to reach Maestro Cloud. Please check your network connection and try again.")
+            throw e
+        }
+
+        val platformOrder = listOf(Platform.IOS, Platform.ANDROID, Platform.WEB)
+        val platforms = if (platformFilter != null) listOf(platformFilter) else platformOrder
+
+        val sections = platforms.mapNotNull { p ->
+            val key = p.name.lowercase()
+            val raw = cloudDevices[key] ?: return@mapNotNull null
+            val groups = raw.map { (model, osList) -> DeviceGroup(model, osList) }
+            p to groups
+        }.filter { it.second.isNotEmpty() }
 
         if (sections.isEmpty()) {
-            println("No devices found")
+            println("No cloud devices found")
             return 0
         }
 
@@ -69,18 +80,6 @@ class ListDevicesCommand : Callable<Int> {
         val model: String,
         val osList: List<String>,
     )
-
-    private fun List<Device>.groupedByModel(): List<DeviceGroup> {
-        val groups = LinkedHashMap<String, MutableList<String>>()
-        for (device in this) {
-            if (device.deviceSpec.model.isEmpty()) continue
-            val osList = groups.getOrPut(device.deviceSpec.model) { mutableListOf() }
-            if (device.deviceSpec.os.isNotEmpty() && device.deviceSpec.os !in osList) {
-                osList.add(device.deviceSpec.os)
-            }
-        }
-        return groups.map { (model, osList) -> DeviceGroup(model, osList) }
-    }
 
     private fun printSection(platform: Platform, groups: List<DeviceGroup>) {
         println(platform.description.bold())

--- a/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
@@ -91,7 +91,12 @@ class ListDevicesCommand : Callable<Int> {
         PrintUtils.info("Cloud Devices", bold = true)
         println("─".repeat(SEPARATOR_WIDTH))
 
-        val cloudDevices = apiClient.listCloudDevices(authToken)
+      val cloudDevices = try {
+        apiClient.listCloudDevices(authToken)
+      } catch (e: ApiClient.ApiException) {
+        if (e.statusCode == null) PrintUtils.err("Unable to reach Maestro Cloud. Please check your network connection and try again.")
+        throw e
+      }
 
         val platformOrder = listOf(Platform.IOS, Platform.ANDROID, Platform.WEB)
         val platforms = if (platformFilter != null) listOf(platformFilter) else platformOrder

--- a/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
@@ -84,19 +84,17 @@ class ListDevicesCommand : Callable<Int> {
 
     private fun showCloudDevices(platformFilter: Platform?): Int {
         val apiClient = ApiClient(EnvUtils.BASE_API_URL)
-        val authToken = Auth(apiClient).getAuthToken(apiKey = null)
-            ?: throw CliError("Not logged in. Please run 'maestro login'.")
 
         println()
         PrintUtils.info("Cloud Devices", bold = true)
         println("─".repeat(SEPARATOR_WIDTH))
 
-      val cloudDevices = try {
-        apiClient.listCloudDevices(authToken)
-      } catch (e: ApiClient.ApiException) {
-        if (e.statusCode == null) PrintUtils.err("Unable to reach Maestro Cloud. Please check your network connection and try again.")
-        throw e
-      }
+        val cloudDevices = try {
+            apiClient.listCloudDevices()
+        } catch (e: ApiClient.ApiException) {
+            if (e.statusCode == null) PrintUtils.err("Unable to reach Maestro Cloud. Please check your network connection and try again.")
+            throw e
+        }
 
         val platformOrder = listOf(Platform.IOS, Platform.ANDROID, Platform.WEB)
         val platforms = if (platformFilter != null) listOf(platformFilter) else platformOrder

--- a/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
@@ -15,7 +15,7 @@ import picocli.CommandLine
 import java.util.concurrent.Callable
 
 @CommandLine.Command(
-    name = "list-device",
+    name = "list-devices",
     description = ["List local devices available, grouped by platform"],
 )
 class ListDevicesCommand : Callable<Int> {

--- a/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
@@ -1,0 +1,156 @@
+package maestro.cli.command
+
+import maestro.cli.App
+import maestro.cli.CliError
+import maestro.cli.ShowHelpMixin
+import maestro.cli.api.ApiClient
+import maestro.cli.auth.Auth
+import maestro.cli.report.TestDebugReporter
+import maestro.cli.util.EnvUtils
+import maestro.cli.util.PrintUtils
+import maestro.cli.view.bold
+import maestro.cli.view.cyan
+import maestro.cli.view.faint
+import maestro.device.Device
+import maestro.device.DeviceService
+import maestro.device.Platform
+import picocli.CommandLine
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+    name = "list-device",
+    description = ["List local devices available, grouped by platform"],
+)
+class ListDevicesCommand : Callable<Int> {
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
+
+    @CommandLine.ParentCommand
+    private val parent: App? = null
+
+    @CommandLine.Option(
+        names = ["--platform"],
+        description = ["Filter by platform: android, ios, web"],
+    )
+    private var platform: String? = null
+
+    @CommandLine.Option(
+        names = ["--cloud"],
+        description = ["List available devices for cloud"],
+    )
+    private var cloud: Boolean? = null
+
+    override fun call(): Int {
+        TestDebugReporter.install(null, printToConsole = parent?.verbose == true)
+
+        val platformFilter = platform?.let { input ->
+            Platform.fromString(input) ?: throw CliError(
+                "Unknown platform: '$input'. Supported values: ${Platform.entries.joinToString { it.name.lowercase() }}"
+            )
+        }
+
+        return if (cloud == true) {
+            showCloudDevices(platformFilter)
+        } else {
+            showLocalDevices(platformFilter)
+        }
+    }
+
+    private fun showLocalDevices(platformFilter: Platform?): Int {
+        println("Showing local devices. Use --cloud to list devices available on Maestro Cloud.".faint())
+        println()
+
+        PrintUtils.info("Local Devices", bold = true)
+        println("─".repeat(SEPARATOR_WIDTH))
+
+        val devices = DeviceService.listDevices(includeWeb = true)
+        val platforms = if (platformFilter != null) listOf(platformFilter) else Platform.entries
+        val sections = platforms.map { p -> p to devices.filter { it.platform == p }.groupedByModel() }
+            .filter { it.second.isNotEmpty() }
+
+        if (sections.isEmpty()) {
+            println("No devices found")
+            return 0
+        }
+
+        sections.forEachIndexed { idx, (p, groups) ->
+            if (idx > 0) println()
+            printSection(p, groups)
+        }
+
+        return 0
+    }
+
+    private fun showCloudDevices(platformFilter: Platform?): Int {
+        val apiClient = ApiClient(EnvUtils.BASE_API_URL)
+        val authToken = Auth(apiClient).getAuthToken(apiKey = null)
+            ?: throw CliError("Not logged in. Please run 'maestro login'.")
+
+        println()
+        PrintUtils.info("Cloud Devices", bold = true)
+        println("─".repeat(SEPARATOR_WIDTH))
+
+        val cloudDevices = apiClient.listCloudDevices(authToken)
+
+        val platformOrder = listOf(Platform.IOS, Platform.ANDROID, Platform.WEB)
+        val platforms = if (platformFilter != null) listOf(platformFilter) else platformOrder
+
+        val sections = platforms.mapNotNull { p ->
+            val key = p.name.lowercase()
+            val raw = cloudDevices[key] ?: return@mapNotNull null
+            val groups = raw.map { (model, osList) -> DeviceGroup(model, osList) }
+            p to groups
+        }.filter { it.second.isNotEmpty() }
+
+        if (sections.isEmpty()) {
+            println("No cloud devices found")
+            return 0
+        }
+
+        sections.forEachIndexed { idx, (p, groups) ->
+            if (idx > 0) println()
+            printSection(p, groups)
+        }
+
+        return 0
+    }
+
+    private data class DeviceGroup(
+        val model: String,
+        val osList: List<String>,
+    )
+
+    private fun List<Device>.groupedByModel(): List<DeviceGroup> {
+        val groups = LinkedHashMap<String, MutableList<String>>()
+        for (device in this) {
+            if (device.deviceSpec.model.isEmpty()) continue
+            val osList = groups.getOrPut(device.deviceSpec.model) { mutableListOf() }
+            if (device.deviceSpec.os.isNotEmpty() && device.deviceSpec.os !in osList) {
+                osList.add(device.deviceSpec.os)
+            }
+        }
+        return groups.map { (model, osList) -> DeviceGroup(model, osList) }
+    }
+
+    // ── Output ───────────────────────────────────────────────────────────────
+    private fun printSection(platform: Platform, groups: List<DeviceGroup>) {
+        println(platform.description.bold())
+
+        val modelW = groups.maxOf { it.model.length }
+
+        for (g in groups) {
+            val osLine = g.osList.joinToString(", ")
+            println(row(g.model.cyan().padEnd(modelW + ansiExtra(g.model.cyan())), osLine))
+        }
+    }
+
+    private fun row(vararg cols: String) = "  " + cols.joinToString("   ")
+
+    private fun ansiExtra(s: String) = s.length - s.replace(ANSI_RE, "").length
+
+    companion object {
+        private val ANSI_RE = Regex("\u001B\\[[\\d;]*[^\\d;]")
+        private const val SEPARATOR_WIDTH = 53
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -57,8 +57,8 @@ class StartDeviceCommand : Callable<Int> {
         names = ["--device-model"],
         description = [
             "Device model to run against",
-            "iOS: iPhone-11, iPhone-11-Pro, etc. Run command: maestro list-device",
-            "Android: pixel_6, pixel_7, etc. Run command: maestro list-device"
+            "iOS: iPhone-11, iPhone-11-Pro, etc. Run command: maestro list-devices",
+            "Android: pixel_6, pixel_7, etc. Run command: maestro list-devices"
         ],
     )
     private var deviceModel: String? = null
@@ -68,8 +68,8 @@ class StartDeviceCommand : Callable<Int> {
         names = ["--device-os"],
         description = [
             "OS version to use:",
-            "iOS: iOS-16-2, iOS-17-5, iOS-18-2, etc. maestro list-device",
-            "Android: android-33, android-34, etc. maestro list-device"
+            "iOS: iOS-16-2, iOS-17-5, iOS-18-2, etc. maestro list-devices",
+            "Android: android-33, android-34, etc. maestro list-devices"
         ],
     )
     private var deviceOs: String? = null

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -55,8 +55,8 @@ class StartDeviceCommand : Callable<Int> {
         names = ["--device-model"],
         description = [
             "Device model to run against",
-            "iOS: iPhone-11, iPhone-11-Pro, etc. Run command: xcrun simctl list devicetypes --json | jq -r '.devicetypes[].identifier | split(\".\") | last'\n",
-            "Android: pixel_6, pixel_7, etc. Run command: avdmanager list device -c"
+            "iOS: iPhone-11, iPhone-11-Pro, etc. Run command: maestro list-device",
+            "Android: pixel_6, pixel_7, etc. Run command: maestro list-device"
         ],
     )
     private var deviceModel: String? = null
@@ -66,8 +66,8 @@ class StartDeviceCommand : Callable<Int> {
         names = ["--device-os"],
         description = [
             "OS version to use:",
-            "iOS: iOS-16-2, iOS-17-5, iOS-18-2, etc. xcrun simctl list runtimes --json | jq -r '.runtimes[].identifier | split(\".\") | last'\n",
-            "Android: android-33, android-34, etc. Run command: sdkmanager --list | grep \"system-images\" | awk -F';' '{print \$2}' | sort -u\n"
+            "iOS: iOS-16-2, iOS-17-5, iOS-18-2, etc. maestro list-device",
+            "Android: android-33, android-34, etc. maestro list-device"
         ],
     )
     private var deviceOs: String? = null

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -284,7 +284,16 @@ fun main() {
             flowName = "Flow for playing around",
             device = Device.Connected(
                 instanceId = "device",
-                deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name),
+                deviceSpec = DeviceCatalog.resolve(
+                    platform = Platform.ANDROID.name,
+                    model = null,
+                    os = null,
+                    locale = null,
+                    orientation = null,
+                    disableAnimations = null,
+                    snapshotKeyHonorModalViews = null,
+                    systemArchitecture = null,
+                ),
                 description = "description",
                 platform = Platform.ANDROID,
                 deviceType = Device.DeviceType.EMULATOR

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -24,6 +24,7 @@ import maestro.device.Device
 import maestro.device.Platform
 import maestro.cli.runner.CommandState
 import maestro.cli.runner.CommandStatus
+import maestro.device.DeviceCatalog
 import maestro.orchestra.AssertWithAICommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.LaunchAppCommand
@@ -281,7 +282,13 @@ fun main() {
     view.setState(
         UiState.Running(
             flowName = "Flow for playing around",
-            device = Device.Connected("device", "description", Platform.ANDROID, Device.DeviceType.EMULATOR),
+            device = Device.Connected(
+                instanceId = "device",
+                deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name),
+                description = "description",
+                platform = Platform.ANDROID,
+                deviceType = Device.DeviceType.EMULATOR
+            ),
             onFlowStartCommands = listOf(),
             onFlowCompleteCommands = listOf(),
             commands = listOf(

--- a/maestro-client/src/main/java/maestro/device/Device.kt
+++ b/maestro-client/src/main/java/maestro/device/Device.kt
@@ -3,7 +3,8 @@ package maestro.device
 sealed class Device(
     open val description: String,
     open val platform: Platform,
-    open val deviceType: DeviceType
+    open val deviceType: DeviceType,
+    open val deviceSpec: DeviceSpec
 ) {
 
     enum class DeviceType {
@@ -15,17 +16,18 @@ sealed class Device(
 
     data class Connected(
         val instanceId: String,
+        override val deviceSpec: DeviceSpec,
         override val description: String,
         override val platform: Platform,
         override val deviceType: DeviceType,
-    ) : Device(description, platform, deviceType)
+    ) : Device(description, platform, deviceType, deviceSpec)
 
     data class AvailableForLaunch(
         val modelId: String,
-        val deviceSpec: DeviceSpec,
+        override val deviceSpec: DeviceSpec,
         override val description: String,
         override val platform: Platform,
         override val deviceType: DeviceType,
-    ) : Device(description, platform, deviceType)
+    ) : Device(description, platform, deviceType, deviceSpec)
 
 }

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -21,6 +21,8 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
+data class AvdInfo(val name: String, val model: String, val os: String)
+
 object DeviceService {
     private val logger = LoggerFactory.getLogger(DeviceService::class.java)
 
@@ -219,7 +221,7 @@ object DeviceService {
         }
 
         // Fetch AVD info once (model + os) to avoid repeated avdmanager calls
-        val avdInfoMap = fetchAndroidAvdInfoMap()
+        val avdInfoList = fetchAndroidAvdInfo()
 
         val connected = runCatching {
             Dadb.list(host = host).map { dadb ->
@@ -244,7 +246,7 @@ object DeviceService {
                     instanceId.startsWith("emulator") -> Device.DeviceType.EMULATOR
                     else -> Device.DeviceType.REAL
                 }
-                val (model, os) = if (avdName != null) avdInfoMap[avdName] ?: ("" to "") else ("" to "")
+                val avdInfo = avdInfoList.find { it.name == avdName } ?: AvdInfo(name = avdName ?: "", model = "", os = "")
                 Device.Connected(
                     instanceId = instanceId,
                     description = avdName ?: dadb.toString(),
@@ -252,8 +254,8 @@ object DeviceService {
                     deviceType = deviceType,
                     deviceSpec = DeviceCatalog.resolve(
                         platform = Platform.ANDROID.name,
-                        model = model,
-                        os = os,
+                        model = avdInfo.model,
+                        os = avdInfo.os,
                         locale = null,
                         orientation = null,
                         disableAnimations = null,
@@ -275,7 +277,7 @@ object DeviceService {
                 .useLines { lines ->
                     lines
                         .map { avdName ->
-                            val (model, os) = avdInfoMap[avdName] ?: ("" to "")
+                            val avdInfo = avdInfoList.find { it.name == avdName } ?: AvdInfo(name = avdName, model = "", os = "")
                             Device.AvailableForLaunch(
                                 modelId = avdName,
                                 description = avdName,
@@ -283,8 +285,8 @@ object DeviceService {
                                 deviceType = Device.DeviceType.EMULATOR,
                                 deviceSpec = DeviceCatalog.resolve(
                                     Platform.ANDROID.name,
-                                    model = model,
-                                    os = os,
+                                    model = avdInfo.model,
+                                    os = avdInfo.os,
                                     locale = null,
                                     orientation = null,
                                     disableAnimations = null,
@@ -303,14 +305,15 @@ object DeviceService {
     }
 
     /**
-     * Runs `avdmanager list avd` and returns a map of AVD name → (model, os).
+     * Runs `avdmanager list avd` and returns a list of AvdInfo
+     * - name
      * - model: the canonical device ID from avdmanager, e.g. "pixel_6"
-     * - os:    "android-XX" derived from the API level, e.g. "android-34"
+     * - os: "android-XX" derived from the API level, e.g. "android-34"
      *
      * Falls back to config.ini for the OS if avdmanager output lacks it.
-     * Returns empty map on any failure.
+     * Returns empty string on any failure
      */
-    private fun fetchAndroidAvdInfoMap(): Map<String, Pair<String, String>> {
+    private fun fetchAndroidAvdInfo(): List<AvdInfo> {
         return try {
             val avd = requireAvdManagerBinary()
             val output = ProcessBuilder(avd.absolutePath, "list", "avd")
@@ -318,48 +321,51 @@ object DeviceService {
                 .start()
                 .apply { waitFor(30, TimeUnit.SECONDS) }
                 .inputStream.bufferedReader().readText()
+            parseAvdInfo(output, AndroidEnvUtils.androidAvdHome)
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
 
-            val result = mutableMapOf<String, Pair<String, String>>()
-            var currentName: String? = null
-            var currentModel: String? = null
-            var currentOs: String? = null
+    internal fun parseAvdInfo(output: String, avdHome: File): List<AvdInfo> {
+        val result = mutableListOf<AvdInfo>()
+        var currentName: String? = null
+        var currentModel: String? = null
+        var currentOs: String? = null
 
-            for (line in output.lines()) {
-                val trimmed = line.trim()
-                when {
-                    trimmed.startsWith("Name:") -> {
-                        // Save previous block
-                        if (currentName != null) {
-                            result[currentName] = (currentModel ?: "") to (currentOs ?: "")
-                        }
-                        currentName = trimmed.removePrefix("Name:").trim()
-                        currentModel = null
-                        currentOs = null
+        for (line in output.lines()) {
+            val trimmed = line.trim()
+            when {
+                trimmed.startsWith("Name:") -> {
+                    // Save previous block
+                    if (currentName != null) {
+                        result += AvdInfo(name = currentName, model = currentModel ?: "", os = currentOs ?: "")
                     }
-                    trimmed.startsWith("Device:") -> {
-                        // "pixel_6 (Google Pixel 6)" → "pixel_6"
-                        currentModel = trimmed.removePrefix("Device:").trim().substringBefore(" ")
-                    }
-                    currentOs == null && currentName != null -> {
-                        // Read OS from config.ini once we have the AVD name
-                        val configFile = File(AndroidEnvUtils.androidAvdHome, "$currentName.avd/config.ini")
-                        if (configFile.exists()) {
-                            val sysdir = configFile.readLines()
-                                .firstOrNull { it.startsWith("image.sysdir.1=") }
-                                ?.substringAfter("=")
-                            currentOs = sysdir?.split("/")?.firstOrNull { it.startsWith("android-") }
-                        }
+                    currentName = trimmed.removePrefix("Name:").trim()
+                    currentModel = null
+                    currentOs = null
+                }
+                trimmed.startsWith("Device:") -> {
+                    // "pixel_6 (Google Pixel 6)" → "pixel_6"
+                    currentModel = trimmed.removePrefix("Device:").trim().substringBefore(" ")
+                }
+                currentOs == null && currentName != null -> {
+                    // Read OS from config.ini once we have the AVD name
+                    val configFile = File(avdHome, "$currentName.avd/config.ini")
+                    if (configFile.exists()) {
+                        val sysdir = configFile.readLines()
+                            .firstOrNull { it.startsWith("image.sysdir.1=") }
+                            ?.substringAfter("=")
+                        currentOs = sysdir?.split("/")?.firstOrNull { it.startsWith("android-") }
                     }
                 }
             }
-            // Save last block
-            if (currentName != null) {
-                result[currentName] = (currentModel ?: "") to (currentOs ?: "")
-            }
-            result
-        } catch (e: Exception) {
-            emptyMap()
         }
+        // Save last block
+        if (currentName != null) {
+            result += AvdInfo(name = currentName, model = currentModel ?: "", os = currentOs ?: "")
+        }
+        return result
     }
 
     private fun listIOSDevices(): List<Device> {

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -14,7 +14,7 @@ import okio.source
 import org.slf4j.LoggerFactory
 import util.DeviceCtlResponse
 import java.io.File
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 
@@ -50,6 +50,7 @@ object DeviceService {
                     description = device.description,
                     platform = device.platform,
                     deviceType = device.deviceType,
+                    deviceSpec = device.deviceSpec,
                 )
             }
 
@@ -107,6 +108,7 @@ object DeviceService {
                     description = device.description,
                     platform = device.platform,
                     deviceType = device.deviceType,
+                    deviceSpec = device.deviceSpec,
                 )
             }
 
@@ -119,6 +121,7 @@ object DeviceService {
                     description = "Chromium Web Browser",
                     platform = device.platform,
                     deviceType = device.deviceType,
+                    deviceSpec = device.deviceSpec,
                 )
             }
         }
@@ -157,7 +160,8 @@ object DeviceService {
                 platform = Platform.WEB,
                 description = "Chromium Web Browser",
                 instanceId = "chromium",
-                deviceType = Device.DeviceType.BROWSER
+                deviceType = Device.DeviceType.BROWSER,
+                deviceSpec = DeviceCatalog.resolve(Platform.WEB.name)
             ),
             Device.AvailableForLaunch(
                 modelId = "chromium",
@@ -178,10 +182,15 @@ object DeviceService {
                     instanceId = dadb.toString(),
                     description = dadb.toString(),
                     platform = Platform.ANDROID,
-                    deviceType = Device.DeviceType.EMULATOR
+                    deviceType = Device.DeviceType.EMULATOR,
+                    deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name)
                 )
             )
         }
+
+        // Fetch AVD info once (model + os) to avoid repeated avdmanager calls
+        val avdInfoMap = fetchAndroidAvdInfoMap()
+
         val connected = runCatching {
             Dadb.list(host = host).map { dadb ->
                 val avdName = runCatching {
@@ -201,15 +210,17 @@ object DeviceService {
                 }.getOrNull()
 
                 val instanceId = dadb.toString()
-                val deviceType = when  {
+                val deviceType = when {
                     instanceId.startsWith("emulator") -> Device.DeviceType.EMULATOR
                     else -> Device.DeviceType.REAL
                 }
+                val (model, os) = if (avdName != null) avdInfoMap[avdName] ?: ("" to "") else ("" to "")
                 Device.Connected(
                     instanceId = instanceId,
                     description = avdName ?: dadb.toString(),
                     platform = Platform.ANDROID,
-                    deviceType = deviceType
+                    deviceType = deviceType,
+                    deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name, model, os),
                 )
             }
         }.getOrNull() ?: emptyList()
@@ -224,13 +235,14 @@ object DeviceService {
                 .bufferedReader()
                 .useLines { lines ->
                     lines
-                        .map {
+                        .map { avdName ->
+                            val (model, os) = avdInfoMap[avdName] ?: ("" to "")
                             Device.AvailableForLaunch(
-                                modelId = it,
-                                description = it,
+                                modelId = avdName,
+                                description = avdName,
                                 platform = Platform.ANDROID,
                                 deviceType = Device.DeviceType.EMULATOR,
-                                deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name)
+                                deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name, model, os),
                             )
                         }
                         .toList()
@@ -240,6 +252,66 @@ object DeviceService {
         }
 
         return connected + avds
+    }
+
+    /**
+     * Runs `avdmanager list avd` and returns a map of AVD name → (model, os).
+     * - model: the canonical device ID from avdmanager, e.g. "pixel_6"
+     * - os:    "android-XX" derived from the API level, e.g. "android-34"
+     *
+     * Falls back to config.ini for the OS if avdmanager output lacks it.
+     * Returns empty map on any failure.
+     */
+    private fun fetchAndroidAvdInfoMap(): Map<String, Pair<String, String>> {
+        return try {
+            val avd = requireAvdManagerBinary()
+            val output = ProcessBuilder(avd.absolutePath, "list", "avd")
+                .redirectErrorStream(true)
+                .start()
+                .apply { waitFor(30, TimeUnit.SECONDS) }
+                .inputStream.bufferedReader().readText()
+
+            val result = mutableMapOf<String, Pair<String, String>>()
+            var currentName: String? = null
+            var currentModel: String? = null
+            var currentOs: String? = null
+
+            for (line in output.lines()) {
+                val trimmed = line.trim()
+                when {
+                    trimmed.startsWith("Name:") -> {
+                        // Save previous block
+                        if (currentName != null) {
+                            result[currentName] = (currentModel ?: "") to (currentOs ?: "")
+                        }
+                        currentName = trimmed.removePrefix("Name:").trim()
+                        currentModel = null
+                        currentOs = null
+                    }
+                    trimmed.startsWith("Device:") -> {
+                        // "pixel_6 (Google Pixel 6)" → "pixel_6"
+                        currentModel = trimmed.removePrefix("Device:").trim().substringBefore(" ")
+                    }
+                    currentOs == null && currentName != null -> {
+                        // Read OS from config.ini once we have the AVD name
+                        val configFile = File(AndroidEnvUtils.androidAvdHome, "$currentName.avd/config.ini")
+                        if (configFile.exists()) {
+                            val sysdir = configFile.readLines()
+                                .firstOrNull { it.startsWith("image.sysdir.1=") }
+                                ?.substringAfter("=")
+                            currentOs = sysdir?.split("/")?.firstOrNull { it.startsWith("android-") }
+                        }
+                    }
+                }
+            }
+            // Save last block
+            if (currentName != null) {
+                result[currentName] = (currentModel ?: "") to (currentOs ?: "")
+            }
+            result
+        } catch (e: Exception) {
+            emptyMap()
+        }
     }
 
     private fun listIOSDevices(): List<Device> {
@@ -281,7 +353,8 @@ object DeviceService {
                 instanceId = udid,
                 description = description,
                 platform = Platform.IOS,
-                deviceType = Device.DeviceType.REAL
+                deviceType = Device.DeviceType.REAL,
+                deviceSpec = DeviceCatalog.resolve(Platform.IOS.name)
             )
         }
     }
@@ -294,20 +367,26 @@ object DeviceService {
         val runtimeName = runtimeNameByIdentifier[runtime.key] ?: "Unknown runtime"
         val description = "${device.name} - $runtimeName - ${device.udid}"
 
+        // "com.apple.CoreSimulator.SimDeviceType.iPhone-XS" → "iPhone-XS"
+        val model = device.deviceTypeIdentifier?.substringAfterLast(".") ?: ""
+        // "com.apple.CoreSimulator.SimRuntime.iOS-17-5" → "iOS-17-5"
+        val os = runtime.key.substringAfterLast(".")
+
         return if (device.state == "Booted") {
             Device.Connected(
                 instanceId = device.udid,
                 description = description,
                 platform = Platform.IOS,
-                deviceType = Device.DeviceType.SIMULATOR
+                deviceType = Device.DeviceType.SIMULATOR,
+                deviceSpec = DeviceCatalog.resolve(Platform.IOS.name)
             )
         } else {
             Device.AvailableForLaunch(
                 modelId = device.udid,
                 description = description,
                 platform = Platform.IOS,
-                deviceType =  Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceCatalog.resolve(Platform.IOS.name)
+                deviceType = Device.DeviceType.SIMULATOR,
+                deviceSpec = DeviceCatalog.resolve(Platform.IOS.name, model, os),
             )
         }
     }
@@ -329,7 +408,8 @@ object DeviceService {
                             instanceId = output,
                             description = output,
                             platform = Platform.ANDROID,
-                            deviceType = Device.DeviceType.EMULATOR
+                            deviceType = Device.DeviceType.EMULATOR,
+                            deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name)
                         )
                     }
                     .find { connectedDevice -> connectedDevice.description.contains(deviceName, ignoreCase = true) }

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -164,7 +164,16 @@ object DeviceService {
                 description = "Chromium Web Browser",
                 instanceId = "chromium",
                 deviceType = Device.DeviceType.BROWSER,
-                deviceSpec = DeviceCatalog.resolve(Platform.WEB.name)
+                deviceSpec = DeviceCatalog.resolve(
+                    Platform.WEB.name,
+                    model = null,
+                    os = null,
+                    locale = null,
+                    orientation = null,
+                    disableAnimations = null,
+                    snapshotKeyHonorModalViews = null,
+                    systemArchitecture = null
+                )
             ),
             Device.AvailableForLaunch(
                 modelId = "chromium",
@@ -195,7 +204,16 @@ object DeviceService {
                     description = dadb.toString(),
                     platform = Platform.ANDROID,
                     deviceType = Device.DeviceType.EMULATOR,
-                    deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name)
+                    deviceSpec = DeviceCatalog.resolve(
+                        Platform.ANDROID.name,
+                        model = null,
+                        os = null,
+                        locale = null,
+                        orientation = null,
+                        disableAnimations = null,
+                        snapshotKeyHonorModalViews = null,
+                        systemArchitecture = null
+                    )
                 )
             )
         }
@@ -232,7 +250,16 @@ object DeviceService {
                     description = avdName ?: dadb.toString(),
                     platform = Platform.ANDROID,
                     deviceType = deviceType,
-                    deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name, model, os),
+                    deviceSpec = DeviceCatalog.resolve(
+                        platform = Platform.ANDROID.name,
+                        model = model,
+                        os = os,
+                        locale = null,
+                        orientation = null,
+                        disableAnimations = null,
+                        snapshotKeyHonorModalViews = null,
+                        systemArchitecture = null
+                    ),
                 )
             }
         }.getOrNull() ?: emptyList()
@@ -375,7 +402,16 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType = Device.DeviceType.REAL,
-                deviceSpec = DeviceCatalog.resolve(Platform.IOS.name)
+                deviceSpec = DeviceCatalog.resolve(
+                    platform = Platform.IOS.name,
+                    model = null,
+                    os = null,
+                    locale = null,
+                    orientation = null,
+                    disableAnimations = null,
+                    snapshotKeyHonorModalViews = null,
+                    systemArchitecture = null
+                )
             )
         }
     }
@@ -399,7 +435,16 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType = Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceCatalog.resolve(Platform.IOS.name)
+                deviceSpec = DeviceCatalog.resolve(
+                    platform = Platform.IOS.name,
+                    model = null,
+                    os = null,
+                    locale = null,
+                    orientation = null,
+                    disableAnimations = null,
+                    snapshotKeyHonorModalViews = null,
+                    systemArchitecture = null
+                )
             )
         } else {
             Device.AvailableForLaunch(
@@ -439,7 +484,16 @@ object DeviceService {
                             description = output,
                             platform = Platform.ANDROID,
                             deviceType = Device.DeviceType.EMULATOR,
-                            deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name)
+                            deviceSpec = DeviceCatalog.resolve(
+                                platform =Platform.ANDROID.name,
+                                model = null,
+                                os = null,
+                                locale = null,
+                                orientation = null,
+                                disableAnimations = null,
+                                snapshotKeyHonorModalViews = null,
+                                systemArchitecture = null
+                            )
                         )
                     }
                     .find { connectedDevice -> connectedDevice.description.contains(deviceName, ignoreCase = true) }

--- a/maestro-client/src/main/java/maestro/device/util/AndroidEnvUtils.kt
+++ b/maestro-client/src/main/java/maestro/device/util/AndroidEnvUtils.kt
@@ -29,6 +29,12 @@ object AndroidEnvUtils {
             return Paths.get(System.getProperty("user.home"), ".android")
         }
 
+    val androidAvdHome: File
+        get() {
+            System.getenv("ANDROID_AVD_HOME")?.let { return File(it) }
+            return androidUserHome.resolve("avd").toFile()
+        }
+
     /**
      * Returns SDK versions that are used by AVDs present in the system.
      */

--- a/maestro-client/src/test/java/maestro/device/DeviceServiceTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceServiceTest.kt
@@ -1,0 +1,220 @@
+package maestro.device
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+internal class DeviceServiceTest {
+
+    @TempDir
+    lateinit var avdHome: File
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /** Creates <avdHome>/<avdName>.avd/config.ini with the given content. */
+    private fun writeConfigIni(avdName: String, content: String) {
+        val dir = File(avdHome, "$avdName.avd").also { it.mkdirs() }
+        File(dir, "config.ini").writeText(content)
+    }
+
+    private fun List<AvdInfo>.named(name: String) = find { it.name == name }
+
+    // -------------------------------------------------------------------------
+    // Happy-path
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `single AVD with all fields and config ini present`() {
+        writeConfigIni(
+            "Pixel_6_API_34",
+            "image.sysdir.1=system-images/android-34/google_apis/arm64-v8a/\n"
+        )
+
+        val output = """
+            Available Android Virtual Devices:
+                Name: Pixel_6_API_34
+              Device: pixel_6 (Google Pixel 6)
+                Path: /home/user/.android/avd/Pixel_6_API_34.avd
+              Target: Google APIs (Google Inc.)
+                      Based on: Android 14.0 ("UpsideDownCake") Tag/ABI: google_apis/arm64-v8a
+                Skin: pixel_6
+              Sdcard: 512M
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result).hasSize(1)
+        assertThat(result.named("Pixel_6_API_34")).isEqualTo(AvdInfo(name = "Pixel_6_API_34", model = "pixel_6", os = "android-34"))
+    }
+
+    @Test
+    fun `multiple AVDs are all parsed`() {
+        writeConfigIni("Pixel_6_API_34", "image.sysdir.1=system-images/android-34/google_apis/arm64-v8a/\n")
+        writeConfigIni("Pixel_7_API_33", "image.sysdir.1=system-images/android-33/google_apis/x86_64/\n")
+
+        val output = """
+            Available Android Virtual Devices:
+                Name: Pixel_6_API_34
+              Device: pixel_6 (Google Pixel 6)
+                Path: /home/user/.android/avd/Pixel_6_API_34.avd
+              Target: Google APIs (Google Inc.)
+                      Based on: Android 14.0 Tag/ABI: google_apis/arm64-v8a
+            ---------
+                Name: Pixel_7_API_33
+              Device: pixel_7 (Google Pixel 7)
+                Path: /home/user/.android/avd/Pixel_7_API_33.avd
+              Target: Google APIs (Google Inc.)
+                      Based on: Android 13.0 Tag/ABI: google_apis/x86_64
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.named("Pixel_6_API_34")).isEqualTo(AvdInfo(name = "Pixel_6_API_34", model = "pixel_6", os = "android-34"))
+        assertThat(result.named("Pixel_7_API_33")).isEqualTo(AvdInfo(name = "Pixel_7_API_33", model = "pixel_7", os = "android-33"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Model (Device:) field edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `Device field with no parenthetical description uses full token as model`() {
+        writeConfigIni("Pixel_6_API_34", "image.sysdir.1=system-images/android-34/google_apis/arm64-v8a/\n")
+
+        val output = """
+            Available Android Virtual Devices:
+                Name: Pixel_6_API_34
+              Device: pixel_6
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result.named("Pixel_6_API_34")).isEqualTo(AvdInfo(name = "Pixel_6_API_34", model = "pixel_6", os = ""))
+    }
+
+    @Test
+    fun `missing Device field results in empty model string`() {
+        writeConfigIni("Pixel_6_API_34", "image.sysdir.1=system-images/android-34/google_apis/arm64-v8a/\n")
+
+        val output = """
+            Available Android Virtual Devices:
+                Name: Pixel_6_API_34
+                Path: /home/user/.android/avd/Pixel_6_API_34.avd
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result.named("Pixel_6_API_34")).isEqualTo(AvdInfo(name = "Pixel_6_API_34", model = "", os = "android-34"))
+    }
+
+    // -------------------------------------------------------------------------
+    // OS / config.ini edge cases
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `config ini missing results in empty OS string`() {
+        // No config.ini written for this AVD
+
+        val output = """
+            Available Android Virtual Devices:
+                Name: No_Config_AVD
+              Device: pixel_6 (Google Pixel 6)
+                Path: /home/user/.android/avd/No_Config_AVD.avd
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result.named("No_Config_AVD")).isEqualTo(AvdInfo(name = "No_Config_AVD", model = "pixel_6", os = ""))
+    }
+
+    @Test
+    fun `config ini present but lacks image sysdir line results in empty OS string`() {
+        writeConfigIni("AVD_No_Sysdir", "hw.ramSize=2048\ntarget=android-34\n")
+
+        // Path: line triggers the config.ini fallback branch
+        val output = """
+            Available Android Virtual Devices:
+                Name: AVD_No_Sysdir
+              Device: pixel_6 (Google Pixel 6)
+                Path: /home/user/.android/avd/AVD_No_Sysdir.avd
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result.named("AVD_No_Sysdir")).isEqualTo(AvdInfo(name = "AVD_No_Sysdir", model = "pixel_6", os = ""))
+    }
+
+    @Test
+    fun `config ini sysdir with no android-XX segment results in empty OS string`() {
+        writeConfigIni("AVD_Weird_Sysdir", "image.sysdir.1=custom-images/vendor-image/arm64-v8a/\n")
+
+        // Path: line triggers the config.ini fallback branch
+        val output = """
+            Available Android Virtual Devices:
+                Name: AVD_Weird_Sysdir
+              Device: pixel_6 (Google Pixel 6)
+                Path: /home/user/.android/avd/AVD_Weird_Sysdir.avd
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result.named("AVD_Weird_Sysdir")).isEqualTo(AvdInfo(name = "AVD_Weird_Sysdir", model = "pixel_6", os = ""))
+    }
+
+    @Test
+    fun `config ini sysdir with android-XX at a non-first segment is still found`() {
+        writeConfigIni(
+            "Nested_AVD",
+            "image.sysdir.1=sdk/system-images/android-30/google_apis_playstore/x86/\n"
+        )
+
+        // A non-Name/non-Device line (e.g. Path:) is required to trigger the
+        // config.ini fallback branch — it only fires on "other" lines.
+        val output = """
+            Available Android Virtual Devices:
+                Name: Nested_AVD
+              Device: pixel_4 (Google Pixel 4)
+                Path: /home/user/.android/avd/Nested_AVD.avd
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result.named("Nested_AVD")).isEqualTo(AvdInfo(name = "Nested_AVD", model = "pixel_4", os = "android-30"))
+    }
+
+    // -------------------------------------------------------------------------
+    // Empty / degenerate input
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `empty output returns empty list`() {
+        val result = DeviceService.parseAvdInfo("", avdHome)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `output with no AVDs returns empty list`() {
+        val output = "Available Android Virtual Devices:\n"
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `Name line with no subsequent Device or config ini still saved with empty values`() {
+        // AVD block containing only a Name: line — no Device:, no config.ini
+        val output = """
+            Available Android Virtual Devices:
+                Name: Bare_AVD
+        """.trimIndent()
+
+        val result = DeviceService.parseAvdInfo(output, avdHome)
+
+        assertThat(result).hasSize(1)
+        assertThat(result.named("Bare_AVD")).isEqualTo(AvdInfo(name = "Bare_AVD", model = "", os = ""))
+    }
+
+}


### PR DESCRIPTION
# Changes
- Extended `Device` type to include `deviceSpec` with correct `model` and `os`
- Local setup now also get `model` and `os` to create `deviceSpec`
- Added api request to get and print the available cloud devices
- Added list device command

# Command view

### List local device
<img width="764" height="480" alt="Screenshot 2026-03-11 at 3 04 41 PM" src="https://github.com/user-attachments/assets/1c5e0d22-9d87-4531-9dd5-007354712ea6" />

### List cloud device
<img width="804" height="870" alt="Screenshot 2026-03-11 at 3 05 00 PM" src="https://github.com/user-attachments/assets/8f34c99f-0bbf-4e6f-8463-d585fcf4b5f1" />

### Filter by platform
<img width="667" height="110" alt="Screenshot 2026-03-11 at 3 05 21 PM" src="https://github.com/user-attachments/assets/48779ac9-3b7a-40b0-a582-056acd02caf0" />
