### PR TITLE
fix: drop use_fuzzy_matching from tap_on MCP schema

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TapOnTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TapOnTool.kt
@@ -24,7 +24,7 @@ object TapOnTool {
                         }
                         putJsonObject("text") {
                             put("type", "string")
-                            put("description", "Regex matching the element text (anchored/full-match; use '.*foo.*' for partial). Typically copied from the 'text' field of inspect_view_hierarchy output.")
+                            put("description", "Regex matching the element text (anchored/full-match; use '.*foo.*' for partial). Often copied from the 'text' field of inspect_view_hierarchy output, but might also be 'accessibilityText' or 'hintText'")
                         }
                         putJsonObject("id") {
                             put("type", "string")

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TapOnTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TapOnTool.kt
@@ -24,19 +24,15 @@ object TapOnTool {
                         }
                         putJsonObject("text") {
                             put("type", "string")
-                            put("description", "Text content to match (from 'text' field in inspect_ui output)")
+                            put("description", "Regex matching the element text (anchored/full-match; use '.*foo.*' for partial). Typically copied from the 'text' field of inspect_view_hierarchy output.")
                         }
                         putJsonObject("id") {
                             put("type", "string")
-                            put("description", "Element ID to match (from 'id' field in inspect_ui output)")
+                            put("description", "Regex matching the element ID (anchored/full-match; use '.*foo.*' for partial). Typically copied from the 'id' field of inspect_view_hierarchy output.")
                         }
                         putJsonObject("index") {
                             put("type", "integer")
                             put("description", "0-based index if multiple elements match the same criteria")
-                        }
-                        putJsonObject("use_fuzzy_matching") {
-                            put("type", "boolean")
-                            put("description", "Whether to use fuzzy/partial text matching (true, default) or exact regex matching (false)")
                         }
                         putJsonObject("enabled") {
                             put("type", "boolean")
@@ -64,7 +60,6 @@ object TapOnTool {
                 val text = request.arguments["text"]?.jsonPrimitive?.content
                 val id = request.arguments["id"]?.jsonPrimitive?.content
                 val index = request.arguments["index"]?.jsonPrimitive?.intOrNull
-                val useFuzzyMatching = request.arguments["use_fuzzy_matching"]?.jsonPrimitive?.booleanOrNull ?: true
                 val enabled = request.arguments["enabled"]?.jsonPrimitive?.booleanOrNull
                 val checked = request.arguments["checked"]?.jsonPrimitive?.booleanOrNull
                 val focused = request.arguments["focused"]?.jsonPrimitive?.booleanOrNull
@@ -92,14 +87,9 @@ object TapOnTool {
                     deviceId = deviceId,
                     platform = null
                 ) { session ->
-                    // Escape special regex characters to prevent regex injection issues
-                    fun escapeRegex(input: String): String {
-                        return input.replace(Regex("[()\\[\\]{}+*?^$|.\\\\]")) { "\\${it.value}" }
-                    }
-                    
                     val elementSelector = ElementSelector(
-                        textRegex = if (useFuzzyMatching && text != null) ".*${escapeRegex(text)}.*" else text,
-                        idRegex = if (useFuzzyMatching && id != null) ".*${escapeRegex(id)}.*" else id,
+                        textRegex = text,
+                        idRegex = id,
                         index = index?.toString(),
                         enabled = enabled,
                         checked = checked,


### PR DESCRIPTION
## Summary

`tap_on` had a `use_fuzzy_matching` boolean parameter. When true (the default), it wrapped the `text` / `id` value in `.*escapeRegex(...).*` before building the `ElementSelector`.

Two problems with that shape:

1. **Schema leak into YAML.** The other fields on the schema (`text`, `id`, `index`, `enabled`, `checked`, `focused`, `selected`) are all real YAML selector keys. `use_fuzzy_matching` had no YAML equivalent. When the model generated flow files instead of calling the tool live, it copied the flag into the `tapOn:` block and produced invalid YAML.
2. **Wrap was more permissive than YAML.** `Filters.textMatches` / `idMatches` use `regex.matches(...)`, which is anchored/full-match. So YAML `tapOn: text: "OK"` only matches elements with text literally `"OK"`, while the MCP wrap (`.*OK.*`) would also match `"OK Button"`, `"Not OK"`, etc. For short strings that's a real footgun.

## Fix

Remove the parameter and remove the wrap. Pass `text` / `id` straight through as regex, matching YAML semantics exactly. If the model wants partial matching it can write `.*foo.*` itself, same as YAML users do.

Fixes [MA-4007](https://linear.app/mobile-dev/issue/MA-4007/fix-incorrect-insertion-of-use-fuzzy-matching-in-tapon-yaml).