### PR TITLE
fix: guard WorkingDirectory.resolve(String) against absolute paths

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/util/WorkingDirectory.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/WorkingDirectory.kt
@@ -5,6 +5,6 @@ import java.io.File
 object WorkingDirectory {
     var baseDir: File = File(System.getProperty("user.dir"))
 
-    fun resolve(path: String): File = File(baseDir, path)
+    fun resolve(path: String): File = resolve(File(path))
     fun resolve(file: File): File = if (file.isAbsolute) file else File(baseDir, file.path)
 }


### PR DESCRIPTION
## Summary

- `WorkingDirectory.resolve(path: String)` did not check `isAbsolute`, so `File(baseDir, absolutePath)` stripped the leading separator and concatenated, producing duplicated paths like `/Users/foo/mcp-sandbox/Users/foo/mcp-sandbox/flow.yaml`.
- The sibling `resolve(file: File)` overload already guards correctly; the `String` overload now delegates to it so the absolute-path rule lives in one place.
- Fixes [MA-4005](https://linear.app/mobile-dev/issue/MA-4005/mcp-error-on-first-auto-run-due-to-doubled-file-path) — "MCP: Error on first auto-run due to doubled file path". The only MCP caller is `RunFlowFilesTool.kt:70`, and its tool description explicitly encourages absolute paths, so this path is well-exercised in practice.


🤖 Generated with [Claude Code](https://claude.com/claude-code)