### PR TITLE
chore: upgrade MCP Kotlin SDK to official 0.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ jarchivelib = "1.2.0"
 jcodec = "0.2.5"
 junit = "5.10.2"
 kotlin = "2.2.0"
+mcpSdk = "0.11.1"
 kotlinRetry = "2.0.1"
 kotlinResult = "2.0.1"
 kotlinx-serialization-json = "1.5.0"
@@ -151,7 +152,7 @@ logging-api = { module = "org.apache.logging.log4j:log4j-api", version.ref = "lo
 logging-layout-template = { module = "org.apache.logging.log4j:log4j-layout-template-json", version.ref = "log4j" }
 log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
 gmsLocation = { module = "com.google.android.gms:play-services-location", version.ref = "gmsLocation" }
-mcp-kotlin-sdk = { module = "io.modelcontextprotocol:kotlin-sdk" }
+mcp-kotlin-sdk = { module = "io.modelcontextprotocol:kotlin-sdk", version.ref = "mcpSdk" }
 
 [bundles]
 

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -189,10 +189,8 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation("org.jetbrains.kotlinx:kotlinx-io-core:0.2.0")
     implementation(libs.mcp.kotlin.sdk) {
-        version {
-            branch = "steviec/kotlin-1.8"
-        }
         exclude(group = "org.slf4j", module = "slf4j-simple")
+        exclude(group = "io.ktor")
     }
     implementation(libs.logging.sl4j)
     implementation(libs.logging.api)

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -1,14 +1,15 @@
 package maestro.cli.mcp
 
-import io.ktor.utils.io.streams.*
-import io.modelcontextprotocol.kotlin.sdk.*
 import io.modelcontextprotocol.kotlin.sdk.server.Server
 import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
 import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.*
-import kotlinx.io.*
+import kotlinx.io.asSink
+import kotlinx.io.asSource
+import kotlinx.io.buffered
 import maestro.cli.session.MaestroSessionManager
 import maestro.debuglog.LogConfig
 import maestro.cli.mcp.tools.ListDevicesTool
@@ -36,11 +37,11 @@ fun runMaestroMcpServer() {
 
     // Create the MCP Server instance with Maestro implementation
     val server = Server(
-        Implementation(
+        serverInfo = Implementation(
             name = "maestro",
             version = "1.0.0"
         ),
-        ServerOptions(
+        options = ServerOptions(
             capabilities = ServerCapabilities(
                 tools = ServerCapabilities.Tools(listChanged = true)
             )
@@ -75,11 +76,9 @@ fun runMaestroMcpServer() {
     System.err.println("MCP Server: Started. Waiting for messages. Working directory: ${WorkingDirectory.baseDir}")
 
     runBlocking {
-        server.connect(transport)
+        val session = server.createSession(transport)
         val done = Job()
-        server.onClose {
-            done.complete()
-        }
+        session.onClose { done.complete() }
         done.join()
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/BackTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/BackTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -15,7 +15,7 @@ object BackTool {
             Tool(
                 name = "back",
                 description = "Press the back button on the device",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -27,7 +27,7 @@ object BackTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
                 
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheatSheetTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheatSheetTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.auth.ApiKey
@@ -15,7 +15,7 @@ object CheatSheetTool {
                 name = "cheat_sheet",
                 description = "Get the Maestro cheat sheet with common commands and syntax examples. " +
                     "Returns comprehensive documentation on Maestro flow syntax, commands, and best practices.",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {},
                     required = emptyList()
                 )

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheckFlowSyntaxTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheckFlowSyntaxTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.orchestra.yaml.YamlCommandReader
@@ -11,7 +11,7 @@ object CheckFlowSyntaxTool {
             Tool(
                 name = "check_flow_syntax",
                 description = "Validates the syntax of a block of Maestro code. Valid maestro code must be well-formatted YAML.",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("flow_yaml") {
                             put("type", "string")
@@ -23,7 +23,7 @@ object CheckFlowSyntaxTool {
             )
         ) { request ->
             try {
-                val flowYaml = request.arguments["flow_yaml"]?.jsonPrimitive?.content
+                val flowYaml = request.arguments?.get("flow_yaml")?.jsonPrimitive?.content
                 
                 if (flowYaml == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InputTextTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InputTextTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -15,7 +15,7 @@ object InputTextTool {
             Tool(
                 name = "input_text",
                 description = "Input text into the currently focused text field",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -31,8 +31,8 @@ object InputTextTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
-                val text = request.arguments["text"]?.jsonPrimitive?.content
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val text = request.arguments?.get("text")?.jsonPrimitive?.content
                 
                 if (deviceId == null || text == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -16,7 +16,7 @@ object InspectViewHierarchyTool {
                     "with bounds coordinates for interaction. Use this to understand screen layout, find specific elements " +
                     "by text/id, or locate interactive components. Elements include bounds (x,y,width,height), text content, " +
                     "resource IDs, and interaction states (clickable, enabled, checked).",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -28,7 +28,7 @@ object InspectViewHierarchyTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
                 
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/LaunchAppTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/LaunchAppTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -15,7 +15,7 @@ object LaunchAppTool {
             Tool(
                 name = "launch_app",
                 description = "Launch an application on the connected device",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -31,8 +31,8 @@ object LaunchAppTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
-                val appId = request.arguments["appId"]?.jsonPrimitive?.content
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val appId = request.arguments?.get("appId")?.jsonPrimitive?.content
                 
                 if (deviceId == null || appId == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/ListDevicesTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/ListDevicesTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.device.DeviceService
@@ -11,7 +11,7 @@ object ListDevicesTool {
             Tool(
                 name = "list_devices",
                 description = "List all available devices that can be launched for automation.",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject { },
                     required = emptyList()
                 )

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/QueryDocsTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/QueryDocsTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.auth.ApiKey
@@ -18,7 +18,7 @@ object QueryDocsTool {
                 description = "Query the Maestro documentation for specific information. " +
                     "Ask questions about Maestro features, commands, best practices, and troubleshooting. " +
                     "Returns relevant documentation content and examples.",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("question") {
                             put("type", "string")
@@ -30,7 +30,7 @@ object QueryDocsTool {
             )
         ) { request ->
             try {
-                val question = request.arguments["question"]?.jsonPrimitive?.content
+                val question = request.arguments?.get("question")?.jsonPrimitive?.content
                 if (question.isNullOrBlank()) {
                     return@RegisteredTool CallToolResult(
                         content = listOf(TextContent("question parameter is required")),

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowFilesTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowFilesTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -20,7 +20,7 @@ object RunFlowFilesTool {
             Tool(
                 name = "run_flow_files",
                 description = "Run one or more full Maestro test files. If no device is running, you'll need to start a device first. If the command fails using a relative path, try using an absolute path.",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -43,9 +43,9 @@ object RunFlowFilesTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
-                val flowFilesString = request.arguments["flow_files"]?.jsonPrimitive?.content
-                val envParam = request.arguments["env"]?.jsonObject
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val flowFilesString = request.arguments?.get("flow_files")?.jsonPrimitive?.content
+                val envParam = request.arguments?.get("env")?.jsonObject
                 
                 if (deviceId == null || flowFilesString == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunFlowTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -54,7 +54,7 @@ object RunFlowTool {
                     # other commands here
                     ```
                 """.trimIndent(),
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -77,9 +77,9 @@ object RunFlowTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
-                val flowYaml = request.arguments["flow_yaml"]?.jsonPrimitive?.content
-                val envParam = request.arguments["env"]?.jsonObject
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val flowYaml = request.arguments?.get("flow_yaml")?.jsonPrimitive?.content
+                val envParam = request.arguments?.get("env")?.jsonObject
                 
                 if (deviceId == null || flowYaml == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/StartDeviceTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/StartDeviceTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.device.DeviceService
@@ -15,7 +15,7 @@ object StartDeviceTool {
                     "You must provide either a device_id (from list_devices) or a platform (ios or android). " +
                     "If device_id is provided, starts that device. If platform is provided, starts any available device for that platform. " +
                     "If neither is provided, defaults to platform = ios.",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -31,8 +31,8 @@ object StartDeviceTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
-                val platformStr = request.arguments["platform"]?.jsonPrimitive?.content ?: "ios"
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val platformStr = request.arguments?.get("platform")?.jsonPrimitive?.content ?: "ios"
                 
                 // Get all connected and available devices
                 val availableDevices = DeviceService.listAvailableForLaunchDevices(includeWeb = true)

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/StopAppTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/StopAppTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -15,7 +15,7 @@ object StopAppTool {
             Tool(
                 name = "stop_app",
                 description = "Stop an application on the connected device",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -31,8 +31,8 @@ object StopAppTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
-                val appId = request.arguments["appId"]?.jsonPrimitive?.content
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val appId = request.arguments?.get("appId")?.jsonPrimitive?.content
                 
                 if (deviceId == null || appId == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
@@ -17,7 +17,7 @@ object TakeScreenshotTool {
             Tool(
                 name = "take_screenshot",
                 description = "Take a screenshot of the current device screen",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -29,7 +29,7 @@ object TakeScreenshotTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
                 
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TapOnTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TapOnTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.cli.session.MaestroSessionManager
@@ -16,7 +16,7 @@ object TapOnTool {
             Tool(
                 name = "tap_on",
                 description = "Tap on a UI element by selector or description",
-                inputSchema = Tool.Input(
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {
                             put("type", "string")
@@ -56,14 +56,14 @@ object TapOnTool {
             )
         ) { request ->
             try {
-                val deviceId = request.arguments["device_id"]?.jsonPrimitive?.content
-                val text = request.arguments["text"]?.jsonPrimitive?.content
-                val id = request.arguments["id"]?.jsonPrimitive?.content
-                val index = request.arguments["index"]?.jsonPrimitive?.intOrNull
-                val enabled = request.arguments["enabled"]?.jsonPrimitive?.booleanOrNull
-                val checked = request.arguments["checked"]?.jsonPrimitive?.booleanOrNull
-                val focused = request.arguments["focused"]?.jsonPrimitive?.booleanOrNull
-                val selected = request.arguments["selected"]?.jsonPrimitive?.booleanOrNull
+                val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
+                val text = request.arguments?.get("text")?.jsonPrimitive?.content
+                val id = request.arguments?.get("id")?.jsonPrimitive?.content
+                val index = request.arguments?.get("index")?.jsonPrimitive?.intOrNull
+                val enabled = request.arguments?.get("enabled")?.jsonPrimitive?.booleanOrNull
+                val checked = request.arguments?.get("checked")?.jsonPrimitive?.booleanOrNull
+                val focused = request.arguments?.get("focused")?.jsonPrimitive?.booleanOrNull
+                val selected = request.arguments?.get("selected")?.jsonPrimitive?.booleanOrNull
                 
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,12 +16,6 @@ dependencyResolutionManagement {
     }
 }
 
-// Configure Source Control for forked kotlin-sdk
-sourceControl {
-    gitRepository(uri("https://github.com/steviec/kotlin-sdk.git")) {
-        producesModule("io.modelcontextprotocol:kotlin-sdk")
-    }
-}
 
 include("maestro-utils")
 include("maestro-android")


### PR DESCRIPTION
## Summary
- Replace the forked kotlin-sdk (`steviec/kotlin-1.8` branch via git source control) with the official `io.modelcontextprotocol:kotlin-sdk:0.11.1` from Maven Central
- The project's Kotlin 2.2 / Java 17 now meets the SDK's requirements, so the fork is no longer needed
- Migrate all MCP tool code to the new API surface
- Exclude Ktor from the MCP SDK to avoid conflicts with the project's Ktor 2.3.6 (the SDK uses Ktor for its HTTP/SSE transport, but we only use stdio)

## API changes
- Types moved from `io.modelcontextprotocol.kotlin.sdk.*` → `io.modelcontextprotocol.kotlin.sdk.types.*`
- `Tool.Input` renamed to `ToolSchema`
- `request.arguments` is now nullable (`JsonObject?`)
- `server.connect(transport)` replaced with `server.createSession(transport)`

## Runtime dependency version changes

| Dependency | Before | After |
|---|---|---|
| **MCP SDK** | forked git branch | `0.11.1` (official, split into core/client/server modules) |
| **kotlin-stdlib-common** | 2.2.20 | 2.3.10 |
| **kotlinx-coroutines** | 1.8.0 | 1.10.2 |
| **kotlinx-io-bytestring** | 0.2.0 | 0.9.0 |
| **kotlinx-io-core** | 0.2.0 | 0.9.0 |
| **kotlinx-serialization-core** | 1.5.0 | 1.10.0 |
| **kotlinx-serialization-json** | 1.5.0 | 1.10.0 |
| **kotlin-logging** | 7.0.0 | 8.0.01 |
| **typesafe config** | 1.4.2 | 1.4.5 |
| **jansi** | 2.4.0 | 2.4.2 |
| **kotlinx-collections-immutable** | — | 0.4.0 |
| **kotlinx-serialization-bom** | — | 1.10.0 |
| **kotlinx-serialization-json-io** | — | 1.10.0 |
| **Ktor** | 2.3.6 | 2.3.6 (unchanged — excluded from MCP SDK) |

## Test plan
- [x] Verify `maestro mcp` starts and responds to tool calls
- [x] Run MCP tool tests (`run_mcp_tool_tests.sh`)
- [x] Verify web driver still works (Ktor `HttpTimeout` regression fixed)