### PR TITLE
feat(mcp): server instructions + clean stdout handshake

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -40,6 +40,7 @@ import maestro.cli.command.StartDeviceCommand
 import maestro.cli.command.StudioCommand
 import maestro.cli.command.TestCommand
 import maestro.cli.insights.TestAnalysisManager
+import maestro.cli.mcp.claimMcpStdout
 import maestro.cli.update.Updates
 import maestro.cli.util.ChangeLogUtils
 import maestro.cli.util.ErrorReporter
@@ -113,6 +114,11 @@ private fun printVersion() {
 }
 
 fun main(args: Array<String>) {
+    // Must run before any other init: analytics notices, dependency banners, and
+    // kotlin-logging's first-load message will otherwise land on the MCP JSON-RPC
+    // channel and break the handshake for strict clients like Claude Desktop.
+    if (args.firstOrNull() == "mcp") claimMcpStdout()
+
     // Disable icon in Mac dock
     // https://stackoverflow.com/a/17544259
     try {

--- a/maestro-cli/src/main/java/maestro/cli/command/McpCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/McpCommand.kt
@@ -26,4 +26,4 @@ class McpCommand : Callable<Int> {
         runMaestroMcpServer()
         return 0
     }
-} 
+}

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -23,7 +23,7 @@ import maestro.cli.util.WorkingDirectory
 import java.io.PrintStream
 
 internal val INSTRUCTIONS = """
-    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug on a device or browser, or when you need to self-validate a user-facing change you just built on a mobile simulator / emulator / real device or browser.
+    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug, or when you need to self-validate a user-facing change you just built on a mobile simulator / emulator / real device or browser.
 
     Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring non-trivial flows.
 
@@ -33,7 +33,7 @@ internal val INSTRUCTIONS = """
 
     1. `list_devices`: pick a `device_id` (mobile simulator/emulator, or `chromium` for web). If empty, ask the user to boot one. Use only IDs returned.
     2. `inspect_view_hierarchy`: fetch the view hierarchy before targeting elements. Use `take_screenshot` when a visual helps. Re-inspect after any UI change.
