### PR TITLE
Replace flat resolve() params with sealed DeviceRequest

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -8,6 +8,8 @@ import maestro.device.DeviceService
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.util.EnvUtils
 import maestro.device.DeviceCatalog
+import maestro.device.DeviceRequest
+import maestro.device.Platform
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
@@ -87,15 +89,27 @@ class StartDeviceCommand : Callable<Int> {
         }
 
         // Get the device configuration
+        val parsedPlatform = Platform.fromString(platform)
+            ?: throw CliError("Unsupported platform $platform. Please specify one of: android, ios, web")
         val maestroDeviceConfiguration = DeviceCatalog.resolve(
-            platform = platform,
-            model = deviceModel,
-            os = deviceOs ?: osVersion,
-            locale = deviceLocale,
-            systemArchitecture = EnvUtils.getMacOSArchitecture(),
-            orientation = null,
-            disableAnimations = null,
-            snapshotKeyHonorModalViews = null
+            when (parsedPlatform) {
+                Platform.ANDROID -> DeviceRequest.Android(
+                    model = deviceModel,
+                    os = deviceOs ?: osVersion,
+                    locale = deviceLocale,
+                    systemArchitecture = EnvUtils.getMacOSArchitecture(),
+                )
+                Platform.IOS -> DeviceRequest.Ios(
+                    model = deviceModel,
+                    os = deviceOs ?: osVersion,
+                    locale = deviceLocale,
+                )
+                Platform.WEB -> DeviceRequest.Web(
+                    model = deviceModel,
+                    os = deviceOs ?: osVersion,
+                    locale = deviceLocale,
+                )
+            }
         )
 
         // Get/Create the device

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
@@ -4,6 +4,7 @@ import maestro.cli.CliError
 import maestro.cli.util.PrintUtils
 import maestro.device.Device
 import maestro.device.DeviceCatalog
+import maestro.device.DeviceRequest
 import maestro.device.DeviceSpec
 import maestro.device.Platform
 import org.fusesource.jansi.Ansi.ansi
@@ -31,14 +32,11 @@ object PickDeviceView {
             } ?: throw CliError("Please specify a platform"))
 
         val spec = DeviceCatalog.resolve(
-            platform = selectedPlatform.toString(),
-            model = null,
-            os = null,
-            locale = null,
-            orientation = null,
-            disableAnimations = null,
-            snapshotKeyHonorModalViews = null,
-            systemArchitecture = null,
+            when (selectedPlatform) {
+                Platform.ANDROID -> DeviceRequest.Android()
+                Platform.IOS -> DeviceRequest.Ios()
+                Platform.WEB -> DeviceRequest.Web()
+            }
         )
 
         return spec

--- a/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
@@ -14,6 +14,9 @@ enum class CPU_ARCHITECTURE(val value: String) {
   }
 }
 
+/**
+ * Returned Sealed class that has all non-nullable values
+ */
 sealed class DeviceSpec {
     abstract val platform: Platform
     abstract val model: String
@@ -61,59 +64,72 @@ sealed class DeviceSpec {
     }
 }
 
