### PR TITLE
fix: organize e2e debug output by app name and test type

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ github.workspace }}/e2e
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: ./run_tests android
 
       - name: Stop screen recording of AVD

--- a/e2e/demo_app/.maestro/commands/killApp.yaml
+++ b/e2e/demo_app/.maestro/commands/killApp.yaml
@@ -1,11 +1,14 @@
-# Why doesn't this stop our demo app? adb command behind killApp doesn't work either.
 appId: com.example.example
 tags:
   - passing
   - android
 ---
-
 - launchApp
-- assertVisible: 'Form Test'
+- tapOn:
+    id: "fabAddIcon"
+- assertVisible: "1"
+- pressKey: Home
 - killApp
-- assertNotVisible: 'Form Test'
+- launchApp:
+    stopApp: false    # just brings app to foreground, no force-stop
+- assertVisible: "0"  # process was killed, counter reset

--- a/e2e/demo_app/.maestro/commands/openLink.yaml
+++ b/e2e/demo_app/.maestro/commands/openLink.yaml
@@ -2,7 +2,6 @@ appId: com.example.example
 tags:
   - passing
 ---
-- launchApp
 
 # Deeplink
 - stopApp

--- a/e2e/demo_app/.maestro/commands/waitForAnimationToEnd.yaml
+++ b/e2e/demo_app/.maestro/commands/waitForAnimationToEnd.yaml
@@ -9,7 +9,7 @@ tags:
 - evalScript: ${maestro.startTime = new Date()}
 - waitForAnimationToEnd
 - evalScript: ${maestro.endTime = new Date()}
-- assertTrue: ${maestro.endTime - maestro.startTime < 1000} # Nothing to wait for
+- assertTrue: ${maestro.endTime - maestro.startTime < 3000} # Nothing to wait for (allow for page transition settle)
 
 - tapOn: 
     text: "Animate (30s)"

--- a/e2e/demo_app/android/app/src/main/AndroidManifest.xml
+++ b/e2e/demo_app/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,12 @@
                 <data android:scheme="https" />
                 <data android:host="maestro.mobile.dev" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="example" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/e2e/demo_app/android/app/src/main/kotlin/com/example/example/MainActivity.kt
+++ b/e2e/demo_app/android/app/src/main/kotlin/com/example/example/MainActivity.kt
@@ -5,12 +5,14 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.view.Surface
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity: FlutterActivity() {
+
     private val CHANNEL = "com.example.example/sensors"
     private val BAROMETER_CHANNEL = "com.example.example/barometer"
     private val LIGHT_CHANNEL = "com.example.example/light"
@@ -24,6 +26,23 @@ class MainActivity: FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
         sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, "com.example.demo_app/orientation").setMethodCallHandler { call, result ->
+            if (call.method == "getOrientation") {
+                @Suppress("DEPRECATION")
+                val rotation = windowManager.defaultDisplay.rotation
+                val label = when (rotation) {
+                    Surface.ROTATION_0   -> "Portrait"
+                    Surface.ROTATION_90  -> "Landscape Left"
+                    Surface.ROTATION_180 -> "Portrait Upside Down"
+                    Surface.ROTATION_270 -> "Landscape Right"
+                    else                 -> "Unknown"
+                }
+                result.success(label)
+            } else {
+                result.notImplemented()
+            }
+        }
 
         // Method channel to check sensor availability
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->

--- a/e2e/demo_app/ios/Runner/AppDelegate.swift
+++ b/e2e/demo_app/ios/Runner/AppDelegate.swift
@@ -25,6 +25,27 @@ import UIKit
       }
     }
 
