### PR TITLE
Drop obvious non-flow artifacts from workspace uploads

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -74,6 +74,7 @@ class CloudInteractor(
         flowFile: File,
         appFile: File?,
         async: Boolean,
+        configFile: File? = null,
         mapping: File? = null,
         apiKey: String? = null,
         uploadName: String? = null,
@@ -126,7 +127,11 @@ class CloudInteractor(
 
         TemporaryDirectory.use { tmpDir ->
             val workspaceZip = tmpDir.resolve("workspace.zip")
-            WorkspaceUtils.createWorkspaceZip(flowFile.toPath().absolute(), workspaceZip)
+            WorkspaceUtils.createWorkspaceZip(
+                file = flowFile.toPath().absolute(),
+                out = workspaceZip,
+                configOverride = configFile?.toPath()?.absolute(),
+            )
             val progressBar = ProgressBar(20)
 
             // Binary id or Binary file

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -219,6 +219,7 @@ class CloudCommand : Callable<Int> {
             async = async,
             flowFile = flowsFile,
             appFile = appFile,
+            configFile = configFile,
             mapping = mapping,
             env = env,
             uploadName = uploadName,

--- a/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
@@ -1,5 +1,6 @@
 package maestro.cli.util
 
+import maestro.orchestra.workspace.isWorkspaceConfigFile
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.utils.StringUtils.toRegexSafe
 import java.io.File
@@ -27,11 +28,7 @@ object FileUtils {
             name.endsWith(".yaml", ignoreCase = true) ||
             name.endsWith(".yml", ignoreCase = true)
 
-        if (
-            !isYaml ||
-            name.equals("config.yaml", ignoreCase = true) ||
-            name.equals("config.yml", ignoreCase = true)
-        ) {
+        if (!isYaml || isWorkspaceConfigFile(toPath())) {
             return false
         }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/Filters.kt
@@ -18,7 +18,7 @@ fun isFlowFile(path: Path, config: Path?): Boolean {
     return !isWorkspaceConfigFile(path)
 }
 
-private fun isWorkspaceConfigFile(path: Path): Boolean {
+fun isWorkspaceConfigFile(path: Path): Boolean {
     return try {
         val content = path.readText()
         if (content.contains("\n---")) return false // Flow files have a document separator

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
@@ -9,38 +9,92 @@ import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.copyTo
 import kotlin.io.path.exists
+import kotlin.io.path.extension
 import kotlin.io.path.isDirectory
+import kotlin.io.path.readText
 import kotlin.streams.toList
 
 object WorkspaceUtils {
 
-    fun createWorkspaceZip(file: Path, out: Path) {
+    /**
+     * Builds a workspace zip for cloud upload. The resulting zip has exactly one
+     * workspace configuration, always at `/config.yaml`:
+     *
+     *   - If [configOverride] is non-null, its bytes are injected as `/config.yaml`.
+     *     The override may live outside [file] entirely (e.g. `--config=/some/other/path.yaml`).
+     *   - Else, if [file] is a directory and contains a root-level `config.yaml`/`config.yml`,
+     *     its bytes are injected as `/config.yaml`.
+     *   - Else, if [file] is a single flow file, a synthetic `flows: [<relative path>]`
+     *     config is injected so the worker only runs the requested flow.
+     *   - Else (directory upload with no config anywhere), no `/config.yaml` is written.
+     *
+     * Workspace-config-shaped YAMLs anywhere in [file] (detected by
+     * [isWorkspaceConfigFile]) are always stripped from the zip contents. This keeps
+     * the invariant simple for the cloud side, where [maestro.orchestra.workspace.WorkspaceValidator]
+     * hardcodes its lookup to `/config.yaml` / `/config.yml` at the zip root — that
+     * validator relies on this builder to guarantee there is exactly one.
+     */
+    fun createWorkspaceZip(file: Path, out: Path, configOverride: Path? = null) {
         if (!file.exists()) throw FileNotFoundException(file.absolutePathString())
         if (out.exists()) throw FileAlreadyExistsException(out.toFile())
+        if (configOverride != null && !configOverride.exists()) {
+            throw FileNotFoundException(configOverride.absolutePathString())
+        }
 
-        val filesToInclude = if (!file.isDirectory()) {
+        val walkedFiles = if (!file.isDirectory()) {
             DependencyResolver.discoverAllDependencies(file)
         } else {
             Files.walk(file).filter { !it.isDirectory() }.toList()
         }
+
+        // The cloud validator assumes exactly one workspace config at the zip root.
+        // Strip every workspace-config-shaped YAML from the walk so we can inject a
+        // single canonical /config.yaml below without ever producing a duplicate.
+        val filesToInclude = walkedFiles.filter { !isWorkspaceConfigYaml(it) }
+
         val relativeTo = if (file.isDirectory()) file else findCommonAncestor(filesToInclude)
         createWorkspaceZipFromFiles(filesToInclude, relativeTo, out)
 
-        // For single-file uploads, inject a synthetic config.yaml that restricts
-        // execution to only the requested flow. Without this, the worker would
-        // discover and run sibling flow files that ended up in the ZIP due to
-        // the common ancestor being higher than the flow's parent directory.
-        if (!file.isDirectory()) {
-            val flowRelativePath = relativeTo.relativize(normalizePath(file)).toString()
-            injectConfigYaml(out, flowRelativePath)
+        val injectedConfigContent: String? = when {
+            // --config=<path>: caller explicitly picked a config; use it verbatim,
+            // regardless of whether it lives inside or outside the workspace.
+            configOverride != null -> configOverride.readText()
+
+            // Directory upload: preserve the workspace's own root config.yaml / config.yml
+            // (or skip injection if the workspace doesn't define one).
+            file.isDirectory() -> findRootConfigFile(file)?.readText()
+
+            // Single-file upload: synthesize a config that restricts execution to just this
+            // flow. Without this, sibling flows pulled in via the dependency resolver would
+            // also be executed because the common ancestor sits above the flow's directory.
+            else -> syntheticSingleFlowConfig(file, relativeTo)
+        }
+
+        if (injectedConfigContent != null) {
+            injectConfigYamlContent(out, injectedConfigContent)
         }
     }
 
-    private fun injectConfigYaml(zipPath: Path, flowRelativePath: String) {
+    private fun findRootConfigFile(workspaceDir: Path): Path? {
+        return workspaceDir.resolve("config.yaml").takeIf { it.exists() }
+            ?: workspaceDir.resolve("config.yml").takeIf { it.exists() }
+    }
+
+    private fun syntheticSingleFlowConfig(flowFile: Path, relativeTo: Path): String {
+        val flowRelativePath = relativeTo.relativize(normalizePath(flowFile)).toString()
+        return "flows:\n  - \"$flowRelativePath\"\n"
+    }
+
+    private fun isWorkspaceConfigYaml(path: Path): Boolean {
+        val ext = path.extension
+        if (ext != "yaml" && ext != "yml") return false
+        return isWorkspaceConfigFile(path)
+    }
+
+    private fun injectConfigYamlContent(zipPath: Path, content: String) {
         val zipUri = URI.create("jar:${zipPath.toUri()}")
         FileSystems.newFileSystem(zipUri, mapOf("create" to "false")).use { fs ->
             val configEntry = fs.getPath("config.yaml")
-            val content = "flows:\n  - \"$flowRelativePath\"\n"
             Files.writeString(configEntry, content)
         }
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
@@ -33,6 +33,12 @@ object WorkspaceUtils {
      * the invariant simple for the cloud side, where [maestro.orchestra.workspace.WorkspaceValidator]
      * hardcodes its lookup to `/config.yaml` / `/config.yml` at the zip root — that
      * validator relies on this builder to guarantee there is exactly one.
+     *
+     * Obvious non-flow artifacts — app binaries (.apk/.aab/.ipa), other archives, OS
+     * metadata, and VCS/IDE directories (see [isIgnoredWorkspaceFile]) — are also
+     * stripped so a workspace with stray `sample.apk`, `wikipedia.zip`, `.DS_Store`,
+     * `.git/` files doesn't bloat the upload. Genuine assets (images, video, scripts,
+     * fixture text) pass through untouched because they can be referenced by flows.
      */
     fun createWorkspaceZip(file: Path, out: Path, configOverride: Path? = null) {
         if (!file.exists()) throw FileNotFoundException(file.absolutePathString())
@@ -41,6 +47,7 @@ object WorkspaceUtils {
             throw FileNotFoundException(configOverride.absolutePathString())
         }
 
+        val walkRoot = if (file.isDirectory()) file else file.parent
         val walkedFiles = if (!file.isDirectory()) {
             DependencyResolver.discoverAllDependencies(file)
         } else {
@@ -50,7 +57,11 @@ object WorkspaceUtils {
         // The cloud validator assumes exactly one workspace config at the zip root.
         // Strip every workspace-config-shaped YAML from the walk so we can inject a
         // single canonical /config.yaml below without ever producing a duplicate.
-        val filesToInclude = walkedFiles.filter { !isWorkspaceConfigYaml(it) }
+        // Also drop obvious non-flow artifacts (app binaries, other archives, OS /
+        // VCS metadata) so the upload doesn't carry tens of MB of junk.
+        val filesToInclude = walkedFiles
+            .filter { !isWorkspaceConfigYaml(it) }
+            .filter { !isIgnoredWorkspaceFile(it, walkRoot) }
 
         val relativeTo = if (file.isDirectory()) file else findCommonAncestor(filesToInclude)
         createWorkspaceZipFromFiles(filesToInclude, relativeTo, out)
@@ -89,6 +100,44 @@ object WorkspaceUtils {
         val ext = path.extension
         if (ext != "yaml" && ext != "yml") return false
         return isWorkspaceConfigFile(path)
+    }
+
+    // Extensions for files that are never part of a flow workspace: app binaries and
+    // arbitrary archives. Kept deliberately narrow so legitimate assets (images, video,
+    // scripts, fixtures, text payloads) still make it into the upload.
+    private val IGNORED_EXTENSIONS = setOf(
+        "apk", "aab", "ipa",           // Android / iOS app binaries
+        "zip", "tar", "gz", "tgz", "7z", "rar",  // archives
+    )
+
+    // File names that are OS / editor detritus.
+    private val IGNORED_FILE_NAMES = setOf(
+        ".DS_Store",
+        "Thumbs.db",
+    )
+
+    // Directory names that should never be uploaded in their entirety.
+    private val IGNORED_DIRECTORY_NAMES = setOf(
+        ".git", ".hg", ".svn",
+        ".idea", ".vscode",
+        ".gradle", "build", "target",
+        "node_modules",
+    )
+
+    private fun isIgnoredWorkspaceFile(path: Path, walkRoot: Path): Boolean {
+        if (path.fileName.toString() in IGNORED_FILE_NAMES) return true
+        if (path.extension.lowercase() in IGNORED_EXTENSIONS) return true
+
+        // Check each path segment between walkRoot and the file for an ignored
+        // directory name. relativize() can fail across filesystem roots, so fall
+        // back to walking the parent chain in that case.
+        val segments = try {
+            val relative = walkRoot.relativize(path)
+            (0 until relative.nameCount - 1).map { relative.getName(it).toString() }
+        } catch (e: IllegalArgumentException) {
+            generateSequence(path.parent) { it.parent }.map { it.fileName?.toString() ?: "" }.toList()
+        }
+        return segments.any { it in IGNORED_DIRECTORY_NAMES }
     }
 
     private fun injectConfigYamlContent(zipPath: Path, content: String) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
@@ -58,6 +58,10 @@ object WorkspaceValidator {
             val allFlows = mutableListOf<ValidatedFlow>()
 
             val workspaceConfig = FileSystems.newFileSystem(workspace.toPath()).use { fs ->
+                // Cloud-side contract: the workspace config, if any, lives at the zip
+                // root as /config.yaml (or /config.yml). WorkspaceUtils.createWorkspaceZip
+                // guarantees this invariant — it strips every other workspace-config-shaped
+                // YAML before zipping and injects the effective config at the root.
                 val configPath = fs.getPath("/config.yaml").takeIf { it.exists() }
                     ?: fs.getPath("/config.yml").takeIf { it.exists() }
                 WorkspaceExecutionPlanner.plan(

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
@@ -335,6 +335,94 @@ class WorkspaceUtilsTest {
     }
 
     @Test
+    fun `directory upload strips app binaries, archives, and OS metadata but keeps assets`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir.resolve("assets"))
+        Files.createDirectories(workspaceDir.resolve("scripts"))
+
+        Files.writeString(
+            workspaceDir.resolve("flow.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        // Junk that must not be uploaded.
+        Files.write(workspaceDir.resolve("sample.apk"), ByteArray(16) { 0x1 })
+        Files.write(workspaceDir.resolve("debug.aab"), ByteArray(16) { 0x2 })
+        Files.write(workspaceDir.resolve("legacy.ipa"), ByteArray(16) { 0x3 })
+        Files.write(workspaceDir.resolve("fixtures.zip"), ByteArray(16) { 0x4 })
+        Files.write(workspaceDir.resolve("backup.tar.gz"), ByteArray(16) { 0x5 })
+        Files.write(workspaceDir.resolve(".DS_Store"), ByteArray(16) { 0x6 })
+        Files.write(workspaceDir.resolve("assets/.DS_Store"), ByteArray(16) { 0x7 })
+
+        // Legitimate assets that must be kept.
+        Files.write(workspaceDir.resolve("assets/test.jpg"), ByteArray(32) { 0x8 })
+        Files.write(workspaceDir.resolve("assets/demo.mp4"), ByteArray(32) { 0x9 })
+        Files.writeString(workspaceDir.resolve("scripts/helper.js"), "console.log('ok');")
+        Files.writeString(workspaceDir.resolve("assets/fixture.txt"), "hello")
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip)
+
+        val entryNames = readZipEntryNames(outZip)
+
+        assertThat(entryNames).containsAtLeast(
+            "flow.yaml",
+            "assets/test.jpg",
+            "assets/demo.mp4",
+            "assets/fixture.txt",
+            "scripts/helper.js",
+        )
+        assertThat(entryNames).containsNoneOf(
+            "sample.apk",
+            "debug.aab",
+            "legacy.ipa",
+            "fixtures.zip",
+            "backup.tar.gz",
+            ".DS_Store",
+            "assets/.DS_Store",
+        )
+    }
+
+    @Test
+    fun `directory upload drops files under VCS, IDE, and build directories`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir.resolve(".git/objects"))
+        Files.createDirectories(workspaceDir.resolve(".idea"))
+        Files.createDirectories(workspaceDir.resolve("node_modules/foo"))
+        Files.createDirectories(workspaceDir.resolve("build/reports"))
+
+        Files.writeString(workspaceDir.resolve(".git/HEAD"), "ref: refs/heads/main")
+        Files.write(workspaceDir.resolve(".git/objects/abc"), ByteArray(16))
+        Files.writeString(workspaceDir.resolve(".idea/workspace.xml"), "<xml/>")
+        Files.writeString(workspaceDir.resolve("node_modules/foo/index.js"), "exports = {};")
+        Files.writeString(workspaceDir.resolve("build/reports/report.html"), "<html/>")
+
+        Files.writeString(
+            workspaceDir.resolve("flow.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip)
+
+        val entryNames = readZipEntryNames(outZip)
+
+        assertThat(entryNames).contains("flow.yaml")
+        assertThat(entryNames.filter { it.startsWith(".git/") }).isEmpty()
+        assertThat(entryNames.filter { it.startsWith(".idea/") }).isEmpty()
+        assertThat(entryNames.filter { it.startsWith("node_modules/") }).isEmpty()
+        assertThat(entryNames.filter { it.startsWith("build/") }).isEmpty()
+    }
+
+    @Test
     fun `createWorkspaceZip throws when configOverride does not exist`(@TempDir tempDir: Path) {
         val workspaceDir = tempDir.resolve("workspace")
         Files.createDirectories(workspaceDir)

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
@@ -162,7 +162,7 @@ class WorkspaceUtilsTest {
     }
 
     @Test
-    fun `directory upload does not get synthetic config yaml`(@TempDir tempDir: Path) {
+    fun `directory upload without any workspace config does not get a synthetic config yaml`(@TempDir tempDir: Path) {
         val workspaceDir = tempDir.resolve("workspace")
         Files.createDirectories(workspaceDir)
 
@@ -191,5 +191,167 @@ class WorkspaceUtilsTest {
         assertThat(entryNames).doesNotContain("config.yaml")
         assertThat(entryNames).contains("flow_a.yaml")
         assertThat(entryNames).contains("flow_b.yaml")
+    }
+
+    @Test
+    fun `directory upload with workspace config yaml preserves it at zip root`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir)
+
+        val originalConfig = """
+            flows:
+              - flow_a.yaml
+        """.trimIndent()
+        Files.writeString(workspaceDir.resolve("config.yaml"), originalConfig)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(originalConfig)
+    }
+
+    @Test
+    fun `configOverride with non-default filename inside workspace injects override content`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir.resolve("nested"))
+
+        val overrideContent = """
+            flows:
+              - flow_a.yaml
+        """.trimIndent()
+        val overrideConfig = workspaceDir.resolve("nested/config2.yaml")
+        Files.writeString(overrideConfig, overrideContent)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = overrideConfig)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(entryNames).doesNotContain("nested/config2.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(overrideContent)
+    }
+
+    @Test
+    fun `configOverride outside the workspace injects override content`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        val externalDir = tempDir.resolve("external")
+        Files.createDirectories(workspaceDir)
+        Files.createDirectories(externalDir)
+
+        val overrideContent = """
+            flows:
+              - flow_a.yaml
+            includeTags:
+              - smoke
+        """.trimIndent()
+        val overrideConfig = externalDir.resolve("my-config.yaml")
+        Files.writeString(overrideConfig, overrideContent)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = overrideConfig)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(overrideContent)
+    }
+
+    @Test
+    fun `configOverride strips every workspace-config-shaped yaml in the workspace`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir.resolve("subdir"))
+
+        // Root-level config that would otherwise be preserved
+        Files.writeString(
+            workspaceDir.resolve("config.yaml"),
+            """
+            flows:
+              - flow_a.yaml
+            """.trimIndent()
+        )
+
+        // Additional config-shaped YAML (e.g. regression_config.yaml) that PR #3150
+        // taught the planner to recognize as a workspace config, not a flow.
+        Files.writeString(
+            workspaceDir.resolve("subdir/regression_config.yaml"),
+            """
+            includeTags:
+              - regression
+            """.trimIndent()
+        )
+
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val overrideContent = """
+            flows:
+              - flow_a.yaml
+        """.trimIndent()
+        val overrideConfig = tempDir.resolve("override.yaml")
+        Files.writeString(overrideConfig, overrideContent)
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = overrideConfig)
+
+        val entryNames = readZipEntryNames(outZip)
+        assertThat(entryNames).contains("config.yaml")
+        assertThat(entryNames).contains("flow_a.yaml")
+        assertThat(entryNames).doesNotContain("subdir/regression_config.yaml")
+        assertThat(readZipEntry(outZip, "config.yaml")).isEqualTo(overrideContent)
+    }
+
+    @Test
+    fun `createWorkspaceZip throws when configOverride does not exist`(@TempDir tempDir: Path) {
+        val workspaceDir = tempDir.resolve("workspace")
+        Files.createDirectories(workspaceDir)
+        Files.writeString(
+            workspaceDir.resolve("flow_a.yaml"),
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        val missing = tempDir.resolve("does-not-exist.yaml")
+
+        assertThrows<java.io.FileNotFoundException> {
+            WorkspaceUtils.createWorkspaceZip(workspaceDir, outZip, configOverride = missing)
+        }
     }
 }


### PR DESCRIPTION
### Why

`WorkspaceUtils.createWorkspaceZip` walks the workspace with `Files.walk(file).filter { !it.isDirectory() }` and uploads everything under it. On real workspaces this sweeps up material that is never consumed by a flow - app binaries left in place from local testing, nested archives, editor/VCS directories - bloating the upload by tens of MB which needs to be dowloaded on worker for each run and slowing the runs. 

### What changed

`WorkspaceUtils.createWorkspaceZip` now filters out a narrow, explicit set of clearly-non-flow artifacts before zipping:
- **Extensions**: `.apk`, `.aab`, `.ipa`, `.zip`, `.tar`, `.gz`, `.tgz`, `.7z`, `.rar`
- **Filenames**: `.DS_Store`, `Thumbs.db`
- **Ancestor directories**: `.git`, `.hg`, `.svn`, `.idea`, `.vscode`, `.gradle`, `build`, `target`, `node_modules`

Everything else passes through unchanged. Genuine assets a flow might reference via `addMedia`, `runScript`, text fixtures, etc. - images, video, audio,`.js`, `.txt`, `.json` - are untouched. The list is deliberately narrow; the rule of thumb is "only add an entry if a flow can provably never use it."