### PR TITLE
fix: tapOn '<text>' fails for React Native Pressable with accessibilityLabel on iOS (#1409)

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -194,7 +194,16 @@ class IOSDriver(
         attributes["accessibilityText"] = element.label
         attributes["title"] = element.title ?: ""
         attributes["value"] = element.value ?: ""
-        attributes["text"] = element.title?.ifEmpty { element.value } ?: ""
+        // Fall back to accessibility label when title and value are both empty.
+        // This is the common case for React Native Pressable with accessibilityLabel —
+        // iOS collapses child Text into the parent's accessibility label, leaving
+        // title and value empty. Without this fallback, `tapOn: "<text>"` cannot
+        // find buttons that are clearly visible to users. See #1409.
+        attributes["text"] = element.title
+            ?.takeIf { it.isNotEmpty() }
+            ?: element.value
+                ?.takeIf { it.isNotEmpty() }
+            ?: element.label
         attributes["hintText"] = element.placeholderValue ?: ""
         attributes["resource-id"] = element.identifier
         attributes["bounds"] = element.frame.boundsString

--- a/maestro-client/src/test/java/maestro/ios/IOSViewHierarchyTest.kt
+++ b/maestro-client/src/test/java/maestro/ios/IOSViewHierarchyTest.kt
@@ -1,0 +1,105 @@
+package maestro.ios
+
+import com.google.common.truth.Truth.assertThat
+import hierarchy.AXElement
+import hierarchy.AXFrame
+import maestro.TreeNode
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the iOS view hierarchy mapping logic.
+ *
+ * Since IOSDriver.mapViewHierarchy is private, we test the same mapping
+ * logic by constructing AXElements and verifying the expected TreeNode
+ * attribute behavior through the public mapping contract:
+ * - text = title ?: value ?: label
+ * - accessibilityText = label
+ */
+class IOSViewHierarchyTest {
+
+    @Test
+    fun `text attribute uses title when present`() {
+        val element = axElement(title = "Submit", value = "", label = "Submit button")
+
+        val attributes = mapAttributes(element)
+
+        assertThat(attributes["text"]).isEqualTo("Submit")
+        assertThat(attributes["accessibilityText"]).isEqualTo("Submit button")
+    }
+
+    @Test
+    fun `text attribute uses value when title is empty`() {
+        val element = axElement(title = "", value = "42", label = "Counter")
+
+        val attributes = mapAttributes(element)
+
+        assertThat(attributes["text"]).isEqualTo("42")
+    }
+
+    @Test
+    fun `text attribute falls back to label when title and value are empty`() {
+        // This is the React Native Pressable + accessibilityLabel case (#1409)
+        val element = axElement(title = "", value = "", label = "Continue with Google")
+
+        val attributes = mapAttributes(element)
+
+        assertThat(attributes["text"]).isEqualTo("Continue with Google")
+        assertThat(attributes["accessibilityText"]).isEqualTo("Continue with Google")
+    }
+
+    @Test
+    fun `text attribute falls back to label when title is null`() {
+        val element = axElement(title = null, value = null, label = "Sign Out")
+
+        val attributes = mapAttributes(element)
+
+        assertThat(attributes["text"]).isEqualTo("Sign Out")
+    }
+
+    @Test
+    fun `text attribute is empty when everything is empty`() {
+        val element = axElement(title = "", value = "", label = "")
+
+        val attributes = mapAttributes(element)
+
+        assertThat(attributes["text"]).isEqualTo("")
+    }
+
+    // Replicates the mapping logic from IOSDriver.mapViewHierarchy
+    private fun mapAttributes(element: AXElement): Map<String, String> {
+        val attributes = mutableMapOf<String, String>()
+        attributes["accessibilityText"] = element.label
+        attributes["title"] = element.title ?: ""
+        attributes["value"] = element.value ?: ""
+        attributes["text"] = element.title
+            ?.takeIf { it.isNotEmpty() }
+            ?: element.value
+                ?.takeIf { it.isNotEmpty() }
+            ?: element.label
+        attributes["hintText"] = element.placeholderValue ?: ""
+        attributes["resource-id"] = element.identifier
+        return attributes
+    }
+
+    private fun axElement(
+        title: String? = "",
+        value: String? = "",
+        label: String = "",
+    ): AXElement = AXElement(
+        label = label,
+        elementType = 0,
+        identifier = "",
+        horizontalSizeClass = 0,
+        windowContextID = 0,
+        verticalSizeClass = 0,
+        selected = false,
+        displayID = 0,
+        hasFocus = false,
+        placeholderValue = null,
+        value = value,
+        frame = AXFrame(0f, 0f, 100f, 50f),
+        enabled = true,
+        title = title,
+        children = arrayListOf(),
+    )
+}


### PR DESCRIPTION
## Proposed changes

**`tapOn: "<text>"` fails to find React Native buttons that have `accessibilityLabel` set on iOS** — even though users clearly see the text on screen. This has been broken for **2.5 years** (#1409, opened in 2023) and affects every React Native app that uses the recommended accessibility pattern.

### Impact

- **Resolves #1409** — open since June 2023 with multiple confirmations from the community, including someone who [identified the exact line of broken code](https://github.com/mobile-dev-inc/Maestro/issues/1409#issuecomment-2711811886)
- **Likely resolves #2448** — "tapOn succeeds but doesn't trigger navigation" on React Native iOS tabs has the same root cause (matching the wrong element)
- **One-line fix** in `IOSDriver.kt:mapViewHierarchy` plus a clarifying comment

### Root cause

When a React Native `Pressable` has `accessibilityLabel` set, iOS collapses child Text elements into the parent's accessibility label. The element's `title` and `value` are empty — only `label` is populated.

Maestro's iOS hierarchy mapping (`IOSDriver.kt:197`) populates the `text` attribute from `title` or `value`:

```kotlin
attributes["text"] = element.title?.ifEmpty { element.value } ?: ""
```

So for these Pressables, `text` is always `""`. The user types `tapOn: "Continue with Google"` and Maestro can't find the element.

### Reproduction

```jsx
<Pressable
  accessibilityLabel="Continue with Google"
  accessibilityRole="button"
  onPress={handler}
>
  <Ionicons name="logo-google" />
  <Text>Continue with Google</Text>
</Pressable>
```

```yaml
- tapOn: "Continue with Google"  # FAILS — element not found
```

The hierarchy dump from `maestro hierarchy` shows:

```json
{
  "accessibilityText": "Continue with Google",
  "title": "",
  "value": "",
  "text": "",
  "bounds": "[24,582][378,630]",
  "enabled": "true"
}
```

The element exists, the bounds are correct, the user can see it — but `text` is empty so the most natural selector fails.

### Why the existing workarounds aren't acceptable

1. **`tapOn { label: "Continue with Google" }`**: Users shouldn't need to know the difference between `text:` and `label:`. They see text on screen, they expect `tapOn: "that text"` to work.
2. **`tapOn: ".*Continue with Google.*"` (regex)**: Finds the element via the existing `Filters.textMatches` accessibilityText fallback, but Maestro then taps the bounds-center of whatever element matches — which can be a parent View instead of the Pressable. This is the root of #2448's "tap succeeds but onPress doesn't fire."
3. **Removing `accessibilityLabel`**: Bad workaround. The label exists for screen reader users (localization, icon+text combos, etc.).
4. **Coordinate taps**: Defeats the entire purpose of using Maestro.

### Fix

```kotlin
attributes["text"] = element.title
    ?.takeIf { it.isNotEmpty() }
    ?: element.value
        ?.takeIf { it.isNotEmpty() }
    ?: element.label
```

Falls back to `element.label` (the iOS accessibility label) when `title` and `value` are both empty. The `accessibilityText` attribute still uses `element.label` as its canonical source, so `Filters.textMatches`'s existing fallback through `accessibilityText` continues to work as before.

This also indirectly fixes the "tap doesn't fire onPress" symptom from #2448: when `text` is populated on the Pressable itself, normal element ranking picks the deepest text-bearing match (the Pressable) rather than a parent View, and the bounds-center tap lands on the actual touchable area.

### Why this hasn't been fixed for 2.5 years

[The maintainer noted](https://github.com/mobile-dev-inc/Maestro/issues/1409#issuecomment-4067013169) that "It doesn't look like anyone in the community has been motivated to attempt a fix." A community member [identified the exact code location](https://github.com/mobile-dev-inc/Maestro/issues/1409#issuecomment-2711811886) in March 2025 but no PR followed. This change is small (10 lines + comment) and well-isolated.

## Testing

- Builds and unit tests pass
- The change is purely additive: when `title` or `value` is set (e.g., UIButton, text fields), behavior is unchanged. The fallback only triggers when both are empty.
- Verified against the hierarchy dump from a real React Native app exhibiting this bug

> **Depends on**: #3141 → #3140 → #3139 → #3138 (stacked PR chain for parallel iOS execution and performance)

## Issues fixed

Closes #1409
Likely fixes #2448 (same root cause class)
