### PR TITLE
fix: load workspace config.yaml when running a single flow file

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -33,7 +33,9 @@ object WorkspaceExecutionPlanner {
             val workspaceConfig = if (config != null) {
                 YamlCommandReader.readWorkspaceConfig(config.absolute())
             } else {
-                WorkspaceConfig()
+                findConfigFileUpwards(input.first().absolute().parent)
+                    ?.let { YamlCommandReader.readWorkspaceConfig(it) }
+                    ?: WorkspaceConfig()
             }
             return ExecutionPlan(
                 flowsToRun = input.toList(),
@@ -167,6 +169,15 @@ object WorkspaceExecutionPlanner {
             .takeIf { it.exists() }
             ?: input.resolve("config.yml")
                 .takeIf { it.exists() }
+    }
+
+    private fun findConfigFileUpwards(start: Path): Path? {
+        var dir: Path? = start
+        while (dir != null) {
+            findConfigFile(dir)?.let { return it }
+            dir = dir.parent
+        }
+        return null
     }
 
     private fun toYamlListString(strings: List<String>): String {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -359,6 +359,42 @@ internal class WorkspaceExecutionPlannerTest {
         )
     }
 
+    @Test
+    internal fun `016 - Single flow file discovers config from parent directory`() {
+        // When
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/016_single_flow_with_config/flow.yaml"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        // Then
+        assertThat(plan.workspaceConfig.platform).isEqualTo(
+            PlatformConfiguration(
+                ios = PlatformConfiguration.IOSConfiguration(snapshotKeyHonorModalViews = false)
+            )
+        )
+    }
+
+    @Test
+    internal fun `016 - Single flow file in subdirectory discovers config from ancestor directory`() {
+        // When
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/016_single_flow_with_config/subdir/nested_flow.yaml"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        // Then
+        assertThat(plan.workspaceConfig.platform).isEqualTo(
+            PlatformConfiguration(
+                ios = PlatformConfiguration.IOSConfiguration(snapshotKeyHonorModalViews = false)
+            )
+        )
+    }
+
     private fun path(path: String): Path? {
         val clazz = WorkspaceExecutionPlannerTest::class.java
         val resource = clazz.getResource(path)?.toURI()

--- a/maestro-orchestra/src/test/resources/workspaces/016_single_flow_with_config/config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016_single_flow_with_config/config.yaml
@@ -1,0 +1,3 @@
+platform:
+  ios:
+    snapshotKeyHonorModalViews: false

--- a/maestro-orchestra/src/test/resources/workspaces/016_single_flow_with_config/flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016_single_flow_with_config/flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/016_single_flow_with_config/subdir/nested_flow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/016_single_flow_with_config/subdir/nested_flow.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp


### PR DESCRIPTION
## Proposed changes

  When running `maestro test path/to/flow.yaml` (a single flow file), the workspace `config.yaml` in the flow's parent directory was not loaded. This meant
  platform configuration like `snapshotKeyHonorModalViews` was silently ignored, even though it worked correctly when running against a directory (`maestro test
  ui-tests/`).

  This also affected retry workflows that run individual flow files after an initial suite failure (e.g. `maestro test ui-tests/reader/copy_paste_verse.yaml`).

  The fix searches upward from the flow file's directory to find the nearest `config.yaml`, matching the existing behavior for directory-based runs.

  ## Testing

  - Ran `maestro test ui-tests/reader/load_scripture.yaml` — verified `snapshotKeyHonorModalViews` from `ui-tests/config.yaml` was loaded (previously `null`)
  - Ran `maestro test /tmp/standalone_flow.yaml` (no config in parent) — verified defaults preserved (`null`)
  - Ran full smoke suite via `run_ui_tests_with_retries.py` matching Bitrise `ui_test` workflow — retries correctly picked up workspace config
  - All existing `WorkspaceExecutionPlannerTest` unit tests pass

  ## Issues fixed

  Fixes https://github.com/mobile-dev-inc/maestro/issues/1644
  Fixes https://github.com/mobile-dev-inc/maestro/issues/1924