+/**
+ * Request for setting up device config
+ */
+sealed class DeviceRequest {
+    abstract val platform: Platform
+
+    data class Android(
+        val model: String? = null,
+        val os: String? = null,
+        val locale: String? = null,
+        val orientation: DeviceOrientation? = null,
+        val disableAnimations: Boolean? = null,
+        val snapshotKeyHonorModalViews: Boolean? = null,
+        val systemArchitecture: CPU_ARCHITECTURE? = null,
+    ) : DeviceRequest() {
+        override val platform = Platform.ANDROID
+    }
+
+    data class Ios(
+        val model: String? = null,
+        val os: String? = null,
+        val locale: String? = null,
+        val orientation: DeviceOrientation? = null,
+        val disableAnimations: Boolean? = null,
+    ) : DeviceRequest() {
+        override val platform = Platform.IOS
+    }
+
+    data class Web(
+        val model: String? = null,
+        val os: String? = null,
+        val locale: String? = null,
+    ) : DeviceRequest() {
+        override val platform = Platform.WEB
+    }
+}
+
 object DeviceCatalog {
     /**
-     * Resolves device specifications with platform-aware defaults
-     * This returns a valid device spec which is not environment validated
-     * Environment specific validation for modal & os can happen on their respective Environment (Local, Cloud, etc.)
+     * Resolves device specifications with platform-aware defaults.
+     * This returns a valid device spec which is not environment validated.
+     * Environment specific validation for model & os can happen on their respective Environment (Local, Cloud, etc.)
      */
-    fun resolve(
-        platform: String,
-        model: String?,
-        os: String?,
-        locale: String?,
-        orientation: DeviceOrientation?,
-        disableAnimations: Boolean?,
-        snapshotKeyHonorModalViews: Boolean?,
-        systemArchitecture: CPU_ARCHITECTURE?,
-    ): DeviceSpec {
-        val resolvedLocale = locale ?: "en_US"
-        val resolvedOrientation = orientation ?: DeviceOrientation.PORTRAIT
-        val resolvedDisableAnimation = disableAnimations ?: false
-        val resolvedSnapshotKeyHonorModalViews = snapshotKeyHonorModalViews ?: false
-        val resolvedSystemArchitecture = systemArchitecture ?: CPU_ARCHITECTURE.ARM64
-
-        val platform = Platform.fromString(platform)
-            ?: throw IllegalArgumentException("Unsupported platform $platform. Please specify one of: android, ios, web")
-
-        return when (platform) {
-            Platform.ANDROID -> {
-                DeviceSpec.Android(
-                    model = model ?: "pixel_6",
-                    os = os ?: "android-34",
-                    locale = DeviceLocale.fromString(resolvedLocale, platform),
-                    orientation = resolvedOrientation,
-                    disableAnimations = resolvedDisableAnimation,
-                    snapshotKeyHonorModalViews = resolvedSnapshotKeyHonorModalViews,
-                    cpuArchitecture = resolvedSystemArchitecture,
-                )
-            }
-            Platform.IOS -> {
-                DeviceSpec.Ios(
-                    model = model ?: "iPhone-11",
-                    os = os ?: "iOS-18-2",
-                    locale = DeviceLocale.fromString(resolvedLocale, platform),
-                    orientation = resolvedOrientation,
-                    disableAnimations = resolvedDisableAnimation,
-                )
-            }
-            Platform.WEB -> {
-                DeviceSpec.Web(
-                    model = model ?: "chromium",
-                    os = os ?: "default",
-                    locale = DeviceLocale.fromString(resolvedLocale, platform),
-                )
-            }
+    fun resolve(request: DeviceRequest): DeviceSpec {
+        return when (request) {
+            is DeviceRequest.Android -> DeviceSpec.Android(
+                model = request.model ?: "pixel_6",
+                os = request.os ?: "android-34",
+                locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.ANDROID),
+                orientation = request.orientation ?: DeviceOrientation.PORTRAIT,
+                disableAnimations = request.disableAnimations ?: false,
+                snapshotKeyHonorModalViews = request.snapshotKeyHonorModalViews ?: false,
+                cpuArchitecture = request.systemArchitecture ?: CPU_ARCHITECTURE.ARM64,
+            )
+            is DeviceRequest.Ios -> DeviceSpec.Ios(
+                model = request.model ?: "iPhone-11",
+                os = request.os ?: "iOS-18-2",
+                locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.IOS),
+                orientation = request.orientation ?: DeviceOrientation.PORTRAIT,
+                disableAnimations = request.disableAnimations ?: false,
+            )
+            is DeviceRequest.Web -> DeviceSpec.Web(
+                model = request.model ?: "chromium",
+                os = request.os ?: "default",
+                locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.WEB),
+            )
         }
     }
 }

