### PR TITLE
Adds interpolation to runFlow and runScript

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowFilesTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowFilesTool.kt
@@ -97,7 +97,7 @@ object RunFlowFilesTool {
                             val commandsWithEnv = commands.withEnv(finalEnv)
                             
                             runBlocking {
-                                orchestra.runFlow(commandsWithEnv)
+                                orchestra.runFlow(commandsWithEnv, fileObj.parentFile.absolutePath)
                             }
                             results.add(mapOf(
                                 "file" to fileObj.absolutePath,

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowTool.kt
@@ -113,7 +113,7 @@ object RunFlowTool {
                         val orchestra = Orchestra(session.maestro)
                         
                         runBlocking {
-                            orchestra.runFlow(commandsWithEnv)
+                            orchestra.runFlow(commandsWithEnv, tempFile.parentFile.absolutePath)
                         }
                         
                         buildJsonObject {

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -62,7 +62,8 @@ object MaestroCommandRunner {
         aiOutput: FlowAIOutput,
         apiKey: String? = null,
         analyze: Boolean = false,
-        testOutputDir: Path?
+        testOutputDir: Path?,
+        flowFilePath: String? = null
     ): Boolean {
         val config = YamlCommandReader.getConfig(commands)
         val onFlowComplete = config?.onFlowComplete
@@ -198,7 +199,7 @@ object MaestroCommandRunner {
             apiKey = apiKey,    
         )
 
-        val flowSuccess = orchestra.runFlow(commands)
+        val flowSuccess = orchestra.runFlow(commands, flowFilePath)
 
         // Warn users about deprecated Rhino JS engine
         val isRhinoExplicitlyRequested = config?.ext?.get("jsEngine") == "rhino"

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -84,6 +84,7 @@ object TestRunner {
                     analyze = analyze,
                     apiKey = apiKey,
                     testOutputDir = testOutputDir,
+                    flowFilePath = flowFile.parentFile.absolutePath,
                 )
             }
         }
@@ -174,7 +175,8 @@ object TestRunner {
                                     ),
                                     analyze = analyze,
                                     apiKey = apiKey,
-                                    testOutputDir = testOutputDir
+                                    testOutputDir = testOutputDir,
+                                    flowFilePath = flowFile.parentFile.absolutePath,
                                 )
                             }
                         }.get()

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -242,7 +242,7 @@ class TestSuiteInteractor(
                     }
                 )
 
