### PR TITLE
Read hierarchy from iFrames

### DIFF
--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -53,7 +53,7 @@
         return `[${Math.round(l)},${Math.round(t)}][${Math.round(r)},${Math.round(b)}]`
     }
 
-    const getNodeBounds = (node) => {
+    const getNodeBounds = (node, iframeOffsetX = 0, iframeOffsetY = 0) => {
         if (isSynthetic(node)) {
             return getSyntheticNodeBounds(node);
         }
@@ -66,26 +66,45 @@
 
         const scaleX = vpw / window.innerWidth;
         const scaleY = vph / window.innerHeight;
-        const l = rect.x * scaleX + vpx;
-        const t = rect.y * scaleY + vpy;
-        const r = (rect.x + rect.width) * scaleX + vpx;
-        const b = (rect.y + rect.height) * scaleY + vpy;
+        const l = (rect.x + iframeOffsetX) * scaleX + vpx;
+        const t = (rect.y + iframeOffsetY) * scaleY + vpy;
+        const r = (rect.x + rect.width + iframeOffsetX) * scaleX + vpx;
+        const b = (rect.y + rect.height + iframeOffsetY) * scaleY + vpy;
 
         return `[${Math.round(l)},${Math.round(t)}][${Math.round(r)},${Math.round(b)}]`
     }
 
     const isDocumentLoading = () => document.readyState !== 'complete'
 
-    const traverse = (node, includeChildren = true) => {
+    const traverse = (node, includeChildren = true, iframeOffsetX = 0, iframeOffsetY = 0) => {
       if (!node || isInvalidTag(node)) return null
 
+      // Traverse into same-origin iframes; skip cross-origin ones silently
+      if (node.tagName.toLowerCase() === 'iframe') {
+          try {
+              const iframeDoc = node.contentDocument || node.contentWindow?.document;
+              if (iframeDoc && iframeDoc.body) {
+                  const iframeRect = node.getBoundingClientRect();
+                  return traverse(
+                      iframeDoc.body,
+                      true,
+                      iframeOffsetX + iframeRect.x,
+                      iframeOffsetY + iframeRect.y
+                  );
+              }
+          } catch (e) {
+              // Cross-origin — cannot access content
+          }
+          return null;
+      }
+
       const children = includeChildren
-        ? [...node.children || []].map(child => traverse(child)).filter(el => !!el)
+        ? [...node.children || []].map(child => traverse(child, true, iframeOffsetX, iframeOffsetY)).filter(el => !!el)
         : []
 
       const attributes = {
           text: getNodeText(node),
-          bounds: getNodeBounds(node),
+          bounds: getNodeBounds(node, iframeOffsetX, iframeOffsetY),
       }
 
       // If this is an <option> element, we only want to include it if the parent <select> element is focused.


### PR DESCRIPTION
## Proposed changes

Access iFrame hierarchy content from Maestro Web. Before, we were just seeing "Your browser doesn't support iframes".

The impl reads child iframe content, and adjusts hierarchy bounds for its perceived "reset" position within the child document.

## Testing

Variants on this:

```
url: https://iframe-example-ten.vercel.app/
# https://github.com/mobile-dev-inc/maestro/issues/3009
---
- launchApp
- assertVisible: .*lives inside an iframe.*
```

Tested in CLI.

Also tested using a custom build of Maestro Studio to see that iFrames could have elements picked and tapped, etc.

e2e test: https://github.com/mobile-dev-inc/demo_app/pull/23

## Issues fixed

Fixes #3009 