### PR TITLE
Store hierarchy with screenshot when an assertion failure occurs

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -117,6 +117,15 @@ object TestDebugReporter {
 
             it.screenshot.copyTo(file)
         }
+
+        // hierarchy
+        debugOutput.commands.values
+            .filter { it.status == CommandStatus.FAILED && it.hierarchy != null }
+            .forEach { metadata ->
+                val filename = "hierarchy-$shardPrefix❌-${metadata.timestamp}-(${flowName.replace("/", "_")}).json"
+                val file = File(path.absolutePathString(), filename)
+                mapper.writeValue(file, metadata.hierarchy)
+            }
     }
 
     fun deleteOldFiles(days: Long = 14) {

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -136,6 +136,13 @@ object MaestroCommandRunner {
                     status = CommandStatus.FAILED
                     calculateDuration()
                     error = e
+                    if (e is MaestroException.AssertionFailure) {
+                        hierarchy = e.hierarchyRoot
+                    }
+                }
+
+                if (e is MaestroException.AssertionFailure) {
+                    logger.info("Saving hierarchy")
                 }
 
                 ScreenshotUtils.takeDebugScreenshot(maestro, debugOutput, CommandStatus.FAILED)

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -207,6 +207,13 @@ class TestSuiteInteractor(
                             it.status = CommandStatus.FAILED
                             it.calculateDuration()
                             it.error = e
+                            if (e is MaestroException.AssertionFailure) {
+                                it.hierarchy = e.hierarchyRoot
+                            }
+                        }
+
+                        if (e is MaestroException.AssertionFailure) {
+                            logger.info("${shardPrefix}Saving hierarchy")
                         }
 
                         ScreenshotUtils.takeDebugScreenshot(maestro, debugOutput, CommandStatus.FAILED)


### PR DESCRIPTION
## Proposed changes

When failures occur, debugging can be difficult, especially if they occur with CI (like our own e2e tests). This change stores the hierarchy snapshot on failure, and stores it as a debug test artifact.

## Testing

Tested locally with demo_app:

```
maestro test ./.maestro/fail_fast.yaml
maestro test  --include-tags failing ./.maestro
```

## Issues fixed
