### PR TITLE
Enrich AppMetadata as single source of truth for app analysis

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -36,8 +36,8 @@ import maestro.cli.view.cyan
 import maestro.cli.view.render
 import maestro.cli.promotion.PromotionStateManager
 import maestro.orchestra.validation.AppMetadataAnalyzer
+import maestro.orchestra.validation.AppMetadata
 import maestro.cli.web.WebInteractor
-import maestro.device.AppValidationResult
 import maestro.orchestra.validation.AppValidationException
 import maestro.orchestra.validation.AppValidator
 import maestro.orchestra.validation.WorkspaceValidationException
@@ -62,7 +62,7 @@ val terminalStatuses = listOf<FlowStatus>(FlowStatus.CANCELED, FlowStatus.STOPPE
 
 class CloudInteractor(
     private val client: ApiClient,
-    private val appFileValidator: (File) -> AppValidationResult?,
+    private val appFileValidator: (File) -> AppMetadata?,
     private val workspaceValidator: WorkspaceValidator,
     private val webManifestProvider: (() -> File?)? = null,
     private val auth: Auth = Auth(client),

--- a/maestro-client/src/main/java/maestro/device/AppValidationResult.kt
+++ b/maestro-client/src/main/java/maestro/device/AppValidationResult.kt
@@ -1,6 +1,0 @@
-package maestro.device
-
-data class AppValidationResult(
-    val platform: Platform,
-    val appIdentifier: String,
-)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/util/AppMetadataAnalyzer.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/util/AppMetadataAnalyzer.kt
@@ -4,7 +4,6 @@ import com.dd.plist.NSDictionary
 import com.dd.plist.PropertyListParser
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import maestro.device.AppValidationResult
 import maestro.device.Platform
 import net.dongliu.apk.parser.ApkFile
 import java.io.File
@@ -14,21 +13,21 @@ import java.util.zip.ZipFile
 
 object AppMetadataAnalyzer {
 
-    fun validateAppFile(file: File): AppValidationResult? {
+    fun validateAppFile(file: File): AppMetadata? {
         getWebMetadata(file)?.let {
-            return AppValidationResult(Platform.WEB, it.url)
+            return it
         }
         getIosAppMetadata(file)?.let {
             require(it.platformName == "iphonesimulator") {
                 "App build target '${it.platformName}' not supported, set build target to 'iphonesimulator'"
             }
-            return AppValidationResult(Platform.IOS, it.bundleId)
+            return it
         }
         getAndroidAppMetadata(file)?.let {
             require(it.supportedArchitectures.isEmpty() || "arm64-v8a" in it.supportedArchitectures) {
                 "APK does not support arm64-v8a architecture. Found: ${it.supportedArchitectures}"
             }
-            return AppValidationResult(Platform.ANDROID, it.packageId)
+            return it
         }
         return null
     }
@@ -110,6 +109,7 @@ object AppMetadataAnalyzer {
 sealed class AppMetadata(
     open val name: String,
     val appIdentifier: String,
+    val platform: Platform,
     val internalVersion: String,
     val version: String,
 )
@@ -124,6 +124,7 @@ data class IosAppMetadata(
 ) : AppMetadata(
     name = name,
     appIdentifier = bundleId,
+    platform = Platform.IOS,
     internalVersion = bundleVersion,
     version = appVersion,
 )
@@ -137,6 +138,7 @@ data class AndroidAppMetadata(
 ) : AppMetadata(
     name = name,
     appIdentifier = packageId,
+    platform = Platform.ANDROID,
     internalVersion = versionCode.toString(),
     version = versionName,
 )
@@ -146,6 +148,7 @@ data class WebAppMetadata(
 ) : AppMetadata(
     name = url,
     appIdentifier = url,
+    platform = Platform.WEB,
     internalVersion = "",
     version = "",
 )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/validation/AppValidator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/validation/AppValidator.kt
@@ -1,6 +1,5 @@
 package maestro.orchestra.validation
 
-import maestro.device.AppValidationResult
 import maestro.device.Platform
 import java.io.File
 import maestro.device.DeviceSpec
@@ -16,7 +15,7 @@ import maestro.device.DeviceSpec
  * @param iosMinOSVersionProvider extracts the minimum OS version from an iOS app binary file
  */
 class AppValidator(
-    private val appFileValidator: (File) -> AppValidationResult?,
+    private val appFileValidator: (File) -> AppMetadata?,
     private val appBinaryInfoProvider: ((String) -> AppBinaryInfoResult)? = null,
     private val webManifestProvider: (() -> File?)? = null,
     private val iosMinOSVersionProvider: ((File) -> IosMinOSVersion?)? = null,
@@ -30,7 +29,7 @@ class AppValidator(
 
     data class IosMinOSVersion(val major: Int, val full: String)
 
-    fun validate(appFile: File?, appBinaryId: String?): AppValidationResult {
+    fun validate(appFile: File?, appBinaryId: String?): AppMetadata {
         return when {
             appFile != null -> validateLocalAppFile(appFile)
             appBinaryId != null -> validateAppBinaryId(appBinaryId)
@@ -39,12 +38,12 @@ class AppValidator(
         }
     }
 
-    private fun validateLocalAppFile(appFile: File): AppValidationResult {
+    private fun validateLocalAppFile(appFile: File): AppMetadata {
         return appFileValidator(appFile)
             ?: throw AppValidationException.UnrecognizedAppFile()
     }
 
-    private fun validateAppBinaryId(appBinaryId: String): AppValidationResult {
+    private fun validateAppBinaryId(appBinaryId: String): AppMetadata {
         val provider = appBinaryInfoProvider
             ?: throw AppValidationException.MissingAppSource()
 
@@ -56,13 +55,14 @@ class AppValidator(
             throw AppValidationException.UnsupportedPlatform(info.platform)
         }
 
-        return AppValidationResult(
-            platform = platform,
-            appIdentifier = info.appId,
+        return AppBinaryResponse(
+            appBinaryId = appBinaryId,
+            appId = info.appId,
+            remotePlatform = platform,
         )
     }
 
-    private fun validateWebManifest(): AppValidationResult {
+    private fun validateWebManifest(): AppMetadata {
         val manifest = webManifestProvider?.invoke()
         return manifest?.let { appFileValidator(it) }
             ?: throw AppValidationException.UnrecognizedAppFile()
@@ -88,3 +88,15 @@ class AppValidator(
         }
     }
 }
+
+data class AppBinaryResponse(
+    val appBinaryId: String,
+    val appId: String,
+    val remotePlatform: Platform,
+) : AppMetadata(
+    name = appId,
+    appIdentifier = appId,
+    platform = remotePlatform,
+    internalVersion = "",
+    version = "",
+)

--- a/maestro-orchestra/src/test/java/maestro/orchestra/util/AppMetadataAnalyzerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/util/AppMetadataAnalyzerTest.kt
@@ -58,7 +58,7 @@ class AppMetadataAnalyzerTest {
     // ---- validateAppFile ----
 
     @Test
-    fun `validateAppFile returns AppValidationResult for iOS zip`() {
+    fun `validateAppFile returns AppMetadata for iOS zip`() {
         val result = AppMetadataAnalyzer.validateAppFile(makeIosZip())
         assertThat(result).isNotNull()
         assertThat(result!!.platform).isEqualTo(Platform.IOS)
@@ -66,7 +66,7 @@ class AppMetadataAnalyzerTest {
     }
 
     @Test
-    fun `validateAppFile returns AppValidationResult for web JSON`() {
+    fun `validateAppFile returns AppMetadata for web JSON`() {
         val result = AppMetadataAnalyzer.validateAppFile(makeWebJson())
         assertThat(result).isNotNull()
         assertThat(result!!.platform).isEqualTo(Platform.WEB)

--- a/maestro-orchestra/src/test/java/maestro/orchestra/validation/AppValidatorTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/validation/AppValidatorTest.kt
@@ -1,19 +1,34 @@
 package maestro.orchestra.validation
 
 import com.google.common.truth.Truth.assertThat
-import maestro.device.AppValidationResult
 import maestro.device.DeviceSpec
 import maestro.device.DeviceSpecRequest
 import maestro.device.Platform
+import maestro.orchestra.validation.AndroidAppMetadata
+import maestro.orchestra.validation.IosAppMetadata
+import maestro.orchestra.validation.WebAppMetadata
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 
 class AppValidatorTest {
 
-    private val androidResult = AppValidationResult(Platform.ANDROID, "com.example.app")
-    private val iosResult = AppValidationResult(Platform.IOS, "com.example.ios")
-    private val webResult = AppValidationResult(Platform.WEB, "https://example.com")
+    private val androidResult = AndroidAppMetadata(
+        name = "Example",
+        packageId = "com.example.app",
+        supportedArchitectures = listOf("arm64-v8a"),
+        versionName = "1.0",
+        versionCode = 1L,
+    )
+    private val iosResult = IosAppMetadata(
+        name = "Example iOS",
+        bundleId = "com.example.ios",
+        platformName = "iphonesimulator",
+        minimumOSVersion = "16.0",
+        appVersion = "1.0",
+        bundleVersion = "1",
+    )
+    private val webResult = WebAppMetadata(url = "https://example.com")
 
     @Test
     fun `validates local app file successfully`() {


### PR DESCRIPTION
- Enrich `IosAppMetadata` with `appVersion`, `bundleVersion` and `AndroidAppMetadata` with `name`, `versionName`, `versionCode` - extracted in a single parse pass by `AppMetadataAnalyzer`
- Add sealed base class `AppMetadata` with common fields (`name`, `appIdentifier`, `platform`, `version`, `internalVersion`)
- `validateAppFile()` now returns full AppMetadata? instead of the lightweight `AppValidationResult`
- Delete `AppValidationResult` - replaced by `AppMetadata` + `AppBinaryResponse` for the remote binary ID path

This eliminates duplicated plist/APK parsing in the copilot backend, which currently re-parses binaries to extract fields that `AppMetadataAnalyzer` already reads.