### PR TITLE
Skip additional config files in workspace execution planner

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
@@ -2,6 +2,7 @@ package maestro.orchestra
 
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.annotation.JsonCreator
+import kotlin.reflect.full.declaredMemberProperties
 
 data class WorkspaceConfig(
     val flows: StringList? = null,
@@ -72,6 +73,12 @@ data class WorkspaceConfig(
                     add(string)
                 }
             }
+        }
+    }
+
+    companion object {
+        val KNOWN_KEYS: Set<String> by lazy {
+            WorkspaceConfig::class.declaredMemberProperties.map { it.name }.toSet()
         }
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -1,23 +1,12 @@
 package maestro.orchestra.workspace
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import maestro.orchestra.WorkspaceConfig
+import maestro.orchestra.yaml.YamlCommandReader
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.extension
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.readText
-import kotlin.reflect.full.declaredMemberProperties
-
-private val WORKSPACE_CONFIG_KEYS: Set<String> by lazy {
-    WorkspaceConfig::class.declaredMemberProperties.map { it.name }.toSet()
-}
-
-private val YAML_MAPPER by lazy {
-    ObjectMapper(YAMLFactory())
-}
 
 fun isFlowFile(path: Path, config: Path?): Boolean {
     if (!path.isRegularFile()) return false // Not a file
@@ -33,8 +22,7 @@ private fun isWorkspaceConfigFile(path: Path): Boolean {
     return try {
         val content = path.readText()
         if (content.contains("\n---")) return false // Flow files have a document separator
-        val topLevelKeys = YAML_MAPPER.readValue(content, Map::class.java)?.keys ?: return false
-        topLevelKeys.all { it in WORKSPACE_CONFIG_KEYS }
+        YamlCommandReader.findUnknownWorkspaceConfigKeys(content)?.isEmpty() ?: false
     } catch (e: Exception) {
         false
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -32,8 +32,9 @@ fun isFlowFile(path: Path, config: Path?): Boolean {
 private fun isWorkspaceConfigFile(path: Path): Boolean {
     return try {
         val content = path.readText()
+        if (content.contains("\n---")) return false // Flow files have a document separator
         val topLevelKeys = YAML_MAPPER.readValue(content, Map::class.java)?.keys ?: return false
-        topLevelKeys.any { it in WORKSPACE_CONFIG_KEYS }
+        topLevelKeys.all { it in WORKSPACE_CONFIG_KEYS }
     } catch (e: Exception) {
         false
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -12,5 +12,6 @@ fun isFlowFile(path: Path, config: Path?): Boolean {
     val extension = path.extension
     if (extension != "yaml" && extension != "yml") return false // Not YAML
     if (path.nameWithoutExtension == "config") return false // Config file
+    if (path.nameWithoutExtension.endsWith("config")) return false // Additional config file (e.g. regression_config.yaml, ci-config.yaml)
     return true
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -12,5 +12,7 @@ fun isFlowFile(path: Path, config: Path?): Boolean {
     val extension = path.extension
     if (extension != "yaml" && extension != "yml") return false // Not YAML
     if (path.nameWithoutExtension == "config") return false // Config file
+    if (path.nameWithoutExtension.endsWith("_config")) return false // Additional config file (e.g. regression_config.yaml)
+    if (path.nameWithoutExtension.endsWith("-config")) return false // Additional config file (e.g. regression-config.yaml)
     return true
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -12,6 +12,5 @@ fun isFlowFile(path: Path, config: Path?): Boolean {
     val extension = path.extension
     if (extension != "yaml" && extension != "yml") return false // Not YAML
     if (path.nameWithoutExtension == "config") return false // Config file
-    if (path.nameWithoutExtension.endsWith("config")) return false // Additional config file (e.g. regression_config.yaml, ci-config.yaml)
     return true
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -1,10 +1,23 @@
 package maestro.orchestra.workspace
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import maestro.orchestra.WorkspaceConfig
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.extension
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.nameWithoutExtension
+import kotlin.io.path.readText
+import kotlin.reflect.full.declaredMemberProperties
+
+private val WORKSPACE_CONFIG_KEYS: Set<String> by lazy {
+    WorkspaceConfig::class.declaredMemberProperties.map { it.name }.toSet()
+}
+
+private val YAML_MAPPER by lazy {
+    ObjectMapper(YAMLFactory())
+}
 
 fun isFlowFile(path: Path, config: Path?): Boolean {
     if (!path.isRegularFile()) return false // Not a file
@@ -12,7 +25,16 @@ fun isFlowFile(path: Path, config: Path?): Boolean {
     val extension = path.extension
     if (extension != "yaml" && extension != "yml") return false // Not YAML
     if (path.nameWithoutExtension == "config") return false // Config file
-    if (path.nameWithoutExtension.endsWith("_config")) return false // Additional config file (e.g. regression_config.yaml)
-    if (path.nameWithoutExtension.endsWith("-config")) return false // Additional config file (e.g. regression-config.yaml)
-    return true
+
+    return !isWorkspaceConfigFile(path)
+}
+
+private fun isWorkspaceConfigFile(path: Path): Boolean {
+    return try {
+        val content = path.readText()
+        val topLevelKeys = YAML_MAPPER.readValue(content, Map::class.java)?.keys ?: return false
+        topLevelKeys.any { it in WORKSPACE_CONFIG_KEYS }
+    } catch (e: Exception) {
+        false
+    }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -46,10 +46,14 @@ object WorkspaceExecutionPlanner {
 
         val (files, directories) = input.partition { it.isRegularFile() }
 
-        val flowFiles = files.filter { isFlowFile(it, config) }
+        // Resolve config path before filtering, so auto-discovered configs are also excluded
+        val resolvedConfigPath = config?.absolute()
+            ?: directories.firstNotNullOfOrNull { findConfigFile(it) }
+
+        val flowFiles = files.filter { isFlowFile(it, resolvedConfigPath) }
         val flowFilesInDirs: List<Path> = directories.flatMap { dir -> Files
             .walk(dir)
-            .filter { isFlowFile(it, config) }
+            .filter { isFlowFile(it, resolvedConfigPath) }
             .toList()
         }
         if (flowFilesInDirs.isEmpty() && flowFiles.isEmpty()) {
@@ -61,10 +65,8 @@ object WorkspaceExecutionPlanner {
         // Filter flows based on flows config
 
         val workspaceConfig =
-            if (config != null) YamlCommandReader.readWorkspaceConfig(config.absolute())
-            else directories.firstNotNullOfOrNull { findConfigFile(it) }
-                ?.let { YamlCommandReader.readWorkspaceConfig(it) }
-                ?: WorkspaceConfig()
+            if (resolvedConfigPath != null) YamlCommandReader.readWorkspaceConfig(resolvedConfigPath)
+            else WorkspaceConfig()
 
         val globs = workspaceConfig.flows ?: listOf("*")
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -1,9 +1,7 @@
 package maestro.orchestra.workspace
 
 import maestro.orchestra.MaestroCommand
-import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
-import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.ExecutionOrderPlanner.getFlowsToRunInSequence
 import maestro.orchestra.yaml.YamlCommandReader
@@ -98,25 +96,14 @@ object WorkspaceExecutionPlanner {
 
         // Filter flows based on tags
 
-        val configPerFlowFile = mutableMapOf<Path, MaestroConfig?>()
-        val filteredFlowFiles = unsortedFlowFiles.filter { path ->
-            try {
-                val commands = validateFlowFile(path)
-                configPerFlowFile[path] = YamlCommandReader.getConfig(commands)
-                true
-            } catch (e: SyntaxError) {
-                if (isWorkspaceConfig(path)) {
-                    logger.info("Skipping {} (detected as workspace config file, not a flow)", path)
-                    false
-                } else {
-                    throw e
-                }
-            }
+        val configPerFlowFile = unsortedFlowFiles.associateWith {
+            val commands = validateFlowFile(it)
+            YamlCommandReader.getConfig(commands)
         }
 
         val allIncludeTags = includeTags + (workspaceConfig.includeTags?.toList() ?: emptyList())
         val allExcludeTags = excludeTags + (workspaceConfig.excludeTags?.toList() ?: emptyList())
-        val allFlows = filteredFlowFiles.filter {
+        val allFlows = unsortedFlowFiles.filter {
             val config = configPerFlowFile[it]
             val tags = config?.tags ?: emptyList()
 
@@ -173,15 +160,6 @@ object WorkspaceExecutionPlanner {
 
     private fun validateFlowFile(topLevelFlowPath: Path): List<MaestroCommand> {
         return YamlCommandReader.readCommands(topLevelFlowPath)
-    }
-
-    private fun isWorkspaceConfig(path: Path): Boolean {
-        return try {
-            YamlCommandReader.readWorkspaceConfig(path.absolute())
-            true
-        } catch (_: Exception) {
-            false
-        }
     }
 
     private fun findConfigFile(input: Path): Path? {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -1,9 +1,7 @@
 package maestro.orchestra.workspace
 
 import maestro.orchestra.MaestroCommand
-import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
-import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.ExecutionOrderPlanner.getFlowsToRunInSequence
 import maestro.orchestra.yaml.YamlCommandReader
@@ -100,25 +98,14 @@ object WorkspaceExecutionPlanner {
 
         // Filter flows based on tags
 
-        val configPerFlowFile = mutableMapOf<Path, MaestroConfig?>()
-        val filteredFlowFiles = unsortedFlowFiles.filter { path ->
-            try {
-                val commands = validateFlowFile(path)
-                configPerFlowFile[path] = YamlCommandReader.getConfig(commands)
-                true
-            } catch (e: SyntaxError) {
-                if (isWorkspaceConfig(path)) {
-                    logger.info("Skipping {} (detected as workspace config file, not a flow)", path)
-                    false
-                } else {
-                    throw e
-                }
-            }
+        val configPerFlowFile = unsortedFlowFiles.associateWith {
+            val commands = validateFlowFile(it)
+            YamlCommandReader.getConfig(commands)
         }
 
         val allIncludeTags = includeTags + (workspaceConfig.includeTags?.toList() ?: emptyList())
         val allExcludeTags = excludeTags + (workspaceConfig.excludeTags?.toList() ?: emptyList())
-        val allFlows = filteredFlowFiles.filter {
+        val allFlows = unsortedFlowFiles.filter {
             val config = configPerFlowFile[it]
             val tags = config?.tags ?: emptyList()
 
@@ -175,15 +162,6 @@ object WorkspaceExecutionPlanner {
 
     private fun validateFlowFile(topLevelFlowPath: Path): List<MaestroCommand> {
         return YamlCommandReader.readCommands(topLevelFlowPath)
-    }
-
-    private fun isWorkspaceConfig(path: Path): Boolean {
-        return try {
-            YamlCommandReader.readWorkspaceConfig(path.absolute())
-            true
-        } catch (_: Exception) {
-            false
-        }
     }
 
     private fun findConfigFile(input: Path): Path? {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -1,7 +1,9 @@
 package maestro.orchestra.workspace
 
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
+import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.ExecutionOrderPlanner.getFlowsToRunInSequence
 import maestro.orchestra.yaml.YamlCommandReader
@@ -98,14 +100,25 @@ object WorkspaceExecutionPlanner {
 
         // Filter flows based on tags
 
-        val configPerFlowFile = unsortedFlowFiles.associateWith {
-            val commands = validateFlowFile(it)
-            YamlCommandReader.getConfig(commands)
+        val configPerFlowFile = mutableMapOf<Path, MaestroConfig?>()
+        val filteredFlowFiles = unsortedFlowFiles.filter { path ->
+            try {
+                val commands = validateFlowFile(path)
+                configPerFlowFile[path] = YamlCommandReader.getConfig(commands)
+                true
+            } catch (e: SyntaxError) {
+                if (isWorkspaceConfig(path)) {
+                    logger.info("Skipping {} (detected as workspace config file, not a flow)", path)
+                    false
+                } else {
+                    throw e
+                }
+            }
         }
 
         val allIncludeTags = includeTags + (workspaceConfig.includeTags?.toList() ?: emptyList())
         val allExcludeTags = excludeTags + (workspaceConfig.excludeTags?.toList() ?: emptyList())
-        val allFlows = unsortedFlowFiles.filter {
+        val allFlows = filteredFlowFiles.filter {
             val config = configPerFlowFile[it]
             val tags = config?.tags ?: emptyList()
 
@@ -162,6 +175,15 @@ object WorkspaceExecutionPlanner {
 
     private fun validateFlowFile(topLevelFlowPath: Path): List<MaestroCommand> {
         return YamlCommandReader.readCommands(topLevelFlowPath)
+    }
+
+    private fun isWorkspaceConfig(path: Path): Boolean {
+        return try {
+            YamlCommandReader.readWorkspaceConfig(path.absolute())
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun findConfigFile(input: Path): Path? {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -1,7 +1,9 @@
 package maestro.orchestra.workspace
 
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
+import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.ExecutionOrderPlanner.getFlowsToRunInSequence
 import maestro.orchestra.yaml.YamlCommandReader
@@ -96,14 +98,25 @@ object WorkspaceExecutionPlanner {
 
         // Filter flows based on tags
 
-        val configPerFlowFile = unsortedFlowFiles.associateWith {
-            val commands = validateFlowFile(it)
-            YamlCommandReader.getConfig(commands)
+        val configPerFlowFile = mutableMapOf<Path, MaestroConfig?>()
+        val filteredFlowFiles = unsortedFlowFiles.filter { path ->
+            try {
+                val commands = validateFlowFile(path)
+                configPerFlowFile[path] = YamlCommandReader.getConfig(commands)
+                true
+            } catch (e: SyntaxError) {
+                if (isWorkspaceConfig(path)) {
+                    logger.info("Skipping {} (detected as workspace config file, not a flow)", path)
+                    false
+                } else {
+                    throw e
+                }
+            }
         }
 
         val allIncludeTags = includeTags + (workspaceConfig.includeTags?.toList() ?: emptyList())
         val allExcludeTags = excludeTags + (workspaceConfig.excludeTags?.toList() ?: emptyList())
-        val allFlows = unsortedFlowFiles.filter {
+        val allFlows = filteredFlowFiles.filter {
             val config = configPerFlowFile[it]
             val tags = config?.tags ?: emptyList()
 
@@ -160,6 +173,15 @@ object WorkspaceExecutionPlanner {
 
     private fun validateFlowFile(topLevelFlowPath: Path): List<MaestroCommand> {
         return YamlCommandReader.readCommands(topLevelFlowPath)
+    }
+
+    private fun isWorkspaceConfig(path: Path): Boolean {
+        return try {
+            YamlCommandReader.readWorkspaceConfig(path.absolute())
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun findConfigFile(input: Path): Path? {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -21,18 +21,23 @@ package maestro.orchestra.yaml
 
 import com.fasterxml.jackson.core.JsonLocation
 import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
 import maestro.orchestra.error.SyntaxError
 import maestro.utils.drawTextBox
+import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.readText
 
 object YamlCommandReader {
+
+    private val logger = LoggerFactory.getLogger(YamlCommandReader::class.java)
 
     // If it exists, automatically resolves the initFlow file and inlines the commands into the config
     fun readCommands(flowPath: Path): List<MaestroCommand> = mapParsingErrors(flowPath) {
@@ -49,10 +54,38 @@ object YamlCommandReader {
         MaestroFlowParser.parseConfigOnly(flowPath, flow)
     }
 
+    private val YAML_MAPPER by lazy { ObjectMapper(YAMLFactory()) }
+
     fun readWorkspaceConfig(configPath: Path): WorkspaceConfig = mapParsingErrors(configPath) {
         val config = configPath.readText()
         if (config.isBlank()) return@mapParsingErrors WorkspaceConfig()
+        validateWorkspaceConfigKeys(configPath, config)
         MaestroFlowParser.parseWorkspaceConfig(configPath, config)
+    }
+
+    private fun validateWorkspaceConfigKeys(configPath: Path, config: String) {
+        val unknownKeys = findUnknownWorkspaceConfigKeys(config) ?: return
+        if (unknownKeys.isNotEmpty()) {
+            logger.warn(
+                "Config file '{}' contains unknown keys: {}. Valid keys are: {}",
+                configPath.absolutePathString(),
+                unknownKeys,
+                WorkspaceConfig.KNOWN_KEYS.sorted(),
+            )
+        }
+    }
+
+    /**
+     * Returns the list of top-level keys in the config that are not recognized WorkspaceConfig properties,
+     * or null if the content cannot be parsed as a YAML map.
+     */
+    internal fun findUnknownWorkspaceConfigKeys(config: String): List<Any?>? {
+        val topLevelKeys = try {
+            YAML_MAPPER.readValue(config, Map::class.java)?.keys ?: return null
+        } catch (e: Exception) {
+            return null
+        }
+        return topLevelKeys.filter { it !in WorkspaceConfig.KNOWN_KEYS }
     }
 
     // Files to watch for changes. Includes any referenced files.

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -359,6 +359,23 @@ internal class WorkspaceExecutionPlannerTest {
         )
     }
 
+    @Test
+    internal fun `018 - Additional config files in workspace are not treated as flows`() {
+        // When
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/018_additional_config_files"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        // Then - regression_config.yaml should be excluded, only flow files should be included
+        assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/018_additional_config_files/flowA.yaml"),
+            path("/workspaces/018_additional_config_files/flowB.yaml"),
+        )
+    }
+
     private fun path(path: String): Path? {
         val clazz = WorkspaceExecutionPlannerTest::class.java
         val resource = clazz.getResource(path)?.toURI()

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -369,12 +369,13 @@ internal class WorkspaceExecutionPlannerTest {
             config = null,
         )
 
-        // Then - regression_config.yaml should be excluded, only flow files should be included
+        // Then - regression_config.yaml and platform_settings.yaml should be excluded, only flow files should be included
         assertThat(plan.flowsToRun).containsExactly(
             path("/workspaces/018_additional_config_files/flowA.yaml"),
             path("/workspaces/018_additional_config_files/flowB.yaml"),
         )
     }
+
 
     private fun path(path: String): Path? {
         val clazz = WorkspaceExecutionPlannerTest::class.java

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -826,6 +826,41 @@ internal class YamlCommandReaderTest {
     }
 
 
+    @Test
+    fun `findUnknownWorkspaceConfigKeys returns empty for valid keys`() {
+        val config = """
+            flows:
+              - "*"
+            includeTags:
+              - smoke
+        """.trimIndent()
+        assertThat(YamlCommandReader.findUnknownWorkspaceConfigKeys(config)).isEmpty()
+    }
+
+    @Test
+    fun `findUnknownWorkspaceConfigKeys detects unknown keys`() {
+        val config = """
+            flows:
+              - "*"
+            tapOn: some button
+            invalidKey: true
+        """.trimIndent()
+        assertThat(YamlCommandReader.findUnknownWorkspaceConfigKeys(config))
+            .containsExactly("tapOn", "invalidKey")
+    }
+
+    @Test
+    fun `findUnknownWorkspaceConfigKeys returns null for malformed yaml`() {
+        val config = "not: valid: yaml: ["
+        assertThat(YamlCommandReader.findUnknownWorkspaceConfigKeys(config)).isNull()
+    }
+
+    @Test
+    fun `findUnknownWorkspaceConfigKeys returns null for non-map yaml`() {
+        val config = "- launchApp"
+        assertThat(YamlCommandReader.findUnknownWorkspaceConfigKeys(config)).isNull()
+    }
+
     private fun commands(vararg commands: Command): List<MaestroCommand> =
         commands.map(::MaestroCommand).toList()
 }

--- a/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/config.yaml
@@ -1,0 +1,2 @@
+includeTags:
+  - included

--- a/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/flowA.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/flowA.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+tags:
+  - included
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/flowB.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/flowB.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+tags:
+  - included
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/platform_settings.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/platform_settings.yaml
@@ -1,0 +1,5 @@
+platform:
+  ios:
+    disableAnimations: true
+  android:
+    disableAnimations: true

--- a/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/regression_config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/018_additional_config_files/regression_config.yaml
@@ -1,0 +1,5 @@
+platform:
+  ios:
+    disableAnimations: true
+  android:
+    disableAnimations: true


### PR DESCRIPTION
When running a workspace, Maestro needs to distinguish between flow files (test scripts) and config files (workspace settings like platform configuration, tag filters, etc.). Previously, config files were only detected by filename - checking for exact match `config.yaml`. This meant any config file other than "config" name (e.g. platform_settings.yaml) would be incorrectly treated as a flow file and fail to parse.  [Maestro docs](https://docs.maestro.dev/maestro-flows/workspace-management/project-configuration#working-with-multiple-configs)

This PR replaces the filename-based heuristic with content-based detection. It reads the top-level YAML keys of each file and checks if any match known `WorkspaceConfig` properties (platform, includeTags, excludeTags, flows, etc.). The set of known keys is derived via reflection from the WorkspaceConfig data class, so it automatically stays in sync as new config fields are added - no hardcoded lists to maintain.
  
  
Test
  - 018 - Additional config files in workspace are not treated as flows