### PR TITLE
fix: handle inputText, eraseText, and pressKey inside cross-origin iframes

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -415,12 +415,8 @@ class CdpWebDriver(
     }
 
     override fun pressKey(code: KeyCode) {
-        val driver = ensureOpen()
-
-        val xPath = executeJS("window.maestro.createXPathFromElement(document.activeElement)") as String
-        val element = driver.findElement(By.ByXPath(xPath))
         val key = mapToSeleniumKey(code)
-        element.sendKeys(key)
+        withActiveElement { it.sendKeys(key) }
     }
 
     private fun mapToSeleniumKey(code: KeyCode): Keys {
@@ -502,13 +498,11 @@ class CdpWebDriver(
     }
 
     override fun inputText(text: String) {
-        val driver = ensureOpen()
-
-        val xPath = executeJS("window.maestro.createXPathFromElement(document.activeElement)") as String
-        val element = driver.findElement(By.ByXPath(xPath))
-        for (c in text.toCharArray()) {
-            element.sendKeys("$c")
-            sleep(random(20, 100).toLong())
+        withActiveElement { element ->
+            for (c in text.toCharArray()) {
+                element.sendKeys("$c")
+                sleep(random(20, 100).toLong())
+            }
         }
     }
 
@@ -570,15 +564,12 @@ class CdpWebDriver(
     }
 
     override fun eraseText(charactersToErase: Int) {
-        val driver = ensureOpen()
-
-        val xPath = executeJS("window.maestro.createXPathFromElement(document.activeElement)") as String
-        val element = driver.findElement(By.ByXPath(xPath))
-        for (i in 0 until charactersToErase) {
-            element.sendKeys(Keys.BACK_SPACE)
-            sleep(random(20, 50).toLong())
+        withActiveElement { element ->
+            for (i in 0 until charactersToErase) {
+                element.sendKeys(Keys.BACK_SPACE)
+                sleep(random(20, 50).toLong())
+            }
         }
-
         sleep(1000)
     }
 
@@ -726,6 +717,44 @@ class CdpWebDriver(
         } finally {
             try { driver.switchTo().defaultContent() }
             catch (e: Exception) { LOGGER.warn("Failed to switch back to default content", e) }
+        }
+    }
+
+    /**
+     * Locates the truly focused element, even when it lives inside a cross-origin iframe.
+     *
+     * When the user taps inside a cross-origin iframe the main frame's
+     * `document.activeElement` is the `<iframe>` element itself.  This helper
+     * detects that case, switches Selenium into the iframe, resolves the real
+     * active element there, runs [action], and switches back to the default
+     * content so subsequent commands target the main frame again.
+     */
+    private fun withActiveElement(action: (WebElement) -> Unit) {
+        val driver = ensureOpen()
+        val jsExecutor = driver as JavascriptExecutor
+
+        val isIframeFocused = jsExecutor.executeScript(
+            "return document.activeElement && document.activeElement.tagName.toLowerCase() === 'iframe'"
+        ) as? Boolean ?: false
+
+        if (isIframeFocused) {
+            val iframe = jsExecutor.executeScript("return document.activeElement") as WebElement
+            driver.switchTo().frame(iframe)
+            try {
+                jsExecutor.executeScript("$maestroWebScript")
+                val xPath = jsExecutor.executeScript(
+                    "return window.maestro.createXPathFromElement(document.activeElement)"
+                ) as String
+                val element = driver.findElement(By.ByXPath(xPath))
+                action(element)
+            } finally {
+                try { driver.switchTo().defaultContent() }
+                catch (e: Exception) { LOGGER.warn("Failed to switch back to default content", e) }
+            }
+        } else {
+            val xPath = executeJS("window.maestro.createXPathFromElement(document.activeElement)") as String
+            val element = driver.findElement(By.ByXPath(xPath))
+            action(element)
         }
     }
 


### PR DESCRIPTION
## Problem

While testing against `help.sumup.com` I found that `inputText`, `eraseText`, and `pressKey` silently fail when the focused element is inside a cross-origin iframe. The issue is that `document.activeElement` in the main frame returns the `<iframe>` element itself rather than the actual input inside it, so `sendKeys` targets the wrong element.

## Solution

Introduced a `withActiveElement` helper in `CdpWebDriver` that:

1. Checks if `document.activeElement` is an `<iframe>` tag
2. If **yes** — switches Selenium into that frame via `switchTo().frame()`, injects the maestro-web script, resolves the *real* `document.activeElement` inside the iframe, performs the action, then switches back to `defaultContent()`
3. If **no** — runs the exact original logic (no behavioral change for non-iframe workflows)

All three methods (`inputText`, `eraseText`, `pressKey`) now delegate through this helper.

## Testing

Tested against a site that loads a chat widget inside a cross-origin iframe. After tapping on the input field inside the iframe, `inputText` now correctly types into it.

Happy to adjust anything if needed.

<img width="613" height="678" alt="Screenshot 2026-03-31 at 13 40 20" src="https://github.com/user-attachments/assets/685b2b51-ca22-405f-b61b-c854216e3c8c" />
