### PR TITLE
Detect Azure as CI provider

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/CiUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/CiUtils.kt
@@ -15,7 +15,7 @@ object CiUtils {
         "GITLAB_CI" to "gitlab",
         "JENKINS_HOME" to "jenkins",
         "TEAMCITY_VERSION" to "teamcity", // since v1.37.4
-        "TF_BUILD" to "azure",
+        "TF_BUILD" to "azure", // since v2.5.0
         "CI" to "ci"
     )
 

--- a/maestro-cli/src/main/java/maestro/cli/util/CiUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/CiUtils.kt
@@ -15,6 +15,7 @@ object CiUtils {
         "GITLAB_CI" to "gitlab",
         "JENKINS_HOME" to "jenkins",
         "TEAMCITY_VERSION" to "teamcity", // since v1.37.4
+        "TF_BUILD" to "azure",
         "CI" to "ci"
     )
 


### PR DESCRIPTION
## Proposed changes

Detect Azure as CI provider via the [TF_BUILD environment variable](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#:~:text=TF_BUILD).

## Testing

Tested locally by setting the `TF_BUILD` environment variable and seeing that no promotional messages are shown when running `maestro test` (ensuring they aren't hidden for other reasons).

## Issues fixed

Maestro CLI shows promotional messages when used in Azure pipelines.