### PR TITLE
fix: resolve config path before filtering flow files

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -46,10 +46,14 @@ object WorkspaceExecutionPlanner {
 
         val (files, directories) = input.partition { it.isRegularFile() }
 
-        val flowFiles = files.filter { isFlowFile(it, config) }
+        // Resolve config path before filtering, so auto-discovered configs are also excluded
+        val resolvedConfigPath = config?.absolute()
+            ?: directories.firstNotNullOfOrNull { findConfigFile(it) }
+
+        val flowFiles = files.filter { isFlowFile(it, resolvedConfigPath) }
         val flowFilesInDirs: List<Path> = directories.flatMap { dir -> Files
             .walk(dir)
-            .filter { isFlowFile(it, config) }
+            .filter { isFlowFile(it, resolvedConfigPath) }
             .toList()
         }
         if (flowFilesInDirs.isEmpty() && flowFiles.isEmpty()) {
@@ -61,10 +65,8 @@ object WorkspaceExecutionPlanner {
         // Filter flows based on flows config
 
         val workspaceConfig =
-            if (config != null) YamlCommandReader.readWorkspaceConfig(config.absolute())
-            else directories.firstNotNullOfOrNull { findConfigFile(it) }
-                ?.let { YamlCommandReader.readWorkspaceConfig(it) }
-                ?: WorkspaceConfig()
+            if (resolvedConfigPath != null) YamlCommandReader.readWorkspaceConfig(resolvedConfigPath)
+            else WorkspaceConfig()
 
         val globs = workspaceConfig.flows ?: listOf("*")
 


### PR DESCRIPTION
Previously, when no `--config` flag was passed, `findConfigFile()` was called after `isFlowFile()` had already filtered flows with `config=null`. This meant the auto-discovered config.yaml was never excluded by path comparison — it only worked because of a hardcoded name check (`nameWithoutExtension == "config"`).

This PR moves `findConfigFile()` before the filtering step, so `isFlowFile` always receives the resolved config path.