### PR TITLE
fix: reduce websocket response timeout to 5 seconds

### DIFF
--- a/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
@@ -154,8 +154,8 @@ class DadbChromeDevToolsClient(private val dadb: Dadb): Closeable {
         )
         ws.send(message)
         val response = try {
-            future.get(5000, TimeUnit.SECONDS)
-        } catch (e: TimeoutException) {
+            future.get(5, TimeUnit.SECONDS)
+        } catch (_: TimeoutException) {
             throw TimeoutException("Timed out waiting for websocket response")
         } catch (e: ExecutionException) {
             throw e.cause ?: e


### PR DESCRIPTION
## Proposed changes

In `DadbChromeDevToolsClient.makeSingleWebsocketRequest()`, the specified timeout is 5000 seconds instead of intended 5 seconds.
This PR is to address decrease the timeout and make sure the calling the calling thread and entire test isn't in a forever loading state in case WebSocket response is never received.

copilot:summary

## Testing

Run unit tests.

> **Does this need e2e tests?** Please consider contributing them to the [demo app](https://github.com/mobile-dev-inc/demo_app) repository.

## Issues fixed
https://github.com/mobile-dev-inc/Maestro/issues/3092
