### PR TITLE
Fix list-cloud-devices command suggestion typo

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListDevicesCommand.kt
@@ -39,7 +39,7 @@ class ListDevicesCommand : Callable<Int> {
             Platform.fromString(input)
         }
 
-        println("Showing local devices. Use 'maestro list-cloud-device' to list devices available on Maestro Cloud.".faint())
+        println("Showing local devices. Use 'maestro list-cloud-devices' to list devices available on Maestro Cloud.".faint())
         println()
 
         PrintUtils.info("Local Devices", bold = true)


### PR DESCRIPTION
## Proposed changes

list-cloud-devices command suggestion from ListDevicesCommand.kt was missing an S, so users were suggested a non-existing command

## Testing

N/A

## Issues fixed

Typo in list-cloud-devices command