### PR TITLE
refactor: use device spec in response of ApiClient

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -204,6 +204,10 @@ dependencies {
     testImplementation(libs.google.truth)
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -27,6 +27,11 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.Protocol
 import okhttp3.Request
+import maestro.device.CPU_ARCHITECTURE
+import maestro.device.DeviceOrientation
+import maestro.device.DeviceSpec
+import maestro.device.Platform
+import maestro.device.locale.DeviceLocale
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -468,32 +473,8 @@ class ApiClient(
         }
     }
 
-    private fun parseUploadResponse(responseBody: Map<*, *>): UploadResponse {
-        @Suppress("UNCHECKED_CAST")
-        val orgId = responseBody["orgId"] as String
-        val uploadId = responseBody["uploadId"] as String
-        val appId = responseBody["appId"] as String
-        val appBinaryId = responseBody["appBinaryId"] as String
-
-        val deviceConfigMap = responseBody["deviceConfiguration"] as Map<String, Any>
-        val platform = deviceConfigMap["platform"].toString().uppercase()
-        val deviceConfiguration = DeviceConfiguration(
-            platform = platform,
-            deviceName = deviceConfigMap["deviceName"] as String,
-            orientation = deviceConfigMap["orientation"] as String,
-            osVersion = deviceConfigMap["osVersion"] as String,
-            displayInfo = deviceConfigMap["displayInfo"] as String,
-            deviceLocale = deviceConfigMap["deviceLocale"] as? String
-        )
-
-        return UploadResponse(
-            orgId = orgId,
-            uploadId = uploadId,
-            deviceConfiguration = deviceConfiguration,
-            appId = appId,
-            appBinaryId = appBinaryId
-        )
-    }
+    private fun parseUploadResponse(responseBody: Map<*, *>): UploadResponse =
+        maestro.cli.api.parseUploadResponse(responseBody)
 
 
     private inline fun <reified T> post(path: String, body: Any): Result<T, Response> {
@@ -790,26 +771,10 @@ data class UploadResponse(
     val orgId: String,
     val uploadId: String,
     val appId: String,
-    val deviceConfiguration: DeviceConfiguration?,
+    val deviceSpec: DeviceSpec?,
     val appBinaryId: String?,
 )
 
-data class DeviceConfiguration(
-    val platform: String,
-    val deviceName: String,
-    val orientation: String,
-    val osVersion: String,
-    val displayInfo: String,
-    val deviceLocale: String?
-)
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-data class DeviceInfo(
-    val platform: String,
-    val displayInfo: String,
-    val isDefaultOsVersion: Boolean,
-    val deviceLocale: String,
-)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class UploadStatus(
@@ -951,6 +916,52 @@ data class StartTrialRequest(
     val companyName: String,
     val referralSource: String,
 )
+
+@Suppress("UNCHECKED_CAST")
+fun parseUploadResponse(responseBody: Map<*, *>): UploadResponse {
+    val orgId = responseBody["orgId"] as String
+    val uploadId = responseBody["uploadId"] as String
+    val appId = responseBody["appId"] as String
+    val appBinaryId = responseBody["appBinaryId"] as String
+
+    val deviceConfigMap = responseBody["deviceConfiguration"] as Map<String, Any?>
+    val platform = deviceConfigMap["platform"].toString().uppercase()
+    val model = deviceConfigMap["deviceName"] as String
+    val os = deviceConfigMap["deviceOs"] as String
+    val localeCode = deviceConfigMap["deviceLocale"] as? String ?: "en_US"
+
+    val deviceSpec = when (platform) {
+        "ANDROID" -> DeviceSpec.Android(
+            model = model,
+            os = os,
+            locale = DeviceLocale.fromString(localeCode, Platform.ANDROID),
+            orientation = DeviceOrientation.valueOf(deviceConfigMap["orientation"] as String),
+            disableAnimations = false,
+            cpuArchitecture = CPU_ARCHITECTURE.ARM64,
+        )
+        "IOS" -> DeviceSpec.Ios(
+            model = model,
+            os = os,
+            locale = DeviceLocale.fromString(localeCode, Platform.IOS),
+            orientation = DeviceOrientation.valueOf(deviceConfigMap["orientation"] as String),
+            disableAnimations = false,
+            snapshotKeyHonorModalViews = false,
+        )
+        else -> DeviceSpec.Web(
+            model = model,
+            os = os,
+            locale = DeviceLocale.fromString(localeCode, Platform.WEB),
+        )
+    }
+
+    return UploadResponse(
+        orgId = orgId,
+        uploadId = uploadId,
+        deviceSpec = deviceSpec,
+        appId = appId,
+        appBinaryId = appBinaryId
+    )
+}
 
 class AnalyzeResponse(
     val htmlReport: String?,

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -5,8 +5,8 @@ import maestro.cli.analytics.Analytics
 import maestro.cli.analytics.CloudUploadStartedEvent
 import maestro.cli.analytics.CloudUploadTriggeredEvent
 import maestro.cli.api.ApiClient
-import maestro.cli.api.DeviceConfiguration
 import maestro.cli.api.OrgResponse
+import maestro.device.DeviceSpec
 import maestro.cli.api.ProjectResponse
 import maestro.cli.api.UploadStatus
 import maestro.cli.auth.Auth
@@ -169,7 +169,7 @@ class CloudInteractor(
             )
 
             // Track finish after upload completion
-            val platform = response.deviceConfiguration?.platform?.lowercase() ?: "unknown"
+            val platform = response.deviceSpec?.platform?.toString()?.lowercase() ?: "unknown"
             Analytics.trackEvent(CloudUploadSucceededEvent(
                 projectId = selectedProjectId,
                 platform = platform,
@@ -183,7 +183,7 @@ class CloudInteractor(
             val appId = response.appId
             val uploadUrl = uploadUrl(project, appId, response.uploadId, client.domain)
             val deviceMessage =
-                if (response.deviceConfiguration != null) printDeviceInfo(response.deviceConfiguration) else ""
+                if (response.deviceSpec != null) printDeviceInfo(response.deviceSpec) else ""
 
             val uploadResponse = printMaestroCloudResponse(
                 async,
@@ -401,19 +401,19 @@ class CloudInteractor(
         }
     }
 
-    private fun printDeviceInfo(deviceConfiguration: DeviceConfiguration): String {
-        val platform = Platform.fromString(deviceConfiguration.platform)
+    private fun printDeviceInfo(deviceSpec: DeviceSpec): String {
+        val platform = deviceSpec.platform
         PrintUtils.info("\n")
 
-        val version = deviceConfiguration.osVersion
+        val version = deviceSpec.osVersion
         val lines = listOf(
-            "Maestro cloud device specs:\n* @|magenta ${deviceConfiguration.displayInfo} - ${deviceConfiguration.deviceLocale}|@\n",
+            "Maestro cloud device specs:\n* @|magenta ${deviceSpec.deviceName} - ${deviceSpec.locale.code}|@\n",
             "To change OS version use this option: @|magenta ${if (platform == Platform.IOS) "--device-os=<version>" else "--android-api-level=<version>"}|@",
             "To change devices use this option: @|magenta --device-model=<device_model>|@",
             "To change device locale use this option: @|magenta --device-locale=<device_locale>|@",
             "To create a similar device locally, run: @|magenta `maestro start-device --platform=${
                 platform.toString().lowercase()
-            } --os-version=$version --device-locale=${deviceConfiguration.deviceLocale}`|@"
+            } --os-version=$version --device-locale=${deviceSpec.locale.code}`|@"
         )
 
         return lines.joinToString("\n").render().box()

--- a/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientParseUploadResponseTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientParseUploadResponseTest.kt
@@ -1,0 +1,108 @@
+package maestro.cli.api
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.google.common.truth.Truth.assertThat
+import maestro.device.DeviceOrientation
+import maestro.device.DeviceSpec
+import maestro.device.Platform
+import org.junit.jupiter.api.Test
+
+class ApiClientParseUploadResponseTest {
+
+    private val mapper = jacksonObjectMapper()
+
+    // Real JSON format sent by the server (from RunMaestroRoute.kt DeviceConfigurationResponse)
+    private val androidResponseJson = """
+        {
+          "orgId": "org-123",
+          "uploadId": "upload-456",
+          "appId": "app-789",
+          "appBinaryId": "binary-abc",
+          "deviceConfiguration": {
+            "platform": "ANDROID",
+            "deviceLocale": "en_US",
+            "deviceName": "pixel_6",
+            "deviceOs": "android-33",
+            "osVersion": "33",
+            "orientation": "PORTRAIT",
+            "displayInfo": "Maestro_ANDROID_pixel_6_android-33"
+          }
+        }
+    """.trimIndent()
+
+    private val iosResponseJson = """
+        {
+          "orgId": "org-123",
+          "uploadId": "upload-456",
+          "appId": "app-789",
+          "appBinaryId": "binary-abc",
+          "deviceConfiguration": {
+            "platform": "IOS",
+            "deviceLocale": "en_US",
+            "deviceName": "iPhone-11",
+            "deviceOs": "iOS-18-2",
+            "osVersion": "18",
+            "orientation": "PORTRAIT",
+            "displayInfo": "Maestro_IOS_iPhone-11_18"
+          }
+        }
+    """.trimIndent()
+
+    private val webResponseJson = """
+        {
+          "orgId": "org-123",
+          "uploadId": "upload-456",
+          "appId": "app-789",
+          "appBinaryId": "binary-abc",
+          "deviceConfiguration": {
+            "platform": "WEB",
+            "deviceLocale": "en_US",
+            "deviceName": "chromium",
+            "deviceOs": "default",
+            "osVersion": "0",
+            "displayInfo": "Maestro_WEB_chromium_0"
+          }
+        }
+    """.trimIndent()
+
+    @Test
+    fun `parseUploadResponse - android response creates Android DeviceSpec`() {
+        val result = parse(androidResponseJson)
+
+        assertThat(result.orgId).isEqualTo("org-123")
+        assertThat(result.uploadId).isEqualTo("upload-456")
+        val spec = result.deviceSpec as DeviceSpec.Android
+        assertThat(spec.platform).isEqualTo(Platform.ANDROID)
+        assertThat(spec.model).isEqualTo("pixel_6")
+        assertThat(spec.os).isEqualTo("android-33")
+        assertThat(spec.orientation).isEqualTo(DeviceOrientation.PORTRAIT)
+        assertThat(spec.locale.code).isEqualTo("en_US")
+    }
+
+    @Test
+    fun `parseUploadResponse - ios response creates Ios DeviceSpec`() {
+        val result = parse(iosResponseJson)
+
+        val spec = result.deviceSpec as DeviceSpec.Ios
+        assertThat(spec.platform).isEqualTo(Platform.IOS)
+        assertThat(spec.model).isEqualTo("iPhone-11")
+        assertThat(spec.os).isEqualTo("iOS-18-2")
+        assertThat(spec.orientation).isEqualTo(DeviceOrientation.PORTRAIT)
+        assertThat(spec.locale.code).isEqualTo("en_US")
+    }
+
+    @Test
+    fun `parseUploadResponse - web response with null orientation creates Web DeviceSpec`() {
+        val result = parse(webResponseJson)
+
+        val spec = result.deviceSpec as DeviceSpec.Web
+        assertThat(spec.platform).isEqualTo(Platform.WEB)
+        assertThat(spec.model).isEqualTo("chromium")
+        assertThat(spec.os).isEqualTo("default")
+        assertThat(spec.locale.code).isEqualTo("en_US")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parse(json: String): UploadResponse =
+        parseUploadResponse(mapper.readValue(json, Map::class.java) as Map<*, *>)
+}


### PR DESCRIPTION
## Proposed changes

Use Device Spec to deserialize the maestro upload response so that we get valid device.

## Testing

<!--- Please describe how you tested your changes. -->

> **Does this need e2e tests?** Please consider contributing them to the [demo app](https://github.com/mobile-dev-inc/demo_app) repository.

## Issues fixed
