### PR TITLE
fix: Android driver not installed when another Maestro session is active

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
@@ -61,7 +61,9 @@ object SessionStore {
         platform: Platform
     ): Boolean {
         synchronized(keyValueStore) {
+            val platformPrefix = "${platform}_"
             return activeSessions()
+                .filter { it.startsWith(platformPrefix) }
                 .any { it != key(sessionId, platform) }
         }
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -210,6 +210,7 @@ class AndroidDriver(
     }
 
     override fun deviceInfo(): DeviceInfo {
+        if (!open) open()
         return runDeviceCall("deviceInfo") {
             val response = blockingStubWithTimeout.deviceInfo(deviceInfoRequest {})
 


### PR DESCRIPTION
## Problem

Closes #3065

When Maestro Studio is open (or any other Maestro session is active — even on a different platform), running `maestro test` on Android silently skips driver installation and fails with:

```
Connection refused: 127.0.0.1:7001
```

## Root cause

`SessionStore.hasActiveSessions()` stores session keys as `${platform}_${sessionId}` but was checking for *any* active session without filtering by platform:

```kotlin
// Before — matches sessions from ANY platform
return activeSessions()
    .any { it != key(sessionId, platform) }
```

This causes `MaestroSessionManager` to set `connectToExistingSession = true` → `openDriver = false` → `driver.open()` never called → Android driver APKs never installed → port 7001 never forwarded.

A secondary issue: `AndroidDriver.deviceInfo()` (called first during JS engine init) lacked the `if (!open) open()` guard that `launchApp()` already has, so even a partial recovery path was missing.

## Changes

**`SessionStore.kt`** — filter by platform prefix before checking for other active sessions:

```kotlin
fun hasActiveSessions(sessionId: String, platform: Platform): Boolean {
    synchronized(keyValueStore) {
        val platformPrefix = "${platform}_"
        return activeSessions()
            .filter { it.startsWith(platformPrefix) }
            .any { it != key(sessionId, platform) }
    }
}
```

**`AndroidDriver.kt`** — add `if (!open) open()` guard to `deviceInfo()`, consistent with `launchApp()`:

```kotlin
override fun deviceInfo(): DeviceInfo {
    if (!open) open()
    return runDeviceCall("deviceInfo") { ... }
}
```

## Testing

Reproduced on Maestro 2.3.0 / macOS / Android emulator API 35 with Maestro Studio running in the background. After this fix, `maestro test` correctly installs the driver and runs the flow end-to-end.