### PR TITLE
fix: align web aria-label handling with native accessibilityText behavior

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -296,6 +296,9 @@ class CdpWebDriver(
         if (attrs.containsKey("ignoreBoundsFiltering") && attrs["ignoreBoundsFiltering"] != null) {
             attributes["ignoreBoundsFiltering"] = (attrs["ignoreBoundsFiltering"] as Boolean).toString()
         }
+        if (attrs.containsKey("accessibilityText") && attrs["accessibilityText"] != null) {
+            attributes["accessibilityText"] = attrs["accessibilityText"] as String
+        }
 
         val children = domRepresentation["children"] as List<Map<String, Any>>
 

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -264,6 +264,9 @@ class WebDriver(
         if (attrs.containsKey("ignoreBoundsFiltering") && attrs["ignoreBoundsFiltering"] != null) {
             attributes["ignoreBoundsFiltering"] = (attrs["ignoreBoundsFiltering"] as Boolean).toString()
         }
+        if (attrs.containsKey("accessibilityText") && attrs["accessibilityText"] != null) {
+            attributes["accessibilityText"] = attrs["accessibilityText"] as String
+        }
 
         val children = domRepresentation["children"] as List<Map<String, Any>>
 

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -107,14 +107,18 @@
           bounds: getNodeBounds(node, iframeOffsetX, iframeOffsetY),
       }
 
+      if (node.ariaLabel) {
+          attributes['accessibilityText'] = node.ariaLabel
+      }
+
       // If this is an <option> element, we only want to include it if the parent <select> element is focused.
       if (node.tagName.toLowerCase() === 'option' && !node.parentElement.matches(':focus-within')) {
         return null;
       }
 
-      if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
+      if (!!node.id || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid'] || !!node.ariaLabel) {
         const title = typeof node.title === 'string' ? node.title : null
-        attributes['resource-id'] = node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
+        attributes['resource-id'] = node.id || node.name || title || node.htmlFor || node.attributes['data-testid']?.value || node.ariaLabel
       }
 
       if (node.tagName.toLowerCase() === 'body') {

--- a/maestro-client/src/test/java/maestro/FiltersTest.kt
+++ b/maestro-client/src/test/java/maestro/FiltersTest.kt
@@ -41,6 +41,118 @@ class FiltersTest {
         assertThat(result).isEmpty()
     }
 
+    @Test
+    fun `textMatches finds node by accessibilityText`() {
+        val button = TreeNode(attributes = mutableMapOf(
+            "text" to "",
+            "accessibilityText" to "Add to favourites",
+        ))
+        val nodes = listOf(button)
+
+        val result = Filters.textMatches(Regex("Add to favourites"))(nodes)
+
+        assertThat(result).containsExactly(button)
+    }
+
+    @Test
+    fun `textMatches finds node by text even when accessibilityText differs`() {
+        val button = TreeNode(attributes = mutableMapOf(
+            "text" to "Click me",
+            "accessibilityText" to "Submit button",
+        ))
+
+        val result = Filters.textMatches(Regex("Click me"))(listOf(button))
+
+        assertThat(result).containsExactly(button)
+    }
+
+    @Test
+    fun `textMatches returns union of text and accessibilityText matches`() {
+        val byText = TreeNode(attributes = mutableMapOf("text" to "Search", "bounds" to "0,0,1,1"))
+        val byLabel = TreeNode(attributes = mutableMapOf(
+            "text" to "",
+            "accessibilityText" to "Search",
+            "bounds" to "0,0,2,2",
+        ))
+        val noMatch = TreeNode(attributes = mutableMapOf("text" to "Cancel", "bounds" to "0,0,3,3"))
+
+        val result = Filters.textMatches(Regex("Search"))(listOf(byText, byLabel, noMatch))
+
+        assertThat(result).containsExactly(byText, byLabel)
+    }
+
+    @Test
+    fun `textMatches does not duplicate when text and accessibilityText both match`() {
+        val button = TreeNode(attributes = mutableMapOf(
+            "text" to "Save",
+            "accessibilityText" to "Save",
+        ))
+
+        val result = Filters.textMatches(Regex("Save"))(listOf(button))
+
+        assertThat(result).containsExactly(button)
+    }
+
+    @Test
+    fun `textMatches does not match accessibilityText absent`() {
+        val button = TreeNode(attributes = mutableMapOf("text" to ""))
+
+        val result = Filters.textMatches(Regex("Add to favourites"))(listOf(button))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `idMatches does not match accessibilityText alone`() {
+        val button = TreeNode(attributes = mutableMapOf(
+            "text" to "",
+            "accessibilityText" to "some-label",
+        ))
+
+        val result = Filters.idMatches(Regex("some-label"))(listOf(button))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `idMatches finds node by resource-id when accessibilityText also present`() {
+        val button = TreeNode(attributes = mutableMapOf(
+            "text" to "",
+            "resource-id" to "test-id",
+            "accessibilityText" to "some-label",
+        ))
+
+        val result = Filters.idMatches(Regex("test-id"))(listOf(button))
+
+        assertThat(result).containsExactly(button)
+    }
+
+    @Test
+    fun `idMatches finds aria-label as resource-id fallback`() {
+        val button = TreeNode(attributes = mutableMapOf(
+            "text" to "",
+            "resource-id" to "Add to favourites",
+            "accessibilityText" to "Add to favourites",
+        ))
+
+        val result = Filters.idMatches(Regex("Add to favourites"))(listOf(button))
+
+        assertThat(result).containsExactly(button)
+    }
+
+    @Test
+    fun `idMatches prefers data-testid over aria-label in resource-id`() {
+        val button = TreeNode(attributes = mutableMapOf(
+            "text" to "",
+            "resource-id" to "submit-btn",
+            "accessibilityText" to "Submit form",
+        ))
+
+        val result = Filters.idMatches(Regex("Submit form"))(listOf(button))
+
+        assertThat(result).isEmpty()
+    }
+
     private fun sampleNodes(): List<TreeNode> {
         return listOf(
             node(bounds(0, 0)),

--- a/maestro-client/src/test/java/maestro/drivers/CdpWebDriverParseDomTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/CdpWebDriverParseDomTest.kt
@@ -1,0 +1,219 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class CdpWebDriverParseDomTest {
+
+    private val driver = CdpWebDriver(
+        isStudio = false,
+        screenSize = null,
+    )
+
+    private fun node(
+        text: String = "",
+        bounds: String = "0,0,100,100",
+        resourceId: String? = null,
+        selected: Boolean? = null,
+        synthetic: Boolean? = null,
+        ignoreBoundsFiltering: Boolean? = null,
+        accessibilityText: String? = null,
+        children: List<Map<String, Any>> = emptyList(),
+    ): Map<String, Any> {
+        val attrs = mutableMapOf<String, Any>(
+            "text" to text,
+            "bounds" to bounds,
+        )
+        if (resourceId != null) attrs["resource-id"] = resourceId
+        if (selected != null) attrs["selected"] = selected
+        if (synthetic != null) attrs["synthetic"] = synthetic
+        if (ignoreBoundsFiltering != null) attrs["ignoreBoundsFiltering"] = ignoreBoundsFiltering
+        if (accessibilityText != null) attrs["accessibilityText"] = accessibilityText
+        return mapOf(
+            "attributes" to attrs,
+            "children" to children,
+        )
+    }
+
+    @Test
+    fun `parses text and bounds`() {
+        val result = driver.parseDomAsTreeNodes(node(text = "Hello", bounds = "10,20,30,40"))
+
+        assertThat(result.attributes["text"]).isEqualTo("Hello")
+        assertThat(result.attributes["bounds"]).isEqualTo("10,20,30,40")
+        assertThat(result.children).isEmpty()
+    }
+
+    @Test
+    fun `handles empty text`() {
+        val result = driver.parseDomAsTreeNodes(node(text = ""))
+
+        assertThat(result.attributes["text"]).isEqualTo("")
+    }
+
+    @Test
+    fun `does not include optional attributes when absent`() {
+        val result = driver.parseDomAsTreeNodes(node())
+
+        assertThat(result.attributes).containsExactly("text", "", "bounds", "0,0,100,100")
+    }
+
+    @Test
+    fun `parses resource-id`() {
+        val result = driver.parseDomAsTreeNodes(node(resourceId = "my-button"))
+
+        assertThat(result.attributes["resource-id"]).isEqualTo("my-button")
+    }
+
+    @Test
+    fun `parses selected true`() {
+        val result = driver.parseDomAsTreeNodes(node(selected = true))
+
+        assertThat(result.attributes["selected"]).isEqualTo("true")
+    }
+
+    @Test
+    fun `parses selected false`() {
+        val result = driver.parseDomAsTreeNodes(node(selected = false))
+
+        assertThat(result.attributes["selected"]).isEqualTo("false")
+    }
+
+    @Test
+    fun `parses synthetic`() {
+        val result = driver.parseDomAsTreeNodes(node(synthetic = true))
+
+        assertThat(result.attributes["synthetic"]).isEqualTo("true")
+    }
+
+    @Test
+    fun `parses ignoreBoundsFiltering`() {
+        val result = driver.parseDomAsTreeNodes(node(ignoreBoundsFiltering = true))
+
+        assertThat(result.attributes["ignoreBoundsFiltering"]).isEqualTo("true")
+    }
+
+    @Test
+    fun `parses accessibilityText`() {
+        val result = driver.parseDomAsTreeNodes(node(accessibilityText = "Add to favourites"))
+
+        assertThat(result.attributes["accessibilityText"]).isEqualTo("Add to favourites")
+    }
+
+    @Test
+    fun `accessibilityText with special characters`() {
+        val result = driver.parseDomAsTreeNodes(node(accessibilityText = "★ Close (dialog) — 日本語"))
+
+        assertThat(result.attributes["accessibilityText"]).isEqualTo("★ Close (dialog) — 日本語")
+    }
+
+    @Test
+    fun `accessibilityText does not affect resource-id`() {
+        val result = driver.parseDomAsTreeNodes(node(accessibilityText = "label"))
+
+        assertThat(result.attributes).doesNotContainKey("resource-id")
+    }
+
+    @Test
+    fun `accessibilityText coexists with resource-id`() {
+        val result = driver.parseDomAsTreeNodes(
+            node(accessibilityText = "Submit", resourceId = "btn-submit")
+        )
+
+        assertThat(result.attributes["accessibilityText"]).isEqualTo("Submit")
+        assertThat(result.attributes["resource-id"]).isEqualTo("btn-submit")
+    }
+
+    @Test
+    fun `parses all optional attributes together`() {
+        val result = driver.parseDomAsTreeNodes(
+            node(
+                text = "Click me",
+                resourceId = "btn-1",
+                selected = true,
+                synthetic = true,
+                ignoreBoundsFiltering = true,
+                accessibilityText = "Submit form",
+            )
+        )
+
+        assertThat(result.attributes).containsExactly(
+            "text", "Click me",
+            "bounds", "0,0,100,100",
+            "resource-id", "btn-1",
+            "selected", "true",
+            "synthetic", "true",
+            "ignoreBoundsFiltering", "true",
+            "accessibilityText", "Submit form",
+        )
+    }
+
+    @Test
+    fun `parses children recursively`() {
+        val dom = node(
+            text = "parent",
+            children = listOf(
+                node(text = "child1", accessibilityText = "label1"),
+                node(text = "child2"),
+            ),
+        )
+
+        val result = driver.parseDomAsTreeNodes(dom)
+
+        assertThat(result.children).hasSize(2)
+        assertThat(result.children[0].attributes["text"]).isEqualTo("child1")
+        assertThat(result.children[0].attributes["accessibilityText"]).isEqualTo("label1")
+        assertThat(result.children[1].attributes["text"]).isEqualTo("child2")
+        assertThat(result.children[1].attributes).doesNotContainKey("accessibilityText")
+    }
+
+    @Test
+    fun `parses deeply nested children`() {
+        val dom = node(
+            text = "root",
+            children = listOf(
+                node(
+                    text = "level1",
+                    children = listOf(
+                        node(text = "level2", accessibilityText = "deep label"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = driver.parseDomAsTreeNodes(dom)
+
+        val grandchild = result.children[0].children[0]
+        assertThat(grandchild.attributes["text"]).isEqualTo("level2")
+        assertThat(grandchild.attributes["accessibilityText"]).isEqualTo("deep label")
+    }
+
+    @Test
+    fun `handles empty children list`() {
+        val result = driver.parseDomAsTreeNodes(node(children = emptyList()))
+
+        assertThat(result.children).isEmpty()
+    }
+
+    @Test
+    fun `skips null optional attribute values`() {
+        val attrs = mutableMapOf<String, Any?>(
+            "text" to "hi",
+            "bounds" to "0,0,1,1",
+            "resource-id" to null,
+            "selected" to null,
+            "synthetic" to null,
+            "ignoreBoundsFiltering" to null,
+            "accessibilityText" to null,
+        )
+        @Suppress("UNCHECKED_CAST")
+        val dom = mapOf(
+            "attributes" to (attrs as Map<String, Any>),
+            "children" to emptyList<Map<String, Any>>(),
+        )
+
+        val result = driver.parseDomAsTreeNodes(dom)
+
+        assertThat(result.attributes).containsExactly("text", "hi", "bounds", "0,0,1,1")
+    }
+}

--- a/maestro-client/src/test/java/maestro/drivers/MaestroWebJsSmokeTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/MaestroWebJsSmokeTest.kt
@@ -1,0 +1,124 @@
+package maestro.drivers
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.google.common.truth.Truth.assertThat
+import maestro.Maestro
+import org.graalvm.polyglot.Context
+import org.junit.jupiter.api.Test
+
+class MaestroWebJsSmokeTest {
+
+    private val mapper = jacksonObjectMapper()
+    private val maestroWebScript = Maestro::class.java.getResourceAsStream("/maestro-web.js")?.bufferedReader()?.use {
+        it.readText()
+    } ?: error("Could not read maestro web script")
+
+    @Test
+    fun `maestro web maps aria-label to accessibilityText and keeps resource-id fallback behavior`() {
+        val buttons = buttonAttributes(
+            """
+            {
+              tagName: 'body',
+              children: [
+                createElement({
+                  tagName: 'button',
+                  ariaLabel: 'Some label',
+                  attributes: { 'data-testid': { value: 'some-test-id' } },
+                  children: [createElement({ tagName: 'svg' })]
+                }),
+                createElement({
+                  tagName: 'button',
+                  ariaLabel: 'Fallback label',
+                  children: [createElement({ tagName: 'svg' })]
+                })
+              ]
+            }
+            """.trimIndent()
+        )
+
+        assertThat(buttons).hasSize(2)
+
+        assertThat(buttons[0]["accessibilityText"]).isEqualTo("Some label")
+        assertThat(buttons[0]["resource-id"]).isEqualTo("some-test-id")
+        assertThat(buttons[1]["accessibilityText"]).isEqualTo("Fallback label")
+        assertThat(buttons[1]["resource-id"]).isEqualTo("Fallback label")
+    }
+
+    private fun buttonAttributes(bodyProps: String): List<Map<String, Any?>> {
+        val root = contentDescription(bodyProps)
+        @Suppress("UNCHECKED_CAST")
+        val children = root["children"] as List<Map<String, Any?>>
+        return children.map {
+            @Suppress("UNCHECKED_CAST")
+            it["attributes"] as Map<String, Any?>
+        }
+    }
+
+    private fun contentDescription(bodyProps: String): Map<String, Any?> {
+        val source = """
+            const Node = { TEXT_NODE: 3 };
+            globalThis.Node = Node;
+
+            function createElement(props = {}) {
+              const node = {
+                tagName: props.tagName || 'div',
+                ariaLabel: props.ariaLabel,
+                id: props.id,
+                name: props.name,
+                title: props.title,
+                htmlFor: props.htmlFor,
+                value: props.value,
+                placeholder: props.placeholder,
+                selected: props.selected,
+                attributes: props.attributes || {},
+                childNodes: props.childNodes || [],
+                children: props.children || [],
+                getBoundingClientRect: () => ({
+                  x: props.x || 0,
+                  y: props.y || 0,
+                  width: props.width || 40,
+                  height: props.height || 20,
+                }),
+                matches: (selector) => selector === ':focus-within' ? !!props.focusWithin : false,
+              };
+
+              node.parentElement = null;
+              node.parentNode = null;
+
+              node.children.forEach((child) => {
+                child.parentElement = node;
+                child.parentNode = node;
+              });
+
+              node.childNodes.forEach((child) => {
+                if (typeof child === 'object') {
+                  child.parentNode = node;
+                }
+              });
+
+              return node;
+            }
+
+            globalThis.window = {
+              innerWidth: 100,
+              innerHeight: 200,
+              maestro: {},
+            };
+
+            globalThis.document = {
+              readyState: 'complete',
+            };
+
+            document.body = createElement($bodyProps);
+
+            $maestroWebScript
+        """.trimIndent()
+
+        Context.newBuilder("js").allowAllAccess(true).build().use { context ->
+            context.eval("js", source)
+            val json = context.eval("js", "JSON.stringify(window.maestro.getContentDescription())").asString()
+            return mapper.readValue(json)
+        }
+    }
+}

--- a/maestro-client/src/test/java/maestro/drivers/WebDriverParseDomTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/WebDriverParseDomTest.kt
@@ -1,0 +1,224 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import maestro.web.selenium.SeleniumFactory
+import org.junit.jupiter.api.Test
+import org.openqa.selenium.WebDriver as SeleniumWebDriver
+
+class WebDriverParseDomTest {
+
+    private val driver = WebDriver(
+        isStudio = false,
+        seleniumFactory = object : SeleniumFactory {
+            override fun create(): SeleniumWebDriver = throw UnsupportedOperationException()
+        },
+        screenSize = null,
+    )
+
+    private fun node(
+        text: String = "",
+        bounds: String = "0,0,100,100",
+        resourceId: String? = null,
+        selected: Boolean? = null,
+        synthetic: Boolean? = null,
+        ignoreBoundsFiltering: Boolean? = null,
+        accessibilityText: String? = null,
+        children: List<Map<String, Any>> = emptyList(),
+    ): Map<String, Any> {
+        val attrs = mutableMapOf<String, Any>(
+            "text" to text,
+            "bounds" to bounds,
+        )
+        if (resourceId != null) attrs["resource-id"] = resourceId
+        if (selected != null) attrs["selected"] = selected
+        if (synthetic != null) attrs["synthetic"] = synthetic
+        if (ignoreBoundsFiltering != null) attrs["ignoreBoundsFiltering"] = ignoreBoundsFiltering
+        if (accessibilityText != null) attrs["accessibilityText"] = accessibilityText
+        return mapOf(
+            "attributes" to attrs,
+            "children" to children,
+        )
+    }
+
+    @Test
+    fun `parses text and bounds`() {
+        val result = driver.parseDomAsTreeNodes(node(text = "Hello", bounds = "10,20,30,40"))
+
+        assertThat(result.attributes["text"]).isEqualTo("Hello")
+        assertThat(result.attributes["bounds"]).isEqualTo("10,20,30,40")
+        assertThat(result.children).isEmpty()
+    }
+
+    @Test
+    fun `handles empty text`() {
+        val result = driver.parseDomAsTreeNodes(node(text = ""))
+
+        assertThat(result.attributes["text"]).isEqualTo("")
+    }
+
+    @Test
+    fun `does not include optional attributes when absent`() {
+        val result = driver.parseDomAsTreeNodes(node())
+
+        assertThat(result.attributes).containsExactly("text", "", "bounds", "0,0,100,100")
+    }
+
+    @Test
+    fun `parses resource-id`() {
+        val result = driver.parseDomAsTreeNodes(node(resourceId = "my-button"))
+
+        assertThat(result.attributes["resource-id"]).isEqualTo("my-button")
+    }
+
+    @Test
+    fun `parses selected true`() {
+        val result = driver.parseDomAsTreeNodes(node(selected = true))
+
+        assertThat(result.attributes["selected"]).isEqualTo("true")
+    }
+
+    @Test
+    fun `parses selected false`() {
+        val result = driver.parseDomAsTreeNodes(node(selected = false))
+
+        assertThat(result.attributes["selected"]).isEqualTo("false")
+    }
+
+    @Test
+    fun `parses synthetic`() {
+        val result = driver.parseDomAsTreeNodes(node(synthetic = true))
+
+        assertThat(result.attributes["synthetic"]).isEqualTo("true")
+    }
+
+    @Test
+    fun `parses ignoreBoundsFiltering`() {
+        val result = driver.parseDomAsTreeNodes(node(ignoreBoundsFiltering = true))
+
+        assertThat(result.attributes["ignoreBoundsFiltering"]).isEqualTo("true")
+    }
+
+    @Test
+    fun `parses accessibilityText`() {
+        val result = driver.parseDomAsTreeNodes(node(accessibilityText = "Add to favourites"))
+
+        assertThat(result.attributes["accessibilityText"]).isEqualTo("Add to favourites")
+    }
+
+    @Test
+    fun `accessibilityText with special characters`() {
+        val result = driver.parseDomAsTreeNodes(node(accessibilityText = "★ Close (dialog) — 日本語"))
+
+        assertThat(result.attributes["accessibilityText"]).isEqualTo("★ Close (dialog) — 日本語")
+    }
+
+    @Test
+    fun `accessibilityText does not affect resource-id`() {
+        val result = driver.parseDomAsTreeNodes(node(accessibilityText = "label"))
+
+        assertThat(result.attributes).doesNotContainKey("resource-id")
+    }
+
+    @Test
+    fun `accessibilityText coexists with resource-id`() {
+        val result = driver.parseDomAsTreeNodes(
+            node(accessibilityText = "Submit", resourceId = "btn-submit")
+        )
+
+        assertThat(result.attributes["accessibilityText"]).isEqualTo("Submit")
+        assertThat(result.attributes["resource-id"]).isEqualTo("btn-submit")
+    }
+
+    @Test
+    fun `parses all optional attributes together`() {
+        val result = driver.parseDomAsTreeNodes(
+            node(
+                text = "Click me",
+                resourceId = "btn-1",
+                selected = true,
+                synthetic = true,
+                ignoreBoundsFiltering = true,
+                accessibilityText = "Submit form",
+            )
+        )
+
+        assertThat(result.attributes).containsExactly(
+            "text", "Click me",
+            "bounds", "0,0,100,100",
+            "resource-id", "btn-1",
+            "selected", "true",
+            "synthetic", "true",
+            "ignoreBoundsFiltering", "true",
+            "accessibilityText", "Submit form",
+        )
+    }
+
+    @Test
+    fun `parses children recursively`() {
+        val dom = node(
+            text = "parent",
+            children = listOf(
+                node(text = "child1", accessibilityText = "label1"),
+                node(text = "child2"),
+            ),
+        )
+
+        val result = driver.parseDomAsTreeNodes(dom)
+
+        assertThat(result.children).hasSize(2)
+        assertThat(result.children[0].attributes["text"]).isEqualTo("child1")
+        assertThat(result.children[0].attributes["accessibilityText"]).isEqualTo("label1")
+        assertThat(result.children[1].attributes["text"]).isEqualTo("child2")
+        assertThat(result.children[1].attributes).doesNotContainKey("accessibilityText")
+    }
+
+    @Test
+    fun `parses deeply nested children`() {
+        val dom = node(
+            text = "root",
+            children = listOf(
+                node(
+                    text = "level1",
+                    children = listOf(
+                        node(text = "level2", accessibilityText = "deep label"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = driver.parseDomAsTreeNodes(dom)
+
+        val grandchild = result.children[0].children[0]
+        assertThat(grandchild.attributes["text"]).isEqualTo("level2")
+        assertThat(grandchild.attributes["accessibilityText"]).isEqualTo("deep label")
+    }
+
+    @Test
+    fun `handles empty children list`() {
+        val result = driver.parseDomAsTreeNodes(node(children = emptyList()))
+
+        assertThat(result.children).isEmpty()
+    }
+
+    @Test
+    fun `skips null optional attribute values`() {
+        val attrs = mutableMapOf<String, Any?>(
+            "text" to "hi",
+            "bounds" to "0,0,1,1",
+            "resource-id" to null,
+            "selected" to null,
+            "synthetic" to null,
+            "ignoreBoundsFiltering" to null,
+            "accessibilityText" to null,
+        )
+        @Suppress("UNCHECKED_CAST")
+        val dom = mapOf(
+            "attributes" to (attrs as Map<String, Any>),
+            "children" to emptyList<Map<String, Any>>(),
+        )
+
+        val result = driver.parseDomAsTreeNodes(dom)
+
+        assertThat(result.attributes).containsExactly("text", "hi", "bounds", "0,0,1,1")
+    }
+}


### PR DESCRIPTION
## Proposed changes

on web, `aria-label` was never stored as `accessibilityText`, so text selectors couldn't find elements by their aria-label. additionally, `aria-label` was incorrectly included in the `resource-id` priority chain ahead of `data-testid`.

this pr:
- maps `aria-label` to `accessibilityText` in `maestro-web.js`, mirroring how android uses `content-desc` and ios uses `AXElement.label`
- moves `aria-label` to the end of the `resource-id` fallback chain (last resort), so it no longer shadows `data-testid` but existing `tapOn: id: "some-aria-label"` tests keep working unless the element also has a higher-priority identifier
- parses `accessibilityText` in both `WebDriver.kt` and `CdpWebDriver.kt`

## Testing

added 45 unit tests covering:
- `parseDomAsTreeNodes` for both `WebDriver` and `CdpWebDriver` (all attribute branches, null guards, recursive children)
- `Filters.textMatches` matching on `accessibilityText`
- `Filters.idMatches` not matching on `accessibilityText`

## Issues fixed

fixes #2914
fixes #3049