### PR TITLE
Fix `--config` on `maestro cloud` and unify workspace-config handling

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -74,6 +74,7 @@ class CloudInteractor(
         flowFile: File,
         appFile: File?,
         async: Boolean,
+        configFile: File? = null,
         mapping: File? = null,
         apiKey: String? = null,
         uploadName: String? = null,
@@ -126,7 +127,11 @@ class CloudInteractor(
 
         TemporaryDirectory.use { tmpDir ->
             val workspaceZip = tmpDir.resolve("workspace.zip")
-            WorkspaceUtils.createWorkspaceZip(flowFile.toPath().absolute(), workspaceZip)
+            WorkspaceUtils.createWorkspaceZip(
+                file = flowFile.toPath().absolute(),
+                out = workspaceZip,
+                configOverride = configFile?.toPath()?.absolute(),
+            )
             val progressBar = ProgressBar(20)
 
             // Binary id or Binary file

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -219,6 +219,7 @@ class CloudCommand : Callable<Int> {
             async = async,
             flowFile = flowsFile,
             appFile = appFile,
+            configFile = configFile,
             mapping = mapping,
             env = env,
             uploadName = uploadName,

--- a/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
@@ -1,5 +1,6 @@
 package maestro.cli.util
 
+import maestro.orchestra.workspace.isWorkspaceConfigFile
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.utils.StringUtils.toRegexSafe
 import java.io.File
@@ -27,11 +28,7 @@ object FileUtils {
             name.endsWith(".yaml", ignoreCase = true) ||
             name.endsWith(".yml", ignoreCase = true)
 
-        if (
-            !isYaml ||
-            name.equals("config.yaml", ignoreCase = true) ||
-            name.equals("config.yml", ignoreCase = true)
-        ) {
+        if (!isYaml || isWorkspaceConfigFile(toPath())) {
             return false
         }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -18,7 +18,7 @@ fun isFlowFile(path: Path, config: Path?): Boolean {
     return !isWorkspaceConfigFile(path)
 }
 
-private fun isWorkspaceConfigFile(path: Path): Boolean {
+fun isWorkspaceConfigFile(path: Path): Boolean {
     return try {
         val content = path.readText()
         if (content.contains("\n---")) return false // Flow files have a document separator

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
@@ -9,38 +9,92 @@ import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.copyTo
 import kotlin.io.path.exists
+import kotlin.io.path.extension
 import kotlin.io.path.isDirectory
+import kotlin.io.path.readText
 import kotlin.streams.toList
 
 object WorkspaceUtils {
 
-    fun createWorkspaceZip(file: Path, out: Path) {
+    /**
+     * Builds a workspace zip for cloud upload. The resulting zip has exactly one
+     * workspace configuration, always at `/config.yaml`:
+     *
+     *   - If [configOverride] is non-null, its bytes are injected as `/config.yaml`.
+     *     The override may live outside [file] entirely (e.g. `--config=/some/other/path.yaml`).
+     *   - Else, if [file] is a directory and contains a root-level `config.yaml`/`config.yml`,
+     *     its bytes are injected as `/config.yaml`.
+     *   - Else, if [file] is a single flow file, a synthetic `flows: [<relative path>]`
+     *     config is injected so the worker only runs the requested flow.
+     *   - Else (directory upload with no config anywhere), no `/config.yaml` is written.
+     *
+     * Workspace-config-shaped YAMLs anywhere in [file] (detected by
+     * [isWorkspaceConfigFile]) are always stripped from the zip contents. This keeps
+     * the invariant simple for the cloud side, where [maestro.orchestra.workspace.WorkspaceValidator]
+     * hardcodes its lookup to `/config.yaml` / `/config.yml` at the zip root — that
+     * validator relies on this builder to guarantee there is exactly one.
+     */
+    fun createWorkspaceZip(file: Path, out: Path, configOverride: Path? = null) {
         if (!file.exists()) throw FileNotFoundException(file.absolutePathString())
         if (out.exists()) throw FileAlreadyExistsException(out.toFile())
+        if (configOverride != null && !configOverride.exists()) {
+            throw FileNotFoundException(configOverride.absolutePathString())
+        }
 
-        val filesToInclude = if (!file.isDirectory()) {
+        val walkedFiles = if (!file.isDirectory()) {
             DependencyResolver.discoverAllDependencies(file)
         } else {
             Files.walk(file).filter { !it.isDirectory() }.toList()
         }
+
+        // The cloud validator assumes exactly one workspace config at the zip root.
+        // Strip every workspace-config-shaped YAML from the walk so we can inject a
+        // single canonical /config.yaml below without ever producing a duplicate.
+        val filesToInclude = walkedFiles.filter { !isWorkspaceConfigYaml(it) }
+
         val relativeTo = if (file.isDirectory()) file else findCommonAncestor(filesToInclude)
         createWorkspaceZipFromFiles(filesToInclude, relativeTo, out)
 
-        // For single-file uploads, inject a synthetic config.yaml that restricts
-        // execution to only the requested flow. Without this, the worker would
-        // discover and run sibling flow files that ended up in the ZIP due to
-        // the common ancestor being higher than the flow's parent directory.
-        if (!file.isDirectory()) {
-            val flowRelativePath = relativeTo.relativize(normalizePath(file)).toString()
-            injectConfigYaml(out, flowRelativePath)
+        val injectedConfigContent: String? = when {
+            // --config=<path>: caller explicitly picked a config; use it verbatim,
+            // regardless of whether it lives inside or outside the workspace.
+            configOverride != null -> configOverride.readText()
+
+            // Directory upload: preserve the workspace's own root config.yaml / config.yml
+            // (or skip injection if the workspace doesn't define one).
+            file.isDirectory() -> findRootConfigFile(file)?.readText()
+
+            // Single-file upload: synthesize a config that restricts execution to just this
+            // flow. Without this, sibling flows pulled in via the dependency resolver would
+            // also be executed because the common ancestor sits above the flow's directory.
+            else -> syntheticSingleFlowConfig(file, relativeTo)
+        }
+
+        if (injectedConfigContent != null) {
+            injectConfigYamlContent(out, injectedConfigContent)
         }
     }
 
-    private fun injectConfigYaml(zipPath: Path, flowRelativePath: String) {
+    private fun findRootConfigFile(workspaceDir: Path): Path? {
+        return workspaceDir.resolve("config.yaml").takeIf { it.exists() }
+            ?: workspaceDir.resolve("config.yml").takeIf { it.exists() }
+    }
+
+    private fun syntheticSingleFlowConfig(flowFile: Path, relativeTo: Path): String {
+        val flowRelativePath = relativeTo.relativize(normalizePath(flowFile)).toString()
+        return "flows:\n  - \"$flowRelativePath\"\n"
+    }
+
+    private fun isWorkspaceConfigYaml(path: Path): Boolean {
+        val ext = path.extension
+        if (ext != "yaml" && ext != "yml") return false
+        return isWorkspaceConfigFile(path)
+    }
+
+    private fun injectConfigYamlContent(zipPath: Path, content: String) {
         val zipUri = URI.create("jar:${zipPath.toUri()}")
         FileSystems.newFileSystem(zipUri, mapOf("create" to "false")).use { fs ->
             val configEntry = fs.getPath("config.yaml")
-            val content = "flows:\n  - \"$flowRelativePath\"\n"
             Files.writeString(configEntry, content)
         }
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
@@ -58,6 +58,10 @@ object WorkspaceValidator {
             val allFlows = mutableListOf<ValidatedFlow>()
 
             val workspaceConfig = FileSystems.newFileSystem(workspace.toPath()).use { fs ->
+                // Cloud-side contract: the workspace config, if any, lives at the zip
+                // root as /config.yaml (or /config.yml). WorkspaceUtils.createWorkspaceZip
+                // guarantees this invariant — it strips every other workspace-config-shaped
+                // YAML before zipping and injects the effective config at the root.
                 val configPath = fs.getPath("/config.yaml").takeIf { it.exists() }
                     ?: fs.getPath("/config.yml").takeIf { it.exists() }
                 WorkspaceExecutionPlanner.plan(

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
@@ -162,7 +162,7 @@ class WorkspaceUtilsTest {
     }
 
     @Test
-    fun `directory upload does not get synthetic config yaml`(@TempDir tempDir: Path) {
+    fun `directory upload without any workspace config does not get a synthetic config yaml`(@TempDir tempDir: Path) {
         val workspaceDir = tempDir.resolve("workspace")
         Files.createDirectories(workspaceDir)
 
@@ -191,5 +191,167 @@ class WorkspaceUtilsTest {
         assertThat(entryNames).doesNotContain("config.yaml")
         assertThat(entryNames).contains("flow_a.yaml")
         assertThat(entryNames).contains("flow_b.yaml")
+    }
+
+    @Test
+    fun `directory upload with workspace config yaml preserves it at zip root`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir)
+
+        val originalConfig = """
+            flows:
+              - flow_a.yaml
+        """.trimIndent()
+        Files.writeString(workspaceDir.resolve("config.yaml"), originalConfig)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(originalConfig)
+    }
+
+    @Test
+    fun `configOverride with non-default filename inside workspace injects override content`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir.resolve("nested"))
+
+        val overrideContent = """
+            flows:
+              - flow_a.yaml
+        """.trimIndent()
+        val overrideConfig = workspaceDir.resolve("nested/config2.yaml")
+        Files.writeString(overrideConfig, overrideContent)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = overrideConfig)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(entryNames).doesNotContain("nested/config2.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(overrideContent)
+    }
+
+    @Test
+    fun `configOverride outside the workspace injects override content`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        val externalDir = tempDir.resolve("external")
+        Files.createDirectories(workspaceDir)
+        Files.createDirectories(externalDir)
+
+        val overrideContent = """
+            flows:
+              - flow_a.yaml
+            includeTags:
+              - smoke
+        """.trimIndent()
+        val overrideConfig = externalDir.resolve("my-config.yaml")
+        Files.writeString(overrideConfig, overrideContent)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = overrideConfig)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(overrideContent)
+    }
+
+    @Test
+    fun `configOverride strips every workspace-config-shaped yaml in the workspace`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir.resolve("subdir"))
+
+        // Root-level config that would otherwise be preserved
+        Files.writeString(
+            workspaceDir.resolve("config.yaml"),
+            """
+            flows:
+              - flow_a.yaml
+            """.trimIndent()
+        )
+
+        // Additional config-shaped YAML (e.g. regression_config.yaml) that PR #3150
+        // taught the planner to recognize as a workspace config, not a flow.
+        Files.writeString(
+            workspaceDir.resolve("subdir/regression_config.yaml"),
+            """
+            includeTags:
+              - regression
+            """.trimIndent()
+        )
+
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val overrideContent = """
+            flows:
+              - flow_a.yaml
+        """.trimIndent()
+        val overrideConfig = tempDir.resolve("override.yaml")
+        Files.writeString(overrideConfig, overrideContent)
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = overrideConfig)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(entryNames).doesNotContain("subdir/regression_config.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(overrideContent)
+    }
+
+    @Test
+    fun `createWorkspaceZip throws when configOverride does not exist`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        val missing = tempDir.resolve("does-not-exist.yaml")
+
+        assertThrows<java.io.FileNotFoundException> {
+            WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = missing)
+        }
     }
 }


### PR DESCRIPTION
## Why

`maestro cloud --config=<path>` was broken for any config filename other than `config.yaml`/`config.yml`.

Two independent problems, both on the cloud path:

1. **`FileUtils.isWebFlow()` did its own workspace traversal** that only skipped the hardcoded filenames `config.yaml`/`config.yml`. Any other name (`config2.yaml`, `regression_config.yaml`, `platform_settings.yaml`, …) was parsed as a flow and threw before the planner ever ran. The content-based `isWorkspaceConfigFile` detection added in #3150 was never consulted on this path.

2. **`CloudInteractor.upload()` never received `configFile`.** Even once local validation passed, the zip that got uploaded contained the workspace unchanged, and the cloud-side `WorkspaceValidator` hardcodes a lookup for `/config.yaml` / `/config.yml` at the zip root. So `--config=<non-default-name>` was effectively ignored during actual cloud execution. Maestro validate against one config locally and run against a different one (or none) in the cloud.
  
Rather than patch these in isolation, the design is now: **`--config=<path>` means "this file IS the workspace config, wherever it lives"** including **outside the workspace directory entirely**. You can now keep a library of configs in a shared location (e.g. `~/maestro-configs/smoke.yaml`, `~/maestro-configs/regression.yaml`) and point `--config` at any of them; the CLI injects the right one into the upload without touching your workspace layout.


## What changed

- **`Filters.kt`** — promoted `isWorkspaceConfigFile` from `private` to top-level `fun` so it's reusable as the single source of truth for "is this a workspace config YAML?"
- **`FileUtils.isWebFlow()`** — replaced the hardcoded `"config.yaml"`/`"config.yml"` filename skip with `isWorkspaceConfigFile(toPath())`. Fixes both`cloud` and `test` (both call `isWebFlow`) in one change, and removes the filename-coupling that made non-default config names explode.
- **`WorkspaceUtils.createWorkspaceZip`** — new optional `configOverride: Path?`. The function now enforces a single invariant: the resulting zip has exactly one workspace configuration, always at `/config.yaml`.
    - With `--config=<path>` (including paths outside the workspace): the override's bytes are written as `/config.yaml`.
    - Without `--config` but with a root-level `config.yaml`/`config.yml` in the workspace: its bytes are written as `/config.yaml`.
    - Single-file upload: synthetic `flows: [<relative path>]` is written as today.
    - All workspace-config-shaped YAMLs detected by `isWorkspaceConfigFile` are always stripped from the zip contents — in both override and no-override cases. This prevents duplicate/conflicting config entries and shrinks zips that were previously carrying along `regression_config.yaml`,`platform_settings.yaml`, etc. that the worker was going to skip anyway.
- **`CloudInteractor.upload`** — new `configFile: File?` parameter, threaded into `createWorkspaceZip` as `configOverride`.
- **`CloudCommand.call`** — forwards `configFile` to `upload`.
- **`WorkspaceValidator.validate`** — comment added at the zip-root lookup documenting that the invariant is provided by `createWorkspaceZip`, so future readers don't go hunting for how the filename guarantee is enforced.

### Why this shape

  - One helper (`isWorkspaceConfigFile`) used everywhere that needs to answer "is this a workspace config?" — planner, zip builder, web-flow detector. Keeps future fixes in one place.
  - Cloud wire format keeps a single invariant: the zip always has exactly one `/config.yaml` at the root. No protocol or server changes needed.
  - Enables `--config` to live anywhere on disk, not just inside the workspace. The override is a file reference, not a workspace member.
  - Always-strip applies to both override and non-override paths, so "what ends up in the zip" is the same question regardless of whether `--config` is set.
  
  
### Verified end-to-end

Original repro now completes the build+validate pipeline and proceeds into the real upload.