### PR TITLE
fix start device command for os-version flag

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -94,13 +94,13 @@ class StartDeviceCommand : Callable<Int> {
             when (parsedPlatform) {
                 Platform.ANDROID -> DeviceRequest.Android(
                     model = deviceModel,
-                    os = deviceOs ?: osVersion,
+                    os = deviceOs ?: osVersion.let { "android-$it" },
                     locale = deviceLocale,
                     systemArchitecture = EnvUtils.getMacOSArchitecture(),
                 )
                 Platform.IOS -> DeviceRequest.Ios(
                     model = deviceModel,
-                    os = deviceOs ?: osVersion,
+                    os = deviceOs ?: osVersion.let { "iOS-$it" },
                     locale = deviceLocale,
                 )
                 Platform.WEB -> DeviceRequest.Web(

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
@@ -44,8 +44,14 @@ object DeviceCreateUtil {
         if (existingDeviceId != null) PrintUtils.message("Using existing device ${deviceSpec.deviceName} (${existingDeviceId}).")
         else PrintUtils.message("Attempting to create iOS simulator: ${deviceSpec.deviceName} ")
 
-        val deviceUUID = try {
-            existingDeviceId ?: DeviceService.createIosDevice(deviceSpec.deviceName, deviceSpec.model, deviceSpec.os).toString()
+        val deviceUUID = existingDeviceId ?: try {
+            // To find the closest matching os: "iOS-18" -> "iOS-18-2", "iOS-17" -> "iOS-17-5"
+            val closestInstalledRuntime = DeviceService.listIOSDevices().firstOrNull {
+                it.deviceSpec.os.startsWith(deviceSpec.os)
+            }?.deviceSpec?.os ?: deviceSpec.os
+
+            //  Start the device
+            DeviceService.createIosDevice(deviceSpec.deviceName, deviceSpec.model, closestInstalledRuntime).toString()
         } catch (e: IllegalStateException) {
             val error = e.message ?: ""
             if (error.contains("Invalid runtime")) {

--- a/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceCatalog.kt
@@ -34,8 +34,8 @@ sealed class DeviceSpec {
         val cpuArchitecture: CPU_ARCHITECTURE,
     ) : DeviceSpec() {
         override val platform = Platform.ANDROID
-        override val deviceName = "Maestro_ANDROID_${model}_${os}"
         override val osVersion: Int = os.removePrefix("android-").toIntOrNull() ?: 0
+        override val deviceName = "Maestro_ANDROID_${model}_${os}"
         val tag = "google_apis"
         val emulatorImage = "system-images;$os;$tag;${cpuArchitecture.value}"
     }
@@ -49,8 +49,8 @@ sealed class DeviceSpec {
         val snapshotKeyHonorModalViews: Boolean,
     ) : DeviceSpec() {
         override val platform = Platform.IOS
-        override val deviceName = "Maestro_IOS_${model}_${os}"
         override val osVersion: Int = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
+        override val deviceName = "Maestro_IOS_${model}_${osVersion}"
     }
 
     data class Web(
@@ -59,8 +59,8 @@ sealed class DeviceSpec {
       override val locale: DeviceLocale
     ) : DeviceSpec() {
         override val platform = Platform.WEB
-        override val deviceName = "Maestro_WEB_${model}_${os}"
         override val osVersion: Int = 0
+        override val deviceName = "Maestro_WEB_${model}_${osVersion}"
     }
 }
 

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -329,7 +329,7 @@ object DeviceService {
         return result
     }
 
-    private fun listIOSDevices(): List<Device> {
+    fun listIOSDevices(): List<Device> {
         val simctlList = try {
             localSimulatorUtils.list()
         } catch (ignored: Exception) {


### PR DESCRIPTION
## Fix

- Convert os-version to new format for backward compatibility
- Create a general device Name, so its easier to relaunch the same device with just ios version number
- Use list device to get closest matching install ios os version


## Ticket
https://linear.app/mobile-dev/issue/MA-3996/issues-with-starting-devices-due-to-missing-system-images