-    3. `run`: pass exactly one of `{ yaml }` (inline, preferred for exploration), `{ files }`, or `{ dir, include_tags, exclude_tags }`. Always include `device_id`. Pass `env` (object of variable -> value) for flow variables. `run` validates syntax and returns errors without executing if invalid.
+    3. `run`: pass exactly one of `{ yaml }` (inline, preferred for exploration), `{ files }`, or `{ dir, include_tags, exclude_tags }`. Always include `device_id`. Pass `env` for flow variables. `run` validates syntax.
 
     Mobile flows declare `appId` and start with `launchApp`; web flows declare `url` and start with `openLink`. Ask the user for the bundle ID or URL if unknown. `include_tags`/`exclude_tags` are bare names without `@`. Prefer one full flow over many single-command calls.
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -25,7 +25,7 @@ import java.io.PrintStream
 internal val INSTRUCTIONS = """
     Maestro MCP authors and runs UI tests via declarative YAML flows on Android and iOS simulators/emulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug on a device or browser.
 
-    Docs: https://docs.maestro.dev/llms.txt. Call `cheat_sheet` before authoring non-trivial flows.
+    Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring non-trivial flows.
 
     ## Local workflow
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -20,15 +20,55 @@ import maestro.cli.mcp.tools.CheatSheetTool
 import maestro.cli.mcp.tools.RunOnCloudTool
 import maestro.cli.mcp.tools.GetCloudRunStatusTool
 import maestro.cli.util.WorkingDirectory
+import java.io.PrintStream
 
-// Main function to run the Maestro MCP server
+internal val INSTRUCTIONS = """
+    Maestro MCP authors and runs UI tests via declarative YAML flows on Android and iOS simulators/emulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug on a device or browser.
+
+    Docs: https://docs.maestro.dev/llms.txt. Call `cheat_sheet` before authoring non-trivial flows.
+
+    ## Local workflow
+
+    `list_devices` -> `inspect_view_hierarchy` -> `run`.
+
+    1. `list_devices`: pick a `device_id` (mobile simulator/emulator, or `chromium` for web). If empty, ask the user to boot one. Use only IDs returned.
+    2. `inspect_view_hierarchy`: fetch the view hierarchy before targeting elements. Use `take_screenshot` when a visual helps. Re-inspect after any UI change.
+    3. `run`: pass exactly one of `{ yaml }` (inline, preferred for exploration), `{ files }`, or `{ dir, include_tags, exclude_tags }`. Always include `device_id`. Pass `env` (object of variable -> value) for flow variables. `run` validates syntax and returns errors without executing if invalid.
+
+    Mobile flows declare `appId` and start with `launchApp`; web flows declare `url` and start with `openLink`. Ask the user for the bundle ID or URL if unknown. `include_tags`/`exclude_tags` are bare names without `@`. Prefer one full flow over many single-command calls.
+
+    ## Cloud workflow
+
+    `run_on_cloud` -> `get_cloud_run_status` (poll).
+
+    `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 30s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). For long-running suites, surface the dashboard URL and let the user watch there rather than polling indefinitely. Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
+
+    Auth: `maestro login` (or `MAESTRO_CLOUD_API_KEY` for non-interactive). Never echo the API key.
+""".trimIndent()
+
+// Captures the real stdout so the MCP protocol channel stays pristine even after
+// `claimMcpStdout()` routes `System.out` to stderr. Defaults to `System.out` for
+// test/dev paths that invoke `runMaestroMcpServer()` without going through main().
+private var mcpProtocolOut: PrintStream = System.out
+
+/**
+ * Must run before any MCP-adjacent class loads: static init (kotlin-logging banner,
+ * first-run analytics notice, third-party println-on-load) writes to whatever stdout
+ * is at that moment and corrupts the JSON-RPC handshake for strict clients like
+ * Claude Desktop.
+ */
+internal fun claimMcpStdout() {
+    mcpProtocolOut = System.out
+    System.setOut(System.err)
+}
+
 fun runMaestroMcpServer() {
-    // Disable all console logging to prevent interference with JSON-RPC communication
+    // LogConfig silences log4j; the stdout redirect in `claimMcpStdout` catches
+    // everything else. Keep both; they cover different noise sources.
     LogConfig.configure(logFileName = null, printToConsole = false)
-    
+
     val sessionManager = MaestroSessionManager
 
-    // Create the MCP Server instance with Maestro implementation
     val server = Server(
         serverInfo = Implementation(
             name = "maestro",
@@ -38,10 +78,10 @@ fun runMaestroMcpServer() {
             capabilities = ServerCapabilities(
                 tools = ServerCapabilities.Tools(listChanged = true)
             )
-        )
+        ),
+        instructions = INSTRUCTIONS
     )
 
-    // Register tools
     server.addTools(listOf(
         ListDevicesTool.create(),
         TakeScreenshotTool.create(sessionManager),
@@ -52,11 +92,9 @@ fun runMaestroMcpServer() {
         GetCloudRunStatusTool.create()
     ))
 
-
-    // Create a transport using standard IO for server communication
     val transport = StdioServerTransport(
         System.`in`.asSource().buffered(),
-        System.out.asSink().buffered()
+        mcpProtocolOut.asSink().buffered()
     )
 
     System.err.println("MCP Server: Started. Waiting for messages. Working directory: ${WorkingDirectory.baseDir}")

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -23,7 +23,7 @@ import maestro.cli.util.WorkingDirectory
 import java.io.PrintStream
 
 internal val INSTRUCTIONS = """
-    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug on a device or browser.
+    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug on a device or browser, or when you need to self-validate a user-facing change you just built on a mobile simulator / emulator / real device or browser.
 
     Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring non-trivial flows.
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -23,7 +23,7 @@ import maestro.cli.util.WorkingDirectory
 import java.io.PrintStream
 
 internal val INSTRUCTIONS = """
-    Maestro MCP authors and runs UI tests via declarative YAML flows on Android and iOS simulators/emulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug on a device or browser.
+    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug on a device or browser.
 
     Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring non-trivial flows.
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/McpServerTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/McpServerTest.kt
@@ -1,0 +1,28 @@
+package maestro.cli.mcp
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class McpServerTest {
+
+    @Test
+    fun `instructions fit the 2KB MCP cap`() {
+        assertThat(INSTRUCTIONS.toByteArray(Charsets.UTF_8).size).isLessThan(2048)
+    }
+
+    @Test
+    fun `instructions reference every registered tool`() {
+        val registeredTools = listOf(
+            "list_devices",
+            "take_screenshot",
+            "run",
+            "inspect_view_hierarchy",
+            "cheat_sheet",
+            "run_on_cloud",
+            "get_cloud_run_status",
+        )
+        registeredTools.forEach { tool ->
+            assertThat(INSTRUCTIONS).contains(tool)
+        }
+    }
+}


### PR DESCRIPTION
Two things, one PR since they hit the same `McpServer.kt` block.

**1. Server instructions ([MA-4026](https://linear.app/mobile-dev/issue/MA-4026/mcp-add-server-instructions-to-maestro-mcp-server))** — sets `instructions` on the MCP `Server` init. Text is the approved Notion spec, ~1.8KB, under the 2KB Claude Code cap. One substitution: `inspect_screen` became `inspect_view_hierarchy` until [MA-4025](https://linear.app/mobile-dev/issue/MA-4025/mcp-rename-inspect-view-hierarchy-to-inspect-screen-and-ship-compact) lands.

**2. Clean stdout handshake** — Leland ran into this on Claude Desktop: the MCP would die at startup with `Unexpected token 'k'`. Stdout IS the JSON-RPC channel, so anything that writes there before the handshake corrupts the stream. Claude Code's parser tolerates the garbage and keeps going; Claude Desktop's is strict and marks the server dead. The culprits were the first-run analytics notice and the kotlin-logging init banner.

`claimMcpStdout()` runs at the top of `main()` (only when the subcommand is `mcp`), swaps `System.out` with `System.err`, and keeps the original stdout for `StdioServerTransport`.

## Tests

Two JUnit checks in `McpServerTest.kt`:
- instructions fit the 2KB cap
- every registered tool name appears in the text (so renames break CI, not the LLM)

## Manual verification

Ran the built binary end-to-end as a user would:
- Fresh first-run simulation (empty `XDG_STATE_HOME`) confirms stdout stays pure JSON-RPC while the analytics opt-in notice and the kotlin-logging banner both land on stderr.
- `initialize` response includes the full `instructions` payload.
- Happy paths: `list_devices`, `cheat_sheet`, `run` on chromium (openLink + assertVisible succeeds).
- `run` error paths: missing `device_id`, multiple modes at once, no modes, invalid YAML (returns a parsing error), failed assertion (returns an assertion error). All set `isError: true` with readable messages.
- `mcp-server-tester` evals (`tool-tests-without-device.yaml`): tool discovery passes 7/7 and `list_devices` passes. The three "expect API key required" failures are pre-existing fixture coupling with local auth state, unrelated to this PR.

## Follow-up

When [MA-4025](https://linear.app/mobile-dev/issue/MA-4025/mcp-rename-inspect-view-hierarchy-to-inspect-screen-and-ship-compact) lands, flip the `inspect_view_hierarchy` reference in the text back to `inspect_screen`.