### PR TITLE
feat: make all options for resolve to be passed explisitly + added os…

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -1,6 +1,5 @@
 package maestro.cli.command
 
-import maestro.device.DeviceCatalog
 import maestro.cli.App
 import maestro.cli.CliError
 import maestro.cli.ShowHelpMixin
@@ -8,6 +7,7 @@ import maestro.cli.device.DeviceCreateUtil
 import maestro.device.DeviceService
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.util.EnvUtils
+import maestro.device.DeviceCatalog
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
@@ -92,7 +92,10 @@ class StartDeviceCommand : Callable<Int> {
             model = deviceModel,
             os = deviceOs ?: osVersion,
             locale = deviceLocale,
-            systemArchitecture = EnvUtils.getMacOSArchitecture()
+            systemArchitecture = EnvUtils.getMacOSArchitecture(),
+            orientation = null,
+            disableAnimations = null,
+            snapshotKeyHonorModalViews = null
         )
 
         // Get/Create the device

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
@@ -32,6 +32,13 @@ object PickDeviceView {
 
         val spec = DeviceCatalog.resolve(
             platform = selectedPlatform.toString(),
+            model = null,
+            os = null,
+            locale = null,
+            orientation = null,
+            disableAnimations = null,
+            snapshotKeyHonorModalViews = null,
+            systemArchitecture = null,
         )
 
         return spec

--- a/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
@@ -18,6 +18,7 @@ sealed class DeviceSpec {
     abstract val platform: Platform
     abstract val model: String
     abstract val os: String
+    abstract val osVersion: Int
     abstract val deviceName: String
     abstract val locale: DeviceLocale
 
@@ -32,6 +33,7 @@ sealed class DeviceSpec {
     ) : DeviceSpec() {
         override val platform = Platform.ANDROID
         override val deviceName = "Maestro_ANDROID_${model}_${os}"
+        override val osVersion: Int = os.removePrefix("android-").toIntOrNull() ?: 0
         val tag = "google_apis"
         val emulatorImage = "system-images;$os;$tag;${cpuArchitecture.value}"
     }
@@ -45,6 +47,7 @@ sealed class DeviceSpec {
     ) : DeviceSpec() {
         override val platform = Platform.IOS
         override val deviceName = "Maestro_IOS_${model}_${os}"
+        override val osVersion: Int = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
     }
 
     data class Web(
@@ -54,6 +57,7 @@ sealed class DeviceSpec {
     ) : DeviceSpec() {
         override val platform = Platform.WEB
         override val deviceName = "Maestro_WEB_${model}_${os}"
+        override val osVersion: Int = 0
     }
 }
 
@@ -65,15 +69,20 @@ object DeviceCatalog {
      */
     fun resolve(
         platform: String,
-        model: String? = null,
-        os: String? = null,
-        locale: String? = "en_US",
-        orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
-        disableAnimations: Boolean = false,
-        snapshotKeyHonorModalViews: Boolean = false,
-        systemArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
+        model: String?,
+        os: String?,
+        locale: String?,
+        orientation: DeviceOrientation?,
+        disableAnimations: Boolean?,
+        snapshotKeyHonorModalViews: Boolean?,
+        systemArchitecture: CPU_ARCHITECTURE?,
     ): DeviceSpec {
         val resolvedLocale = locale ?: "en_US"
+        val resolvedOrientation = orientation ?: DeviceOrientation.PORTRAIT
+        val resolvedDisableAnimation = disableAnimations ?: false
+        val resolvedSnapshotKeyHonorModalViews = snapshotKeyHonorModalViews ?: false
+        val resolvedSystemArchitecture = systemArchitecture ?: CPU_ARCHITECTURE.ARM64
+
         val platform = Platform.fromString(platform)
             ?: throw IllegalArgumentException("Unsupported platform $platform. Please specify one of: android, ios, web")
 
@@ -83,10 +92,10 @@ object DeviceCatalog {
                     model = model ?: "pixel_6",
                     os = os ?: "android-34",
                     locale = DeviceLocale.fromString(resolvedLocale, platform),
-                    orientation = orientation,
-                    disableAnimations = disableAnimations,
-                    snapshotKeyHonorModalViews = snapshotKeyHonorModalViews,
-                    cpuArchitecture = systemArchitecture,
+                    orientation = resolvedOrientation,
+                    disableAnimations = resolvedDisableAnimation,
+                    snapshotKeyHonorModalViews = resolvedSnapshotKeyHonorModalViews,
+                    cpuArchitecture = resolvedSystemArchitecture,
                 )
             }
             Platform.IOS -> {
@@ -94,8 +103,8 @@ object DeviceCatalog {
                     model = model ?: "iPhone-11",
                     os = os ?: "iOS-18-2",
                     locale = DeviceLocale.fromString(resolvedLocale, platform),
-                    orientation = orientation,
-                    disableAnimations = disableAnimations,
+                    orientation = resolvedOrientation,
+                    disableAnimations = resolvedDisableAnimation,
                 )
             }
             Platform.WEB -> {

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -13,6 +13,9 @@ import okio.buffer
 import okio.source
 import org.slf4j.LoggerFactory
 import util.DeviceCtlResponse
+import util.LocalIOSDevice
+import util.LocalSimulatorUtils
+import util.SimctlList
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
@@ -22,7 +25,7 @@ object DeviceService {
     private val logger = LoggerFactory.getLogger(DeviceService::class.java)
 
     private val tempFileHandler = TempFileHandler()
-    private val localSimulatorUtils = util.LocalSimulatorUtils(tempFileHandler)
+    private val localSimulatorUtils = LocalSimulatorUtils(tempFileHandler)
 
     fun startDevice(
         device: Device.AvailableForLaunch,
@@ -40,7 +43,7 @@ object DeviceService {
                     localSimulatorUtils.reboot(device.modelId)
                     localSimulatorUtils.launchSimulator(device.modelId)
                     localSimulatorUtils.awaitLaunch(device.modelId)
-                } catch (e: util.LocalSimulatorUtils.SimctlError) {
+                } catch (e: LocalSimulatorUtils.SimctlError) {
                     logger.error("Failed to launch simulator", e)
                     throw DeviceError(e.message)
                 }
@@ -164,7 +167,16 @@ object DeviceService {
                 description = "Chromium Web Browser",
                 platform = Platform.WEB,
                 deviceType = Device.DeviceType.BROWSER,
-                deviceSpec = DeviceCatalog.resolve(Platform.WEB.name)
+                deviceSpec = DeviceCatalog.resolve(
+                    Platform.WEB.name,
+                    model = null,
+                    os = null,
+                    locale = null,
+                    orientation = null,
+                    disableAnimations = null,
+                    snapshotKeyHonorModalViews = null,
+                    systemArchitecture = null
+                )
             )
         )
     }
@@ -230,7 +242,16 @@ object DeviceService {
                                 description = it,
                                 platform = Platform.ANDROID,
                                 deviceType = Device.DeviceType.EMULATOR,
-                                deviceSpec = DeviceCatalog.resolve(Platform.ANDROID.name)
+                                deviceSpec = DeviceCatalog.resolve(
+                                    Platform.ANDROID.name,
+                                    model = null,
+                                    os = null,
+                                    locale = null,
+                                    orientation = null,
+                                    disableAnimations = null,
+                                    snapshotKeyHonorModalViews = null,
+                                    systemArchitecture = null
+                                )
                             )
                         }
                         .toList()
@@ -263,7 +284,7 @@ object DeviceService {
     }
 
     fun listIOSConnectedDevices(): List<Device.Connected> {
-        val connectedIphoneList = util.LocalIOSDevice().listDeviceViaDeviceCtl()
+        val connectedIphoneList = LocalIOSDevice().listDeviceViaDeviceCtl()
 
         return connectedIphoneList.mapNotNull { device ->
             val udid = device.hardwareProperties?.udid
@@ -287,9 +308,9 @@ object DeviceService {
     }
 
     private fun device(
-        runtimeNameByIdentifier: Map<String, String>,
-        runtime: Map.Entry<String, List<util.SimctlList.Device>>,
-        device: util.SimctlList.Device,
+      runtimeNameByIdentifier: Map<String, String>,
+      runtime: Map.Entry<String, List<SimctlList.Device>>,
+      device: SimctlList.Device,
     ): Device {
         val runtimeName = runtimeNameByIdentifier[runtime.key] ?: "Unknown runtime"
         val description = "${device.name} - $runtimeName - ${device.udid}"
@@ -307,7 +328,16 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType =  Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceCatalog.resolve(Platform.IOS.name)
+                deviceSpec = DeviceCatalog.resolve(
+                    Platform.IOS.name,
+                    model = null,
+                    os = null,
+                    locale = null,
+                    orientation = null,
+                    disableAnimations = null,
+                    snapshotKeyHonorModalViews = null,
+                    systemArchitecture = null
+                )
             )
         }
     }

--- a/maestro-client/src/test/java/maestro/device/DeviceCatalogTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceCatalogTest.kt
@@ -8,7 +8,16 @@ import org.junit.jupiter.api.assertThrows
 internal class DeviceCatalogTest {
     @Test
     fun `resolve Android with no overrides uses defaults`() {
-        val spec = DeviceCatalog.resolve("android") as DeviceSpec.Android
+        val spec = DeviceCatalog.resolve(
+            platform = "android",
+            model = null,
+            os = null,
+            locale = null,
+            orientation = null,
+            disableAnimations = null,
+            snapshotKeyHonorModalViews = null,
+            systemArchitecture = null
+        ) as DeviceSpec.Android
 
         assertThat(spec.platform).isEqualTo(Platform.ANDROID)
         assertThat(spec.model).isEqualTo("pixel_6")
@@ -21,7 +30,16 @@ internal class DeviceCatalogTest {
 
     @Test
     fun `resolve iOS with no overrides uses defaults`() {
-        val spec = DeviceCatalog.resolve("ios") as DeviceSpec.Ios
+        val spec = DeviceCatalog.resolve(
+            platform = "ios",
+            model = null,
+            os = null,
+            locale = null,
+            orientation = null,
+            disableAnimations = null,
+            snapshotKeyHonorModalViews = null,
+            systemArchitecture = null
+        ) as DeviceSpec.Ios
 
         assertThat(spec.platform).isEqualTo(Platform.IOS)
         assertThat(spec.model).isEqualTo("iPhone-11")
@@ -33,7 +51,16 @@ internal class DeviceCatalogTest {
 
     @Test
     fun `resolve Web with no overrides uses defaults`() {
-        val spec = DeviceCatalog.resolve("web") as DeviceSpec.Web
+        val spec = DeviceCatalog.resolve(
+            platform = "web",
+            model = null,
+            os = null,
+            locale = null,
+            orientation = null,
+            disableAnimations = null,
+            snapshotKeyHonorModalViews = null,
+            systemArchitecture = null
+        ) as DeviceSpec.Web
 
         assertThat(spec.platform).isEqualTo(Platform.WEB)
         assertThat(spec.model).isEqualTo("chromium")
@@ -50,6 +77,8 @@ internal class DeviceCatalogTest {
             locale = "de_DE",
             orientation = DeviceOrientation.LANDSCAPE_LEFT,
             systemArchitecture = CPU_ARCHITECTURE.ARM64,
+            disableAnimations = null,
+            snapshotKeyHonorModalViews = null,
         ) as DeviceSpec.Android
 
         assertThat(spec.model).isEqualTo("pixel_xl")
@@ -69,6 +98,8 @@ internal class DeviceCatalogTest {
             locale = "de_DE",
             orientation = DeviceOrientation.LANDSCAPE_LEFT,
             systemArchitecture = CPU_ARCHITECTURE.X86_64,
+            disableAnimations = null,
+            snapshotKeyHonorModalViews = null,
         ) as DeviceSpec.Android
 
         assertThat(spec.emulatorImage).isEqualTo("system-images;android-33;google_apis;x86_64")
@@ -77,7 +108,16 @@ internal class DeviceCatalogTest {
     @Test
     fun `resolve throws on unsupported platform`() {
         assertThrows<IllegalArgumentException> {
-            DeviceCatalog.resolve("windows")
+            DeviceCatalog.resolve(
+                platform = "windows",
+                model = null,
+                os = null,
+                locale = null,
+                orientation = null,
+                disableAnimations = null,
+                snapshotKeyHonorModalViews = null,
+                systemArchitecture = null
+            )
         }
     }
 
@@ -86,21 +126,48 @@ internal class DeviceCatalogTest {
         // Arabic is a supported language, US is a supported country,
         // but ar_US is not a valid Java locale combination
         assertThrows<LocaleValidationException> {
-            DeviceCatalog.resolve("android", locale = "ar_US")
+            DeviceCatalog.resolve(
+                platform = "android",
+                locale = "ar_US",
+                model = null,
+                os = null,
+                orientation = null,
+                disableAnimations = null,
+                snapshotKeyHonorModalViews = null,
+                systemArchitecture = null
+            )
         }
     }
 
     @Test
     fun `resolve Android throws on unsupported language code`() {
         assertThrows<LocaleValidationException> {
-            DeviceCatalog.resolve("android", locale = "xx_US")
+            DeviceCatalog.resolve(
+              platform = "android",
+              locale = "xx_US",
+              model = null,
+              os = null,
+              orientation = null,
+              disableAnimations = null,
+              snapshotKeyHonorModalViews = null,
+              systemArchitecture = null
+            )
         }
     }
 
     @Test
     fun `resolve Android throws on malformed locale missing country`() {
         assertThrows<LocaleValidationException> {
-            DeviceCatalog.resolve("android", locale = "en")
+            DeviceCatalog.resolve(
+                platform = "android",
+                locale = "en",
+                model = null,
+                os = null,
+                orientation = null,
+                disableAnimations = null,
+                snapshotKeyHonorModalViews = null,
+                systemArchitecture = null
+            )
         }
     }
 }


### PR DESCRIPTION
# Changes

1. Made `DeviceCatalog.resolve` to take in all value rather than using null in case value is not passed. Reason: By keeping them option, its easy to leave the option out and later realised we were not passing anything hence always default was getting picked.

2. Added `osVersion` in deviceSpec, that is being used in backend and worker. Rather than having separate logic there, it will just create `osVersion` along with config.
