### PR TITLE
fix: Orchestra properly respects coroutine cancellation

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -232,6 +232,7 @@ class Orchestra(
             initJsEngine(config)
         }
 
+        yield()
         initAndroidChromeDevTools(config)
 
         commands

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -823,7 +823,7 @@ class Orchestra(
                 ?.let { evaluateCondition(it, commandOptional = command.optional) } != false
         }
 
-        while (checkCondition() && counter < maxRuns && currentCoroutineContext().isActive) {
+        while (checkCondition() && counter < maxRuns) {
             yield()
             if (counter > 0) {
                 command.commands.forEach { resetCommand(it) }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -19,8 +19,10 @@
 
 package maestro.orchestra
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.yield
 import maestro.Driver
 import maestro.ElementFilter
 import maestro.Filters
@@ -196,16 +198,22 @@ class Orchestra(
                     screenRecording?.close()
                 }
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Throwable) {
             exception = e
         } finally {
-            val onCompleteSuccess = config?.onFlowComplete?.commands?.let {
-                executeCommands(
-                    commands = it,
-                    config = config,
-                    shouldReinitJsEngine = false,
-                )
-            } ?: true
+            val onCompleteSuccess = if (currentCoroutineContext().isActive) {
+                config?.onFlowComplete?.commands?.let {
+                    executeCommands(
+                        commands = it,
+                        config = config,
+                        shouldReinitJsEngine = false,
+                    )
+                } ?: true
+            } else {
+                true
+            }
 
             jsEngine.close()
 
@@ -224,19 +232,11 @@ class Orchestra(
             initJsEngine(config)
         }
 
-        if (!currentCoroutineContext().isActive) {
-            logger.info("Flow cancelled, skipping initAndroidChromeDevTools...")
-        } else {
-            initAndroidChromeDevTools(config)
-        }
+        initAndroidChromeDevTools(config)
 
         commands
             .forEachIndexed { index, command ->
-                if (!currentCoroutineContext().isActive) {
-                    logger.info("[Command execution] Command skipped due to cancellation: $command")
-                    onCommandSkipped(index, command)
-                    return@forEachIndexed
-                }
+                yield()
 
                 // Check for pause before executing each command
                 flowController.waitIfPaused()
@@ -288,6 +288,8 @@ class Orchestra(
                     logger.info("[Command execution] CommandSkipped: ${ignored.message}")
                     // Swallow exception
                     onCommandSkipped(index, command)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Throwable) {
                     logger.error("[Command execution] CommandFailed: ${e.message}")
                     val errorResolution = onCommandFailed(index, command, e)
@@ -321,10 +323,6 @@ class Orchestra(
      */
     private suspend fun executeCommand(maestroCommand: MaestroCommand, config: MaestroConfig?): Boolean {
         val command = maestroCommand.asCommand()
-
-        if (!currentCoroutineContext().isActive) {
-            throw CommandSkipped
-        }
 
         flowController.waitIfPaused()
 
@@ -709,7 +707,7 @@ class Orchestra(
         return true
     }
 
-    private fun scrollUntilVisible(command: ScrollUntilVisibleCommand): Boolean {
+    private suspend fun scrollUntilVisible(command: ScrollUntilVisibleCommand): Boolean {
         val endTime = System.currentTimeMillis() + command.timeout.toLong()
         val direction = command.direction.toSwipeDirection()
         val deviceInfo = maestro.deviceInfo()
@@ -718,6 +716,7 @@ class Orchestra(
         val maxRetryCenterCount = 4 // for when the list is no longer scrollable (last element) but the element is visible
 
         do {
+            yield()
             try {
                 val element = findElement(command.selector, command.optional, 500).element
                 val visibility = element.getVisiblePercentage(deviceInfo.widthGrid, deviceInfo.heightGrid)
@@ -825,6 +824,7 @@ class Orchestra(
         }
 
         while (checkCondition() && counter < maxRuns && currentCoroutineContext().isActive) {
+            yield()
             if (counter > 0) {
                 command.commands.forEach { resetCommand(it) }
             }
@@ -853,6 +853,8 @@ class Orchestra(
         while (attempt <= maxRetries) {
             try {
                 return runSubFlow(command.commands, config, command.config)
+            } catch (e: CancellationException) {
+                throw e
             } catch (exception: Throwable) {
                 if (attempt == maxRetries) {
                     logger.error("Max retries ($maxRetries) reached. Commands failed.", exception)
@@ -981,6 +983,7 @@ class Orchestra(
         return try {
             commands
                 .mapIndexed { index, command ->
+                    yield()
                     onCommandStart(index, command)
 
                     val evaluatedCommand = command.evaluateScripts(jsEngine)
@@ -1013,6 +1016,8 @@ class Orchestra(
                         logger.info("[Command execution subflow] CommandSkipped: ${ignored.message}")
                         onCommandSkipped(index, command)
                         false
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Throwable) {
                         when (onCommandFailed(index, command, e)) {
                             ErrorResolution.FAIL -> throw e
@@ -1051,12 +1056,18 @@ class Orchestra(
                 if (onStartSuccess) {
                     flowSuccess = executeSubflowCommands(filteredCommands, config)
                 }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Throwable) {
                 throw e
             } finally {
-                onCompleteSuccess = subflowConfig?.onFlowComplete?.commands?.let {
-                    executeSubflowCommands(it, config)
-                } ?: true
+                onCompleteSuccess = if (currentCoroutineContext().isActive) {
+                    subflowConfig?.onFlowComplete?.commands?.let {
+                        executeSubflowCommands(it, config)
+                    } ?: true
+                } else {
+                    true
+                }
             }
             onCompleteSuccess && flowSuccess
         } finally {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -31,7 +31,12 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.Orchestra
 import maestro.orchestra.RunFlowCommand
+import maestro.orchestra.RetryCommand
+import maestro.orchestra.ScrollUntilVisibleCommand
+import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.error.UnicodeNotSupportedError
+import maestro.ScrollDirection
+import kotlinx.coroutines.TimeoutCancellationException
 import maestro.js.JsEngine
 import maestro.js.GraalJsEngine
 import maestro.orchestra.util.Env.withDefaultEnvVars
@@ -3619,57 +3624,38 @@ class IntegrationTest {
 
         var skipped = 0
         var completed = 0
-        val expectedSkipped = 7
-
 
         // When
         Maestro(driver).use { maestro ->
             runBlocking {
-                // Create a job that we can cancel
                 val job = Job()
-
-                // Create a supervisor scope so our skipped counter can still update after cancellation
                 val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
-                // Launch the work in our cancellable scope
-                scope.launch(job) {
-                    // Cancel the job immediately
+                val flowJob = scope.launch(job) {
+                    // Cancel the job immediately — before runFlow starts
                     coroutineContext.cancel()
 
-                    try {
-                        Orchestra(
-                            maestro,
-                            lookupTimeoutMs = 0L,
-                            optionalLookupTimeoutMs = 0L,
-                            onCommandComplete = { _, _ ->
-                                completed += 1
-                            },
-                            onCommandSkipped = { _, cmd ->
-                                skipped += 1
-                            },
-                        ).runFlow(commands)
-                    } catch (e: CancellationException) {
-                        // Expected cancellation
-                    }
+                    Orchestra(
+                        maestro,
+                        lookupTimeoutMs = 0L,
+                        optionalLookupTimeoutMs = 0L,
+                        onCommandComplete = { _, _ -> completed += 1 },
+                        onCommandSkipped = { _, _ -> skipped += 1 },
+                    ).runFlow(commands)
                 }
 
-                // Actively wait for skipped count to reach expected value or timeout
-                withTimeout(3000) {
-                    while (skipped < expectedSkipped) {
-                        yield() // Cooperatively yield to let other coroutines run
-
-                        // Check every 10ms
-                        delay(10)
-                    }
+                try {
+                    flowJob.join()
+                } catch (e: CancellationException) {
+                    // Expected
                 }
 
-                // Clean up the scope
                 scope.cancel()
             }
         }
 
-        // Then
-        assertThat(skipped).isEqualTo(7)
+        // Then — cancellation now throws immediately, no commands are skipped or completed
+        assertThat(skipped).isEqualTo(0)
         assertThat(completed).isEqualTo(0)
     }
 
@@ -3852,23 +3838,9 @@ class IntegrationTest {
                     try {
                         val orchestra = Orchestra(
                             maestro,
-                            onCommandComplete = { cmd, _ ->
-                                val isActive = coroutineContext[Job]?.isActive ?: false
-                                if (!isActive) {
-                                    skipped += 1
-                                    return@Orchestra
-                                }
-                                completed += 1
-                            },
-                            onCommandSkipped = { _, _ ->
-                                skipped += 1
-                            },
+                            onCommandComplete = { _, _ -> completed += 1 },
+                            onCommandSkipped = { _, _ -> skipped += 1 },
                             onCommandMetadataUpdate = { cmd, _ ->
-                                val isActive = coroutineContext[Job]?.isActive ?: false
-                                if (!isActive) {
-                                    return@Orchestra
-                                }
-
                                 val commandName = when {
                                     cmd.launchAppCommand != null -> "LaunchAppCommand"
                                     cmd.inputTextCommand != null -> "InputTextCommand"
@@ -3913,7 +3885,8 @@ class IntegrationTest {
 
         // Then
         assertThat(completed).isGreaterThan(0)
-        assertThat(skipped).isGreaterThan(0)
+        // Cancellation now throws immediately — no commands are "skipped"
+        assertThat(skipped).isEqualTo(0)
 
         assertThat(executedCommands).containsAtLeast(
             "LaunchAppCommand",
@@ -4170,54 +4143,188 @@ class IntegrationTest {
                 val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
                 try {
-                    val maxReasonableSkips = 1_00
-
                     withTimeout(2000) {
                         val orchestra = Orchestra(
                             maestro = maestro,
                             lookupTimeoutMs = 0L,
                             optionalLookupTimeoutMs = 0L,
-                            onCommandComplete = { index, command ->
-                                println("""
-                                    Completed command ${command.description()} at index $index.
-                                """.trimIndent()
-                                )
-
-                                completed += 1
-                            },
-                            onCommandSkipped = { index, command ->
-                                skipped += 1
-                                /**
-                                 * When this fail it means we might have entered an infinite loop.
-                                 *
-                                 * Our orchestra should not have infinite loops when timeout exceed.
-                                 */
-                                println("""
-                                        Command ${command.description()} at index $index was skipped $skipped times.
-                                """.trimIndent()
-                                )
-                                if (skipped > maxReasonableSkips) {
-                                    fail("Likely infinite loop: onCommandSkipped called $skipped times (command=$command index=$index)")
-                                }
-                            }
+                            onCommandComplete = { _, _ -> completed += 1 },
+                            onCommandSkipped = { _, _ -> skipped += 1 },
                         )
 
-                        // This should be interrupted by withTimeout if repeatWhile keeps going
                         orchestra.runFlow(commands)
                     }
+                    fail("Expected TimeoutCancellationException")
+                } catch (e: TimeoutCancellationException) {
+                    // Expected — cancellation properly propagated
                 } finally {
                     scope.coroutineContext[Job]?.cancel()
                 }
             }
         }
 
-        // Assertions
-        // Some commands actually completed before timeout.
+        // Some commands completed before timeout
         assertThat(completed).isGreaterThan(0)
 
-        // Depending on how you wire onCommandSkipped for cancellation, you may or may not
-        // see skipped > 0; keep this if you convert cancellations to "skipped".
-        assertThat(skipped).isGreaterThan(0)
+        // Cancellation now throws immediately — no commands are "skipped"
+        assertThat(skipped).isEqualTo(0)
+    }
+
+    @Test
+    fun `Case 140 - scrollUntilVisible respects coroutine cancellation`() {
+        // No matching element exists, so scrollUntilVisible loops until its 60s timeout.
+        // We cancel via withTimeout(2000) — Orchestra should stop within ~2s, not 60s.
+        val driver = driver {
+            // No elements — selector will never match, so scrollUntilVisible loops forever
+        }
+
+        var startedCommands = 0
+
+        Maestro(driver).use { maestro ->
+            val exception = assertThrows<TimeoutCancellationException> {
+                runBlocking {
+                    withTimeout(2000) {
+                        val orchestra = Orchestra(
+                            maestro = maestro,
+                            lookupTimeoutMs = 0L,
+                            optionalLookupTimeoutMs = 0L,
+                            onCommandStart = { _, _ -> startedCommands++ },
+                        )
+
+                        orchestra.runFlow(
+                            listOf(
+                                MaestroCommand(
+                                    scrollUntilVisible = ScrollUntilVisibleCommand(
+                                        selector = ElementSelector(textRegex = "Hidden"),
+                                        direction = ScrollDirection.DOWN,
+                                        timeout = "60000",
+                                        visibilityPercentage = 100,
+                                        centerElement = false,
+                                    )
+                                ),
+                                // This command should never start
+                                MaestroCommand(
+                                    tapOnElement = TapOnElementCommand(
+                                        selector = ElementSelector(textRegex = "Hidden"),
+                                    )
+                                ),
+                            )
+                        )
+                    }
+                }
+            }
+
+            // scrollUntilVisible started
+            assertThat(startedCommands).isEqualTo(1)
+            // Swipes happened (loop was running before cancellation)
+            driver.assertAnyEvent { it is Event.SwipeElementWithDirection }
+        }
+    }
+
+    @Test
+    fun `Case 141 - retryCommand respects coroutine cancellation`() {
+        // Retry wraps a command that always fails. maxRetries is high.
+        // withTimeout should cancel before all retries are exhausted.
+        val driver = driver {
+            // No elements — tap will always fail
+        }
+
+        var startedCommands = 0
+
+        Maestro(driver).use { maestro ->
+            assertThrows<TimeoutCancellationException> {
+                runBlocking {
+                    withTimeout(2000) {
+                        val orchestra = Orchestra(
+                            maestro = maestro,
+                            lookupTimeoutMs = 0L,
+                            optionalLookupTimeoutMs = 0L,
+                            onCommandStart = { _, _ -> startedCommands++ },
+                        )
+
+                        orchestra.runFlow(
+                            listOf(
+                                MaestroCommand(
+                                    retryCommand = RetryCommand(
+                                        maxRetries = "3",
+                                        commands = listOf(
+                                            MaestroCommand(
+                                                scrollUntilVisible = ScrollUntilVisibleCommand(
+                                                    selector = ElementSelector(textRegex = "NonExistent"),
+                                                    direction = ScrollDirection.DOWN,
+                                                    timeout = "60000",
+                                                    visibilityPercentage = 100,
+                                                    centerElement = false,
+                                                )
+                                            )
+                                        ),
+                                        config = null,
+                                    )
+                                ),
+                            )
+                        )
+                    }
+                }
+            }
+
+            // Retry started (at least one onCommandStart for the retry command)
+            assertThat(startedCommands).isGreaterThan(0)
+        }
+    }
+
+    @Test
+    fun `Case 142 - no callbacks fire after cancellation`() {
+        // Flow has a slow command followed by many more commands.
+        // After cancellation, no onCommandStart should fire.
+        val driver = driver {
+            // No elements — selector will never match, so scrollUntilVisible loops forever
+        }
+
+        val startedAfterCancellation = mutableListOf<String>()
+        var cancellationDetected = false
+
+        Maestro(driver).use { maestro ->
+            assertThrows<TimeoutCancellationException> {
+                runBlocking {
+                    withTimeout(2000) {
+                        val orchestra = Orchestra(
+                            maestro = maestro,
+                            lookupTimeoutMs = 0L,
+                            optionalLookupTimeoutMs = 0L,
+                            onCommandStart = { _, cmd ->
+                                if (cancellationDetected) {
+                                    startedAfterCancellation.add(cmd.description())
+                                }
+                            },
+                            onCommandFailed = { _, _, _ ->
+                                cancellationDetected = true
+                                Orchestra.ErrorResolution.CONTINUE
+                            },
+                        )
+
+                        orchestra.runFlow(
+                            listOf(
+                                MaestroCommand(
+                                    scrollUntilVisible = ScrollUntilVisibleCommand(
+                                        selector = ElementSelector(textRegex = "Hidden"),
+                                        direction = ScrollDirection.DOWN,
+                                        timeout = "60000",
+                                        visibilityPercentage = 100,
+                                        centerElement = false,
+                                    )
+                                ),
+                                // These should never get onCommandStart called
+                                MaestroCommand(tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "A"))),
+                                MaestroCommand(tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "B"))),
+                                MaestroCommand(tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "C"))),
+                            )
+                        )
+                    }
+                }
+            }
+
+            assertThat(startedAfterCancellation).isEmpty()
+        }
     }
 
     @Test

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -29,6 +29,7 @@ import maestro.orchestra.ElementSelector
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
+import maestro.orchestra.MaestroOnFlowComplete
 import maestro.orchestra.Orchestra
 import maestro.orchestra.RunFlowCommand
 import maestro.orchestra.RetryCommand
@@ -4304,6 +4305,18 @@ class IntegrationTest {
 
                         orchestra.runFlow(
                             listOf(
+                                // Config with onFlowComplete — should NOT run on cancellation
+                                MaestroCommand(
+                                    applyConfigurationCommand = ApplyConfigurationCommand(
+                                        config = MaestroConfig(
+                                            onFlowComplete = MaestroOnFlowComplete(
+                                                commands = listOf(
+                                                    MaestroCommand(tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "cleanup"))),
+                                                )
+                                            )
+                                        )
+                                    )
+                                ),
                                 MaestroCommand(
                                     scrollUntilVisible = ScrollUntilVisibleCommand(
                                         selector = ElementSelector(textRegex = "Hidden"),
@@ -4324,6 +4337,8 @@ class IntegrationTest {
             }
 
             assertThat(startedAfterCancellation).isEmpty()
+            // Verify onFlowComplete commands did not execute
+            driver.assertNoEvent(Event.Tap(Point(0, 0)))
         }
     }
 


### PR DESCRIPTION
## Problem

Orchestra has unexpected and buggy coroutine cancellation behavior. It was originally implemented in [this PR](https://github.com/mobile-dev-inc/Maestro/pull/2488/changes#diff-de990d27a0c12277340b89affbcbe8a8edd03e1c3ab62a36e3c6e5b55b6f17f9), but was never fully implemented.  

Here are the problems with it:

- **`executeCommands`** iterates all remaining commands on cancellation, calling `onCommandSkipped` for each (could be hundreds). This was by design in the original PR, but the behavior is very confusing.
- **`executeSubflowCommands`** fires `onCommandStart` callbacks with no cancellation check
- **`scrollUntilVisible`** has a blocking do-while loop with no cancellation check — scrolls forever after cancellation
- **`retryCommand`** retries indefinitely even after cancellation
- **`catch (Throwable)`** blocks in 5 locations silently swallow `CancellationException`
- **`onFlowComplete`** runs in finally blocks even during cancellation, which can hang

## Fix

- Add `yield()` at 4 key checkpoints (command loops, scroll loop, repeat loop, subflow loop) — each is either the only cancellation point in a blocking loop, or prevents post-cancellation callbacks
- Add `catch (CancellationException) { throw e }` before all `catch (Throwable)` blocks
- Guard `onFlowComplete` in `runFlow()` and `runSubFlow()` finally blocks with `isActive`

## What this enables

Callers can now reliably use `withTimeout` to set a deadline on `orchestra.runFlow()`:

```kotlin
withTimeout(15.minutes) {
    orchestra.runFlow(commands)
}
```

Cancellation propagates immediately — no lingering loops, no post-cancellation callbacks, no `onFlowComplete` hanging. This supersedes #3149.

NOTE: This does not solve the problem of blocking IO calls. This only solves cancellation during places we have control over in Orchestra. Blocking IO calls will be improved in a follow-up PR.

## Test plan

- [x] Case 140: `scrollUntilVisible` stops within 2s when coroutine is cancelled (was infinite)
- [x] Case 141: `retryCommand` stops within 2s when coroutine is cancelled (was infinite)
- [x] Case 142: No `onCommandStart` callbacks fire after cancellation
- [x] Cases 121, 124, 132: Updated to expect immediate `CancellationException` instead of skip-based behavior
- [x] Full integration suite (199 tests) passes