### PR TITLE
refactor: slim DeviceSpec to required fields + sparse serialization

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -42,7 +42,6 @@ import maestro.orchestra.validation.AppValidator
 import maestro.orchestra.validation.WorkspaceValidationException
 import maestro.orchestra.validation.WorkspaceValidator
 import maestro.device.DeviceSpec
-import maestro.device.DeviceSpecRequest
 import maestro.utils.TemporaryDirectory
 import okio.BufferedSink
 import okio.buffer

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -7,9 +7,12 @@ import maestro.cli.device.DeviceCreateUtil
 import maestro.device.DeviceService
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.util.EnvUtils
+import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
-import maestro.device.DeviceSpecRequest
 import maestro.device.Platform
+import maestro.device.locale.AndroidLocale
+import maestro.device.locale.IosLocale
+import maestro.device.locale.WebLocale
 import picocli.CommandLine
 import java.util.concurrent.Callable
 
@@ -90,26 +93,27 @@ class StartDeviceCommand : Callable<Int> {
 
         // Get the device configuration
         val parsedPlatform = Platform.fromString(platform)
-        val maestroDeviceConfiguration = DeviceSpec.fromRequest(
-            when (parsedPlatform) {
-                Platform.ANDROID -> DeviceSpecRequest.Android(
-                    model = deviceModel,
-                    os = deviceOs ?: osVersion.let { "android-$it" },
-                    locale = deviceLocale,
-                    cpuArchitecture = EnvUtils.getMacOSArchitecture(),
-                )
-                Platform.IOS -> DeviceSpecRequest.Ios(
-                    model = deviceModel,
-                    os = deviceOs ?: osVersion.let { "iOS-$it" },
-                    locale = deviceLocale,
-                )
-                Platform.WEB -> DeviceSpecRequest.Web(
-                    model = deviceModel,
-                    os = deviceOs ?: osVersion,
-                    locale = deviceLocale,
-                )
-            }
-        )
+        val maestroDeviceConfiguration: DeviceSpec = when (parsedPlatform) {
+            Platform.ANDROID -> DeviceSpec.Android(
+                model = deviceModel ?: "pixel_6",
+                os = deviceOs ?: osVersion?.let { "android-$it" } ?: "android-33",
+                locale = deviceLocale?.let { AndroidLocale.fromString(it) }
+                    ?: AndroidLocale.fromString("en_US"),
+                cpuArchitecture = EnvUtils.getMacOSArchitecture(),
+            )
+            Platform.IOS -> DeviceSpec.Ios(
+                model = deviceModel ?: "iPhone-11",
+                os = deviceOs ?: osVersion?.let { "iOS-$it" } ?: "iOS-17-5",
+                locale = deviceLocale?.let { IosLocale.fromString(it) }
+                    ?: IosLocale.EN_US,
+            )
+            Platform.WEB -> DeviceSpec.Web(
+                model = deviceModel ?: "chromium",
+                os = deviceOs ?: osVersion ?: "default",
+                locale = deviceLocale?.let { WebLocale.fromString(it) }
+                    ?: WebLocale.EN_US,
+            )
+        }
 
         // Get/Create the device
         val device = DeviceCreateUtil.getOrCreateDevice(

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -94,27 +94,33 @@ class StartDeviceCommand : Callable<Int> {
         // Get the device configuration
         val parsedPlatform = Platform.fromString(platform)
         val deviceSpec: DeviceSpec = when (parsedPlatform) {
-            Platform.ANDROID -> DeviceSpec.Android(
-                model = deviceModel ?: "pixel_6",
-                // osVersion is nullable; ?.let prevents interpolating "android-null"
-                os = deviceOs ?: osVersion?.let { "android-$it" } ?: "android-33",
-                // AndroidLocale is a data class (no pre-defined constant); parse the default
-                locale = deviceLocale?.let { AndroidLocale.fromString(it) }
-                    ?: AndroidLocale.fromString("en_US"),
-                cpuArchitecture = EnvUtils.getMacOSArchitecture(),
-            )
-            Platform.IOS -> DeviceSpec.Ios(
-                model = deviceModel ?: "iPhone-11",
-                os = deviceOs ?: osVersion?.let { "iOS-$it" } ?: "iOS-17-5",
-                locale = deviceLocale?.let { IosLocale.fromString(it) }
-                    ?: IosLocale.EN_US,
-            )
-            Platform.WEB -> DeviceSpec.Web(
-                model = deviceModel ?: "chromium",
-                os = deviceOs ?: osVersion ?: "default",
-                locale = deviceLocale?.let { WebLocale.fromString(it) }
-                    ?: WebLocale.EN_US,
-            )
+            Platform.ANDROID -> {
+                val default = DeviceSpec.Android.DEFAULT
+                DeviceSpec.Android(
+                    // osVersion is nullable; ?.let prevents interpolating "android-null"
+                    model = deviceModel ?: default.model,
+                    os = deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
+                    // AndroidLocale is a data class (no pre-defined constant); parse the default
+                    locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
+                    cpuArchitecture = EnvUtils.getMacOSArchitecture(),
+                )
+            }
+            Platform.IOS -> {
+                val default = DeviceSpec.Ios.DEFAULT
+                DeviceSpec.Ios(
+                    model = deviceModel ?: default.model,
+                    os = deviceOs ?: osVersion?.let { "iOS-$it" } ?: default.os,
+                    locale = deviceLocale?.let { IosLocale.fromString(it) } ?: default.locale,
+                )
+            }
+            Platform.WEB -> {
+                val default = DeviceSpec.Web.DEFAULT
+                DeviceSpec.Web(
+                    model = deviceModel ?: default.model,
+                    os = deviceOs ?: osVersion ?: default.os,
+                    locale = deviceLocale?.let { WebLocale.fromString(it) } ?: default.locale,
+                )
+            }
         }
 
         // Get/Create the device

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -93,10 +93,12 @@ class StartDeviceCommand : Callable<Int> {
 
         // Get the device configuration
         val parsedPlatform = Platform.fromString(platform)
-        val maestroDeviceConfiguration: DeviceSpec = when (parsedPlatform) {
+        val deviceSpec: DeviceSpec = when (parsedPlatform) {
             Platform.ANDROID -> DeviceSpec.Android(
                 model = deviceModel ?: "pixel_6",
+                // osVersion is nullable; ?.let prevents interpolating "android-null"
                 os = deviceOs ?: osVersion?.let { "android-$it" } ?: "android-33",
+                // AndroidLocale is a data class (no pre-defined constant); parse the default
                 locale = deviceLocale?.let { AndroidLocale.fromString(it) }
                     ?: AndroidLocale.fromString("en_US"),
                 cpuArchitecture = EnvUtils.getMacOSArchitecture(),
@@ -117,7 +119,7 @@ class StartDeviceCommand : Callable<Int> {
 
         // Get/Create the device
         val device = DeviceCreateUtil.getOrCreateDevice(
-            maestroDeviceConfiguration,
+            deviceSpec,
             forceCreate
         )
 

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
@@ -3,7 +3,6 @@ package maestro.cli.device
 import maestro.cli.CliError
 import maestro.cli.util.PrintUtils
 import maestro.device.Device
-import maestro.device.DeviceSpecRequest
 import maestro.device.DeviceSpec
 import maestro.device.Platform
 import org.fusesource.jansi.Ansi.ansi
@@ -30,15 +29,11 @@ object PickDeviceView {
                 Platform.fromString(it)
             } ?: throw CliError("Please specify a platform"))
 
-        val spec = DeviceSpec.fromRequest(
-            when (selectedPlatform) {
-                Platform.ANDROID -> DeviceSpecRequest.Android()
-                Platform.IOS -> DeviceSpecRequest.Ios()
-                Platform.WEB -> DeviceSpecRequest.Web()
-            }
-        )
-
-        return spec
+        return when (selectedPlatform) {
+            Platform.ANDROID -> DeviceSpec.Android(model = "pixel_6", os = "android-33")
+            Platform.IOS -> DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
+            Platform.WEB -> DeviceSpec.Web(model = "chromium", os = "default")
+        }
     }
 
     fun pickRunningDevice(devices: List<Device>): Device {

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceView.kt
@@ -30,9 +30,9 @@ object PickDeviceView {
             } ?: throw CliError("Please specify a platform"))
 
         return when (selectedPlatform) {
-            Platform.ANDROID -> DeviceSpec.Android(model = "pixel_6", os = "android-33")
-            Platform.IOS -> DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
-            Platform.WEB -> DeviceSpec.Web(model = "chromium", os = "default")
+            Platform.ANDROID -> DeviceSpec.Android.DEFAULT
+            Platform.IOS -> DeviceSpec.Ios.DEFAULT
+            Platform.WEB -> DeviceSpec.Web.DEFAULT
         }
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -284,7 +284,7 @@ fun main() {
             flowName = "Flow for playing around",
             device = Device.Connected(
                 instanceId = "device",
-                deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-34"),
+                deviceSpec = DeviceSpec.Android.DEFAULT,
                 description = "description",
                 platform = Platform.ANDROID,
                 deviceType = Device.DeviceType.EMULATOR

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -24,7 +24,6 @@ import maestro.device.Device
 import maestro.device.Platform
 import maestro.cli.runner.CommandState
 import maestro.cli.runner.CommandStatus
-import maestro.device.DeviceSpecRequest
 import maestro.device.DeviceSpec
 import maestro.orchestra.AssertWithAICommand
 import maestro.orchestra.ElementSelector
@@ -285,9 +284,7 @@ fun main() {
             flowName = "Flow for playing around",
             device = Device.Connected(
                 instanceId = "device",
-                deviceSpec = DeviceSpec.fromRequest(
-                    DeviceSpecRequest.Android()
-                ),
+                deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-34"),
                 description = "description",
                 platform = Platform.ANDROID,
                 deviceType = Device.DeviceType.EMULATOR

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -37,11 +37,12 @@ object DeviceService {
         when (device.deviceSpec.platform) {
             Platform.IOS -> {
                 PrintUtils.message("Launching Simulator...")
+                val iosSpec = device.deviceSpec as DeviceSpec.Ios
                 try {
                     localSimulatorUtils.bootSimulator(device.modelId)
-                    PrintUtils.message("Setting the device locale to ${device.deviceSpec.locale.code}...")
-                    localSimulatorUtils.setDeviceLanguage(device.modelId, device.deviceSpec.locale.languageCode)
-                    localSimulatorUtils.setDeviceLocale(device.modelId, device.deviceSpec.locale.code)
+                    PrintUtils.message("Setting the device locale to ${iosSpec.locale.code}...")
+                    localSimulatorUtils.setDeviceLanguage(device.modelId, iosSpec.locale.languageCode)
+                    localSimulatorUtils.setDeviceLocale(device.modelId, iosSpec.locale.code)
                     localSimulatorUtils.reboot(device.modelId)
                     localSimulatorUtils.launchSimulator(device.modelId)
                     localSimulatorUtils.awaitLaunch(device.modelId)
@@ -61,6 +62,7 @@ object DeviceService {
 
             Platform.ANDROID -> {
                 PrintUtils.message("Launching Emulator...")
+                val androidSpec = device.deviceSpec as DeviceSpec.Android
                 val emulatorBinary = requireEmulatorBinary()
 
                 ProcessBuilder(
@@ -92,19 +94,19 @@ object DeviceService {
                     Thread.sleep(1000)
                 }
 
-                PrintUtils.message("Setting the device locale to ${device.deviceSpec.locale.code}...")
+                PrintUtils.message("Setting the device locale to ${androidSpec.locale.code}...")
                 val driver = AndroidDriver(dadb, driverHostPort)
                 driver.installMaestroDriverApp()
                 val result = driver.setDeviceLocale(
-                    country = device.deviceSpec.locale.countryCode,
-                    language = device.deviceSpec.locale.languageCode,
+                    country = androidSpec.locale.countryCode,
+                    language = androidSpec.locale.languageCode,
                 )
 
                 when (result) {
-                    SET_LOCALE_RESULT_SUCCESS -> PrintUtils.message("[Done] Setting the device locale to ${device.deviceSpec.locale.code}...")
-                    SET_LOCALE_RESULT_LOCALE_NOT_VALID -> throw IllegalStateException("Failed to set locale ${device.deviceSpec.locale.code}, the locale is not valid for a chosen device")
-                    SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED -> throw IllegalStateException("Failed to set locale ${device.deviceSpec.locale.code}, exception during updating configuration occurred")
-                    else -> throw IllegalStateException("Failed to set locale ${device.deviceSpec.locale.code}, unknown exception happened")
+                    SET_LOCALE_RESULT_SUCCESS -> PrintUtils.message("[Done] Setting the device locale to ${androidSpec.locale.code}...")
+                    SET_LOCALE_RESULT_LOCALE_NOT_VALID -> throw IllegalStateException("Failed to set locale ${androidSpec.locale.code}, the locale is not valid for a chosen device")
+                    SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED -> throw IllegalStateException("Failed to set locale ${androidSpec.locale.code}, exception during updating configuration occurred")
+                    else -> throw IllegalStateException("Failed to set locale ${androidSpec.locale.code}, unknown exception happened")
                 }
                 driver.uninstallMaestroDriverApp()
 
@@ -166,14 +168,14 @@ object DeviceService {
                 description = "Chromium Web Browser",
                 instanceId = "chromium",
                 deviceType = Device.DeviceType.BROWSER,
-                deviceSpec = DeviceSpec.fromRequest(DeviceSpecRequest.Web())
+                deviceSpec = DeviceSpec.Web(model = "chromium", os = "default")
             ),
             Device.AvailableForLaunch(
                 modelId = "chromium",
                 description = "Chromium Web Browser",
                 platform = Platform.WEB,
                 deviceType = Device.DeviceType.BROWSER,
-                deviceSpec = DeviceSpec.fromRequest(DeviceSpecRequest.Web())
+                deviceSpec = DeviceSpec.Web(model = "chromium", os = "default")
             )
         )
     }
@@ -188,9 +190,7 @@ object DeviceService {
                     description = dadb.toString(),
                     platform = Platform.ANDROID,
                     deviceType = Device.DeviceType.EMULATOR,
-                    deviceSpec = DeviceSpec.fromRequest(
-                      DeviceSpecRequest.Android()
-                    )
+                    deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
                 )
             )
         }
@@ -227,9 +227,7 @@ object DeviceService {
                     description = avdName ?: dadb.toString(),
                     platform = Platform.ANDROID,
                     deviceType = deviceType,
-                    deviceSpec = DeviceSpec.fromRequest(
-                        DeviceSpecRequest.Android()
-                    ),
+                    deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-33"),
                 )
             }
         }.getOrNull() ?: emptyList()
@@ -251,8 +249,9 @@ object DeviceService {
                                 description = avdName,
                                 platform = Platform.ANDROID,
                                 deviceType = Device.DeviceType.EMULATOR,
-                                deviceSpec = DeviceSpec.fromRequest(
-                                    DeviceSpecRequest.Android(avdInfo.model, avdInfo.os)
+                                deviceSpec = DeviceSpec.Android(
+                                    model = avdInfo.model.ifBlank { "pixel_6" },
+                                    os = avdInfo.os.ifBlank { "android-33" },
                                 )
                             )
                         }
@@ -369,9 +368,7 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType = Device.DeviceType.REAL,
-                deviceSpec = DeviceSpec.fromRequest(
-                    DeviceSpecRequest.Ios()
-                )
+                deviceSpec = DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
             )
         }
     }
@@ -395,8 +392,9 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType = Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceSpec.fromRequest(
-                    DeviceSpecRequest.Ios(model, os)
+                deviceSpec = DeviceSpec.Ios(
+                    model = model.ifBlank { "iPhone-11" },
+                    os = os.ifBlank { "iOS-17-5" },
                 )
             )
         } else {
@@ -405,8 +403,9 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType =  Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceSpec.fromRequest(
-                    DeviceSpecRequest.Ios(model, os)
+                deviceSpec = DeviceSpec.Ios(
+                    model = model.ifBlank { "iPhone-11" },
+                    os = os.ifBlank { "iOS-17-5" },
                 )
             )
         }
@@ -430,9 +429,7 @@ object DeviceService {
                             description = output,
                             platform = Platform.ANDROID,
                             deviceType = Device.DeviceType.EMULATOR,
-                            deviceSpec = DeviceSpec.fromRequest(
-                                DeviceSpecRequest.Android()
-                            )
+                            deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
                         )
                     }
                     .find { connectedDevice -> connectedDevice.description.contains(deviceName, ignoreCase = true) }

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -37,8 +37,8 @@ object DeviceService {
         when (device.deviceSpec.platform) {
             Platform.IOS -> {
                 PrintUtils.message("Launching Simulator...")
-                val iosSpec = device.deviceSpec as DeviceSpec.Ios
                 try {
+                    val iosSpec = device.deviceSpec as DeviceSpec.Ios
                     localSimulatorUtils.bootSimulator(device.modelId)
                     PrintUtils.message("Setting the device locale to ${iosSpec.locale.code}...")
                     localSimulatorUtils.setDeviceLanguage(device.modelId, iosSpec.locale.languageCode)
@@ -221,7 +221,6 @@ object DeviceService {
                     instanceId.startsWith("emulator") -> Device.DeviceType.EMULATOR
                     else -> Device.DeviceType.REAL
                 }
-                val avdInfo = avdInfoList.find { it.name == avdName } ?: AvdInfo(name = avdName ?: "", model = "", os = "")
                 Device.Connected(
                     instanceId = instanceId,
                     description = avdName ?: dadb.toString(),

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -168,14 +168,14 @@ object DeviceService {
                 description = "Chromium Web Browser",
                 instanceId = "chromium",
                 deviceType = Device.DeviceType.BROWSER,
-                deviceSpec = DeviceSpec.Web(model = "chromium", os = "default")
+                deviceSpec = DeviceSpec.Web.DEFAULT
             ),
             Device.AvailableForLaunch(
                 modelId = "chromium",
                 description = "Chromium Web Browser",
                 platform = Platform.WEB,
                 deviceType = Device.DeviceType.BROWSER,
-                deviceSpec = DeviceSpec.Web(model = "chromium", os = "default")
+                deviceSpec = DeviceSpec.Web.DEFAULT
             )
         )
     }
@@ -190,7 +190,7 @@ object DeviceService {
                     description = dadb.toString(),
                     platform = Platform.ANDROID,
                     deviceType = Device.DeviceType.EMULATOR,
-                    deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
+                    deviceSpec = DeviceSpec.Android.DEFAULT
                 )
             )
         }
@@ -226,7 +226,7 @@ object DeviceService {
                     description = avdName ?: dadb.toString(),
                     platform = Platform.ANDROID,
                     deviceType = deviceType,
-                    deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-33"),
+                    deviceSpec = DeviceSpec.Android.DEFAULT,
                 )
             }
         }.getOrNull() ?: emptyList()
@@ -248,10 +248,11 @@ object DeviceService {
                                 description = avdName,
                                 platform = Platform.ANDROID,
                                 deviceType = Device.DeviceType.EMULATOR,
-                                deviceSpec = DeviceSpec.Android(
-                                    model = avdInfo.model.ifBlank { "pixel_6" },
-                                    os = avdInfo.os.ifBlank { "android-33" },
-                                )
+                                deviceSpec = if (avdInfo.model.isBlank() || avdInfo.os.isBlank()) {
+                                    DeviceSpec.Android.DEFAULT
+                                } else {
+                                    DeviceSpec.Android(model = avdInfo.model, os = avdInfo.os)
+                                }
                             )
                         }
                         .toList()
@@ -367,7 +368,7 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType = Device.DeviceType.REAL,
-                deviceSpec = DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
+                deviceSpec = DeviceSpec.Ios.DEFAULT
             )
         }
     }
@@ -391,10 +392,11 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType = Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceSpec.Ios(
-                    model = model.ifBlank { "iPhone-11" },
-                    os = os.ifBlank { "iOS-17-5" },
-                )
+                deviceSpec = if (model.isBlank() || os.isBlank()) {
+                    DeviceSpec.Ios.DEFAULT
+                } else {
+                    DeviceSpec.Ios(model = model, os = os)
+                }
             )
         } else {
             Device.AvailableForLaunch(
@@ -402,10 +404,11 @@ object DeviceService {
                 description = description,
                 platform = Platform.IOS,
                 deviceType =  Device.DeviceType.SIMULATOR,
-                deviceSpec = DeviceSpec.Ios(
-                    model = model.ifBlank { "iPhone-11" },
-                    os = os.ifBlank { "iOS-17-5" },
-                )
+                deviceSpec = if (model.isBlank() || os.isBlank()) {
+                    DeviceSpec.Ios.DEFAULT
+                } else {
+                    DeviceSpec.Ios(model = model, os = os)
+                }
             )
         }
     }
