### PR TITLE
Fix step ordering in HTML detailed report

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -181,6 +181,7 @@ class TestSuiteInteractor(
 
         val flowTimeMillis = measureTimeMillis {
             try {
+                var commandSequenceNumber = 0
                 val orchestra = Orchestra(
                     maestro = maestro,
                     screenshotsDir = testOutputDir?.resolve("screenshots"),
@@ -188,7 +189,8 @@ class TestSuiteInteractor(
                         logger.info("${shardPrefix}${command.description()} RUNNING")
                         debugOutput.commands[command] = CommandDebugMetadata(
                             timestamp = System.currentTimeMillis(),
-                            status = CommandStatus.RUNNING
+                            status = CommandStatus.RUNNING,
+                            sequenceNumber = commandSequenceNumber++
                         )
                     },
                     onCommandComplete = { _, command ->


### PR DESCRIPTION
## Proposed changes

When running a workspace locally, html-detailed report was jumbling the step ordering. Running a single flow wasn't affected. This was due to an uninitialised variable in the workspace codepath.

This implementation now matches what occurs in [MaestroCommandRunner](https://github.com/mobile-dev-inc/Maestro/blob/46b646d7d3bfce990dc7b40a0c9eb3b04bad1f06/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt#L116).

## Testing

Before
<img width="860" height="941" alt="image" src="https://github.com/user-attachments/assets/0e5611c3-9c5f-4185-9d74-4221f32c7c6f" />

After
<img width="958" height="957" alt="image" src="https://github.com/user-attachments/assets/5232eb16-ae13-47f1-93cf-ea1834f10c50" />


## Issues fixed

Fixes #3045 