### PR TITLE
Never have callTimeout lower than readTimeout

### DIFF
--- a/maestro-utils/src/main/kotlin/HttpClient.kt
+++ b/maestro-utils/src/main/kotlin/HttpClient.kt
@@ -65,18 +65,19 @@ object HttpClient {
         connectTimeout: Duration = 10.seconds,
         readTimeout: Duration = 10.seconds,
         writeTimeout: Duration = 10.seconds,
-        callTimeout: Duration = 60.seconds,
+        callTimeout: Duration? = null,
         interceptors: List<Interceptor> = emptyList(),
         networkInterceptors: List<Interceptor> = emptyList(),
         protocols: List<Protocol> = listOf(Protocol.HTTP_1_1),
         metrics: Metrics = MetricsProvider.getInstance()
     ): OkHttpClient {
+        val effectiveCallTimeout = callTimeout ?: maxOf(60.seconds, readTimeout)
         var b = OkHttpClient.Builder()
             .eventListenerFactory(MetricsEventListener.Factory(metrics, name))
             .connectTimeout(connectTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .readTimeout(readTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .writeTimeout(writeTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-            .callTimeout(callTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+            .callTimeout(effectiveCallTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
             .addNetworkInterceptor(Interceptor { chain ->
                 val start = System.currentTimeMillis()
                 val response = chain.proceed(chain.request())


### PR DESCRIPTION
## Proposed changes

When an HttpClient is built, and sets a readTimeout larger than our default callTimeout of 60s, expand the callTimeout to match. If we don't, the callTimeout remains at 60s and larger timeouts don't apply.

This is seen in ApiClient, where we set a readTimeout of 5 minutes for cloud uploads, but they time out after 1 minute due to this default.