--- a/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
@@ -31,7 +31,6 @@ sealed class DeviceSpec {
         override val locale: DeviceLocale,
         val orientation: DeviceOrientation,
         val disableAnimations: Boolean,
-        val snapshotKeyHonorModalViews: Boolean,
         val cpuArchitecture: CPU_ARCHITECTURE,
     ) : DeviceSpec() {
         override val platform = Platform.ANDROID
@@ -47,6 +46,7 @@ sealed class DeviceSpec {
         override val locale: DeviceLocale,
         val orientation: DeviceOrientation,
         val disableAnimations: Boolean,
+        val snapshotKeyHonorModalViews: Boolean,
     ) : DeviceSpec() {
         override val platform = Platform.IOS
         override val deviceName = "Maestro_IOS_${model}_${os}"
@@ -76,7 +76,6 @@ sealed class DeviceRequest {
         val locale: String? = null,
         val orientation: DeviceOrientation? = null,
         val disableAnimations: Boolean? = null,
-        val snapshotKeyHonorModalViews: Boolean? = null,
         val systemArchitecture: CPU_ARCHITECTURE? = null,
     ) : DeviceRequest() {
         override val platform = Platform.ANDROID
@@ -88,6 +87,7 @@ sealed class DeviceRequest {
         val locale: String? = null,
         val orientation: DeviceOrientation? = null,
         val disableAnimations: Boolean? = null,
+        val snapshotKeyHonorModalViews: Boolean? = null,
     ) : DeviceRequest() {
         override val platform = Platform.IOS
     }
@@ -111,11 +111,10 @@ object DeviceCatalog {
         return when (request) {
             is DeviceRequest.Android -> DeviceSpec.Android(
                 model = request.model ?: "pixel_6",
-                os = request.os ?: "android-34",
+                os = request.os ?: "android-33",
                 locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.ANDROID),
                 orientation = request.orientation ?: DeviceOrientation.PORTRAIT,
                 disableAnimations = request.disableAnimations ?: false,
-                snapshotKeyHonorModalViews = request.snapshotKeyHonorModalViews ?: false,
                 cpuArchitecture = request.systemArchitecture ?: CPU_ARCHITECTURE.ARM64,
             )
             is DeviceRequest.Ios -> DeviceSpec.Ios(
@@ -124,6 +123,7 @@ object DeviceCatalog {
                 locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.IOS),
                 orientation = request.orientation ?: DeviceOrientation.PORTRAIT,
                 disableAnimations = request.disableAnimations ?: false,
+                snapshotKeyHonorModalViews = request.snapshotKeyHonorModalViews ?: false,
             )
             is DeviceRequest.Web -> DeviceSpec.Web(
                 model = request.model ?: "chromium",

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -167,16 +167,7 @@ object DeviceService {
                 description = "Chromium Web Browser",
                 platform = Platform.WEB,
                 deviceType = Device.DeviceType.BROWSER,
-                deviceSpec = DeviceCatalog.resolve(
-                    Platform.WEB.name,
-                    model = null,
-                    os = null,
-                    locale = null,
-                    orientation = null,
-                    disableAnimations = null,
-                    snapshotKeyHonorModalViews = null,
-                    systemArchitecture = null
-                )
+                deviceSpec = DeviceCatalog.resolve(DeviceRequest.Web())
             )
         )
     }
@@ -242,16 +233,7 @@ object DeviceService {
                                 description = it,
                                 platform = Platform.ANDROID,
                                 deviceType = Device.DeviceType.EMULATOR,
-                                deviceSpec = DeviceCatalog.resolve(
-                                    Platform.ANDROID.name,
-                                    model = null,
-                                    os = null,
-                                    locale = null,
-                                    orientation = null,
-                                    disableAnimations = null,
-                                    snapshotKeyHonorModalViews = null,
-                                    systemArchitecture = null
-                                )
+                                deviceSpec = DeviceCatalog.resolve(DeviceRequest.Android())
                             )
                         }
                         .toList()
@@ -328,16 +310,7 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType =  Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceCatalog.resolve(
-                    Platform.IOS.name,
-                    model = null,
-                    os = null,
-                    locale = null,
-                    orientation = null,
-                    disableAnimations = null,
-                    snapshotKeyHonorModalViews = null,
-                    systemArchitecture = null
-                )
+                deviceSpec = DeviceCatalog.resolve(DeviceRequest.Ios())
             )
         }
     }