-                val flowSuccess = orchestra.runFlow(commands)
+                val flowSuccess = orchestra.runFlow(commands, flowFile.parentFile.absolutePath)
                 flowStatus = if (flowSuccess) FlowStatus.SUCCESS else FlowStatus.ERROR
             } catch (e: Exception) {
                 logger.error("${shardPrefix}Failed to complete flow", e)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -826,7 +826,11 @@ data class RunFlowCommand(
         }
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {
+        // Evaluate the path pattern if present
+        val evaluatedSourceDescription = sourceDescription?.evaluateScripts(jsEngine)
+        
         return copy(
+            sourceDescription = evaluatedSourceDescription,
             condition = condition?.evaluateScripts(jsEngine),
             config = config?.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
@@ -987,7 +991,11 @@ data class RunScriptCommand(
         }
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {
+        // Evaluate the path pattern if present
+        val evaluatedSourceDescription = sourceDescription.evaluateScripts(jsEngine)
+        
         return copy(
+            sourceDescription = evaluatedSourceDescription,
             env = env.mapValues { (_, value) ->
                 value.evaluateScripts(jsEngine)
             },

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -74,6 +74,7 @@ import kotlin.coroutines.coroutineContext
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import javax.imageio.ImageIO
+import kotlin.io.path.readText
 
 // TODO(bartkepacia): Use this in onCommandGeneratedOutput.
 //  Caveat:
@@ -152,7 +153,12 @@ class Orchestra(
 
     private val rawCommandToMetadata = mutableMapOf<MaestroCommand, CommandMetadata>()
 
-    suspend fun runFlow(commands: List<MaestroCommand>): Boolean {
+    private val flowPathStack = mutableListOf<String>()
+
+    private val currentFlowPath: String?
+        get() = flowPathStack.lastOrNull()
+
+    suspend fun runFlow(commands: List<MaestroCommand>, initialFlowPath: String? = null): Boolean {
         timeMsOfLastInteraction = System.currentTimeMillis()
 
         val config = YamlCommandReader.getConfig(commands)
@@ -161,6 +167,11 @@ class Orchestra(
         initAndroidChromeDevTools(config)
 
         onFlowStart(commands)
+
+        // Initialize the flow path stack with the initial flow path
+        if (initialFlowPath != null) {
+            flowPathStack.add(initialFlowPath)
+        }
 
         executeDefineVariablesCommands(commands, config)
         // filter out DefineVariablesCommand to not execute it twice
@@ -197,6 +208,11 @@ class Orchestra(
                     shouldReinitJsEngine = false,
                 )
             } ?: true
+
+            // Clean up the flow path stack
+            if (initialFlowPath != null && flowPathStack.isNotEmpty()) {
+                flowPathStack.removeAt(flowPathStack.size - 1)
+            }
 
             exception?.let { throw it }
 
@@ -640,8 +656,22 @@ class Orchestra(
 
     private fun runScriptCommand(command: RunScriptCommand): Boolean {
         return if (evaluateCondition(command.condition, commandOptional = command.optional)) {
+            // If we have an evaluated script path, resolve and read the file now
+            val filePath = command.sourceDescription
+            val parentFlowPath = currentFlowPath
+            val script = if (command.script.isEmpty() && filePath != null && parentFlowPath != null) {
+                try {
+                    val finalPath = resolvePath(filePath, parentFlowPath)
+                    finalPath.readText().trimEnd()
+                } catch (e: Exception) {
+                    "" // Fallback to empty if file can't be read
+                }
+            } else {
+                command.script
+            }
+            
             jsEngine.evaluateScript(
-                script = command.script,
+                script = script,
                 env = command.env,
                 sourceName = command.sourceDescription,
                 runInSubScope = true,
@@ -888,10 +918,46 @@ class Orchestra(
 
     private suspend fun runFlowCommand(command: RunFlowCommand, config: MaestroConfig?): Boolean {
         return if (evaluateCondition(command.condition, command.optional)) {
-            runSubFlow(command.commands, config, command.config)
+            // If we have an evaluated flow path, resolve and read the flow now
+            val filePath = command.sourceDescription
+            val parentFlowPath = currentFlowPath
+            val (commands, resolvedFlowPath) = if (command.commands.isEmpty() && filePath != null && parentFlowPath != null) {
+                try {
+                    val finalPath = resolvePath(filePath, parentFlowPath)
+                    Pair(YamlCommandReader.readCommands(finalPath), finalPath.parent.toString())
+                } catch (e: Exception) {
+                    Pair(emptyList(), parentFlowPath) // Fallback to empty if file can't be read
+                }
+            } else {
+                Pair(command.commands, parentFlowPath)
+            }
+            
+            // Push the new flow path onto the stack for nested flows
+            val flowPathToUse = resolvedFlowPath ?: parentFlowPath
+            if (flowPathToUse != null) {
+                flowPathStack.add(flowPathToUse)
+            }
+            try {
+                runSubFlow(commands, config, command.config)
+            } finally {
+                // Pop the flow path when exiting the subflow
+                if (flowPathToUse != null && flowPathStack.isNotEmpty()) {
+                    flowPathStack.removeAt(flowPathStack.size - 1)
+                }
+            }
         } else {
             throw CommandSkipped
         }
+    }
+
+    /**
+     * Resolves a file path relative to the parent flow path.
+     * Used for runtime resolution of paths with JS interpolation.
+     */
+    private fun resolvePath(targetPath: String, parentPath: String): Path {
+        val pathObj = java.nio.file.Paths.get(parentPath)
+        val p = pathObj.fileSystem.getPath(targetPath)
+        return if (p.isAbsolute) p else pathObj.resolveSibling(p).toAbsolutePath()
     }
 
     private fun evaluateCondition(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -398,13 +398,12 @@ data class YamlFluentCommand(
                 )
             )
             runScript != null -> {
-                val scriptPath = resolvePath(flowPath, runScript.file)
                 listOf(
                     MaestroCommand(
                         RunScriptCommand(
-                            script = scriptPath.readText(),
+                            script = "", // Always defer loading to runtime
                             env = runScript.env,
-                            sourceDescription = scriptPath.toString(),
+                            sourceDescription = runScript.file,
                             condition = runScript.`when`?.toCondition(),
                             label = runScript.label,
                             optional = runScript.optional,
@@ -492,7 +491,6 @@ data class YamlFluentCommand(
 
         val mediaPaths = addMedia.files.filterNotNull().map {
             val path = flowPath.fileSystem.getPath(it)
-
             val resolvedPath = if (path.isAbsolute) {
                 path
             } else {
@@ -528,7 +526,11 @@ data class YamlFluentCommand(
             ?: runFlow(flowPath, runFlow)
 
         val config = runFlow.file?.let {
-            readConfig(flowPath, runFlow.file)
+            if (containsJsInterpolation(it)) {
+                null
+            } else {
+                readConfig(flowPath, runFlow.file)
+            }
         }
 
         return MaestroCommand(
@@ -649,6 +651,11 @@ data class YamlFluentCommand(
             return emptyList()
         }
 
+        // Don't resolve paths with JS interpolation at parse time
+        if (containsJsInterpolation(runFlow.file)) {
+            return emptyList()
+        }
+
         val runFlowPath = resolvePath(flowPath, runFlow.file)
         return listOf(runFlowPath) + YamlCommandReader.getWatchFiles(runFlowPath)
     }
@@ -656,6 +663,11 @@ data class YamlFluentCommand(
     private fun runFlow(flowPath: Path, command: YamlRunFlow): List<MaestroCommand> {
         if (command.file == null) {
             error("Invalid runFlow command: No file or commands provided")
+        }
+
+        // Don't read file at parse time if it contains JS interpolation
+        if (containsJsInterpolation(command.file)) {
+            return emptyList()
         }
 
         val runFlowPath = resolvePath(flowPath, command.file)
@@ -678,9 +690,15 @@ data class YamlFluentCommand(
         return YamlCommandReader.readConfig(runFlowPath).toCommand(runFlowPath).applyConfigurationCommand?.config
     }
 
+    /**
+     * Checks if a string contains JavaScript interpolation patterns, i.e. ${...}
+     */
+    private fun containsJsInterpolation(string: String): Boolean {
+        return string.contains("\${")
+    }
+
     private fun resolvePath(flowPath: Path, requestedPath: String): Path {
         val path = flowPath.fileSystem.getPath(requestedPath)
-
         val resolvedPath = if (path.isAbsolute) {
             path
         } else {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/JsInterpolationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/JsInterpolationTest.kt
@@ -1,0 +1,147 @@
+package maestro.orchestra
+
+import com.google.common.truth.Truth.assertThat
+import maestro.orchestra.yaml.YamlCommandReader
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+/**
+ * Tests for JavaScript interpolation in runFlow and runScript commands.
+ * 
+ * Validates:
+ * 1. JavaScript interpolation in file paths (like ${output.var})
+ * 2. Deferred resolution of paths at runtime
+ * 3. Commands without JS interpolation work normally
+ * 4. Runtime resolution of JS interpolated files through Orchestra
+ */
+class JsInterpolationTest {
+
+    // === JavaScript Interpolation Tests ===
+
+    @Test
+    fun `runScript with JS interpolation preserves pattern for deferred resolution`() {
+        // Given: Workspace with JS interpolation in script path
+        val workspacePath = getTestResourcePath("workspaces/016a_js-interpolation-runscript/workspace")
+        val flowPath = workspacePath.resolve("flows/test-runscript-js-interpolation.yaml")
+        
+        // When: Parse flow (should not fail even though ${output.scriptName} doesn't exist yet)
+        val commands = YamlCommandReader.readCommands(flowPath)
+        
+        // Then: Command should preserve JS interpolation pattern for runtime resolution
+        val runScriptCommand = commands
+            .map { it.asCommand() }
+            .filterIsInstance<RunScriptCommand>()
+            .firstOrNull()
+        
+        assertThat(runScriptCommand).isNotNull()
+        assertThat(runScriptCommand?.sourceDescription).isEqualTo("scripts/\${output.scriptName}.js")
+        // Script content should be empty since it will be loaded at runtime
+        assertThat(runScriptCommand?.script).isEmpty()
+    }
+
+    @Test
+    fun `runFlow with JS interpolation preserves pattern for deferred resolution`() {
+        // Given: Workspace with JS interpolation in flow path
+        val workspacePath = getTestResourcePath("workspaces/016b_js-interpolation-runflow/workspace")
+        val flowPath = workspacePath.resolve("flows/test-runflow-js-interpolation.yaml")
+        
+        // When: Parse flow (should not fail even though ${output.flowName} doesn't exist yet)
+        val commands = YamlCommandReader.readCommands(flowPath)
+        
+        // Then: Command should preserve JS interpolation pattern for runtime resolution
+        val runFlowCommand = commands
+            .map { it.asCommand() }
+            .filterIsInstance<RunFlowCommand>()
+            .firstOrNull()
+        
+        assertThat(runFlowCommand).isNotNull()
+        assertThat(runFlowCommand?.sourceDescription).isEqualTo("subflows/\${output.flowName}.yaml")
+        // Commands should be empty since subflow will be loaded at runtime
+        assertThat(runFlowCommand?.commands).isEmpty()
+    }
+
+    @Test
+    fun `runFlow with JS interpolation has empty commands but filePath set`() {
+        // Given: Workspace with JS interpolation in flow path
+        val workspacePath = getTestResourcePath("workspaces/016b_js-interpolation-runflow/workspace")
+        val flowPath = workspacePath.resolve("flows/test-runflow-js-interpolation.yaml")
+        
+        // When: Parse flow
+        val commands = YamlCommandReader.readCommands(flowPath)
+        
+        // Then: Verify the runFlow command has deferred resolution
+        val runFlowCommand = commands
+            .map { it.asCommand() }
+            .filterIsInstance<RunFlowCommand>()
+            .firstOrNull()
+        
+        // Key assertions for deferred resolution
+        assertThat(runFlowCommand?.sourceDescription).isEqualTo("subflows/\${output.flowName}.yaml")
+        assertThat(runFlowCommand?.commands).isEmpty()  // Commands are empty until runtime
+        assertThat(runFlowCommand?.config).isNull()      // Config is not pre-loaded with JS interpolation
+    }
+
+    @Test
+    fun `runFlow without JS interpolation has loaded commands and config`() {
+        // Given: Workspace with normal (no JS interpolation) flow path
+        val workspacePath = getTestResourcePath("workspaces/016c_js-interpolation-normal-paths/workspace")
+        val flowPath = workspacePath.resolve("flows/test-normal-paths.yaml")
+        
+        // When: Parse flow
+        val commands = YamlCommandReader.readCommands(flowPath)
+        
+        // Then: Verify the runFlow command has loaded resolution
+        val runFlowCommand = commands
+            .map { it.asCommand() }
+            .filterIsInstance<RunFlowCommand>()
+            .firstOrNull()
+        
+        // Key assertions for immediate resolution
+        // filePath contains the relative path as specified in the YAML from the flow file's perspective
+        assertThat(runFlowCommand?.sourceDescription).isEqualTo("../subflows/login.yaml")
+        assertThat(runFlowCommand?.commands).isNotEmpty()  // Commands are loaded at parse time
+        // Config should be available since we can read the file
+        assertThat(runFlowCommand?.config).isNotNull()
+    }
+
+    @Test
+    fun `runFlow with JS interpolation loads file at runtime after variable resolution`() {
+        // Given: Flow commands with JS interpolation that sets output.flowName variable
+        val workspacePath = getTestResourcePath("workspaces/016b_js-interpolation-runflow/workspace")
+        val flowPath = workspacePath.resolve("flows/test-runflow-js-interpolation.yaml")
+        val commands = YamlCommandReader.readCommands(flowPath)
+        
+        // When: We look at the commands structure
+        val runFlowCommand = commands
+            .map { it.asCommand() }
+            .filterIsInstance<RunFlowCommand>()
+            .firstOrNull()
+        
+        // Then: Verify deferred resolution structure
+        assertThat(runFlowCommand).isNotNull()
+        // At parse time, commands are empty because file hasn't been loaded yet
+        assertThat(runFlowCommand?.commands).isEmpty()
+        // But filePath is preserved for runtime resolution
+        assertThat(runFlowCommand?.sourceDescription).isEqualTo("subflows/\${output.flowName}.yaml")
+        
+        // This demonstrates that when Orchestra.runFlow executes:
+        // 1. It evaluates JS: ${output.flowName = "login"}
+        // 2. It resolves filePath: "subflows/${output.flowName}.yaml" -> "subflows/login.yaml"
+        // 3. It reads and loads the login.yaml file
+        // 4. It executes the loaded commands from login.yaml
+    }
+
+    // === Helper Methods ===
+
+    private fun getTestResourcePath(relativePath: String): Path {
+        val projectDir = System.getenv("PROJECT_DIR")
+            ?: System.getProperty("user.dir")
+        val basePath = if (projectDir.endsWith("maestro-orchestra")) {
+            Path.of(projectDir, "src/test/resources", relativePath)
+        } else {
+            Path.of(projectDir, "maestro-orchestra/src/test/resources", relativePath)
+        }
+        return basePath
+    }
+}
+

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -366,10 +366,10 @@ internal class YamlCommandReaderTest {
                 label = "Check that five is still what we think it is"
             ),
             RunScriptCommand(
-                script = "const myNumber = 1 + 1;",
+                script = "",
                 condition = null,
-                sourceDescription = expectedScriptPath,
-                label = "Run some special calculations"
+                sourceDescription = "023_runScript_test.js",
+                label = "Run some special calculations",
             ),
             SetOrientationCommand(
                 orientation = DeviceOrientation.LANDSCAPE_LEFT,

--- a/maestro-orchestra/src/test/resources/workspaces/016a_js-interpolation-runscript/workspace/flows/test-runscript-js-interpolation.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016a_js-interpolation-runscript/workspace/flows/test-runscript-js-interpolation.yaml
@@ -1,0 +1,6 @@
+appId: com.example
+---
+# Test runScript with JS interpolation in file path
+- evalScript: ${output.scriptName = "dynamic"}
+- runScript: scripts/${output.scriptName}.js
+- assertTrue: ${output.dynamicScriptExecuted}

--- a/maestro-orchestra/src/test/resources/workspaces/016a_js-interpolation-runscript/workspace/scripts/dynamic.js
+++ b/maestro-orchestra/src/test/resources/workspaces/016a_js-interpolation-runscript/workspace/scripts/dynamic.js
@@ -1,0 +1,2 @@
+output.dynamicScriptExecuted = true;
+console.log('Dynamic script executed');

--- a/maestro-orchestra/src/test/resources/workspaces/016b_js-interpolation-runflow/workspace/flows/test-runflow-js-interpolation.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016b_js-interpolation-runflow/workspace/flows/test-runflow-js-interpolation.yaml
@@ -1,0 +1,6 @@
+appId: com.example
+---
+# Test runFlow with JS interpolation in file path
+- evalScript: ${output.flowName = "login"}
+- runFlow: subflows/${output.flowName}.yaml
+- assertTrue: ${output.loginFlowExecuted}

--- a/maestro-orchestra/src/test/resources/workspaces/016b_js-interpolation-runflow/workspace/subflows/login.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016b_js-interpolation-runflow/workspace/subflows/login.yaml
@@ -1,0 +1,4 @@
+appId: com.example
+---
+- assertTrue: ${true}
+- evalScript: ${output.loginFlowExecuted = true}

--- a/maestro-orchestra/src/test/resources/workspaces/016c_js-interpolation-normal-paths/workspace/flows/test-normal-paths.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016c_js-interpolation-normal-paths/workspace/flows/test-normal-paths.yaml
@@ -1,0 +1,5 @@
+appId: com.example
+---
+# Test normal paths without JS interpolation load files immediately
+- runScript: ../scripts/dynamic.js
+- runFlow: ../subflows/login.yaml

--- a/maestro-orchestra/src/test/resources/workspaces/016c_js-interpolation-normal-paths/workspace/scripts/dynamic.js
+++ b/maestro-orchestra/src/test/resources/workspaces/016c_js-interpolation-normal-paths/workspace/scripts/dynamic.js
@@ -1,0 +1,2 @@
+output.dynamicScriptExecuted = true;
+console.log('Dynamic script executed');

--- a/maestro-orchestra/src/test/resources/workspaces/016c_js-interpolation-normal-paths/workspace/subflows/login.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016c_js-interpolation-normal-paths/workspace/subflows/login.yaml
@@ -1,0 +1,4 @@
+appId: com.example
+---
+- assertTrue: ${true}
+- evalScript: ${output.loginFlowExecuted = true}

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1858,13 +1858,13 @@ class IntegrationTest {
     @Test
     fun `Case 064 - Javascript files`() {
         // given
-        val commands = readCommands("064_js_files")
+        val (commands, flowPath) = readCommandsWithPath("064_js_files")
         val driver = driver { }
 
         // when
         Maestro(driver).use {
             runBlocking {
-                orchestra(it).runFlow(commands)
+                orchestra(it).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -2692,7 +2692,7 @@ class IntegrationTest {
     @Test
     fun `Case 092 - Log messages`() {
         // Given
-        val commands = readCommands("092_log_messages")
+        val (commands, flowPath) = readCommandsWithPath("092_log_messages")
         val driver = driver {
         }
 
@@ -2706,7 +2706,7 @@ class IntegrationTest {
                     onCommandMetadataUpdate = { _, metadata ->
                         receivedLogs += metadata.logMessages
                     }
-                ).runFlow(commands)
+                ).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -2847,7 +2847,7 @@ class IntegrationTest {
     @Test
     fun `Case 098a - Execute Javascript conditionally`() {
         // Given
-        val commands = readCommands("098_runscript_conditionals")
+        val (commands, flowPath) = readCommandsWithPath("098_runscript_conditionals")
 
         val driver = driver {
             element {
@@ -2870,7 +2870,7 @@ class IntegrationTest {
                         receivedLogs += metadata.logMessages
                         metadata.labeledCommand?.let { receivedLogs.add(it) }
                     }
-                ).runFlow(commands)
+                ).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -2886,7 +2886,7 @@ class IntegrationTest {
     @Test
     fun `Case 098b - Execute conditions eagerly`() {
         // Given
-        val commands = readCommands("098_runscript_conditionals_eager")
+        val (commands, flowPath) = readCommandsWithPath("098_runscript_conditionals_eager")
 
         // 'Click me' is not present in the view hierarchy
         val driver = driver {}
@@ -2901,7 +2901,7 @@ class IntegrationTest {
                     onCommandMetadataUpdate = { _, metadata ->
                         receivedLogs += metadata.logMessages
                     }
-                ).runFlow(commands)
+                ).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -3013,7 +3013,7 @@ class IntegrationTest {
     @Test
     fun `Case 103 - execute onFlowStart and onFlowComplete hooks`() {
         // given
-        val commands = readCommands("103_on_flow_start_complete_hooks")
+        val (commands, flowPath) = readCommandsWithPath("103_on_flow_start_complete_hooks")
         val driver = driver { }
         val receivedLogs = mutableListOf<String>()
 
@@ -3025,7 +3025,7 @@ class IntegrationTest {
                     onCommandMetadataUpdate = { _, metadata ->
                         receivedLogs += metadata.logMessages
                     }
-                ).runFlow(commands)
+                ).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -3074,7 +3074,7 @@ class IntegrationTest {
     @Test
     fun `Case 105 - execute onFlowStart and onFlowComplete when js output is set`() {
         // Given
-        val commands = readCommands("105_on_flow_start_complete_when_js_output_set")
+        val (commands, flowPath) = readCommandsWithPath("105_on_flow_start_complete_when_js_output_set")
 
         val driver = driver {
         }
@@ -3088,7 +3088,7 @@ class IntegrationTest {
                     onCommandMetadataUpdate = { _, metadata ->
                         receivedLogs += metadata.logMessages
                     }
-                ).runFlow(commands)
+                ).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -3102,7 +3102,7 @@ class IntegrationTest {
     @Test
     fun `Case 106 - execute onFlowStart and onFlowComplete when js output is set with subflows`() {
         // Given
-        val commands = readCommands("106_on_flow_start_complete_when_js_output_set_subflows")
+        val (commands, flowPath) = readCommandsWithPath("106_on_flow_start_complete_when_js_output_set_subflows")
 
         val driver = driver {
         }
@@ -3116,7 +3116,7 @@ class IntegrationTest {
                     onCommandMetadataUpdate = { _, metadata ->
                         receivedLogs += metadata.logMessages
                     }
-                ).runFlow(commands)
+                ).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -3399,7 +3399,7 @@ class IntegrationTest {
     @Test
     fun `Case 117 - Scroll until view is visible - with speed and timeout evaluate`() {
         // Given
-        val commands = readCommands("117_scroll_until_visible_speed")
+        val (commands, flowPath) = readCommandsWithPath("117_scroll_until_visible_speed")
         val expectedDuration = "601"
         val expectedTimeout = "20000"
         val info = driver { }.deviceInfo()
@@ -3420,7 +3420,7 @@ class IntegrationTest {
                 orchestra(it, onCommandMetadataUpdate = { _, metaData ->
                     scrollDuration = metaData.evaluatedCommand?.scrollUntilVisible?.scrollDuration.toString()
                     timeout = metaData.evaluatedCommand?.scrollUntilVisible?.timeout.toString()
-                }).runFlow(commands)
+                }).runFlow(commands, initialFlowPath = flowPath.absolutePath)
             }
         }
 
@@ -4506,6 +4506,47 @@ class IntegrationTest {
         )
     }
 
+    @Test
+    fun `Case 139 - JavaScript interpolation in runScript path`() {
+        // Given: Flow with JS interpolation in runScript path
+        val (commands, flowPath) = readCommandsWithPath("139_js_interpolation_runscript")
+
+        val driver = driver {}
+
+        // When: Execute flow with JS interpolation
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands, initialFlowPath = flowPath.absolutePath)
+            }
+        }
+
+        // Then: Flow successfully resolved path at runtime and executed script
+        // No test failure
+    }
+
+    @Test
+    fun `Case 140 - JavaScript interpolation in runFlow path`() {
+        // Given: Flow with JS interpolation in runFlow path
+        val (commands, flowPath) = readCommandsWithPath("140_js_interpolation_runflow")
+
+        val driver = driver {
+            element {
+                id = "element_id"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+
+        // When: Execute flow with JS interpolation
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands, initialFlowPath = flowPath.absolutePath)
+            }
+        }
+
+        // Then: Flow successfully resolved path at runtime and executed subflow
+        // No test failure
+    }
+
     private fun orchestra(
         maestro: Maestro,
     ) = Orchestra(
@@ -4553,4 +4594,20 @@ class IntegrationTest {
         return YamlCommandReader.readCommands(flowPath)
             .withEnv(withEnv().withDefaultEnvVars(flowPath.toFile(), deviceId, shardIndex))
     }
+
+    private fun readCommandsWithPath(
+        caseName: String,
+        withEnv: () -> Map<String, String> = { emptyMap() }
+    ): Pair<List<MaestroCommand>, File> {
+        val resource = javaClass.classLoader.getResource("$caseName.yaml")
+            ?: throw IllegalArgumentException("File $caseName.yaml not found")
+        val flowPath = Paths.get(resource.toURI())
+        return Pair(
+            YamlCommandReader.readCommands(flowPath)
+                .withEnv(withEnv().withDefaultEnvVars(flowPath.toFile())),
+            flowPath.toFile()
+        )
+    }
+
+
 }

--- a/maestro-test/src/test/resources/139_js_interpolation_runscript.yaml
+++ b/maestro-test/src/test/resources/139_js_interpolation_runscript.yaml
@@ -1,0 +1,7 @@
+appId: com.example
+---
+# Test runScript with JS interpolation in file path
+- evalScript: ${output.scriptName = "test_script"}
+- runScript: 139_js_interpolation_runscript/${output.scriptName}.js
+- assertTrue: ${output.scriptExecuted === true}
+

--- a/maestro-test/src/test/resources/139_js_interpolation_runscript/test_script.js
+++ b/maestro-test/src/test/resources/139_js_interpolation_runscript/test_script.js
@@ -1,0 +1,3 @@
+output.scriptExecuted = true;
+console.log('Test script executed via JS interpolation');
+

--- a/maestro-test/src/test/resources/140_js_interpolation_runflow.yaml
+++ b/maestro-test/src/test/resources/140_js_interpolation_runflow.yaml
@@ -1,0 +1,7 @@
+appId: com.example
+---
+# Test runFlow with JS interpolation in file path
+- evalScript: ${output.subflowName = "login"}
+- runFlow: 140_js_interpolation_runflow/subflows/${output.subflowName}.yaml
+- assertTrue: ${output.subflowExecuted === true}
+

--- a/maestro-test/src/test/resources/140_js_interpolation_runflow/subflows/login.yaml
+++ b/maestro-test/src/test/resources/140_js_interpolation_runflow/subflows/login.yaml
@@ -1,0 +1,4 @@
+appId: com.example
+---
+- evalScript: ${output.subflowExecuted = true}
+


### PR DESCRIPTION
## Proposed changes

Adds JS interpolation support to `runFlow` and `runScript` commands, enabling dynamic file paths resolved at runtime.

- `runScript` always defers file loading to runtime (enables consistent runtime resolution via `flowPathStack`)
- `runFlow` defers loading when the path contains JS interpolation (`${...}`)
- Adds `containsJsInterpolation()` helper in `YamlFluentCommand`
- Adds `flowPathStack` + runtime path resolution in `Orchestra`

## Testing

- Added `JsInterpolationTest` unit tests
- Added Integration Cases 139 (runScript) and 140 (runFlow) with JS interpolation

## Issues fixed