### PR TITLE
Add missing string command config for random inputs, and add e2e tests

### DIFF
--- a/e2e/demo_app/.maestro/commands/inputRandomCityName.yaml
+++ b/e2e/demo_app/.maestro/commands/inputRandomCityName.yaml
@@ -2,14 +2,15 @@ appId: com.example.example
 tags:
   - passing
 ---
-- launchApp # For idempotence of sections
+- launchApp:
+    clearState: true
 
 - tapOn: 'Input/Keyboard'
 - tapOn:
     id: 'textInput'
-- inputRandomEmail
+- inputRandomCityName
 
 - assertNotVisible: 'Test Input Field'
 - assertVisible: 
-    text: '.+@.+'
-    id: "textInput"
+    id: textInput
+    text: .+

--- a/e2e/demo_app/.maestro/commands/inputRandomColorName.yaml
+++ b/e2e/demo_app/.maestro/commands/inputRandomColorName.yaml
@@ -2,14 +2,15 @@ appId: com.example.example
 tags:
   - passing
 ---
-- launchApp # For idempotence of sections
+- launchApp:
+    clearState: true
 
 - tapOn: 'Input/Keyboard'
 - tapOn:
     id: 'textInput'
-- inputRandomEmail
+- inputRandomColorName
 
 - assertNotVisible: 'Test Input Field'
 - assertVisible: 
-    text: '.+@.+'
-    id: "textInput"
+    id: textInput
+    text: .+

--- a/e2e/demo_app/.maestro/commands/inputRandomCountryName.yaml
+++ b/e2e/demo_app/.maestro/commands/inputRandomCountryName.yaml
@@ -2,14 +2,15 @@ appId: com.example.example
 tags:
   - passing
 ---
-- launchApp # For idempotence of sections
+- launchApp:
+    clearState: true
 
 - tapOn: 'Input/Keyboard'
 - tapOn:
     id: 'textInput'
-- inputRandomEmail
+- inputRandomCountryName
 
 - assertNotVisible: 'Test Input Field'
 - assertVisible: 
-    text: '.+@.+'
-    id: "textInput"
+    id: textInput
+    text: .+

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
@@ -106,6 +106,18 @@ private val stringCommands = mapOf<String, (JsonLocation) -> YamlFluentCommand>(
         _location = location,
         inputRandomPersonName = YamlInputRandomPersonName(),
     )},
+    "inputRandomCityName" to { location -> YamlFluentCommand(
+        _location = location,
+        inputRandomCityName = YamlInputRandomCityName(),
+    )},
+    "inputRandomCountryName" to { location -> YamlFluentCommand(
+        _location = location,
+        inputRandomCountryName = YamlInputRandomCountryName(),
+    )},
+    "inputRandomColorName" to { location -> YamlFluentCommand(
+        _location = location,
+        inputRandomColorName = YamlInputRandomColorName(),
+    )},
     "back" to { location -> YamlFluentCommand(
         _location = location,
         back = YamlActionBack(),

--- a/maestro-orchestra/src/test/resources/workspaces/e016_config_invalid_command_in_onFlowStart/error.txt
+++ b/maestro-orchestra/src/test/resources/workspaces/e016_config_invalid_command_in_onFlowStart/error.txt
@@ -10,8 +10,8 @@
 │ │ `inp` is not a valid command.                                              │ │
 │ │                                                                            │ │
 │ │ Did you mean one of: inputRandomText, inputRandomNumber, inputRandomEmail, │ │
-│ │ inputRandomPersonName, inputText, inputRandomCityName,                     │ │
-│ │ inputRandomCountryName, inputRandomColorName                               │ │
+│ │ inputRandomPersonName, inputRandomCityName, inputRandomCountryName,        │ │
+│ │ inputRandomColorName, inputText                                            │ │
 │ │                                                                            │ │
 │ │ > https://docs.maestro.dev/api-reference/commands                          │ │
 │ ╰────────────────────────────────────────────────────────────────────────────╯ │


### PR DESCRIPTION
## Proposed changes

Parsing was failing for some random inputText command variants.

Before:
```
% maestro test inputRandomColorName.yaml 

> Missing Command Options
                                                                                                                                                                                                                                                                                                                          
/Users/danc/git/maestro/Maestro/e2e/demo_app/.maestro/commands/inputRandomColorName.yaml:11                                                                                                                                                                                                                               
╭─────────────────────────────────────────────────────────────────────╮                                                                                                                                                                                                                                                   
│ 9 | - tapOn:                                                        │                                                                                                                                                                                                                                                   
│ 10 |     id: 'textInput'                                            │                                                                                                                                                                                                                                                   
│ 11 | - inputRandomColorName                                         │                                                                                                                                                                                                                                                   
│                           ^                                         │                                                                                                                                                                                                                                                   
│ ╭─────────────────────────────────────────────────────────────────╮ │                                                                                                                                                                                                                                                   
│ │ The command `inputRandomColorName` requires additional options. │ │                                                                                                                                                                                                                                                   
│ ╰─────────────────────────────────────────────────────────────────╯ │                                                                                                                                                                                                                                                   
│ 12 |                                                                │                                                                                                                                                                                                                                                   
│ 13 | - assertNotVisible: 'Test Input Field'                         │                                                                                                                                                                                                                                                   
╰─────────────────────────────────────────────────────────────────────╯ 
```

After:
```
% maestro test inputRandomColorName.yaml
Running on Maestro_ANDROID_pixel_6_android-34                    
                                                                 
 ║                                                               
 ║  > Flow: inputRandomColorName                                 
 ║                                                               
 ║    ✅   Launch app "com.example.example" with clear state      
 ║    ✅   Tap on "Input/Keyboard"                                
 ║    ✅   Tap on id: textInput                                   
 ║    ✅   Input text random TEXT_COLOR                           
 ║    ✅   Assert that "Test Input Field" is not visible          
 ║    ✅   Assert that ".+", id: textInput is visible             
 ║                                                               
```

## Testing

New e2e tests

## Issues fixed

Fixes https://github.com/mobile-dev-inc/maestro-studio/issues/58 (but it'll need a Maestro bump when we next release)