### PR TITLE
Add Chrome Extension testing support for web platform

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -218,6 +218,12 @@ class TestCommand : Callable<Int> {
     )
     private var appleTeamId: String? = null
 
+    @Option(
+        names = ["--extension"],
+        description = ["(Web only) Path to unpacked Chrome extension directory. Can be specified multiple times for multiple extensions."],
+    )
+    var extensions: List<String>? = null
+
     @Option(names = ["-p", "--platform"], description = ["Select a platform to run on"])
     var platform: String? = null
 
@@ -483,7 +489,8 @@ class TestCommand : Callable<Int> {
             isHeadless = headless,
             screenSize = screenSize,
             reinstallDriver = reinstallDriver,
-            executionPlan = executionPlan
+            executionPlan = executionPlan,
+            extensionPaths = extensions,
         ) { session ->
             val maestro = session.maestro
             val device = session.device

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -76,6 +76,7 @@ object MaestroSessionManager {
         reinstallDriver: Boolean = true,
         deviceIndex: Int? = null,
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan? = null,
+        extensionPaths: List<String>? = null,
         block: (MaestroSession) -> T,
     ): T {
         val selectedDevice = selectDevice(
@@ -118,7 +119,8 @@ object MaestroSessionManager {
             screenSize = screenSize,
             driverHostPort = driverHostPort,
             reinstallDriver = reinstallDriver,
-            platformConfiguration = executionPlan?.workspaceConfig?.platform
+            platformConfiguration = executionPlan?.workspaceConfig?.platform,
+            extensionPaths = extensionPaths,
         )
         Runtime.getRuntime().addShutdownHook(thread(start = false) {
             heartbeatFuture.cancel(true)
@@ -200,6 +202,7 @@ object MaestroSessionManager {
         reinstallDriver: Boolean,
         driverHostPort: Int?,
         platformConfiguration: PlatformConfiguration? = null,
+        extensionPaths: List<String>? = null,
     ): MaestroSession {
         return when {
             selectedDevice.device != null -> MaestroSession(
@@ -220,7 +223,7 @@ object MaestroSessionManager {
                         platformConfiguration = platformConfiguration
                     )
 
-                    Platform.WEB -> pickWebDevice(isStudio, isHeadless, screenSize)
+                    Platform.WEB -> pickWebDevice(isStudio, isHeadless, screenSize, extensionPaths)
                 },
                 device = selectedDevice.device,
             )
@@ -249,7 +252,7 @@ object MaestroSessionManager {
             )
 
             selectedDevice.platform == Platform.WEB -> MaestroSession(
-                maestro = pickWebDevice(isStudio, isHeadless, screenSize),
+                maestro = pickWebDevice(isStudio, isHeadless, screenSize, extensionPaths),
                 device = null
             )
 
@@ -445,8 +448,8 @@ object MaestroSessionManager {
         )
     }
 
-    private fun pickWebDevice(isStudio: Boolean, isHeadless: Boolean, screenSize: String?): Maestro {
-        return Maestro.web(isStudio, isHeadless, screenSize)
+    private fun pickWebDevice(isStudio: Boolean, isHeadless: Boolean, screenSize: String?, extensionPaths: List<String>? = null): Maestro {
+        return Maestro.web(isStudio, isHeadless, screenSize, extensionPaths)
     }
 
     private data class SelectedDevice(

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -679,6 +679,7 @@ class Maestro(
             isStudio: Boolean,
             isHeadless: Boolean,
             screenSize: String?,
+            extensionPaths: List<String>? = null,
         ): Maestro {
             // Check that JRE is at least 11
             val version = System.getProperty("java.version")
@@ -695,6 +696,7 @@ class Maestro(
                 isStudio = isStudio,
                 isHeadless = isHeadless,
                 screenSize = screenSize,
+                extensionPaths = extensionPaths,
             )
             driver.open()
             return Maestro(driver)

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -48,7 +48,8 @@ private const val SYNTHETIC_COORDINATE_SPACE_OFFSET = 100000
 class CdpWebDriver(
     val isStudio: Boolean,
     private val isHeadless: Boolean = false,
-    private val screenSize: String?
+    private val screenSize: String?,
+    private val extensionPaths: List<String>? = null,
 ) : Driver {
 
     private lateinit var cdpClient: CdpClient
@@ -116,6 +117,10 @@ class CdpWebDriver(
                     "profile.password_manager_leak_detection" to false   // important one
                 )
                 setExperimentalOption("prefs", chromePrefs)
+
+                extensionPaths?.forEach { path ->
+                    addArguments("--load-extension=$path")
+                }
 
                 setExperimentalOption("detach", true)
 
@@ -511,7 +516,12 @@ class CdpWebDriver(
     override fun openLink(link: String, appId: String?, autoVerify: Boolean, browser: Boolean) {
         val driver = ensureOpen()
 
-        driver.get(if (link.startsWith("http")) link else "https://$link")
+        val url = when {
+            link.startsWith("chrome-extension://") -> link
+            link.startsWith("http") -> link
+            else -> "https://$link"
+        }
+        driver.get(url)
     }
 
     override fun hideKeyboard() {
@@ -660,7 +670,7 @@ class CdpWebDriver(
 }
 
 fun main() {
-    val driver = CdpWebDriver(isStudio = false, isHeadless = false, screenSize = null)
+    val driver = CdpWebDriver(isStudio = false, isHeadless = false, screenSize = null, extensionPaths = null)
     driver.open()
 
     try {


### PR DESCRIPTION
## Summary
- Adds `--extension` CLI flag to load unpacked Chrome extensions during web testing
- Extensions are passed as `--load-extension` args to ChromeOptions via Selenium/CDP
- Supports `chrome-extension://` URL scheme in `openLink()` for navigating to extension popup/options pages
- Threaded through `MaestroSessionManager` and `Maestro.web()` factory

## Usage
```bash
# Single extension
maestro test --extension /path/to/unpacked/extension flow.yaml

# Multiple extensions
maestro test --extension /path/to/ext1 --extension /path/to/ext2 flow.yaml
```

## Example flow
```yaml
appId: chrome
---
- openLink: "chrome-extension://<extension-id>/popup.html"
- tapOn: "Enable"
- assertVisible: "Active"
```

## Changes
- `CdpWebDriver.kt` — `extensionPaths` param, `--load-extension` ChromeOptions, `chrome-extension://` URL handling
- `Maestro.kt` — pass `extensionPaths` through `web()` factory
- `MaestroSessionManager.kt` — thread `extensionPaths` through session creation
- `TestCommand.kt` — `--extension` CLI option (repeatable)

Closes #2636