### PR TITLE
feat(mcp): tighten instructions and inspect_view_hierarchy description

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -28,7 +28,7 @@ internal val INSTRUCTIONS = """
 
     Every local tool (`take_screenshot`, `inspect_view_hierarchy`, `run`) needs a `device_id` from `list_devices` first.
 
-    Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring any flow with assertions, conditionals, or multiple screens.
+    Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring any flow with assertions, conditionals, nested properties, or multiple screens.
 
     ## Local workflow
 
@@ -44,7 +44,7 @@ internal val INSTRUCTIONS = """
 
     `list_cloud_devices` -> `run_on_cloud` -> `get_cloud_run_status` (poll).
 
-    `list_cloud_devices` returns valid `{device_model, device_os}` pairs. Pass them verbatim; never lowercase, reformat, or infer. `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 30s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
+    `list_cloud_devices` returns valid `{device_model, device_os}` pairs. Pass them verbatim; never lowercase, reformat, or infer. `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 60s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
 
     Auth: `maestro login` (or `MAESTRO_CLOUD_API_KEY` for non-interactive). Never echo the API key.
 """.trimIndent()

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
@@ -14,11 +14,11 @@ object InspectViewHierarchyTool {
                 name = "inspect_view_hierarchy",
                 description = "Get the nested view hierarchy of the current screen in CSV format. Returns UI elements " +
                     "with bounds coordinates for interaction. Use this to understand screen layout, find specific elements " +
-                    "by text/id, or locate interactive components. Elements include bounds (x,y,width,height), text content, " +
-                    "resource IDs, and interaction states (clickable, enabled, checked). " +
-                    "The column names in this output are NOT valid Maestro selector keys: `tapOn` / `assertVisible` / etc. " +
-                    "accept `text`, `id`, `index`, and position matchers (`below`, `above`, `leftOf`, `rightOf`). " +
-                    "Map the `accessibility` column to `text`; don't pass `accessibilityText` as a selector.",
+                    "by text/id, or locate interactive components. Columns: `element_num,depth,bounds,attributes,parent_num`; " +
+                    "the `attributes` cell holds semicolon-separated `key=value` pairs (e.g. `text=Submit; accessibilityText=Submit button; resource_id=btn_submit`). " +
+                    "Those attribute keys are NOT valid Maestro selector keys. `tapOn` / `assertVisible` / etc. accept " +
+                    "`text`, `id`, `index`, and position matchers (`below`, `above`, `leftOf`, `rightOf`). " +
+                    "Map `accessibilityText=Foo` to `text: Foo`; never pass `accessibilityText` as a selector.",
                 inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
@@ -15,7 +15,10 @@ object InspectViewHierarchyTool {
                 description = "Get the nested view hierarchy of the current screen in CSV format. Returns UI elements " +
                     "with bounds coordinates for interaction. Use this to understand screen layout, find specific elements " +
                     "by text/id, or locate interactive components. Elements include bounds (x,y,width,height), text content, " +
-                    "resource IDs, and interaction states (clickable, enabled, checked).",
+                    "resource IDs, and interaction states (clickable, enabled, checked). " +
+                    "The column names in this output are NOT valid Maestro selector keys: `tapOn` / `assertVisible` / etc. " +
+                    "accept `text`, `id`, `index`, and position matchers (`below`, `above`, `leftOf`, `rightOf`). " +
+                    "Map the `accessibility` column to `text`; don't pass `accessibilityText` as a selector.",
                 inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {


### PR DESCRIPTION
Three small fixes bundled from Simon's recent feedback.

**1. cheat_sheet trigger covers nested properties.** Simon hit a case where the agent wrote `optional: true` at the wrong indent (sibling of `tapOn` instead of inside it) and had to fix manually. The cheat_sheet has the correct shape; the trigger list just didn't nudge the agent to consult it for commands with nested properties. Added to the list alongside assertions, conditionals, and multiple screens.

**2. Cloud polling cadence 30s -> 60s.** Simon flagged polling feeling slow; Claude Code clamps agent-scheduled wake-ups to 60s minimum, so the old 30s was unachievable. Matching reality. The real fix (long-poll inside `get_cloud_run_status` so the tool waits server-side) is a bigger change and will come separately.

**3. [MA-4006](https://linear.app/mobile-dev/issue/MA-4006/mcp-add-method-to-correlate-hierarchy-selectors-to-yaml-flow): correlate hierarchy columns to selector keys.** Simon's ticket. Agent occasionally passed `accessibilityText` as a selector because it appears in the hierarchy CSV. Only `text`, `id`, `index`, and position matchers are valid selectors. `inspect_view_hierarchy` description now spells this out and says to map the `accessibility` column to `text`.

Instructions at 2014 bytes, under the 2KB Claude Code cap.