### PR TITLE
feat(mcp): add list_cloud_devices + device_model param on run_on_cloud

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -24,9 +24,11 @@ import maestro.cli.util.WorkingDirectory
 import java.io.PrintStream
 
 internal val INSTRUCTIONS = """
-    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test or reproduce a bug, or when you need to self-validate a user-facing change you just built on a mobile simulator / emulator / real device or browser.
+    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test, reproduce a bug, or self-validate a user-facing change you just built.
 
-    Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring non-trivial flows.
+    Every local tool (`take_screenshot`, `inspect_view_hierarchy`, `run`) needs a `device_id` from `list_devices` first.
+
+    Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring any flow with assertions, conditionals, or multiple screens.
 
     ## Local workflow
 
@@ -36,13 +38,13 @@ internal val INSTRUCTIONS = """
     2. `inspect_view_hierarchy`: fetch the view hierarchy before targeting elements. Use `take_screenshot` when a visual helps. Re-inspect after any UI change.
     3. `run`: pass exactly one of `{ yaml }` (inline, preferred for exploration), `{ files }`, or `{ dir, include_tags, exclude_tags }`. Always include `device_id`. Pass `env` for flow variables. `run` validates syntax.
 
-    Mobile flows declare `appId` and start with `launchApp`; web flows declare `url` and start with `openLink`. Ask the user for the bundle ID or URL if unknown. `include_tags`/`exclude_tags` are bare names without `@`. Prefer one full flow over many single-command calls.
+    Mobile flows declare `appId` and start with `launchApp`; web flows declare `url` and start with `openLink`. `include_tags`/`exclude_tags` are bare names without `@`. Prefer one full flow over many single-command calls.
 
     ## Cloud workflow
 
     `list_cloud_devices` -> `run_on_cloud` -> `get_cloud_run_status` (poll).
 
-    `list_cloud_devices` returns valid `device_model` / `device_os` pairs (case-sensitive). `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 30s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING); for long suites, hand the user the dashboard URL instead of polling indefinitely. Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
+    `list_cloud_devices` returns valid `{device_model, device_os}` pairs. Pass them verbatim; never lowercase, reformat, or infer. `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 30s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
 
     Auth: `maestro login` (or `MAESTRO_CLOUD_API_KEY` for non-interactive). Never echo the API key.
 """.trimIndent()

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -19,6 +19,7 @@ import maestro.cli.mcp.tools.InspectViewHierarchyTool
 import maestro.cli.mcp.tools.CheatSheetTool
 import maestro.cli.mcp.tools.RunOnCloudTool
 import maestro.cli.mcp.tools.GetCloudRunStatusTool
+import maestro.cli.mcp.tools.ListCloudDevicesTool
 import maestro.cli.util.WorkingDirectory
 import java.io.PrintStream
 
@@ -39,9 +40,9 @@ internal val INSTRUCTIONS = """
 
     ## Cloud workflow
 
-    `run_on_cloud` -> `get_cloud_run_status` (poll).
+    `list_cloud_devices` -> `run_on_cloud` -> `get_cloud_run_status` (poll).
 
