### PR TITLE
Add deprecation warning to legacy Maestro Studio

### DIFF
--- a/maestro-studio/web/src/components/common/Header.tsx
+++ b/maestro-studio/web/src/components/common/Header.tsx
@@ -21,12 +21,30 @@ const HeaderBanner = () => {
   );
 };
 
+const DeprecationBanner = () => (
+  <div className="py-3 px-7 text-sm text-center font-semibold bg-amber-100 dark:bg-amber-900">
+    <span>
+      This feature has been deprecated and will be removed in the near future. Check out{" "}
+      <a
+        href="https://maestro.dev/?utm_source=old_studio&utm_campaign=download_studio#maestro-studio"
+        target="_blank"
+        rel="noreferrer"
+        className="underline"
+      >
+        Maestro Studio Desktop
+      </a>{" "}
+      for similar, fully supported functionality.
+    </span>
+  </div>
+);
+
 const Header = () => (
   <div className="flex flex-col">
     <div className="flex py-3 px-7 items-center bg-white dark:bg-slate-900 dark:text-white border-b border-slate-200 dark:border-slate-800">
       <span className="font-bold cursor-default grow">$ maestro studio</span>
       <ThemeToggle />
     </div>
+    <DeprecationBanner />
     <HeaderBanner />
   </div>
 );


### PR DESCRIPTION
## Proposed changes

We've had Maestro Studio Desktop in Beta for ~9 months now, and it meets most needs for most folks.
This adds a deprecation warning to the old studio so that folks know that it isn't getting new feature work, and could be removed in a future release.
It also adds a way to hide the banner (`MAESTRO_HIDE_DEPRECATION_BANNER=1 maestro studio`)

<img width="1438" height="831" alt="image" src="https://github.com/user-attachments/assets/a3b6c0ff-0301-4031-a6cc-7cf2d6dab182" />


## Testing

```
maestro studio
MAESTRO_HIDE_DEPRECATION_BANNER=1 maestro studio
```

## Issues fixed

n/a