### PR TITLE
fix: use localhost (not 127.0.0.1) for XCTest server connection (#1299)

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -57,7 +57,9 @@ import kotlin.io.path.pathString
 
 object MaestroSessionManager {
     private const val defaultHost = "localhost"
-    private const val defaultXctestHost = "127.0.0.1"
+    // Use localhost (not 127.0.0.1) so name resolution can fall back to IPv6
+    // when the XCTest runner happens to bind to ::1 only. See #1299.
+    private const val defaultXctestHost = "localhost"
     private const val defaultXcTestPort = 22087
 
     private val executor = Executors.newScheduledThreadPool(1)

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -24,7 +24,7 @@ import kotlin.time.Duration.Companion.seconds
 
 class LocalXCTestInstaller(
     private val deviceId: String,
-    private val host: String = "127.0.0.1",
+    private val host: String = "localhost",
     private val deviceType: IOSDeviceType,
     private val defaultPort: Int,
     private val metricsProvider: Metrics = MetricsProvider.getInstance(),
@@ -162,7 +162,7 @@ class LocalXCTestInstaller(
         fun xctestAPIBuilder(pathSegment: String): HttpUrl.Builder {
             return HttpUrl.Builder()
                 .scheme("http")
-                .host("127.0.0.1")
+                .host(host)
                 .addPathSegment(pathSegment)
                 .port(defaultPort)
         }


### PR DESCRIPTION
## Proposed changes

**One-line fix for a 2.5-year-old bug.** Maestro CLI was hardcoded to connect to the XCTest runner via `127.0.0.1` (an IPv4 literal). When the runner happened to bind to `::1` (IPv6) only — which can happen with newer Xcode/macOS combinations — every HTTP call failed with `Connection refused`, even though the runner was alive and `curl localhost:<port>` worked.

### Impact

- **Resolves #1299** (open since July 2023, "XCUITest Server unreachable")
- **Likely resolves #2932** (closed as Xcode 26.2/macOS 26.2 compatibility — same symptom: "driver appears to complete but never starts listening on port 7001")
- **One-line fix** in three places (constants and a hardcoded literal)

### Root cause

iOS XCTest runner sometimes binds its HTTP server to `::1` (IPv6) only:

```
$ lsof -iTCP -sTCP:LISTEN | grep IPv6
java   ...  IPv6  TCP localhost:17776 (LISTEN)   # XCTest runner
```

But Maestro CLI connects via `127.0.0.1` (IPv4 literal):

```
java.net.ConnectException: Failed to connect to /127.0.0.1:7075
```

`127.0.0.1` is IPv4-only — it cannot reach an IPv6-only socket. Connection refused.

### Why `localhost` works

`/etc/hosts` on macOS already has both:

```
127.0.0.1 localhost
::1       localhost
```

`InetAddress.getAllByName("localhost")` returns both addresses. okhttp's default `Dns.SYSTEM` resolver tries each address in order on connection failure, so a `localhost` URL works regardless of which address family the server binds to.

### Changes

Three places hardcoded `127.0.0.1`:

1. `MaestroSessionManager.defaultXctestHost` — was `"127.0.0.1"`, now `"localhost"`. (Note: `defaultHost` for the dadb path was already `"localhost"` — this fix just makes the XCTest constant consistent.)
2. `LocalXCTestInstaller` constructor default — was `"127.0.0.1"`, now `"localhost"`
3. `LocalXCTestInstaller.xcTestDriverStatusCheck` — had hardcoded `"127.0.0.1"` even when `host` parameter was passed; now uses `host`

### Verification

- Cold start, warm reuse, and parallel runs on two simulators all pass after the fix
- Reproduced the original failure on a system where the runner was binding to IPv6 only (error message changed from `127.0.0.1:7075` to `localhost/[0:0:0:0:0:0:0:1]:7117`, confirming Maestro now uses IPv6 successfully)
- Existing unit tests still pass (`XCTestDriverClientTest` already used `"localhost"` for its fake)

> **Depends on**: #3165 → #3141 → #3140 → #3139 → #3138 (stacked PR chain)

## Issues fixed

Closes #1299
Likely closes #2932