--- a/maestro-client/src/test/java/maestro/device/DeviceCatalogTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceCatalogTest.kt
@@ -8,16 +8,7 @@ import org.junit.jupiter.api.assertThrows
 internal class DeviceCatalogTest {
     @Test
     fun `resolve Android with no overrides uses defaults`() {
-        val spec = DeviceCatalog.resolve(
-            platform = "android",
-            model = null,
-            os = null,
-            locale = null,
-            orientation = null,
-            disableAnimations = null,
-            snapshotKeyHonorModalViews = null,
-            systemArchitecture = null
-        ) as DeviceSpec.Android
+        val spec = DeviceCatalog.resolve(DeviceRequest.Android()) as DeviceSpec.Android
 
         assertThat(spec.platform).isEqualTo(Platform.ANDROID)
         assertThat(spec.model).isEqualTo("pixel_6")
@@ -30,16 +21,7 @@ internal class DeviceCatalogTest {
 
     @Test
     fun `resolve iOS with no overrides uses defaults`() {
-        val spec = DeviceCatalog.resolve(
-            platform = "ios",
-            model = null,
-            os = null,
-            locale = null,
-            orientation = null,
-            disableAnimations = null,
-            snapshotKeyHonorModalViews = null,
-            systemArchitecture = null
-        ) as DeviceSpec.Ios
+        val spec = DeviceCatalog.resolve(DeviceRequest.Ios()) as DeviceSpec.Ios
 
         assertThat(spec.platform).isEqualTo(Platform.IOS)
         assertThat(spec.model).isEqualTo("iPhone-11")
@@ -51,16 +33,7 @@ internal class DeviceCatalogTest {
 
     @Test
     fun `resolve Web with no overrides uses defaults`() {
-        val spec = DeviceCatalog.resolve(
-            platform = "web",
-            model = null,
-            os = null,
-            locale = null,
-            orientation = null,
-            disableAnimations = null,
-            snapshotKeyHonorModalViews = null,
-            systemArchitecture = null
-        ) as DeviceSpec.Web
+        val spec = DeviceCatalog.resolve(DeviceRequest.Web()) as DeviceSpec.Web
 
         assertThat(spec.platform).isEqualTo(Platform.WEB)
         assertThat(spec.model).isEqualTo("chromium")
@@ -71,14 +44,13 @@ internal class DeviceCatalogTest {
     @Test
     fun `resolve uses explicit values when provided`() {
         val spec = DeviceCatalog.resolve(
-            platform = "android",
-            model = "pixel_xl",
-            os = "android-33",
-            locale = "de_DE",
-            orientation = DeviceOrientation.LANDSCAPE_LEFT,
-            systemArchitecture = CPU_ARCHITECTURE.ARM64,
-            disableAnimations = null,
-            snapshotKeyHonorModalViews = null,
+            DeviceRequest.Android(
+                model = "pixel_xl",
+                os = "android-33",
+                locale = "de_DE",
+                orientation = DeviceOrientation.LANDSCAPE_LEFT,
+                systemArchitecture = CPU_ARCHITECTURE.ARM64,
+            )
         ) as DeviceSpec.Android
 
         assertThat(spec.model).isEqualTo("pixel_xl")
@@ -92,82 +64,36 @@ internal class DeviceCatalogTest {
     @Test
     fun `resolve also update image when system architecture is different`() {
         val spec = DeviceCatalog.resolve(
-            platform = "android",
-            model = "pixel_xl",
-            os = "android-33",
-            locale = "de_DE",
-            orientation = DeviceOrientation.LANDSCAPE_LEFT,
-            systemArchitecture = CPU_ARCHITECTURE.X86_64,
-            disableAnimations = null,
-            snapshotKeyHonorModalViews = null,
+            DeviceRequest.Android(
+                model = "pixel_xl",
+                os = "android-33",
+                locale = "de_DE",
+                orientation = DeviceOrientation.LANDSCAPE_LEFT,
+                systemArchitecture = CPU_ARCHITECTURE.X86_64,
+            )
         ) as DeviceSpec.Android
 
         assertThat(spec.emulatorImage).isEqualTo("system-images;android-33;google_apis;x86_64")
     }
 
     @Test
-    fun `resolve throws on unsupported platform`() {
-        assertThrows<IllegalArgumentException> {
-            DeviceCatalog.resolve(
-                platform = "windows",
-                model = null,
-                os = null,
-                locale = null,
-                orientation = null,
-                disableAnimations = null,
-                snapshotKeyHonorModalViews = null,
-                systemArchitecture = null
-            )
-        }
-    }
-
-    @Test
     fun `resolve Android throws on invalid locale combination like ar_US`() {
-        // Arabic is a supported language, US is a supported country,
-        // but ar_US is not a valid Java locale combination
         assertThrows<LocaleValidationException> {
-            DeviceCatalog.resolve(
-                platform = "android",
-                locale = "ar_US",
-                model = null,
-                os = null,
-                orientation = null,
-                disableAnimations = null,
-                snapshotKeyHonorModalViews = null,
-                systemArchitecture = null
-            )
+            DeviceCatalog.resolve(DeviceRequest.Android(locale = "ar_US"))
         }
     }
 
     @Test
     fun `resolve Android throws on unsupported language code`() {
         assertThrows<LocaleValidationException> {
-            DeviceCatalog.resolve(
-              platform = "android",
-              locale = "xx_US",
-              model = null,
-              os = null,
-              orientation = null,
-              disableAnimations = null,
-              snapshotKeyHonorModalViews = null,
-              systemArchitecture = null
-            )
+            DeviceCatalog.resolve(DeviceRequest.Android(locale = "xx_US"))
         }
     }
 
     @Test
     fun `resolve Android throws on malformed locale missing country`() {
         assertThrows<LocaleValidationException> {
-            DeviceCatalog.resolve(
-                platform = "android",
-                locale = "en",
-                model = null,
-                os = null,
-                orientation = null,
-                disableAnimations = null,
-                snapshotKeyHonorModalViews = null,
-                systemArchitecture = null
-            )
+            DeviceCatalog.resolve(DeviceRequest.Android(locale = "en"))
         }
     }
 }


### PR DESCRIPTION
The old DeviceCatalog.resolve() accepted a flat list of nullable params spanning all platforms, forcing callers to pass irrelevant nulls (e.g. systemArchitecture for web, snapshotKeyHonorModalViews for iOS) and making it easy to silently omit new fields.
                                                                                                                                                                                                                 
Introduced a sealed DeviceRequest class with platform-specific subclasses (Android, Ios, Web), each exposing only the fields relevant to that platform. All defaults remain centralized in `resolve()`. Fields default to null so callers only specify what they care about.