### PR TITLE
feat: native Maestro Cloud tools in the MCP server

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -25,6 +25,8 @@ import maestro.cli.mcp.tools.CheckFlowSyntaxTool
 import maestro.cli.mcp.tools.InspectViewHierarchyTool
 import maestro.cli.mcp.tools.CheatSheetTool
 import maestro.cli.mcp.tools.QueryDocsTool
+import maestro.cli.mcp.tools.RunOnCloudTool
+import maestro.cli.mcp.tools.GetCloudRunStatusTool
 import maestro.cli.util.WorkingDirectory
 
 // Main function to run the Maestro MCP server
@@ -62,7 +64,9 @@ fun runMaestroMcpServer() {
         CheckFlowSyntaxTool.create(),
         InspectViewHierarchyTool.create(sessionManager),
         CheatSheetTool.create(),
-        QueryDocsTool.create()
+        QueryDocsTool.create(),
+        RunOnCloudTool.create(),
+        GetCloudRunStatusTool.create()
     ))
 
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheatSheetTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/CheatSheetTool.kt
@@ -14,7 +14,8 @@ object CheatSheetTool {
             Tool(
                 name = "cheat_sheet",
                 description = "Get the Maestro cheat sheet with common commands and syntax examples. " +
-                    "Returns comprehensive documentation on Maestro flow syntax, commands, and best practices.",
+                    "Returns comprehensive documentation on Maestro flow syntax, commands, and best practices. " +
+                    "Requires Maestro Cloud authentication: run `maestro login` (recommended), or set MAESTRO_CLOUD_API_KEY for non-interactive use.",
                 inputSchema = ToolSchema(
                     properties = buildJsonObject {},
                     required = emptyList()
@@ -25,7 +26,10 @@ object CheatSheetTool {
                 val apiKey = ApiKey.getToken()
                 if (apiKey.isNullOrBlank()) {
                     return@RegisteredTool CallToolResult(
-                        content = listOf(TextContent("MAESTRO_CLOUD_API_KEY environment variable is required")),
+                        content = listOf(TextContent(
+                            "Not authenticated with Maestro Cloud. Run `maestro login` in your terminal to authenticate " +
+                                "via your browser, then retry this request. For non-interactive setups, set MAESTRO_CLOUD_API_KEY."
+                        )),
                         isError = true
                     )
                 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/GetCloudRunStatusTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/GetCloudRunStatusTool.kt
@@ -1,0 +1,114 @@
+package maestro.cli.mcp.tools
+
+import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
+import kotlinx.serialization.json.*
+import maestro.auth.ApiKey
+import maestro.cli.api.ApiClient
+
+object GetCloudRunStatusTool {
+    fun create(): RegisteredTool {
+        return RegisteredTool(
+            Tool(
+                name = "get_cloud_run_status",
+                description = "Fetch the current status and (optionally) per-flow results of a Maestro Cloud upload. " +
+                    "Use with the upload_id and project_id returned by run_on_cloud. Requires MAESTRO_CLOUD_API_KEY.",
+                inputSchema = Tool.Input(
+                    properties = buildJsonObject {
+                        putJsonObject("upload_id") {
+                            put("type", "string")
+                            put("description", "The upload_id returned by run_on_cloud.")
+                        }
+                        putJsonObject("project_id") {
+                            put("type", "string")
+                            put("description", "The project_id the upload was submitted to (also returned by run_on_cloud).")
+                        }
+                        putJsonObject("include_flow_results") {
+                            put("type", "boolean")
+                            put("description", "If true, include the per-flow breakdown once the run has completed. Default false.")
+                        }
+                    },
+                    required = listOf("upload_id", "project_id")
+                )
+            )
+        ) { request ->
+            val originalOut = System.out
+            System.setOut(System.err)
+            try {
+                val uploadId = request.arguments["upload_id"]?.jsonPrimitive?.content
+                val projectId = request.arguments["project_id"]?.jsonPrimitive?.content
+                val includeFlowResults = request.arguments["include_flow_results"]
+                    ?.jsonPrimitive?.booleanOrNull ?: false
+
+                if (uploadId.isNullOrBlank()) {
+                    return@RegisteredTool errorResult("upload_id is required")
+                }
+                if (projectId.isNullOrBlank()) {
+                    return@RegisteredTool errorResult("project_id is required")
+                }
+
+                val apiKey = ApiKey.getToken()
+                if (apiKey.isNullOrBlank()) {
+                    return@RegisteredTool errorResult(
+                        "MAESTRO_CLOUD_API_KEY environment variable is required. " +
+                            "See https://docs.maestro.dev/api-reference/configuration/workspace-configuration for setup."
+                    )
+                }
+
+                val apiUrl = System.getenv("MAESTRO_CLOUD_API_URL")
+                    ?: System.getenv("MAESTRO_API_URL")
+                    ?: "https://api.copilot.mobile.dev"
+                val client = ApiClient(apiUrl)
+
+                val status = try {
+                    client.uploadStatus(apiKey, uploadId, projectId)
+                } catch (e: ApiClient.ApiException) {
+                    return@RegisteredTool errorResult(
+                        "Failed to fetch cloud run status (HTTP ${e.statusCode}) for upload_id=${uploadId}"
+                    )
+                }
+
+                val result = buildJsonObject {
+                    put("success", true)
+                    put("upload_id", status.uploadId)
+                    put("status", status.status.name)
+                    put("completed", status.completed)
+                    status.startTime?.let { put("started_at", it) }
+                    status.totalTime?.let { put("total_time_ms", it) }
+                    status.appPackageId?.let { put("app_package_id", it) }
+                    put("was_app_launched", status.wasAppLaunched)
+                    if (includeFlowResults) {
+                        putJsonArray("flows") {
+                            status.flows.forEach { flow ->
+                                addJsonObject {
+                                    put("name", flow.name)
+                                    put("status", flow.status.name)
+                                    flow.startTime?.let { put("started_at", it) }
+                                    flow.totalTime?.let { put("total_time_ms", it) }
+                                    if (flow.errors.isNotEmpty()) {
+                                        putJsonArray("errors") {
+                                            flow.errors.forEach { add(it) }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }.toString()
+
+                CallToolResult(content = listOf(TextContent(result)))
+            } catch (e: Exception) {
+                CallToolResult(
+                    content = listOf(TextContent("Failed to get cloud run status: ${e.message ?: e.javaClass.simpleName}")),
+                    isError = true
+                )
+            } finally {
+                System.setOut(originalOut)
+            }
+        }
+    }
+
+    private fun errorResult(message: String): CallToolResult {
+        return CallToolResult(content = listOf(TextContent(message)), isError = true)
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/GetCloudRunStatusTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/GetCloudRunStatusTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.auth.ApiKey
@@ -12,8 +12,9 @@ object GetCloudRunStatusTool {
             Tool(
                 name = "get_cloud_run_status",
                 description = "Fetch the current status and (optionally) per-flow results of a Maestro Cloud upload. " +
-                    "Use with the upload_id and project_id returned by run_on_cloud. Requires MAESTRO_CLOUD_API_KEY.",
-                inputSchema = Tool.Input(
+                    "Use with the upload_id and project_id returned by run_on_cloud. " +
+                    "Requires Maestro Cloud authentication: run `maestro login` (recommended), or set MAESTRO_CLOUD_API_KEY for non-interactive use.",
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("upload_id") {
                             put("type", "string")
@@ -35,9 +36,9 @@ object GetCloudRunStatusTool {
             val originalOut = System.out
             System.setOut(System.err)
             try {
-                val uploadId = request.arguments["upload_id"]?.jsonPrimitive?.content
-                val projectId = request.arguments["project_id"]?.jsonPrimitive?.content
-                val includeFlowResults = request.arguments["include_flow_results"]
+                val uploadId = request.arguments?.get("upload_id")?.jsonPrimitive?.content
+                val projectId = request.arguments?.get("project_id")?.jsonPrimitive?.content
+                val includeFlowResults = request.arguments?.get("include_flow_results")
                     ?.jsonPrimitive?.booleanOrNull ?: false
 
                 if (uploadId.isNullOrBlank()) {
@@ -50,8 +51,8 @@ object GetCloudRunStatusTool {
                 val apiKey = ApiKey.getToken()
                 if (apiKey.isNullOrBlank()) {
                     return@RegisteredTool errorResult(
-                        "MAESTRO_CLOUD_API_KEY environment variable is required. " +
-                            "See https://docs.maestro.dev/api-reference/configuration/workspace-configuration for setup."
+                        "Not authenticated with Maestro Cloud. Run `maestro login` in your terminal to authenticate " +
+                            "via your browser, then retry this request. For non-interactive setups, set MAESTRO_CLOUD_API_KEY."
                     )
                 }
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/QueryDocsTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/QueryDocsTool.kt
@@ -17,7 +17,8 @@ object QueryDocsTool {
                 name = "query_docs",
                 description = "Query the Maestro documentation for specific information. " +
                     "Ask questions about Maestro features, commands, best practices, and troubleshooting. " +
-                    "Returns relevant documentation content and examples.",
+                    "Returns relevant documentation content and examples. " +
+                    "Requires Maestro Cloud authentication: run `maestro login` (recommended), or set MAESTRO_CLOUD_API_KEY for non-interactive use.",
                 inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("question") {
@@ -41,7 +42,10 @@ object QueryDocsTool {
                 val apiKey = ApiKey.getToken()
                 if (apiKey.isNullOrBlank()) {
                     return@RegisteredTool CallToolResult(
-                        content = listOf(TextContent("MAESTRO_CLOUD_API_KEY environment variable is required")),
+                        content = listOf(TextContent(
+                            "Not authenticated with Maestro Cloud. Run `maestro login` in your terminal to authenticate " +
+                                "via your browser, then retry this request. For non-interactive setups, set MAESTRO_CLOUD_API_KEY."
+                        )),
                         isError = true
                     )
                 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
@@ -1,0 +1,201 @@
+package maestro.cli.mcp.tools
+
+import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
+import kotlinx.serialization.json.*
+import maestro.auth.ApiKey
+import maestro.cli.api.ApiClient
+import maestro.cli.util.FileUtils.isZip
+import maestro.cli.util.WorkingDirectory
+import maestro.cli.view.TestSuiteStatusView
+import maestro.orchestra.workspace.WorkspaceUtils
+import maestro.utils.TemporaryDirectory
+import org.rauschig.jarchivelib.ArchiveFormat
+import org.rauschig.jarchivelib.ArchiverFactory
+import kotlin.io.path.absolute
+
+object RunOnCloudTool {
+    fun create(): RegisteredTool {
+        return RegisteredTool(
+            Tool(
+                name = "run_on_cloud",
+                description = "Submit a Maestro flow (or folder of flows) to Maestro Cloud for execution on cloud devices. " +
+                    "Returns immediately with an upload_id and dashboard URL. Use get_cloud_run_status to poll for results. " +
+                    "Requires MAESTRO_CLOUD_API_KEY.",
+                inputSchema = Tool.Input(
+                    properties = buildJsonObject {
+                        putJsonObject("app_file") {
+                            put("type", "string")
+                            put("description", "Path to the app binary (.apk, .ipa, or .zip). Absolute or relative to the current working directory.")
+                        }
+                        putJsonObject("flows") {
+                            put("type", "string")
+                            put("description", "Path to a single flow file or a folder containing flows. Absolute or relative to the current working directory.")
+                        }
+                        putJsonObject("name") {
+                            put("type", "string")
+                            put("description", "Optional human-readable name for this upload.")
+                        }
+                        putJsonObject("project_id") {
+                            put("type", "string")
+                            put("description", "Optional Maestro Cloud project ID. If omitted and the account has exactly one project, it is auto-selected; if the account has multiple projects, this parameter is required.")
+                        }
+                        putJsonObject("env") {
+                            put("type", "object")
+                            put("description", "Optional map of environment variables to inject into the flows (e.g. {\"APP_ID\": \"com.example.app\"}).")
+                            putJsonObject("additionalProperties") {
+                                put("type", "string")
+                            }
+                        }
+                        putJsonObject("include_tags") {
+                            put("type", "array")
+                            put("description", "Only run flows that have any of these tags.")
+                            putJsonObject("items") { put("type", "string") }
+                        }
+                        putJsonObject("exclude_tags") {
+                            put("type", "array")
+                            put("description", "Skip flows that have any of these tags.")
+                            putJsonObject("items") { put("type", "string") }
+                        }
+                        putJsonObject("device_os") {
+                            put("type", "string")
+                            put("description", "Cloud device OS target (e.g. 'ios-17-5', 'android-34'). See the output of `maestro list-cloud-devices` for valid values.")
+                        }
+                    },
+                    required = listOf("app_file", "flows")
+                )
+            )
+        ) { request ->
+            val originalOut = System.out
+            System.setOut(System.err)
+            try {
+                val appFileArg = request.arguments["app_file"]?.jsonPrimitive?.content
+                val flowsArg = request.arguments["flows"]?.jsonPrimitive?.content
+                val name = request.arguments["name"]?.jsonPrimitive?.content
+                val projectIdArg = request.arguments["project_id"]?.jsonPrimitive?.content
+                val envParam = request.arguments["env"]?.jsonObject
+                val includeTags = request.arguments["include_tags"]?.jsonArray?.mapNotNull {
+                    it.jsonPrimitive.contentOrNull
+                } ?: emptyList()
+                val excludeTags = request.arguments["exclude_tags"]?.jsonArray?.mapNotNull {
+                    it.jsonPrimitive.contentOrNull
+                } ?: emptyList()
+                val deviceOs = request.arguments["device_os"]?.jsonPrimitive?.content
+
+                if (appFileArg.isNullOrBlank()) {
+                    return@RegisteredTool errorResult("app_file is required")
+                }
+                if (flowsArg.isNullOrBlank()) {
+                    return@RegisteredTool errorResult("flows is required")
+                }
+
+                val apiKey = ApiKey.getToken()
+                if (apiKey.isNullOrBlank()) {
+                    return@RegisteredTool errorResult(
+                        "MAESTRO_CLOUD_API_KEY environment variable is required. " +
+                            "Set it via your MCP client config (env block) or export it in the shell running the MCP server. " +
+                            "See https://docs.maestro.dev/api-reference/configuration/workspace-configuration for details."
+                    )
+                }
+
+                val appFile = WorkingDirectory.resolve(appFileArg)
+                if (!appFile.exists()) {
+                    return@RegisteredTool errorResult("App file not found: ${appFile.absolutePath}")
+                }
+                val flowsFile = WorkingDirectory.resolve(flowsArg)
+                if (!flowsFile.exists()) {
+                    return@RegisteredTool errorResult("Flows path not found: ${flowsFile.absolutePath}")
+                }
+
+                val apiUrl = System.getenv("MAESTRO_CLOUD_API_URL")
+                    ?: System.getenv("MAESTRO_API_URL")
+                    ?: "https://api.copilot.mobile.dev"
+                val client = ApiClient(apiUrl)
+
+                val projectId = if (!projectIdArg.isNullOrBlank()) {
+                    projectIdArg
+                } else {
+                    val projects = try {
+                        client.getProjects(apiKey)
+                    } catch (e: ApiClient.ApiException) {
+                        return@RegisteredTool errorResult(
+                            "Failed to list Maestro Cloud projects (HTTP ${e.statusCode}). " +
+                                "Check that MAESTRO_CLOUD_API_KEY is valid."
+                        )
+                    } catch (e: Exception) {
+                        return@RegisteredTool errorResult("Failed to list Maestro Cloud projects: ${e.message}")
+                    }
+                    when (projects.size) {
+                        0 -> return@RegisteredTool errorResult(
+                            "No Maestro Cloud projects found for this account. Create one at https://console.mobile.dev."
+                        )
+                        1 -> projects[0].id
+                        else -> return@RegisteredTool errorResult(
+                            "Multiple Maestro Cloud projects found. Pass project_id explicitly. Available: " +
+                                projects.joinToString(", ") { "${it.id}:${it.name}" }
+                        )
+                    }
+                }
+
+                val response = TemporaryDirectory.use { tmpDir ->
+                    val workspaceZip = tmpDir.resolve("workspace.zip")
+                    WorkspaceUtils.createWorkspaceZip(flowsFile.toPath().absolute(), workspaceZip)
+
+                    val appToSend = if (appFile.isZip()) {
+                        appFile
+                    } else {
+                        val archiver = ArchiverFactory.createArchiver(ArchiveFormat.ZIP)
+                        @Suppress("RemoveRedundantSpreadOperator")
+                        archiver.create(appFile.name + ".zip", tmpDir.toFile(), *arrayOf(appFile.absoluteFile))
+                    }
+
+                    client.upload(
+                        authToken = apiKey,
+                        appFile = appToSend.toPath(),
+                        workspaceZip = workspaceZip,
+                        uploadName = name,
+                        mappingFile = null,
+                        repoOwner = null,
+                        repoName = null,
+                        branch = null,
+                        commitSha = null,
+                        pullRequestId = null,
+                        env = envParam?.mapValues { it.value.jsonPrimitive.content },
+                        includeTags = includeTags,
+                        excludeTags = excludeTags,
+                        disableNotifications = false,
+                        projectId = projectId,
+                        deviceOs = deviceOs,
+                        androidApiLevel = null,
+                    )
+                }
+
+                val url = TestSuiteStatusView.uploadUrl(projectId, response.appId, response.uploadId, client.domain)
+
+                val result = buildJsonObject {
+                    put("success", true)
+                    put("upload_id", response.uploadId)
+                    put("project_id", projectId)
+                    put("app_id", response.appId)
+                    response.appBinaryId?.let { put("app_binary_id", it) }
+                    put("url", url)
+                    put("status", "PENDING")
+                    put("message", "Upload submitted. Use get_cloud_run_status with this upload_id and project_id to poll for results.")
+                }.toString()
+
+                CallToolResult(content = listOf(TextContent(result)))
+            } catch (e: Exception) {
+                CallToolResult(
+                    content = listOf(TextContent("Failed to submit cloud run: ${e.message ?: e.javaClass.simpleName}")),
+                    isError = true
+                )
+            } finally {
+                System.setOut(originalOut)
+            }
+        }
+    }
+
+    private fun errorResult(message: String): CallToolResult {
+        return CallToolResult(content = listOf(TextContent(message)), isError = true)
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
@@ -12,6 +12,7 @@ import maestro.orchestra.workspace.WorkspaceUtils
 import maestro.utils.TemporaryDirectory
 import org.rauschig.jarchivelib.ArchiveFormat
 import org.rauschig.jarchivelib.ArchiverFactory
+import java.io.ByteArrayInputStream
 import kotlin.io.path.absolute
 
 object RunOnCloudTool {
@@ -67,7 +68,15 @@ object RunOnCloudTool {
             )
         ) { request ->
             val originalOut = System.out
+            val originalIn = System.`in`
             System.setOut(System.err)
+            // Redirect stdin to an empty stream so ApiClient.upload's interactive
+            // trial-not-started Scanner branch cannot hang waiting for user input
+            // that can never arrive (stdin is the MCP JSON-RPC protocol pipe,
+            // already captured by the transport before this swap). The MCP
+            // transport keeps its own reference to the real System.in, so this
+            // does not affect the protocol channel.
+            System.setIn(ByteArrayInputStream(ByteArray(0)))
             try {
                 val appFileArg = request.arguments?.get("app_file")?.jsonPrimitive?.content
                 val flowsArg = request.arguments?.get("flows")?.jsonPrimitive?.content
@@ -186,17 +195,45 @@ object RunOnCloudTool {
 
                 CallToolResult(content = listOf(TextContent(result)))
             } catch (e: Exception) {
-                CallToolResult(
-                    content = listOf(TextContent("Failed to submit cloud run: ${e.message ?: e.javaClass.simpleName}")),
-                    isError = true
-                )
+                classifyUploadFailure(e)
             } finally {
                 System.setOut(originalOut)
+                System.setIn(originalIn)
             }
         }
     }
 
     private fun errorResult(message: String): CallToolResult {
         return CallToolResult(content = listOf(TextContent(message)), isError = true)
+    }
+
+    /**
+     * Translate an [Exception] from `client.upload` into a user-facing error.
+     *
+     * The backend gates uploads on account subscription state and the CLI's
+     * `ApiClient.upload` surfaces those as `CliError("Upload request failed
+     * (403|402): <message>")` where the message includes phrases like "trial
+     * has not started", "trial has expired", or "payment". It also has an
+     * interactive Scanner branch for trial-not-started that cannot run under
+     * MCP; we redirect stdin to an empty stream beforehand, which makes
+     * `scanner.nextLine()` throw `NoSuchElementException`. Both paths land
+     * here and should resolve to a single clean message that points the user
+     * at `app.maestro.dev` rather than leaking the raw CLI exception text.
+     */
+    private fun classifyUploadFailure(e: Exception): CallToolResult {
+        val message = e.message.orEmpty()
+        val looksLikePlanIssue = e is java.util.NoSuchElementException ||
+            listOf("trial", "payment", "subscription", "has not started", "has expired")
+                .any { message.contains(it, ignoreCase = true) }
+        return if (looksLikePlanIssue) {
+            errorResult(
+                "Your Maestro Cloud account is not ready to run flows on cloud devices. " +
+                    "This typically means your free trial has not started (or has expired), " +
+                    "or there's a payment issue. Start your free trial or manage your " +
+                    "subscription at https://app.maestro.dev, then retry this request."
+            )
+        } else {
+            errorResult("Failed to submit cloud run: ${message.ifBlank { e.javaClass.simpleName }}")
+        }
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
@@ -1,6 +1,6 @@
 package maestro.cli.mcp.tools
 
-import io.modelcontextprotocol.kotlin.sdk.*
+import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
 import maestro.auth.ApiKey
@@ -21,8 +21,8 @@ object RunOnCloudTool {
                 name = "run_on_cloud",
                 description = "Submit a Maestro flow (or folder of flows) to Maestro Cloud for execution on cloud devices. " +
                     "Returns immediately with an upload_id and dashboard URL. Use get_cloud_run_status to poll for results. " +
-                    "Requires MAESTRO_CLOUD_API_KEY.",
-                inputSchema = Tool.Input(
+                    "Requires Maestro Cloud authentication: run `maestro login` (recommended), or set MAESTRO_CLOUD_API_KEY for non-interactive use.",
+                inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("app_file") {
                             put("type", "string")
@@ -69,18 +69,18 @@ object RunOnCloudTool {
             val originalOut = System.out
             System.setOut(System.err)
             try {
-                val appFileArg = request.arguments["app_file"]?.jsonPrimitive?.content
-                val flowsArg = request.arguments["flows"]?.jsonPrimitive?.content
-                val name = request.arguments["name"]?.jsonPrimitive?.content
-                val projectIdArg = request.arguments["project_id"]?.jsonPrimitive?.content
-                val envParam = request.arguments["env"]?.jsonObject
-                val includeTags = request.arguments["include_tags"]?.jsonArray?.mapNotNull {
+                val appFileArg = request.arguments?.get("app_file")?.jsonPrimitive?.content
+                val flowsArg = request.arguments?.get("flows")?.jsonPrimitive?.content
+                val name = request.arguments?.get("name")?.jsonPrimitive?.content
+                val projectIdArg = request.arguments?.get("project_id")?.jsonPrimitive?.content
+                val envParam = request.arguments?.get("env")?.jsonObject
+                val includeTags = request.arguments?.get("include_tags")?.jsonArray?.mapNotNull {
                     it.jsonPrimitive.contentOrNull
                 } ?: emptyList()
-                val excludeTags = request.arguments["exclude_tags"]?.jsonArray?.mapNotNull {
+                val excludeTags = request.arguments?.get("exclude_tags")?.jsonArray?.mapNotNull {
                     it.jsonPrimitive.contentOrNull
                 } ?: emptyList()
-                val deviceOs = request.arguments["device_os"]?.jsonPrimitive?.content
+                val deviceOs = request.arguments?.get("device_os")?.jsonPrimitive?.content
 
                 if (appFileArg.isNullOrBlank()) {
                     return@RegisteredTool errorResult("app_file is required")
@@ -92,9 +92,8 @@ object RunOnCloudTool {
                 val apiKey = ApiKey.getToken()
                 if (apiKey.isNullOrBlank()) {
                     return@RegisteredTool errorResult(
-                        "MAESTRO_CLOUD_API_KEY environment variable is required. " +
-                            "Set it via your MCP client config (env block) or export it in the shell running the MCP server. " +
-                            "See https://docs.maestro.dev/api-reference/configuration/workspace-configuration for details."
+                        "Not authenticated with Maestro Cloud. Run `maestro login` in your terminal to authenticate " +
+                            "via your browser, then retry this request. For non-interactive setups, set MAESTRO_CLOUD_API_KEY."
                     )
                 }
 
@@ -120,7 +119,9 @@ object RunOnCloudTool {
                     } catch (e: ApiClient.ApiException) {
                         return@RegisteredTool errorResult(
                             "Failed to list Maestro Cloud projects (HTTP ${e.statusCode}). " +
-                                "Check that MAESTRO_CLOUD_API_KEY is valid."
+                                "Project auto-pick requires a session token from `maestro login`; " +
+                                "MAESTRO_CLOUD_API_KEY is project-scoped and cannot list projects. " +
+                                "Either run `maestro login`, or pass project_id explicitly in this tool call."
                         )
                     } catch (e: Exception) {
                         return@RegisteredTool errorResult("Failed to list Maestro Cloud projects: ${e.message}")

--- a/maestro-cli/src/test/mcp/tool-tests-without-device.yaml
+++ b/maestro-cli/src/test/mcp/tool-tests-without-device.yaml
@@ -15,6 +15,8 @@ tools:
     - inspect_view_hierarchy
     - cheat_sheet
     - query_docs
+    - run_on_cloud
+    - get_cloud_run_status
 
   tests:
     - name: "List available devices"
@@ -37,6 +39,26 @@ tools:
       tool: "query_docs"
       params:
         question: "How do I tap on an element?"
+      expect:
+        success: false
+        error:
+          contains: "MAESTRO_CLOUD_API_KEY"
+
+    - name: "Run on Cloud (expect API key required)"
+      tool: "run_on_cloud"
+      params:
+        app_file: "ignored.apk"
+        flows: "ignored.yaml"
+      expect:
+        success: false
+        error:
+          contains: "MAESTRO_CLOUD_API_KEY"
+
+    - name: "Get cloud run status (expect API key required)"
+      tool: "get_cloud_run_status"
+      params:
+        upload_id: "deadbeef"
+        project_id: "deadbeef"
       expect:
         success: false
         error:


### PR DESCRIPTION
## Summary

The Maestro MCP had no native integration with Maestro Cloud. If a user asked the agent to run a flow on Cloud, the model had to think for a while, consult `query_docs`, and piece together a Cloud call from the docs. It usually worked, but the UX was poor: slow, brittle, and easy for the model to get wrong. Two new MCP tools close that gap and make it a first-class operation.

### `run_on_cloud`
Submits a flow (or folder of flows) + an app binary to Maestro Cloud asynchronously. Returns `{ upload_id, project_id, app_id, url, status: "PENDING" }` immediately. `url` is the `app.maestro.dev` dashboard link the user can click.

Inputs: `app_file`, `flows`, `name?`, `project_id?`, `env?`, `include_tags?`, `exclude_tags?`, `device_os?`.

### `get_cloud_run_status`
Polls status for a previously-submitted upload. Returns `{ status, completed, started_at, total_time_ms, app_package_id, was_app_launched }` and, when `include_flow_results=true`, the per-flow breakdown.

## Design notes

- **Auth via `maestro login` (recommended) or `MAESTRO_CLOUD_API_KEY` (non-interactive).** Both tool descriptions and missing-auth error messages across all four auth-gated MCP tools (`query_docs`, `cheat_sheet`, and the two new ones) surface `maestro login` as the happy path. `ApiKey.getToken()` already reads from both the env var and the cached token at `~/.mobiledev/authtoken` (written by `maestro login`), so no auth logic changes are needed. Also updated the `getProjects` 500 error path to explain the scope limitation of machine-scoped API keys and suggest either logging in or passing `project_id` explicitly.

- **Cloudless-account handling.** Accounts without an active Cloud plan can authenticate via `maestro login` and even list projects (the backend returns the account's project without plan gating), but the POST to `runMaestroTest` is plan-gated and triggers `ApiClient.upload`'s interactive trial-not-started branch: a `Scanner(System.in).nextLine()` that reads stdin to collect a company name and start a trial. Under MCP that stdin is the JSON-RPC protocol pipe, so this branch would hang forever. The tool now redirects stdin to an empty stream for the duration of the handler and classifies the resulting exception (plus the backend's "trial expired" / "payment" / "subscription" errors) into one actionable message pointing at `https://app.maestro.dev`. Same redirect pattern as the existing `System.out` to `System.err` swap: the MCP transport holds its own reference to the real streams before the handler runs, so the protocol channel is unaffected.

- **Bypasses `CloudInteractor`.** That class does interactive project/org selection via `terminal.interactiveSelectList(...)` and prints liberally via `PrintUtils.message` / raw `println`. Both would break MCP: the interactive prompt hangs on the stdio pipe, and stray stdout corrupts the JSON-RPC stream (MCP's `StdioServerTransport` captures `System.out` as its sink). Going through `ApiClient` directly keeps the handlers silent and non-interactive by construction.

- **Non-interactive project resolution.** If `project_id` is omitted, the tool auto-picks only when the account has exactly one project. Multiple projects (or zero) return a structured error that includes the full project list so the agent can ask the user by name and retry with `project_id` set. This is the expected two-turn flow for customers with more than one project: tool returns the list, agent asks "which project?", user picks, agent retries. The tool never prompts on stdin since that pipe is the MCP protocol channel. Note: auto-pick requires a session token from `maestro login`; the `getProjects` backend endpoint does not accept machine-scoped API keys (see known limitations).

- **`System.setOut(System.err)` swap for the duration of each handler** as defense in depth. Catches any stdout print from downstream code (`ApiClient` retry logic, `Analytics.trackEvent`) before it can land in the protocol channel.

- **Not exposed in v1** to keep the schema small: mapping files, CI metadata (`repo_owner`/`branch`/`commit_sha`/`pull_request_id`), report `format`/`output`, `api_url`/`api_key` (env var only), `device_model`, `device_locale`, `app_binary_id`. Easy to add later if the agent needs them.

## Testing

### Local harness

- `./gradlew :maestro-cli:installDist`: clean build after rebasing onto latest main (includes PR #3182 SDK upgrade and PR #3181 MA-4007 merge).
- `tool-tests-without-device.yaml` via `mcp-server-tester@1.3.1`: **8/8 passed**, including tool discovery at **16/16 expected tools** and missing-auth error cases for all four auth-gated tools. Re-verified after every change on the branch.
- `tool-tests-with-device.yaml` against a booted iPhone 17 sim: **8/9 passed**. The one failure is on `Test tap_on` (`text: "Search"` against Safari returns "Element not found") and is a pre-existing main regression from PR #3181 (MA-4007 removed the implicit `.*...*` wrap, but the test fixture still uses bare `Search`). Unrelated to this PR, not modified by it. Worth a separate followup to update the fixture to `.*Search.*`.

### `maestro login` auth path verified end-to-end

After running `maestro login`, with `MAESTRO_CLOUD_API_KEY` unset and no env-var fallback available, called `run_on_cloud` without `project_id`:

- `ApiKey.getToken()` fell through to the cached token at `~/.mobiledev/authtoken` as designed. Authentication succeeded.
- `getProjects` returned the full project list (session tokens are accepted where machine-scoped API keys return HTTP 500, confirming the known-limitation behavior).
- The multi-project error path fired correctly: the tool listed all accessible projects in the response so the agent can present them to the user by name, exactly the two-turn flow described in the design notes.

### Cloudless-account verification

Logged in with an account on the BASIC pricing plan, all parallel-run quotas zeroed (`max_android_runs_in_parallel.limit=0`, `max_ios_runs_in_parallel.limit=0`, `max_web_runs_in_parallel.limit=0` confirmed via raw `curl` against `/v2/maestro-studio/orgs`). Called `run_on_cloud` with no `project_id`:

- Tool returned in **2.9s** (no stdin hang).
- `isError=true`.
- Payload: `"Your Maestro Cloud account is not ready to run flows on cloud devices. This typically means your free trial has not started (or has expired), or there's a payment issue. Start your free trial or manage your subscription at https://app.maestro.dev, then retry this request."`
- No stdout contamination of the JSON-RPC stream.

Auto-pick of the one accessible project succeeded. The plan-gate fired at the upload step, landed in the new `classifyUploadFailure` path, and was surfaced cleanly to the agent.

### Live Cloud end-to-end, 5 real uploads against my personal account (pre-cloudless-fix)

| # | Scenario | Dashboard shape |
|---|---|---|
| 1 | **Android smoke**. `wikipedia.apk` + trivial `launchApp` flow, minimal required args | `https://app.maestro.dev/project/proj_…/…/upload/mupload_…` |
| 2 | **Android folder-of-flows** with `name` + `env={MCP_MARKER}` + `include_tags=["smoke"]`. Verified on dashboard that only the `smoke`-tagged flow ran and the other was filtered out | `https://app.maestro.dev/project/proj_…/…/upload/mupload_…` |
| 3 | **Android minimal** with required args only (`app_file` + `flows` + `project_id`), no optionals | `https://app.maestro.dev/project/proj_…/…/upload/mupload_…` |
| 4 | **iOS `.zip` bundle**. `SimpleWebViewApp.zip` (already-zipped, exercises the `isZip()` passthrough branch) + `device_os="iOS-17-5"` + `exclude_tags=["drop"]`. Folder with two flows where the `drop`-tagged one gets filtered out | `https://app.maestro.dev/project/proj_…/…/upload/mupload_…` |
| 5 | **Post-migration sanity.** Re-ran the smoke scenario after the SDK 0.11.1 migration and auth-messaging update. `submit` + both status polls (immediate and +15s with flow results) all passed cleanly, confirming no regression from the rebase | `https://app.maestro.dev/project/proj_…/…/upload/mupload_…` |

Full dashboard links (internal): see the [MA-4010 Linear ticket](https://linear.app/mobile-dev/issue/MA-4010/mcp-implement-a-native-cloud-tall-that-can-submit-maestro-cloud-runs) comment. Team members can click through to any of the five runs to verify.

On submission #1, immediately after the 3.5s submit, `get_cloud_run_status` returned `status=RUNNING` with `app_package_id=org.wikipedia` (backend correctly parsed the apk). After 15s: `was_app_launched=true`; per-flow array populated when `include_flow_results=true`. Prior uploads polled later confirmed terminal `SUCCESS`.

### Thorough test matrix: 80 deterministic checks, 80/80 passed

| Tier | What it covers | Checks |
|---|---|---|
| 1 | Local arg validation: missing `app_file`, missing `flows`, nonexistent `app_file` / `flows`, same for `get_cloud_run_status` missing `upload_id` / `project_id` (both error types surfaced with actionable messages) | 12 |
| 2 | Server-side error surfacing: bogus `upload_id` returns structured `HTTP 404`, wrong `project_id` on a valid upload returns a structured `HTTP` error | 4 |
| 3 | Response shape on prior upload, both `include_flow_results=false` (default) and `=true`: required keys present, types correct (bool/int/str), `status` value is in the valid enum, `mupload_` prefix on `upload_id`, `flows` array absent in default and present-and-list-typed when flag on | 17 |
| 4 | Terminal-state polling on an already-completed prior upload: `completed=true` plus `status` is in the terminal set, `flows` array populated, each flow has valid `status` enum and string `name` | 12 |
| 5 | Minimal required-only submission. Response shape conformance: `success=true`, `upload_id` / `app_id` / `project_id` prefix checks, `status="PENDING"`, `url` is an `app.maestro.dev` dashboard link, URL embeds both `upload_id` and `project_id` correctly | 9 |
| 6 | iOS `.zip` submission with `device_os=iOS-17-5` + `exclude_tags`. Verifies the `isZip()` passthrough branch, `device_os` landing server-side, exclude-tag filter path, all on one submit | 9 |
| 7 | Immediate `get_cloud_run_status` against both fresh submits (tier 5 + tier 6): response shape conformance against the ids we just created | 17 |

**Bonus test caught during setup**: initially passed `device_os="ios-17-5"` (lowercase), got back a clean structured error from the backend: `"Upload request failed (400): OS version 'ios-17-5' is not supported for model 'iPhone-11', platform IOS. Supported versions: iOS-16-2, iOS-16-4, iOS-17-5, iOS-18-2, iOS-26-2"`. The tool surfaces the server's full message verbatim, so the agent can self-correct. Re-ran with `"iOS-17-5"` and it submitted cleanly (#4 above).

I tested the behaviors above personally end-to-end, including the `maestro login` path and the cloudless-account path.

## Known limitations / follow-ups

- **`GET /v2/maestro-studio/projects` returns HTTP 500 for machine-scoped API keys.** Reproduced with raw `curl`, not code. Endpoint appears to require a user-session token from `maestro login`. The MCP tool now handles this with a clear error pointing at both recovery paths (either run `maestro login`, or pass `project_id` explicitly). The same underlying issue also affects the CLI's `maestro cloud` auto-pick path for any API-key user.
- `tool-tests-with-device.yaml`'s `tap_on` test case needs its fixture updated to `.*Search.*` post-#3181, unrelated to this PR but surfaced by the test run.
- Multi-project customers using `maestro login` still need to specify `project_id` after the agent surfaces the project list. A future follow-up adding `list_cloud_projects` as a dedicated discovery tool would let the agent enumerate up front and pick by name without needing the error path.

Fixes [MA-4010](https://linear.app/mobile-dev/issue/MA-4010/mcp-implement-a-native-cloud-tall-that-can-submit-maestro-cloud-runs).