+    let orientationChannel = FlutterMethodChannel(
+      name: "com.example.demo_app/orientation",
+      binaryMessenger: controller.binaryMessenger
+    )
+
+    UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+
+    orientationChannel.setMethodCallHandler { (call, result) in
+      if call.method == "getOrientation" {
+        switch UIDevice.current.orientation {
+        case .portrait:             result("Portrait")
+        case .portraitUpsideDown:   result("Portrait Upside Down")
+        case .landscapeLeft:        result("Landscape Left")
+        case .landscapeRight:       result("Landscape Right")
+        default:                    result("Unknown")
+        }
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 

--- a/e2e/demo_app/ios/Runner/Info.plist
+++ b/e2e/demo_app/ios/Runner/Info.plist
@@ -31,6 +31,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
@@ -49,5 +50,16 @@
 	<string>This app uses your location to demonstrate Maestro setLocation and travel commands.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
 	<string>This app uses your location to demonstrate Maestro setLocation and travel commands.</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>example</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/e2e/demo_app/lib/animation_screen.dart
+++ b/e2e/demo_app/lib/animation_screen.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+class AnimationScreen extends StatefulWidget {
+  const AnimationScreen({super.key});
+
+  @override
+  State<AnimationScreen> createState() => _AnimationScreenState();
+}
+
+class _AnimationScreenState extends State<AnimationScreen>
+    with SingleTickerProviderStateMixin {
+  static const List<String> _phases = [
+    '🌑', '🌒', '🌓', '🌔', '🌕', '🌖', '🌗', '🌘',
+  ];
+
+  late final AnimationController _controller;
+  DateTime? _startTime;
+  Duration? _totalDuration;
+
+  bool get _running =>
+      _startTime != null &&
+      _totalDuration != null &&
+      DateTime.now().difference(_startTime!) < _totalDuration!;
+
+  void _startAnimation(Duration totalDuration) {
+    setState(() {
+      _startTime = DateTime.now();
+      _totalDuration = totalDuration;
+    });
+    _controller.repeat();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    )..addListener(() {
+        if (!_running) _controller.stop();
+        setState(() {});
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  String get _countdownText {
+    if (_startTime == null || _totalDuration == null) return '';
+    final elapsed = DateTime.now().difference(_startTime!);
+    final remaining = _totalDuration! - elapsed;
+    if (remaining.isNegative) return '0.0s';
+    final seconds = remaining.inMilliseconds / 1000.0;
+    return '${seconds.toStringAsFixed(1)}s';
+  }
+
+  String get _millisText {
+    if (!_running) return '';
+    return '${DateTime.now().millisecondsSinceEpoch % 10000}';
+  }
+
+  String _globe(int index) {
+    final ms = DateTime.now().millisecondsSinceEpoch;
+    final phase = (ms ~/ 125 + index) % _phases.length;
+    return _phases[phase];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: const Text('Animation Test'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton(
+                  onPressed: () => _startAnimation(const Duration(seconds: 4)),
+                  child: const Text('Animate (4s)'),
+                ),
+                ElevatedButton(
+                  onPressed: () => _startAnimation(const Duration(seconds: 30)),
+                  child: const Text('Animate (30s)'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (int i = 0; i < 4; i++)
+                        Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: Text(
+                            _running ? _globe(i) : '',
+                            style: const TextStyle(fontSize: 36),
+                          ),
+                        ),
+                    ],
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Text(
+                      _countdownText,
+                      style: const TextStyle(
+                          fontSize: 48, fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  Text(
+                    _millisText,
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.grey[600],
+                      fontFeatures: const [FontFeature.tabularFigures()],
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      for (int i = 4; i < 8; i++)
+                        Padding(
+                          padding: const EdgeInsets.all(8),
+                          child: Text(
+                            _running ? _globe(i) : '',
+                            style: const TextStyle(fontSize: 36),
+                          ),
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/e2e/demo_app/lib/input_screen.dart
+++ b/e2e/demo_app/lib/input_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class InputScreen extends StatefulWidget {
   const InputScreen({super.key});
@@ -15,6 +16,10 @@ class _InputScreenState extends State<InputScreen> {
   void initState() {
     super.initState();
     _focusNode = FocusNode();
+    SharedPreferences.getInstance().then((prefs) {
+      final saved = prefs.getString('input_screen_text');
+      if (saved != null) _inputController.text = saved;
+    });
   }
 
   @override
@@ -48,6 +53,14 @@ class _InputScreenState extends State<InputScreen> {
                     border: OutlineInputBorder(),
                   ),
                 ),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () async {
+                  final prefs = await SharedPreferences.getInstance();
+                  await prefs.setString('input_screen_text', _inputController.text);
+                },
+                child: const Text('Save'),
               ),
             ],
           ),

--- a/e2e/demo_app/lib/main.dart
+++ b/e2e/demo_app/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:demo_app/animation_screen.dart';
 import 'package:demo_app/connectivity_screen.dart';
 import 'package:demo_app/cropped_screenshot_screen.dart';
 import 'package:demo_app/defects_screen.dart';
@@ -8,15 +9,19 @@ import 'package:demo_app/issue_1619_repro.dart';
 import 'package:demo_app/issue_1677_repro.dart';
 import 'package:demo_app/location_screen.dart';
 import 'package:demo_app/nesting_screen.dart';
+import 'package:demo_app/orientation_screen.dart';
 import 'package:demo_app/gesture_tester_screen.dart';
+import 'package:demo_app/scrollable_list_screen.dart';
 import 'package:demo_app/sensors_screen.dart';
 import 'package:demo_app/webview.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_launch_arguments/flutter_launch_arguments.dart';
+import 'dart:async';
+import 'package:app_links/app_links.dart';
 
+final _navigatorKey = GlobalKey<NavigatorState>();
 
 void main() {
   runApp(const MyApp());
@@ -31,6 +36,7 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
+      navigatorKey: _navigatorKey,
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
@@ -47,6 +53,7 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   late final FlutterLaunchArguments _flutterLaunchArgumentsPlugin;
+  StreamSubscription<Uri>? _linkSubscription;
 
   int _counter = 0;
   int _delay = 0;
@@ -56,12 +63,34 @@ class _MyHomePageState extends State<MyHomePage> {
     super.initState();
     _flutterLaunchArgumentsPlugin = FlutterLaunchArguments();
     _initializeVars();
+    _initDeepLinks();
+  }
+
+  Future<void> _initDeepLinks() async {
+    final appLinks = AppLinks();
+    final initialUri = await appLinks.getInitialLink();
+    if (initialUri != null) _handleLink(initialUri);
+    _linkSubscription = appLinks.uriLinkStream.listen(_handleLink);
+  }
+
+  void _handleLink(Uri uri) {
+    if (uri.scheme == 'example' && uri.host == 'form') {
+      _navigatorKey.currentState?.push(
+        MaterialPageRoute(builder: (_) => const FormScreen()),
+      );
+    }
+  }
+
+  @override
+  void dispose() {
+    _linkSubscription?.cancel();
+    super.dispose();
   }
 
   Future<void> _initializeVars() async {
     final counterValue = await _flutterLaunchArgumentsPlugin.getInt('initialCounter');
     final delayValue = await _flutterLaunchArgumentsPlugin.getInt('delay');
-    
+
     setState(() {
       _counter = counterValue ?? 0;
       _delay = delayValue ?? 0;
@@ -83,132 +112,162 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(widget.title),
       ),
       body: SingleChildScrollView(
-        child: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              if (!kIsWeb)
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          children: [
+            GridView.count(
+              crossAxisCount: 2,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              childAspectRatio: 3,
+              mainAxisSpacing: 8,
+              crossAxisSpacing: 8,
+              children: [
+                if (!kIsWeb)
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.of(context).push(
+                        MaterialPageRoute(builder: (_) => const SensorsScreen()),
+                      );
+                    },
+                    child: const Text('Sensors'),
+                  ),
                 ElevatedButton(
                   onPressed: () {
                     Navigator.of(context).push(
-                      MaterialPageRoute(builder: (_) => const SensorsScreen()),
+                      MaterialPageRoute(builder: (_) => const LocationScreen()),
                     );
                   },
-                  child: const Text('Sensors'),
+                  child: const Text('Location Test'),
                 ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const LocationScreen()),
-                  );
-                },
-                child: const Text('Location Test'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const DefectsScreen()),
-                  );
-                },
-                child: const Text('Defects Test'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const NestingScreen()),
-                  );
-                },
-                child: const Text('Nesting Test'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const GestureTesterScreen()),
-                  );
-                },
-                child: const Text('Gesture Tester'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const FormScreen()),
-                  );
-                },
-                child: const Text('Form Test'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const InputScreen()),
-                  );
-                },
-                child: const Text('Input/Keyboard'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  const channel = MethodChannel('com.example.demo_app/password_test');
-                  channel.invokeMethod('openPasswordTest');
-                },
-                child: const Text('Password autofill Test'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const Issue1677Repro()),
-                  );
-                },
-                child: const Text('issue 1677 repro'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const Issue1619Repro()),
-                  );
-                },
-                child: const Text('issue 1619 repro'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const WebViewExample()),
-                  );
-                },
-                child: const Text('Webview Test'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const CroppedScreenshotScreen()),
-                  );
-                },
-                child: const Text('Cropped Screenshot Test'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const NotificationsPermissionScreen()),
-                  );
-                },
-                child: const Text('Notifications Permission'),
-              ),
-              ElevatedButton(
-                onPressed: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(builder: (_) => const ConnectivityScreen()),
-                  );
-                },
-                child: const Text('Connectivity Test'),
-              ),
-              const Text(
-                'You have pushed the button this many times',
-              ),
-              Text(
-                '$_counter',
-                style: Theme.of(context).textTheme.headlineMedium,
-              ),
-            ],
-          ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const DefectsScreen()),
+                    );
+                  },
+                  child: const Text('Defects Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const NestingScreen()),
+                    );
+                  },
+                  child: const Text('Nesting Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const GestureTesterScreen()),
+                    );
+                  },
+                  child: const Text('Gesture Tester'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const FormScreen()),
+                    );
+                  },
+                  child: const Text('Form Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const InputScreen()),
+                    );
+                  },
+                  child: const Text('Input/Keyboard'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    const channel = MethodChannel('com.example.demo_app/password_test');
+                    channel.invokeMethod('openPasswordTest');
+                  },
+                  child: const Text('Password autofill Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const Issue1677Repro()),
+                    );
+                  },
+                  child: const Text('issue 1677 repro'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const Issue1619Repro()),
+                    );
+                  },
+                  child: const Text('issue 1619 repro'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const WebViewExample()),
+                    );
+                  },
+                  child: const Text('Webview Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const CroppedScreenshotScreen()),
+                    );
+                  },
+                  child: const Text('Cropped Screenshot Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const NotificationsPermissionScreen()),
+                    );
+                  },
+                  child: const Text('Notifications Permission'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const ConnectivityScreen()),
+                    );
+                  },
+                  child: const Text('Connectivity Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const ScrollableListScreen()),
+                    );
+                  },
+                  child: const Text('Scrollable List'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const AnimationScreen()),
+                    );
+                  },
+                  child: const Text('Animation Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const OrientationScreen()),
+                    );
+                  },
+                  child: const Text('Orientation Test'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            const Text('You have pushed the button this many times'),
+            Text(
+              '$_counter',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+          ],
         ),
       ),
       floatingActionButton: Semantics(

--- a/e2e/demo_app/lib/orientation_screen.dart
+++ b/e2e/demo_app/lib/orientation_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class OrientationScreen extends StatefulWidget {
+  const OrientationScreen({super.key});
+
+  @override
+  State<OrientationScreen> createState() => _OrientationScreenState();
+}
+
+class _OrientationScreenState extends State<OrientationScreen>
+    with WidgetsBindingObserver {
+  static const _channel = MethodChannel('com.example.demo_app/orientation');
+  String _orientation = 'Unknown';
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _fetchOrientation();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeMetrics() {
+    _fetchOrientation();
+  }
+
+  Future<void> _fetchOrientation() async {
+    final result = await _channel.invokeMethod<String>('getOrientation');
+    if (result != null && mounted) {
+      setState(() => _orientation = result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Orientation Test'),
+      ),
+      body: Center(
+        child: Semantics(
+          identifier: 'orientationLabel',
+          child: Text(
+            _orientation,
+            style: Theme.of(context).textTheme.headlineLarge,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/e2e/demo_app/lib/scrollable_list_screen.dart
+++ b/e2e/demo_app/lib/scrollable_list_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class ScrollableListScreen extends StatelessWidget {
+  const ScrollableListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        title: const Text('Scrollable List'),
+      ),
+      body: ListView.builder(
+        itemCount: 20,
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text('Item ${index + 1}'),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/e2e/demo_app/pubspec.yaml
+++ b/e2e/demo_app/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   sensors_plus: ^4.0.2
   geolocator: ^13.0.1
   connectivity_plus: ^7.0.0
+  app_links: ^6.4.1
+  shared_preferences: ^2.5.5
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/e2e/run_tests
+++ b/e2e/run_tests
@@ -41,7 +41,7 @@ if [ "$platform" = "web" ]; then
 		_h3 "$app_name" "web" "$line"
 	done < pipe &
 
-	maestro --verbose --platform "$platform" test --flatten-debug-output --debug-output="$HOME/.maestro/tests/${app_name}/web" --headless --include-tags web --exclude-tags "$exclude_tags" "$workspace_dir" 1>pipe 2>&1 \
+	maestro --verbose --no-ansi --platform "$platform" test --flatten-debug-output --debug-output="$HOME/.maestro/tests/${app_name}/web" --headless --include-tags web --exclude-tags "$exclude_tags" "$workspace_dir" 1>pipe 2>&1 \
 		|| { _h2 "$app_name" "FAIL! Expected all pass, but at least some failed instead"; ALL_PASS=false; }
 else
 	for workspace_dir in ./demo_app/.maestro ./workspaces/*; do
@@ -67,7 +67,7 @@ else
 			_h3 "$app_name" "passing" "$line"
 		done < pipe &
 
-		maestro --verbose --platform "$platform" test --flatten-debug-output --debug-output="$HOME/.maestro/tests/${app_name}/passing" --include-tags passing --exclude-tags "$exclude_tags" "$workspace_dir" 1>pipe 2>&1 \
+		maestro --verbose --no-ansi --platform "$platform" test --flatten-debug-output --debug-output="$HOME/.maestro/tests/${app_name}/passing" --include-tags passing --exclude-tags "$exclude_tags" "$workspace_dir" 1>pipe 2>&1 \
 			|| { _h2 "$app_name" "FAIL! Expected all pass, but at least some failed instead"; ALL_PASS=false; }
 
 		###
@@ -83,7 +83,7 @@ else
 			_h3 "$app_name" "failing" "$line"
 		done < pipe &
 
-		maestro --verbose --platform "$platform" test --flatten-debug-output --debug-output="$HOME/.maestro/tests/${app_name}/failing" --include-tags failing --exclude-tags "$exclude_tags" "$workspace_dir" 1>pipe 2>&1 \
+		maestro --verbose --no-ansi --platform "$platform" test --flatten-debug-output --debug-output="$HOME/.maestro/tests/${app_name}/failing" --include-tags failing --exclude-tags "$exclude_tags" "$workspace_dir" 1>pipe 2>&1 \
 			&& { _h2 "$app_name" "FAIL! Expected all to fail, but at least some passed instead"; ALL_PASS=false; }
 	done
 fi

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -50,8 +50,11 @@ object TestDebugReporter {
 
     // AI outputs must be saved separately at the end of the flow.
     fun saveSuggestions(outputs: List<FlowAIOutput>, path: Path) {
+        val outputsWithContent = outputs.filter { it.screenOutputs.isNotEmpty() }
+        if (outputsWithContent.isEmpty()) return
+
         // This mutates the output.
-        outputs.forEach { output ->
+        outputsWithContent.forEach { output ->
             // Write AI screenshots. Paths need to be changed to the final ones.
             val updatedOutputs = output.screenOutputs.map { newOutput ->
                 val screenshotFilename = newOutput.screenshotPath.name
@@ -69,7 +72,7 @@ object TestDebugReporter {
             mapper.writeValue(jsonFile, output)
         }
 
-        HtmlAITestSuiteReporter().report(outputs, path.toFile())
+        HtmlAITestSuiteReporter().report(outputsWithContent, path.toFile())
     }
 
     /**

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
@@ -3,6 +3,7 @@ package maestro.cli.report
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -30,6 +31,27 @@ class TestDebugReporterTest {
         TestDebugReporter.deleteOldFiles()
         assertThat(Files.exists(oldDir)).isFalse() // Verify that the old directory was deleted
         assertThat(TestDebugReporter.getDebugOutputPath().exists()).isTrue() // Verify that the logs from this run still exist
+    }
+
+    @Test
+    fun `saveSuggestions should not write ai files when flow has no ai outputs`() {
+        val outputDir = Files.createDirectories(tempDir.resolve("debug-output"))
+
+        val outputs = listOf(
+            FlowAIOutput(
+                flowName = "login_test",
+                flowFile = File("flows/login_test.yaml"),
+            ),
+            FlowAIOutput(
+                flowName = "signup_test",
+                flowFile = File("flows/signup_test.yaml"),
+            ),
+        )
+
+        TestDebugReporter.saveSuggestions(outputs, outputDir)
+
+        val files = outputDir.toFile().listFiles()?.map { it.name } ?: emptyList()
+        assertThat(files.filter { it.startsWith("ai-") }).isEmpty()
     }
 
 }

--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -54,10 +54,6 @@ object Filters {
         nodes.filter { this(it) }
     }
 
-    fun nonClickable(): ElementFilter {
-        return { nodes -> nodes.filter { it.clickable == false } }
-    }
-
     fun textMatches(regex: Regex): ElementFilter {
         return { nodes ->
             val textMatches = nodes.filter {
@@ -185,11 +181,12 @@ object Filters {
         }
     }
 
-    fun containsChild(other: UiElement): ElementLookupPredicate {
-        val otherNode = other.treeNode
-        return {
-            it.children
-                .any { child -> child == otherNode }
+    fun containsChild(childFilter: ElementFilter): ElementFilter {
+        return { nodes ->
+            val matchingChildren = childFilter(nodes).toSet()
+            nodes.filter { node ->
+                node.children.any { child -> matchingChildren.contains(child) }
+            }
         }
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -1432,7 +1432,7 @@ class Orchestra(
         selector.containsChild
             ?.let {
                 descriptions += "Contains child: ${it.description()}"
-                relativeFilters += Filters.containsChild(findElement(it, optional = false).element).asFilter()
+                relativeFilters += Filters.containsChild(buildFilter(it).filterFunc)
             }
 
         selector.containsDescendants

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -590,6 +590,64 @@ class IntegrationTest {
     }
 
     @Test
+    fun `Case 139 - containsChild with relative selectors and transient hierarchy changes`() {
+        // Given: a nested layout with containsChild + relative selectors (below, above)
+        // A mutating text sibling inside level-1 simulates transient Android accessibility
+        // attribute changes between hierarchy fetches (e.g. focused state, drawingOrder, etc.)
+        val commands = readCommands("139_contains_child_with_relative_position")
+
+        var callCount = 0
+        val driver = driver {
+            // Reference element for "below" check
+            element {
+                text = "top side"
+                bounds = Bounds(100, 50, 200, 80)
+            }
+            // Reference element for "above" check
+            element {
+                text = "bottom side"
+                bounds = Bounds(100, 500, 200, 530)
+            }
+            // level-0 container
+            element {
+                id = "level-0"
+                bounds = Bounds(50, 100, 300, 450)
+
+                // level-1 container: below "top side" (y=120 > y=50) and above "bottom side" (y=120 < y=500)
+                element {
+                    id = "level-1"
+                    bounds = Bounds(70, 120, 280, 430)
+
+                    // level-2 (stable — no mutating attributes)
+                    element {
+                        id = "level-2"
+                        bounds = Bounds(90, 140, 260, 410)
+                    }
+
+                    // Sibling with transient text — simulates real Android hierarchy
+                    // where attributes like focused/drawingOrder change between dumps.
+                    // This causes level-1's TreeNode subtree to differ across hierarchy
+                    // fetches, breaking containsChild's cross-hierarchy equality check.
+                    element {
+                        mutatingText = { "transient_${callCount++}" }
+                        bounds = Bounds(90, 140, 200, 170)
+                    }
+                }
+            }
+        }
+
+        // When / Then: This SHOULD pass — all elements exist, all position checks are valid.
+        // The bug: containsChild eagerly captures a TreeNode from one hierarchy fetch, then
+        // compares it via data class equals against nodes from a later fetch. The mutating
+        // sibling changes level-1's subtree, so the deep structural equality fails.
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+    }
+
+    @Test
     fun `Case 019 - Do not wait until visible`() {
         // Given
         val commands = readCommands("019_dont_wait_for_visibility")

--- a/maestro-test/src/test/resources/139_contains_child_with_relative_position.yaml
+++ b/maestro-test/src/test/resources/139_contains_child_with_relative_position.yaml
@@ -1,0 +1,10 @@
+appId: com.example.app
+---
+- assertVisible:
+    id: level-0
+    containsChild:
+      id: level-1
+      containsChild:
+        id: level-2
+      below: top side
+      above: bottom side


### PR DESCRIPTION
## Summary
- Organize e2e debug output directory structure by app name and test type for easier debugging

<img width="473" height="124" alt="Screenshot 2026-04-04 at 12 47 35 PM" src="https://github.com/user-attachments/assets/08db432f-ef8e-4a19-a659-19e528a4b50e" />

and

<img width="670" height="93" alt="Screenshot 2026-04-04 at 12 47 51 PM" src="https://github.com/user-attachments/assets/efd85f42-10f8-49db-a1e3-2d7580ea2855" />

and 


<img width="1561" height="1008" alt="Screenshot 2026-04-04 at 12 48 26 PM" src="https://github.com/user-attachments/assets/f458fef9-e6fc-4403-ab11-c40413dc2e20" />

This ensures we have all the tests artifacts in one directory like shown above.


## Test plan
- [x] Run e2e tests and verify debug output is organized correctly