### PR TITLE
fix: implement clearAppState for Selenium-based WebDriver

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -290,7 +290,32 @@ class WebDriver(
     }
 
     override fun clearAppState(appId: String) {
-        // Do nothing
+        val driver = ensureOpen()
+
+        try {
+            val jsExecutor = driver as JavascriptExecutor
+            jsExecutor.executeScript(
+                """
+                try { window.localStorage.clear(); } catch(e) {}
+                try { window.sessionStorage.clear(); } catch(e) {}
+                try {
+                    document.cookie.split(';').forEach(function(c) {
+                        document.cookie = c.trim().split('=')[0] +
+                            '=;expires=Thu, 01 Jan 1970 00:00:00 UTC;path=/';
+                    });
+                } catch(e) {}
+                try {
+                    if (window.indexedDB && window.indexedDB.databases) {
+                        window.indexedDB.databases().then(function(dbs) {
+                            dbs.forEach(function(db) { window.indexedDB.deleteDatabase(db.name); });
+                        });
+                    }
+                } catch(e) {}
+                """.trimIndent()
+            )
+        } catch (e: Exception) {
+            LOGGER.warn("Failed to clear browser state for $appId", e)
+        }
     }
 
     override fun clearKeychain() {


### PR DESCRIPTION
## Summary

- `clearState` was implemented in `CdpWebDriver` (#2996) but **not** in the Selenium-based `WebDriver`, which is what Maestro Cloud uses via Browserbase
- On Cloud, `clearAppState()` was a no-op, causing `clearState` commands to silently do nothing — cookies/localStorage/sessionStorage persisted across navigations
- This fix implements `clearAppState` in `WebDriver` using `JavascriptExecutor` to clear localStorage, sessionStorage, cookies, and IndexedDB

## Root cause

The Maestro worker on Cloud uses `maestro.drivers.WebDriver` (Selenium + Browserbase), not `CdpWebDriver` (local Chrome DevTools). PR #2996 only added the implementation to `CdpWebDriver.clearAppState()`, leaving `WebDriver.clearAppState()` as a no-op (`// Do nothing`).

## Test plan

- [x] Run the `clear_state.yaml` e2e test on Cloud (saucedemo.com) — should now pass
- [x] Verify `clearState` + `launchApp(clearState=true)` both work on Cloud web platform
- [x] Verify no regression on local web testing (CdpWebDriver path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)