@@ -428,7 +431,7 @@ object DeviceService {
                             description = output,
                             platform = Platform.ANDROID,
                             deviceType = Device.DeviceType.EMULATOR,
-                            deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
+                            deviceSpec = DeviceSpec.Android.DEFAULT
                         )
                     }
                     .find { connectedDevice -> connectedDevice.description.contains(deviceName, ignoreCase = true) }

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -64,7 +64,7 @@ sealed class DeviceSpec {
     data class Ios(
         override val model: String,
         override val os: String,
-        val locale: IosLocale = IosLocale.fromString("en_US"),
+        val locale: IosLocale = IosLocale.EN_US,
         val orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
         val disableAnimations: Boolean = true,
         val snapshotKeyHonorModalViews: Boolean = true,
@@ -82,7 +82,7 @@ sealed class DeviceSpec {
     data class Web(
       override val model: String,
       override val os: String,
-      val locale: WebLocale = WebLocale.fromString("en_US"),
+      val locale: WebLocale = WebLocale.EN_US,
     ) : DeviceSpec() {
         init {
             require(model.isNotBlank()) { "DeviceSpec.Web: model cannot be blank" }

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -44,8 +44,6 @@ sealed class DeviceSpec {
         override val model: String,
         override val os: String,
         val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
-        val orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
-        val disableAnimations: Boolean = true,
         val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
     ) : DeviceSpec() {
         init {
@@ -68,9 +66,6 @@ sealed class DeviceSpec {
         override val model: String,
         override val os: String,
         val locale: IosLocale = IosLocale.EN_US,
-        val orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
-        val disableAnimations: Boolean = true,
-        val snapshotKeyHonorModalViews: Boolean = true,
     ) : DeviceSpec() {
         init {
             require(model.isNotBlank()) { "DeviceSpec.Ios: model cannot be blank" }

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -1,8 +1,11 @@
 package maestro.device
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import maestro.device.locale.DeviceLocale
+import maestro.device.locale.AndroidLocale
+import maestro.device.locale.IosLocale
+import maestro.device.locale.WebLocale
 
 enum class CPU_ARCHITECTURE(val value: String) {
   X86_64("x86_64"),
@@ -17,7 +20,15 @@ enum class CPU_ARCHITECTURE(val value: String) {
 }
 
 /**
- * Returned Sealed class that has all non-nullable values
+ * Strongly typed device configuration. Callers must provide `model` and `os`;
+ * all other fields have sensible defaults that can be overridden when needed.
+ *
+ * Derived values (osVersion, deviceName, emulatorImage, tag) are computed at
+ * access time via `get()` properties — they are not stored in the data class
+ * and therefore never serialized or persisted.
+ *
+ * Serialization is sparse: fields that match their constructor default are
+ * omitted from the JSON output. See DeviceSpecSparseSerializer.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "platform")
 @JsonSubTypes(
@@ -29,115 +40,57 @@ sealed class DeviceSpec {
     abstract val platform: Platform
     abstract val model: String
     abstract val os: String
-    abstract val osVersion: Int
-    abstract val deviceName: String
-    abstract val locale: DeviceLocale
 
     data class Android(
         override val model: String,
         override val os: String,
-        override val locale: DeviceLocale,
-        val orientation: DeviceOrientation,
-        val disableAnimations: Boolean,
-        val cpuArchitecture: CPU_ARCHITECTURE,
+        val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
+        val orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
+        val disableAnimations: Boolean = true,
+        val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
     ) : DeviceSpec() {
+        init {
+            require(model.isNotBlank()) { "DeviceSpec.Android: model cannot be blank" }
+            require(os.isNotBlank()) { "DeviceSpec.Android: os cannot be blank" }
+        }
+
         override val platform = Platform.ANDROID
-        override val osVersion: Int = os.removePrefix("android-").toIntOrNull() ?: 0
-        override val deviceName = "Maestro_ANDROID_${model}_${os}"
-        val tag = "google_apis"
-        val emulatorImage = "system-images;$os;$tag;${cpuArchitecture.value}"
+        @get:JsonIgnore val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
+        @get:JsonIgnore val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
+        @get:JsonIgnore val tag: String get() = "google_apis"
+        @get:JsonIgnore val emulatorImage: String get() = "system-images;$os;$tag;${cpuArchitecture.value}"
     }
 
     data class Ios(
         override val model: String,
         override val os: String,
-        override val locale: DeviceLocale,
-        val orientation: DeviceOrientation,
-        val disableAnimations: Boolean,
-        val snapshotKeyHonorModalViews: Boolean,
+        val locale: IosLocale = IosLocale.fromString("en_US"),
+        val orientation: DeviceOrientation = DeviceOrientation.PORTRAIT,
+        val disableAnimations: Boolean = true,
+        val snapshotKeyHonorModalViews: Boolean = true,
     ) : DeviceSpec() {
+        init {
+            require(model.isNotBlank()) { "DeviceSpec.Ios: model cannot be blank" }
+            require(os.isNotBlank()) { "DeviceSpec.Ios: os cannot be blank" }
+        }
+
         override val platform = Platform.IOS
-        override val osVersion: Int = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
-        override val deviceName = "Maestro_IOS_${model}_${osVersion}"
+        @get:JsonIgnore val osVersion: Int get() = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
+        @get:JsonIgnore val deviceName: String get() = "Maestro_IOS_${model}_${osVersion}"
     }
 
     data class Web(
       override val model: String,
       override val os: String,
-      override val locale: DeviceLocale
+      val locale: WebLocale = WebLocale.fromString("en_US"),
     ) : DeviceSpec() {
-        override val platform = Platform.WEB
-        override val osVersion: Int = 0
-        override val deviceName = "Maestro_WEB_${model}_${osVersion}"
-    }
-
-    companion object {
-        /**
-         * Creates a fully resolved DeviceSpec from a DeviceRequest, filling in platform-aware defaults.
-         * The returned spec is not environment-validated.
-         * Environment-specific validation for model & os can happen via SupportedDevices.validate().
-         */
-        fun fromRequest(request: DeviceSpecRequest): DeviceSpec {
-            return when (request) {
-                is DeviceSpecRequest.Android -> Android(
-                    model = request.model ?: "pixel_6",
-                    os = request.os ?: "android-33",
-                    locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.ANDROID),
-                    orientation = request.orientation ?: DeviceOrientation.PORTRAIT,
-                    disableAnimations = request.disableAnimations ?: true,
-                    cpuArchitecture = request.cpuArchitecture ?: CPU_ARCHITECTURE.ARM64,
-                )
-                is DeviceSpecRequest.Ios -> Ios(
-                    model = request.model ?: "iPhone-11",
-                    os = request.os ?: "iOS-17-5",
-                    locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.IOS),
-                    orientation = request.orientation ?: DeviceOrientation.PORTRAIT,
-                    disableAnimations = request.disableAnimations ?: true,
-                    snapshotKeyHonorModalViews = request.snapshotKeyHonorModalViews ?: true,
-                )
-                is DeviceSpecRequest.Web -> Web(
-                    model = request.model ?: "chromium",
-                    os = request.os ?: "default",
-                    locale = DeviceLocale.fromString(request.locale ?: "en_US", Platform.WEB),
-                )
-            }
+        init {
+            require(model.isNotBlank()) { "DeviceSpec.Web: model cannot be blank" }
+            require(os.isNotBlank()) { "DeviceSpec.Web: os cannot be blank" }
         }
-    }
-}
 
-/**
- * Request for setting up device config
- */
-sealed class DeviceSpecRequest {
-    abstract val platform: Platform
-
-    data class Android(
-        val model: String? = null,
-        val os: String? = null,
-        val locale: String? = null,
-        val orientation: DeviceOrientation? = null,
-        val disableAnimations: Boolean? = null,
-        val cpuArchitecture: CPU_ARCHITECTURE? = null,
-    ) : DeviceSpecRequest() {
-        override val platform = Platform.ANDROID
-    }
-
-    data class Ios(
-        val model: String? = null,
-        val os: String? = null,
-        val locale: String? = null,
-        val orientation: DeviceOrientation? = null,
-        val disableAnimations: Boolean? = null,
-        val snapshotKeyHonorModalViews: Boolean? = null,
-    ) : DeviceSpecRequest() {
-        override val platform = Platform.IOS
-    }
-
-    data class Web(
-        val model: String? = null,
-        val os: String? = null,
-        val locale: String? = null,
-    ) : DeviceSpecRequest() {
         override val platform = Platform.WEB
+        @get:JsonIgnore val osVersion: Int get() = 0
+        @get:JsonIgnore val deviceName: String get() = "Maestro_WEB_${model}_${osVersion}"
     }
 }

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -1,6 +1,5 @@
 package maestro.device
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import maestro.device.locale.AndroidLocale
@@ -55,10 +54,14 @@ sealed class DeviceSpec {
         }
 
         override val platform = Platform.ANDROID
-        @get:JsonIgnore val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
-        @get:JsonIgnore val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
-        @get:JsonIgnore val tag: String get() = "google_apis"
-        @get:JsonIgnore val emulatorImage: String get() = "system-images;$os;$tag;${cpuArchitecture.value}"
+        val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
+        val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
+        val tag: String get() = "google_apis"
+        val emulatorImage: String get() = "system-images;$os;$tag;${cpuArchitecture.value}"
+
+        companion object {
+            val DEFAULT: Android = Android(model = "pixel_6", os = "android-33")
+        }
     }
 
     data class Ios(
@@ -75,8 +78,12 @@ sealed class DeviceSpec {
         }
 
         override val platform = Platform.IOS
-        @get:JsonIgnore val osVersion: Int get() = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
-        @get:JsonIgnore val deviceName: String get() = "Maestro_IOS_${model}_${osVersion}"
+        val osVersion: Int get() = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
+        val deviceName: String get() = "Maestro_IOS_${model}_${osVersion}"
+
+        companion object {
+            val DEFAULT: Ios = Ios(model = "iPhone-11", os = "iOS-17-5")
+        }
     }
 
     data class Web(
@@ -90,7 +97,11 @@ sealed class DeviceSpec {
         }
 
         override val platform = Platform.WEB
-        @get:JsonIgnore val osVersion: Int get() = 0
-        @get:JsonIgnore val deviceName: String get() = "Maestro_WEB_${model}_${osVersion}"
+        val osVersion: Int get() = 0
+        val deviceName: String get() = "Maestro_WEB_${model}_${osVersion}"
+
+        companion object {
+            val DEFAULT: Web = Web(model = "chromium", os = "default")
+        }
     }
 }

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -3,6 +3,7 @@ package maestro.device
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import maestro.device.locale.AndroidLocale
+import maestro.device.locale.DeviceLocale
 import maestro.device.locale.IosLocale
 import maestro.device.locale.WebLocale
 
@@ -39,11 +40,14 @@ sealed class DeviceSpec {
     abstract val platform: Platform
     abstract val model: String
     abstract val os: String
+    abstract val locale: DeviceLocale
+    abstract val osVersion: Int
+    abstract val deviceName: String
 
     data class Android(
         override val model: String,
         override val os: String,
-        val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
+        override val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
         val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
     ) : DeviceSpec() {
         init {
@@ -52,8 +56,8 @@ sealed class DeviceSpec {
         }
 
         override val platform = Platform.ANDROID
-        val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
-        val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
+        override val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
+        override val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
         val tag: String get() = "google_apis"
         val emulatorImage: String get() = "system-images;$os;$tag;${cpuArchitecture.value}"
 
@@ -65,7 +69,7 @@ sealed class DeviceSpec {
     data class Ios(
         override val model: String,
         override val os: String,
-        val locale: IosLocale = IosLocale.EN_US,
+        override val locale: IosLocale = IosLocale.EN_US,
     ) : DeviceSpec() {
         init {
             require(model.isNotBlank()) { "DeviceSpec.Ios: model cannot be blank" }
@@ -73,8 +77,8 @@ sealed class DeviceSpec {
         }
 
         override val platform = Platform.IOS
-        val osVersion: Int get() = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
-        val deviceName: String get() = "Maestro_IOS_${model}_${osVersion}"
+        override val osVersion: Int get() = os.removePrefix("iOS-").substringBefore("-").toIntOrNull() ?: 0
+        override val deviceName: String get() = "Maestro_IOS_${model}_${osVersion}"
 
         companion object {
             val DEFAULT: Ios = Ios(model = "iPhone-11", os = "iOS-17-5")
@@ -84,7 +88,7 @@ sealed class DeviceSpec {
     data class Web(
       override val model: String,
       override val os: String,
-      val locale: WebLocale = WebLocale.EN_US,
+      override val locale: WebLocale = WebLocale.EN_US,
     ) : DeviceSpec() {
         init {
             require(model.isNotBlank()) { "DeviceSpec.Web: model cannot be blank" }
@@ -92,8 +96,8 @@ sealed class DeviceSpec {
         }
 
         override val platform = Platform.WEB
-        val osVersion: Int get() = 0
-        val deviceName: String get() = "Maestro_WEB_${model}_${osVersion}"
+        override val osVersion: Int get() = 0
+        override val deviceName: String get() = "Maestro_WEB_${model}_${osVersion}"
 
         companion object {
             val DEFAULT: Web = Web(model = "chromium", os = "default")

--- a/maestro-client/src/main/java/maestro/device/serialization/DeviceLocaleSerializer.kt
+++ b/maestro-client/src/main/java/maestro/device/serialization/DeviceLocaleSerializer.kt
@@ -8,7 +8,10 @@ import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.ser.std.StdSerializer
 import maestro.device.Platform
+import maestro.device.locale.AndroidLocale
 import maestro.device.locale.DeviceLocale
+import maestro.device.locale.IosLocale
+import maestro.device.locale.WebLocale
 
 class DeviceLocaleSerializer : StdSerializer<DeviceLocale>(DeviceLocale::class.java) {
   override fun serialize(value: DeviceLocale, gen: JsonGenerator, provider: SerializerProvider) {
@@ -25,5 +28,29 @@ class DeviceLocaleDeserializer : StdDeserializer<DeviceLocale>(DeviceLocale::cla
     val code = node.get("code").asText()
     val platform = Platform.valueOf(node.get("platform").asText())
     return DeviceLocale.fromString(code, platform)
+  }
+}
+
+class AndroidLocaleDeserializer : StdDeserializer<AndroidLocale>(AndroidLocale::class.java) {
+  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): AndroidLocale {
+    val node = p.codec.readTree<JsonNode>(p)
+    val code = node.get("code").asText()
+    return AndroidLocale.fromString(code)
+  }
+}
+
+class IosLocaleDeserializer : StdDeserializer<IosLocale>(IosLocale::class.java) {
+  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): IosLocale {
+    val node = p.codec.readTree<JsonNode>(p)
+    val code = node.get("code").asText()
+    return IosLocale.fromString(code)
+  }
+}
+
+class WebLocaleDeserializer : StdDeserializer<WebLocale>(WebLocale::class.java) {
+  override fun deserialize(p: JsonParser, ctxt: DeserializationContext): WebLocale {
+    val node = p.codec.readTree<JsonNode>(p)
+    val code = node.get("code").asText()
+    return WebLocale.fromString(code)
   }
 }

--- a/maestro-client/src/main/java/maestro/device/serialization/DeviceSpecModule.kt
+++ b/maestro-client/src/main/java/maestro/device/serialization/DeviceSpecModule.kt
@@ -1,11 +1,18 @@
 package maestro.device.serialization
 
 import com.fasterxml.jackson.databind.module.SimpleModule
+import maestro.device.DeviceSpec
+import maestro.device.locale.AndroidLocale
 import maestro.device.locale.DeviceLocale
+import maestro.device.locale.IosLocale
+import maestro.device.locale.WebLocale
 
 class DeviceSpecModule : SimpleModule("DeviceSpecModule") {
     init {
+        addSerializer(DeviceSpec::class.java, DeviceSpecSparseSerializer())
         addSerializer(DeviceLocale::class.java, DeviceLocaleSerializer())
-        addDeserializer(DeviceLocale::class.java, DeviceLocaleDeserializer())
+        addDeserializer(AndroidLocale::class.java, AndroidLocaleDeserializer())
+        addDeserializer(IosLocale::class.java, IosLocaleDeserializer())
+        addDeserializer(WebLocale::class.java, WebLocaleDeserializer())
     }
 }

--- a/maestro-client/src/main/java/maestro/device/serialization/DeviceSpecSparseSerializer.kt
+++ b/maestro-client/src/main/java/maestro/device/serialization/DeviceSpecSparseSerializer.kt
@@ -1,0 +1,109 @@
+package maestro.device.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import maestro.device.DeviceSpec
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * Custom Jackson serializer for DeviceSpec that omits fields whose values
+ * equal the declared default on the primary constructor.
+ *
+ * Always emitted: the `platform` discriminator and any constructor parameter
+ * that has no default (model, os).
+ *
+ * Omitted: any constructor parameter whose runtime value equals the default
+ * value extracted by invoking the primary constructor with placeholder values
+ * for required params. Computed get() properties defined outside the primary
+ * constructor are never iterated and therefore never emitted.
+ */
+class DeviceSpecSparseSerializer : StdSerializer<DeviceSpec>(DeviceSpec::class.java) {
+
+    private data class DefaultsInfo(
+        val defaults: Map<String, Any?>,
+        val paramOrder: List<String>,
+    )
+
+    private val cache = ConcurrentHashMap<KClass<*>, DefaultsInfo>()
+
+    override fun serialize(value: DeviceSpec, gen: JsonGenerator, provider: SerializerProvider) {
+        gen.writeStartObject()
+        gen.writeStringField("platform", value.platform.name)
+
+        val info = cache.getOrPut(value::class) { buildDefaultsInfo(value::class) }
+        val propsByName = value::class.memberProperties.associateBy { it.name }
+
+        for (paramName in info.paramOrder) {
+            if (paramName == "platform") continue
+            val prop = propsByName[paramName] ?: continue
+            prop.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val runtimeValue = (prop as KProperty1<Any, Any?>).get(value)
+
+            val hasDefault = info.defaults.containsKey(paramName)
+            if (hasDefault && runtimeValue == info.defaults[paramName]) continue
+
+            provider.defaultSerializeField(paramName, runtimeValue, gen)
+        }
+
+        gen.writeEndObject()
+    }
+
+    // DeviceSpec is annotated with @JsonTypeInfo(As.EXISTING_PROPERTY, property = "platform").
+    // Since our serialize() already emits the `platform` discriminator field, we delegate
+    // serializeWithType straight to serialize() rather than letting Jackson try to inject
+    // a type id (which StdSerializer.serializeWithType would otherwise refuse to do).
+    override fun serializeWithType(
+        value: DeviceSpec,
+        gen: JsonGenerator,
+        provider: SerializerProvider,
+        typeSer: TypeSerializer,
+    ) {
+        serialize(value, gen, provider)
+    }
+
+    private fun buildDefaultsInfo(klass: KClass<*>): DefaultsInfo {
+        val ctor = klass.primaryConstructor
+            ?: error("DeviceSpec subtype ${klass.simpleName} must have a primary constructor")
+        ctor.isAccessible = true
+
+        val paramOrder = ctor.parameters.map { it.name!! }
+
+        val requiredArgs: Map<KParameter, Any?> = ctor.parameters
+            .filter { !it.isOptional }
+            .associateWith { param ->
+                when (param.type.classifier) {
+                    String::class -> "placeholder"
+                    else -> null
+                }
+            }
+
+        val defaultInstance = try {
+            ctor.callBy(requiredArgs)
+        } catch (e: Exception) {
+            error("Failed to build default instance of ${klass.simpleName}: ${e.message}")
+        }
+
+        val propsByName = klass.memberProperties.associateBy { it.name }
+        val defaults: Map<String, Any?> = ctor.parameters
+            .filter { it.isOptional }
+            .associate { param ->
+                val prop = propsByName[param.name!!]
+                    ?: error("No member property for parameter ${param.name} on ${klass.simpleName}")
+                prop.isAccessible = true
+                @Suppress("UNCHECKED_CAST")
+                val defaultValue = (prop as KProperty1<Any, Any?>).get(defaultInstance)
+                param.name!! to defaultValue
+            }
+
+        return DefaultsInfo(defaults = defaults, paramOrder = paramOrder)
+    }
+}

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -1,14 +1,16 @@
 package maestro.device
 
 import com.google.common.truth.Truth.assertThat
+import maestro.device.locale.AndroidLocale
 import maestro.device.locale.LocaleValidationException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 internal class DeviceSpecTest {
+
     @Test
-    fun `resolve Android with no overrides uses defaults`() {
-        val spec = DeviceSpec.fromRequest(DeviceSpecRequest.Android()) as DeviceSpec.Android
+    fun `Android with only required fields uses defaults`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
 
         assertThat(spec.platform).isEqualTo(Platform.ANDROID)
         assertThat(spec.model).isEqualTo("pixel_6")
@@ -16,11 +18,12 @@ internal class DeviceSpecTest {
         assertThat(spec.locale.code).isEqualTo("en_US")
         assertThat(spec.orientation).isEqualTo(DeviceOrientation.PORTRAIT)
         assertThat(spec.disableAnimations).isEqualTo(true)
+        assertThat(spec.cpuArchitecture).isEqualTo(CPU_ARCHITECTURE.ARM64)
     }
 
     @Test
-    fun `resolve iOS with no overrides uses defaults`() {
-        val spec = DeviceSpec.fromRequest(DeviceSpecRequest.Ios()) as DeviceSpec.Ios
+    fun `iOS with only required fields uses defaults`() {
+        val spec = DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
 
         assertThat(spec.platform).isEqualTo(Platform.IOS)
         assertThat(spec.model).isEqualTo("iPhone-11")
@@ -32,8 +35,8 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `resolve Web with no overrides uses defaults`() {
-        val spec = DeviceSpec.fromRequest(DeviceSpecRequest.Web()) as DeviceSpec.Web
+    fun `Web with only required fields uses defaults`() {
+        val spec = DeviceSpec.Web(model = "chromium", os = "default")
 
         assertThat(spec.platform).isEqualTo(Platform.WEB)
         assertThat(spec.model).isEqualTo("chromium")
@@ -42,58 +45,81 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `resolve uses explicit values when provided`() {
-        val spec = DeviceSpec.fromRequest(
-            DeviceSpecRequest.Android(
-                model = "pixel_xl",
-                os = "android-33",
-                locale = "de_DE",
-                orientation = DeviceOrientation.LANDSCAPE_LEFT,
-                cpuArchitecture = CPU_ARCHITECTURE.ARM64,
-            )
-        ) as DeviceSpec.Android
+    fun `Android with all fields overridden`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_xl",
+            os = "android-33",
+            locale = AndroidLocale.fromString("de_DE"),
+            orientation = DeviceOrientation.LANDSCAPE_LEFT,
+            cpuArchitecture = CPU_ARCHITECTURE.ARM64,
+        )
 
         assertThat(spec.model).isEqualTo("pixel_xl")
         assertThat(spec.os).isEqualTo("android-33")
-        assertThat(spec.emulatorImage).isEqualTo("system-images;android-33;google_apis;arm64-v8a")
         assertThat(spec.locale.languageCode).isEqualTo("de")
         assertThat(spec.locale.countryCode).isEqualTo("DE")
         assertThat(spec.orientation).isEqualTo(DeviceOrientation.LANDSCAPE_LEFT)
     }
 
     @Test
-    fun `resolve also update image when system architecture is different`() {
-        val spec = DeviceSpec.fromRequest(
-            DeviceSpecRequest.Android(
-                model = "pixel_xl",
-                os = "android-33",
-                locale = "de_DE",
-                orientation = DeviceOrientation.LANDSCAPE_LEFT,
-                cpuArchitecture = CPU_ARCHITECTURE.X86_64,
-            )
-        ) as DeviceSpec.Android
+    fun `Android computed emulatorImage reflects cpuArchitecture`() {
+        val arm = DeviceSpec.Android(model = "pixel_6", os = "android-33", cpuArchitecture = CPU_ARCHITECTURE.ARM64)
+        val x86 = DeviceSpec.Android(model = "pixel_6", os = "android-33", cpuArchitecture = CPU_ARCHITECTURE.X86_64)
 
-        assertThat(spec.emulatorImage).isEqualTo("system-images;android-33;google_apis;x86_64")
+        assertThat(arm.emulatorImage).isEqualTo("system-images;android-33;google_apis;arm64-v8a")
+        assertThat(x86.emulatorImage).isEqualTo("system-images;android-33;google_apis;x86_64")
     }
 
     @Test
-    fun `resolve Android throws on invalid locale combination like ar_US`() {
-        assertThrows<LocaleValidationException> {
-            DeviceSpec.fromRequest(DeviceSpecRequest.Android(locale = "ar_US"))
+    fun `Android computed osVersion is parsed from os string`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
+        assertThat(spec.osVersion).isEqualTo(34)
+    }
+
+    @Test
+    fun `iOS computed osVersion is parsed from os string`() {
+        val spec = DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
+        assertThat(spec.osVersion).isEqualTo(17)
+    }
+
+    @Test
+    fun `Android computed deviceName uses model and os`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
+        assertThat(spec.deviceName).isEqualTo("Maestro_ANDROID_pixel_6_android-34")
+    }
+
+    @Test
+    fun `blank model throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            DeviceSpec.Android(model = "", os = "android-33")
         }
     }
 
     @Test
-    fun `resolve Android throws on unsupported language code`() {
-        assertThrows<LocaleValidationException> {
-            DeviceSpec.fromRequest(DeviceSpecRequest.Android(locale = "xx_US"))
+    fun `blank os throws IllegalArgumentException`() {
+        assertThrows<IllegalArgumentException> {
+            DeviceSpec.Android(model = "pixel_6", os = "")
         }
     }
 
     @Test
-    fun `resolve Android throws on malformed locale missing country`() {
+    fun `invalid Android locale combination throws at locale construction time`() {
         assertThrows<LocaleValidationException> {
-            DeviceSpec.fromRequest(DeviceSpecRequest.Android(locale = "en"))
+            AndroidLocale.fromString("ar_US")
+        }
+    }
+
+    @Test
+    fun `unsupported Android language code throws at locale construction time`() {
+        assertThrows<LocaleValidationException> {
+            AndroidLocale.fromString("xx_US")
+        }
+    }
+
+    @Test
+    fun `malformed Android locale missing country throws at locale construction time`() {
+        assertThrows<LocaleValidationException> {
+            AndroidLocale.fromString("en")
         }
     }
 }

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -16,8 +16,6 @@ internal class DeviceSpecTest {
         assertThat(spec.model).isEqualTo("pixel_6")
         assertThat(spec.os).isEqualTo("android-33")
         assertThat(spec.locale.code).isEqualTo("en_US")
-        assertThat(spec.orientation).isEqualTo(DeviceOrientation.PORTRAIT)
-        assertThat(spec.disableAnimations).isEqualTo(true)
         assertThat(spec.cpuArchitecture).isEqualTo(CPU_ARCHITECTURE.ARM64)
     }
 
@@ -29,9 +27,6 @@ internal class DeviceSpecTest {
         assertThat(spec.model).isEqualTo("iPhone-11")
         assertThat(spec.os).isEqualTo("iOS-17-5")
         assertThat(spec.locale.code).isEqualTo("en_US")
-        assertThat(spec.orientation).isEqualTo(DeviceOrientation.PORTRAIT)
-        assertThat(spec.disableAnimations).isEqualTo(true)
-        assertThat(spec.snapshotKeyHonorModalViews).isEqualTo(true)
     }
 
     @Test
@@ -50,7 +45,6 @@ internal class DeviceSpecTest {
             model = "pixel_xl",
             os = "android-33",
             locale = AndroidLocale.fromString("de_DE"),
-            orientation = DeviceOrientation.LANDSCAPE_LEFT,
             cpuArchitecture = CPU_ARCHITECTURE.ARM64,
         )
 
@@ -58,7 +52,6 @@ internal class DeviceSpecTest {
         assertThat(spec.os).isEqualTo("android-33")
         assertThat(spec.locale.languageCode).isEqualTo("de")
         assertThat(spec.locale.countryCode).isEqualTo("DE")
-        assertThat(spec.orientation).isEqualTo(DeviceOrientation.LANDSCAPE_LEFT)
     }
 
     @Test

--- a/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
+++ b/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.google.common.truth.Truth.assertThat
 import maestro.device.CPU_ARCHITECTURE
-import maestro.device.DeviceOrientation
 import maestro.device.DeviceSpec
 import maestro.device.locale.AndroidLocale
 import org.junit.jupiter.api.Test
@@ -47,8 +46,6 @@ class DeviceSpecSerializationTest {
             model = "pixel_xl",
             os = "android-34",
             locale = AndroidLocale.fromString("de_DE"),
-            orientation = DeviceOrientation.LANDSCAPE_LEFT,
-            disableAnimations = false,
             cpuArchitecture = CPU_ARCHITECTURE.X86_64,
         )
         val json = mapper.writeValueAsString(spec)
@@ -72,21 +69,6 @@ class DeviceSpecSerializationTest {
     }
 
     @Test
-    fun `Android with differing disableAnimations includes only that optional field`() {
-        val spec = DeviceSpec.Android(
-            model = "pixel_6",
-            os = "android-33",
-            disableAnimations = false,
-        )
-        val json = mapper.readTree(mapper.writeValueAsString(spec))
-
-        assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
-            "platform", "model", "os", "disableAnimations"
-        )
-        assertThat(json.get("disableAnimations").asBoolean()).isFalse()
-    }
-
-    @Test
     fun `Android with differing locale includes locale as object`() {
         val spec = DeviceSpec.Android(
             model = "pixel_6",
@@ -100,6 +82,20 @@ class DeviceSpecSerializationTest {
         )
         assertThat(json.get("locale").get("code").asText()).isEqualTo("de_DE")
         assertThat(json.get("locale").get("platform").asText()).isEqualTo("ANDROID")
+    }
+
+    @Test
+    fun `Android with non-default cpuArchitecture includes that field`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-33",
+            cpuArchitecture = CPU_ARCHITECTURE.X86_64,
+        )
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+        assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
+            "platform", "model", "os", "cpuArchitecture"
+        )
+        assertThat(json.get("cpuArchitecture").asText()).isEqualTo("X86_64")
     }
 
     @Test
@@ -166,7 +162,6 @@ class DeviceSpecSerializationTest {
         val spec = lenientMapper.readValue(legacyJson, DeviceSpec::class.java) as DeviceSpec.Android
         assertThat(spec.model).isEqualTo("pixel_6")
         assertThat(spec.os).isEqualTo("android-33")
-        assertThat(spec.disableAnimations).isFalse()
         assertThat(spec.osVersion).isEqualTo(33)  // computed, not from JSON
     }
 

--- a/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
+++ b/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
@@ -2,11 +2,11 @@ package maestro.device.serialization
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceOrientation
 import maestro.device.DeviceSpec
-import maestro.device.DeviceSpecRequest
+import maestro.device.locale.AndroidLocale
 import org.junit.jupiter.api.Test
 
 class DeviceSpecSerializationTest {
@@ -15,64 +15,188 @@ class DeviceSpecSerializationTest {
         .registerKotlinModule()
         .registerModule(DeviceSpecModule())
 
-    @Test
-    fun `round-trip Android DeviceSpec`() {
-        val spec = DeviceSpec.fromRequest(
-          DeviceSpecRequest.Android()
-        )
+    // --- Round-trip tests ---
 
+    @Test
+    fun `round-trip Android DeviceSpec with only required fields`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
         val json = mapper.writeValueAsString(spec)
         val deserialized = mapper.readValue(json, DeviceSpec::class.java)
-
-        Truth.assertThat(deserialized).isEqualTo(spec)
+        assertThat(deserialized).isEqualTo(spec)
     }
 
     @Test
-    fun `round-trip iOS DeviceSpec`() {
-        val spec = DeviceSpec.fromRequest(
-            DeviceSpecRequest.Ios()
-        )
-
+    fun `round-trip iOS DeviceSpec with only required fields`() {
+        val spec = DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
         val json = mapper.writeValueAsString(spec)
         val deserialized = mapper.readValue(json, DeviceSpec::class.java)
-
-        Truth.assertThat(deserialized).isEqualTo(spec)
+        assertThat(deserialized).isEqualTo(spec)
     }
 
     @Test
-    fun `round-trip Web DeviceSpec`() {
-        val spec = DeviceSpec.fromRequest(
-          DeviceSpecRequest.Web()
-        )
-
+    fun `round-trip Web DeviceSpec with only required fields`() {
+        val spec = DeviceSpec.Web(model = "chromium", os = "default")
         val json = mapper.writeValueAsString(spec)
         val deserialized = mapper.readValue(json, DeviceSpec::class.java)
-
-        Truth.assertThat(deserialized).isEqualTo(spec)
+        assertThat(deserialized).isEqualTo(spec)
     }
 
     @Test
-    fun `serialized JSON has expected structure`() {
-        val spec = DeviceSpec.fromRequest(
-            DeviceSpecRequest.Android(
-                model = "pixel_6",
-                os = "android-33",
-                locale = "en_US",
-                orientation = DeviceOrientation.PORTRAIT,
-                disableAnimations = false,
-                cpuArchitecture = CPU_ARCHITECTURE.ARM64,
-            )
+    fun `round-trip Android DeviceSpec with all fields overridden`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_xl",
+            os = "android-34",
+            locale = AndroidLocale.fromString("de_DE"),
+            orientation = DeviceOrientation.LANDSCAPE_LEFT,
+            disableAnimations = false,
+            cpuArchitecture = CPU_ARCHITECTURE.X86_64,
         )
+        val json = mapper.writeValueAsString(spec)
+        val deserialized = mapper.readValue(json, DeviceSpec::class.java)
+        assertThat(deserialized).isEqualTo(spec)
+    }
 
+    // --- Sparse-serialization tests (only required fields + differing values) ---
+
+    @Test
+    fun `Android with only required fields serializes sparsely`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
         val json = mapper.readTree(mapper.writeValueAsString(spec))
 
-        Truth.assertThat(json.get("platform").asText()).isEqualTo("ANDROID")
-        Truth.assertThat(json.get("model").asText()).isEqualTo("pixel_6")
-        Truth.assertThat(json.get("os").asText()).isEqualTo("android-33")
-        Truth.assertThat(json.get("locale").get("code").asText()).isEqualTo("en_US")
-        Truth.assertThat(json.get("locale").get("platform").asText()).isEqualTo("ANDROID")
-        Truth.assertThat(json.get("orientation").asText()).isEqualTo("PORTRAIT")
-        Truth.assertThat(json.get("disableAnimations").asBoolean()).isFalse()
-        Truth.assertThat(json.get("cpuArchitecture").asText()).isEqualTo("ARM64")
+        assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
+            "platform", "model", "os"
+        )
+        assertThat(json.get("platform").asText()).isEqualTo("ANDROID")
+        assertThat(json.get("model").asText()).isEqualTo("pixel_6")
+        assertThat(json.get("os").asText()).isEqualTo("android-33")
+    }
+
+    @Test
+    fun `Android with differing disableAnimations includes only that optional field`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-33",
+            disableAnimations = false,
+        )
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+
+        assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
+            "platform", "model", "os", "disableAnimations"
+        )
+        assertThat(json.get("disableAnimations").asBoolean()).isFalse()
+    }
+
+    @Test
+    fun `Android with differing locale includes locale as object`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-33",
+            locale = AndroidLocale.fromString("de_DE"),
+        )
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+
+        assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
+            "platform", "model", "os", "locale"
+        )
+        assertThat(json.get("locale").get("code").asText()).isEqualTo("de_DE")
+        assertThat(json.get("locale").get("platform").asText()).isEqualTo("ANDROID")
+    }
+
+    @Test
+    fun `iOS with only required fields serializes sparsely`() {
+        val spec = DeviceSpec.Ios(model = "iPhone-11", os = "iOS-17-5")
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+
+        assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
+            "platform", "model", "os"
+        )
+    }
+
+    @Test
+    fun `Web with only required fields serializes sparsely`() {
+        val spec = DeviceSpec.Web(model = "chromium", os = "default")
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+
+        assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
+            "platform", "model", "os"
+        )
+    }
+
+    // --- Computed fields must never appear in output ---
+
+    @Test
+    fun `computed fields are never serialized`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+
+        assertThat(json.has("osVersion")).isFalse()
+        assertThat(json.has("deviceName")).isFalse()
+        assertThat(json.has("tag")).isFalse()
+        assertThat(json.has("emulatorImage")).isFalse()
+    }
+
+    // --- Legacy verbose JSON still deserializes (DB backward compat) ---
+
+    @Test
+    fun `legacy verbose Android JSON with removed fields deserializes`() {
+        val legacyJson = """
+            {
+              "platform": "ANDROID",
+              "model": "pixel_6",
+              "os": "android-33",
+              "locale": {"code": "en_US", "platform": "ANDROID"},
+              "orientation": "PORTRAIT",
+              "disableAnimations": false,
+              "cpuArchitecture": "ARM64",
+              "osVersion": 33,
+              "deviceName": "Maestro_ANDROID_pixel_6_android-33",
+              "tag": "google_apis",
+              "emulatorImage": "system-images;android-33;google_apis;arm64-v8a"
+            }
+        """.trimIndent()
+
+        val lenientMapper = ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(DeviceSpecModule())
+            .configure(
+                com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                false,
+            )
+
+        val spec = lenientMapper.readValue(legacyJson, DeviceSpec::class.java) as DeviceSpec.Android
+        assertThat(spec.model).isEqualTo("pixel_6")
+        assertThat(spec.os).isEqualTo("android-33")
+        assertThat(spec.disableAnimations).isFalse()
+        assertThat(spec.osVersion).isEqualTo(33)  // computed, not from JSON
+    }
+
+    @Test
+    fun `legacy verbose iOS JSON with removed fields deserializes`() {
+        val legacyJson = """
+            {
+              "platform": "IOS",
+              "model": "iPhone-11",
+              "os": "iOS-17-5",
+              "locale": {"code": "en_GB", "platform": "IOS"},
+              "orientation": "PORTRAIT",
+              "disableAnimations": false,
+              "snapshotKeyHonorModalViews": true,
+              "osVersion": 17,
+              "deviceName": "Maestro_IOS_iPhone-11_17"
+            }
+        """.trimIndent()
+
+        val lenientMapper = ObjectMapper()
+            .registerKotlinModule()
+            .registerModule(DeviceSpecModule())
+            .configure(
+                com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
+                false,
+            )
+
+        val spec = lenientMapper.readValue(legacyJson, DeviceSpec::class.java) as DeviceSpec.Ios
+        assertThat(spec.model).isEqualTo("iPhone-11")
+        assertThat(spec.os).isEqualTo("iOS-17-5")
+        assertThat(spec.locale.code).isEqualTo("en_GB")
     }
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/validation/AppValidator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/validation/AppValidator.kt
@@ -76,10 +76,11 @@ class AppValidator(
             Platform.IOS -> {
                 if (appFile == null) return
                 val minOSVersion = iosMinOSVersionProvider?.invoke(appFile) ?: return
-                if (minOSVersion.major > deviceSpec.osVersion) {
+                val iosSpec = deviceSpec as DeviceSpec.Ios
+                if (minOSVersion.major > iosSpec.osVersion) {
                     throw AppValidationException.IncompatibleIOSVersion(
                         appMinVersion = minOSVersion.full,
-                        deviceOsVersion = deviceSpec.osVersion,
+                        deviceOsVersion = iosSpec.osVersion,
                     )
                 }
             }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/validation/AppValidatorTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/validation/AppValidatorTest.kt
@@ -2,7 +2,6 @@ package maestro.orchestra.validation
 
 import com.google.common.truth.Truth.assertThat
 import maestro.device.DeviceSpec
-import maestro.device.DeviceSpecRequest
 import maestro.device.Platform
 import maestro.orchestra.validation.AndroidAppMetadata
 import maestro.orchestra.validation.IosAppMetadata
@@ -145,13 +144,13 @@ class AppValidatorTest {
     // ---- validateDeviceCompatibility tests ----
 
     private fun iosDeviceSpec(os: String = "iOS-18-2"): DeviceSpec =
-        DeviceSpec.fromRequest(DeviceSpecRequest.Ios(os = os))
+        DeviceSpec.Ios(model = "iPhone-11", os = os)
 
     private fun androidDeviceSpec(os: String = "android-33"): DeviceSpec =
-        DeviceSpec.fromRequest(DeviceSpecRequest.Android(os = os))
+        DeviceSpec.Android(model = "pixel_6", os = os)
 
     private fun webDeviceSpec(): DeviceSpec =
-        DeviceSpec.fromRequest(DeviceSpecRequest.Web())
+        DeviceSpec.Web(model = "chromium", os = "default")
 
     @Test
     fun `validateDeviceCompatibility passes when iOS app min version is below device version`() {


### PR DESCRIPTION
> **Stack:** base `main`. Coordinated rollout: mobile-dev-inc/copilot#2398 (worker, deploy first) → this PR → mobile-dev-inc/copilot#2399 (backend, deploy last).

## Problem

`DeviceSpec` required callers to provide values that have permanent, never-changing defaults (locale, cpuArchitecture, etc.) and persisted a handful of fields that are pure derivations (`osVersion`, `deviceName`, `tag`, `emulatorImage`). The result: verbose, noisy payloads, lots of unnecessary stored values in the DB, and confusion about which fields actually carry intent.

It also mixed two different concerns: **provisioning identity** (what device to boot) and **driver-level runtime config** (how to configure the driver after boot). Driver-level config already lives in `WorkspaceConfig`, where the CLI has always read it from; only the cloud worker was pulling it from `DeviceSpec`.

Separately, `DeviceSpecRequest` was a parallel nullable-everything hierarchy that existed only so `fromRequest()` could magically fill in defaults — indirection without a clear reason to exist now that Kotlin constructor defaults do the same thing.

## Approach

- `DeviceSpec` becomes **provisioning identity only**: `platform`, `model`, `os`, `locale`, plus `cpuArchitecture` on Android.
- Driver-level fields (`disableAnimations`, `snapshotKeyHonorModalViews`, `orientation`) are **removed** — consumers read them from `WorkspaceConfig.platform` instead.
- Require only `platform + model + os` from callers. Everything else has a sensible default in the primary constructor.
- Derived values (`osVersion`, `deviceName`, `tag`, `emulatorImage`) become computed `get()` properties — not stored, not serialized.
- Sparse JSON serialization: the wire format contains only the platform discriminator, the required fields, and any optional field whose runtime value differs from the constructor default. Single source of truth for defaults = the constructor signature, read via Kotlin reflection.
- Named `DEFAULT` constant per subtype (`DeviceSpec.Android.DEFAULT`, etc.) for call sites that just want a reasonable device.

## Final shape

```kotlin
data class Android(
    override val model: String,
    override val os: String,
    val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
    val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
) : DeviceSpec()

data class Ios(
    override val model: String,
    override val os: String,
    val locale: IosLocale = IosLocale.EN_US,
) : DeviceSpec()

data class Web(
    override val model: String,
    override val os: String,
    val locale: WebLocale = WebLocale.EN_US,
) : DeviceSpec()
```

## Key changes

- **`DeviceSpec.kt`**: Reshaped to provisioning-only. `DeviceSpecRequest` and `DeviceSpec.fromRequest()` deleted. Driver fields removed.
- **`DeviceSpecSparseSerializer.kt`** (new): custom `JsonSerializer<DeviceSpec>` that reads primary constructor defaults via reflection (cached per subtype) and omits fields matching defaults.
- CLI call sites updated to use `DeviceSpec.X.DEFAULT` instead of scattered hardcoded model/os strings.

## Wire format

Android with only required fields:
```json
{"platform":"ANDROID","model":"pixel_6","os":"android-33"}
```
With a non-default cpuArchitecture:
```json
{"platform":"ANDROID","model":"pixel_6","os":"android-33","cpuArchitecture":"X86_64"}
```

## Coordination with copilot

This PR deliberately removes driver fields that the copilot worker currently reads. The rollout is phased:

1. **copilot#2398** (worker) — worker reads `disableAnimations`/`snapshotKeyHonorModalViews` from `WorkspaceConfig`. Deploy first.
2. **This PR** — merge after worker deploys so no running worker still reads the removed fields.
3. **copilot#<PR4>** (backend) — bump submodule to this PR's head, simplify backend ingestion. Deploy last.

Jackson `FAIL_ON_UNKNOWN_PROPERTIES = false` on the backend and worker mappers ensures existing DB rows with the now-removed fields continue to deserialize cleanly.

## Test plan

- [x] Full compile clean across all modules
- [x] Full test suite passes
- [x] Sparse serializer tests cover locale + cpuArchitecture default-omission
- [x] Legacy-verbose-JSON deserialization tests cover the full set of now-removed fields
- [x] Manual smoke: \`maestro start-device --platform android\` launches a default emulator
- [x] Manual smoke: \`maestro start-device --platform ios --device-model iPhone-14 --device-os iOS-17-5\` launches a simulator