-    `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 30s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). For long-running suites, surface the dashboard URL and let the user watch there rather than polling indefinitely. Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
+    `list_cloud_devices` returns valid `device_model` / `device_os` pairs (case-sensitive). `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 30s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING); for long suites, hand the user the dashboard URL instead of polling indefinitely. Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
 
     Auth: `maestro login` (or `MAESTRO_CLOUD_API_KEY` for non-interactive). Never echo the API key.
 """.trimIndent()
@@ -88,6 +89,7 @@ fun runMaestroMcpServer() {
         RunTool.create(sessionManager),
         InspectViewHierarchyTool.create(sessionManager),
         CheatSheetTool.create(),
+        ListCloudDevicesTool.create(),
         RunOnCloudTool.create(),
         GetCloudRunStatusTool.create()
     ))

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/ListCloudDevicesTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/ListCloudDevicesTool.kt
@@ -12,7 +12,13 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import maestro.cli.api.ApiClient
-import maestro.cli.util.EnvUtils
+
+// Resolves the same way `run_on_cloud` does so both tools hit the same host in one
+// session; `EnvUtils.BASE_API_URL` alone ignores `MAESTRO_CLOUD_API_URL`.
+private fun cloudApiUrl(): String =
+    System.getenv("MAESTRO_CLOUD_API_URL")
+        ?: System.getenv("MAESTRO_API_URL")
+        ?: "https://api.copilot.mobile.dev"
 
 object ListCloudDevicesTool {
     fun create(): RegisteredTool {
@@ -29,7 +35,7 @@ object ListCloudDevicesTool {
             )
         ) { _ ->
             try {
-                val cloudDevices = ApiClient(EnvUtils.BASE_API_URL).listCloudDevices()
+                val cloudDevices = ApiClient(cloudApiUrl()).listCloudDevices()
 
                 val devices = buildJsonArray {
                     cloudDevices.forEach { (platform, models) ->

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/ListCloudDevicesTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/ListCloudDevicesTool.kt
@@ -1,0 +1,67 @@
+package maestro.cli.mcp.tools
+
+import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import maestro.cli.api.ApiClient
+import maestro.cli.util.EnvUtils
+
+object ListCloudDevicesTool {
+    fun create(): RegisteredTool {
+        return RegisteredTool(
+            Tool(
+                name = "list_cloud_devices",
+                description = "List device models and OS versions available on Maestro Cloud. " +
+                    "Call this before `run_on_cloud` to discover valid `device_model` / `device_os` pairs. " +
+                    "OS versions are returned in the exact case the cloud API expects (e.g. `iOS-17-5`, `android-34`).",
+                inputSchema = ToolSchema(
+                    properties = buildJsonObject { },
+                    required = emptyList()
+                )
+            )
+        ) { _ ->
+            try {
+                val cloudDevices = ApiClient(EnvUtils.BASE_API_URL).listCloudDevices()
+
+                val devices = buildJsonArray {
+                    cloudDevices.forEach { (platform, models) ->
+                        models.forEach { (model, osVersions) ->
+                            addJsonObject {
+                                put("platform", platform)
+                                put("model", model)
+                                putJsonArray("supported_os") {
+                                    osVersions.forEach { add(JsonPrimitive(it)) }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                val result = buildJsonObject {
+                    put("devices", devices)
+                }
+
+                CallToolResult(content = listOf(TextContent(result.toString())))
+            } catch (e: ApiClient.ApiException) {
+                val detail = e.statusCode?.let { "HTTP $it" } ?: "network error"
+                CallToolResult(
+                    content = listOf(TextContent("Failed to list cloud devices ($detail). Check your network connection and retry.")),
+                    isError = true,
+                )
+            } catch (e: Exception) {
+                CallToolResult(
+                    content = listOf(TextContent("Failed to list cloud devices: ${e.message ?: e.javaClass.simpleName}")),
+                    isError = true,
+                )
+            }
+        }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
@@ -58,9 +58,13 @@ object RunOnCloudTool {
                             put("description", "Skip flows that have any of these tags.")
                             putJsonObject("items") { put("type", "string") }
                         }
+                        putJsonObject("device_model") {
+                            put("type", "string")
+                            put("description", "Cloud device model (e.g. `iPhone-17-Pro`, `pixel_6`). Call `list_cloud_devices` for valid values.")
+                        }
                         putJsonObject("device_os") {
                             put("type", "string")
-                            put("description", "Cloud device OS target (e.g. 'ios-17-5', 'android-34'). See the output of `maestro list-cloud-devices` for valid values.")
+                            put("description", "Cloud device OS version, case-sensitive (e.g. `iOS-17-5`, `android-34`). Call `list_cloud_devices` for valid values.")
                         }
                     },
                     required = listOf("app_file", "flows")
@@ -89,6 +93,7 @@ object RunOnCloudTool {
                 val excludeTags = request.arguments?.get("exclude_tags")?.jsonArray?.mapNotNull {
                     it.jsonPrimitive.contentOrNull
                 } ?: emptyList()
+                val deviceModel = request.arguments?.get("device_model")?.jsonPrimitive?.content
                 val deviceOs = request.arguments?.get("device_os")?.jsonPrimitive?.content
 
                 if (appFileArg.isNullOrBlank()) {
@@ -175,6 +180,7 @@ object RunOnCloudTool {
                         excludeTags = excludeTags,
                         disableNotifications = false,
                         projectId = projectId,
+                        deviceModel = deviceModel,
                         deviceOs = deviceOs,
                         androidApiLevel = null,
                     )

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/McpServerTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/McpServerTest.kt
@@ -18,6 +18,7 @@ class McpServerTest {
             "run",
             "inspect_view_hierarchy",
             "cheat_sheet",
+            "list_cloud_devices",
             "run_on_cloud",
             "get_cloud_run_status",
         )

--- a/maestro-cli/src/test/mcp/full-evals.yaml
+++ b/maestro-cli/src/test/mcp/full-evals.yaml
@@ -16,10 +16,10 @@ evals:
         - type: llm-judge
           criteria: >
             The assistant makes no tool calls and instead provides a list of all
-            7 available tools: list_devices, take_screenshot, run,
-            inspect_view_hierarchy, cheat_sheet, run_on_cloud, and
-            get_cloud_run_status. The response should be comprehensive and not mention
-            any other tool names.
+            8 available tools: list_devices, take_screenshot, run,
+            inspect_view_hierarchy, cheat_sheet, list_cloud_devices, run_on_cloud,
+            and get_cloud_run_status. The response should be comprehensive and not
+            mention any other tool names.
           threshold: 1.0
 
     - name: Lists all devices

--- a/maestro-cli/src/test/mcp/tool-tests-without-device.yaml
+++ b/maestro-cli/src/test/mcp/tool-tests-without-device.yaml
@@ -6,6 +6,7 @@ tools:
     - run
     - inspect_view_hierarchy
     - cheat_sheet
+    - list_cloud_devices
     - run_on_cloud
     - get_cloud_run_status
 
@@ -17,6 +18,14 @@ tools:
         success: true
         result:
           contains: "device"
+
+    - name: "List cloud devices"
+      tool: "list_cloud_devices"
+      params: {}
+      expect:
+        success: true
+        result:
+          contains: "supported_os"
 
     - name: "Get Maestro cheat sheet (expect API key required)"
       tool: "cheat_sheet"


### PR DESCRIPTION
Adds cloud device discovery to the MCP and the missing `device_model` param on `run_on_cloud`.

Motivated by "run this on cloud on iPhone 17 Pro iOS 26" hitting a dead end: `run_on_cloud` had no way to specify the model (defaulted to iPhone-11), and the agent guessed the OS format wrong (`ios-26-0` vs actual `iOS-26-2`).

## Changes

- New `list_cloud_devices` MCP tool, wraps `ApiClient.listCloudDevices()`. Returns a flat `{platform, model, supported_os[]}` array so the agent can look up valid pairs before submitting.
- `run_on_cloud` accepts `device_model` and threads it into `ApiClient.upload(deviceModel = ...)`. `device_os` description now calls out case sensitivity and points at `list_cloud_devices`.
- Instructions updated: cloud workflow arrow chain becomes `list_cloud_devices -> run_on_cloud -> get_cloud_run_status`, "pass values verbatim, never lowercase/reformat/infer" to kill the format-guessing bug class, and hoisted the "every local tool needs a device_id" rule to the top. 1995 bytes, under the 2KB cap.
- Aligned API URL resolution across both cloud tools.
- Tests + evals: tool count 7 -> 8, smoke test for `list_cloud_devices`.

## Verified

Live submission via MCP with a real iOS app + `device_model=iPhone-17-Pro` + `device_os=iOS-26-2`. Cloud provisioned the device, ran the flow to SUCCESS. Before this PR the same call failed on device validation.