### PR TITLE
fix MaestroTimer.withTimeout usage for iOS app stop / start

### DIFF
--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -209,24 +209,20 @@ class LocalSimulatorUtils(private val tempFileHandler: TempFileHandler) {
 
     private fun ensureStopped(deviceId: String, bundleId: String) {
         MaestroTimer.withTimeout(10000) {
-            while (true) {
-                if (isAppRunning(deviceId, bundleId)) {
-                    Thread.sleep(1000)
-                } else {
-                    return@withTimeout
-                }
+            if (!isAppRunning(deviceId, bundleId)) true
+            else {
+                Thread.sleep(1000)
+                null
             }
         } ?: throw SimctlError("App $bundleId did not stop in time")
     }
 
     private fun ensureRunning(deviceId: String, bundleId: String) {
         MaestroTimer.withTimeout(10000) {
-            while (true) {
-                if (isAppRunning(deviceId, bundleId)) {
-                    return@withTimeout
-                } else {
-                    Thread.sleep(1000)
-                }
+            if (isAppRunning(deviceId, bundleId)) true
+            else {
+                Thread.sleep(1000)
+                null
             }
         } ?: throw SimctlError("App $bundleId did not start in time")
     }


### PR DESCRIPTION
## Proposed changes

I hit a case where trying to test an app that was linking to a missing framework crashed immediately but the launchApp command in maestro never resolved, while looking into that I noticed that both `ensureStopped` / `ensureRunning` use a while loop inside `MaestroTimer.withTimeout` which expects the block to return, but in this case if the app either does not start (or at least is dead until the first check or vice versa never stops) those blocks run indefinitely. This was the fix that helped locally to at least honour the 10s timeout.

A complete fix would be to maybe take into account the state of the original spawn process - if that has exited then the app is dead, but that is a much broader change whereas this fix seems intuitive to me and since i'm new to this tool I dont know the policies etc.

## Testing

<!--- Please describe how you tested your changes. -->

I verified that  an app launch for an app that crashes immediately actually fails after 10s instead of hanging.

> **Does this need e2e tests?** Please consider contributing them to the [demo app](https://github.com/mobile-dev-inc/demo_app) repository.
Regarding e2e tests, I'm not sure, shuld a faulty app be added for e2e in this scenario?
## Issues fixed
