### PR TITLE
feat(mcp): validate text selectors against latest hierarchy snapshot

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.io.asSink
 import kotlinx.io.asSource
 import kotlinx.io.buffered
+import maestro.cli.mcp.hierarchy.HierarchySnapshotStore
 import maestro.cli.session.MaestroSessionManager
 import maestro.debuglog.LogConfig
 import maestro.cli.mcp.tools.ListDevicesTool
@@ -24,7 +25,7 @@ import maestro.cli.util.WorkingDirectory
 import java.io.PrintStream
 
 internal val INSTRUCTIONS = """
-    Maestro MCP authors, edits and runs UI tests via declarative YAML flows on Android emulators, iOS simulators, Chromium browsers, or Maestro Cloud. Use when the user wants to write, run, or debug a mobile or web UI test, reproduce a bug, or self-validate a user-facing change you just built.
+    Maestro MCP authors, edits and runs UI tests (YAML flows) on Android, iOS, Chromium, or Maestro Cloud. Use for writing, running, or debugging a mobile/web UI test, reproducing a bug, or self-validating a UI change.
 
     Every local tool (`take_screenshot`, `inspect_view_hierarchy`, `run`) needs a `device_id` from `list_devices` first.
 
@@ -34,9 +35,9 @@ internal val INSTRUCTIONS = """
 
     `list_devices` -> `inspect_view_hierarchy` -> `run`.
 
-    1. `list_devices`: pick a `device_id` (mobile simulator/emulator, or `chromium` for web). If empty, ask the user to boot one. Use only IDs returned.
-    2. `inspect_view_hierarchy`: fetch the view hierarchy before targeting elements. Use `take_screenshot` when a visual helps. Re-inspect after any UI change.
-    3. `run`: pass exactly one of `{ yaml }` (inline, preferred for exploration), `{ files }`, or `{ dir, include_tags, exclude_tags }`. Always include `device_id`. Pass `env` for flow variables. `run` validates syntax.
+    1. `list_devices`: pick a `device_id` (mobile simulator/emulator, or `chromium` for web). If empty, ask the user to boot one.
+    2. `inspect_view_hierarchy`: fetch the hierarchy before targeting elements. Use `take_screenshot` when a visual helps. Re-inspect after any UI change.
+    3. `run`: pass exactly one of `{ yaml }` (inline, preferred), `{ files }`, or `{ dir, include_tags, exclude_tags }`. Always include `device_id`. Pass `env` for flow variables. `run` validates syntax and checks `text:` selectors against the latest hierarchy; on miss, re-inspect and copy on-screen text verbatim. Pass `skip_selector_validation: true` for dynamically-rendered text.
 
     Mobile flows declare `appId` and start with `launchApp`; web flows declare `url` and start with `openLink`. `include_tags`/`exclude_tags` are bare names without `@`. Prefer one full flow over many single-command calls.
 
@@ -44,7 +45,7 @@ internal val INSTRUCTIONS = """
 
     `list_cloud_devices` -> `run_on_cloud` -> `get_cloud_run_status` (poll).
 
-    `list_cloud_devices` returns valid `{device_model, device_os}` pairs. Pass them verbatim; never lowercase, reformat, or infer. `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 60s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
+    `list_cloud_devices` returns valid `{device_model, device_os}` pairs. Pass them verbatim; never lowercase, reformat, or infer. `run_on_cloud` submits a flow or folder and returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 60s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). No tool lists past runs; ask for the `upload_id` or URL.
 
     Auth: `maestro login` (or `MAESTRO_CLOUD_API_KEY` for non-interactive). Never echo the API key.
 """.trimIndent()
@@ -71,6 +72,7 @@ fun runMaestroMcpServer() {
     LogConfig.configure(logFileName = null, printToConsole = false)
 
     val sessionManager = MaestroSessionManager
+    val snapshotStore = HierarchySnapshotStore()
 
     val server = Server(
         serverInfo = Implementation(
@@ -88,8 +90,8 @@ fun runMaestroMcpServer() {
     server.addTools(listOf(
         ListDevicesTool.create(),
         TakeScreenshotTool.create(sessionManager),
-        RunTool.create(sessionManager),
-        InspectViewHierarchyTool.create(sessionManager),
+        RunTool.create(sessionManager, snapshotStore),
+        InspectViewHierarchyTool.create(sessionManager, snapshotStore),
         CheatSheetTool.create(),
         ListCloudDevicesTool.create(),
         RunOnCloudTool.create(),

--- a/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/HierarchySnapshotStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/HierarchySnapshotStore.kt
@@ -9,8 +9,7 @@ class HierarchySnapshotStore {
 
     private val snapshots = ConcurrentHashMap<String, Snapshot>()
 
-    fun record(deviceId: String, root: TreeNode?) {
-        if (root == null) return
+    fun record(deviceId: String, root: TreeNode) {
         snapshots[deviceId] = Snapshot(root)
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/HierarchySnapshotStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/HierarchySnapshotStore.kt
@@ -3,63 +3,20 @@ package maestro.cli.mcp.hierarchy
 import maestro.TreeNode
 import java.util.concurrent.ConcurrentHashMap
 
-/**
- * Remembers the most recent view-hierarchy snapshot per device so selector
- * validation in [maestro.cli.mcp.tools.RunTool] can check `text:` values
- * against what's actually on screen.
- *
- * `inspect_view_hierarchy` writes here; `run` reads. Snapshots live only in
- * process memory, last-write-wins, and are never persisted across restarts.
- */
 class HierarchySnapshotStore {
 
-    data class Snapshot(
-        val deviceId: String,
-        val texts: Set<String>,
-    )
+    data class Snapshot(val root: TreeNode)
 
     private val snapshots = ConcurrentHashMap<String, Snapshot>()
 
     fun record(deviceId: String, root: TreeNode?) {
-        val texts = collectTexts(root)
-        snapshots[deviceId] = Snapshot(deviceId = deviceId, texts = texts)
+        if (root == null) return
+        snapshots[deviceId] = Snapshot(root)
     }
 
     fun get(deviceId: String): Snapshot? = snapshots[deviceId]
 
     fun clear() {
         snapshots.clear()
-    }
-
-    private fun collectTexts(root: TreeNode?): Set<String> {
-        if (root == null) return emptySet()
-        val out = linkedSetOf<String>()
-        walk(root, out)
-        return out
-    }
-
-    private fun walk(node: TreeNode, out: MutableSet<String>) {
-        TEXT_BEARING_KEYS.forEach { key ->
-            node.attributes[key]
-                ?.takeIf { it.isNotBlank() }
-                ?.let { out.add(it) }
-        }
-        node.children.forEach { walk(it, out) }
-    }
-
-    companion object {
-        // Every attribute a Maestro `text:` selector might plausibly match
-        // against. Sourced from the same fields the CSV/compact formatters
-        // emit for TreeNode.attributes.
-        private val TEXT_BEARING_KEYS = listOf(
-            "text",
-            "accessibilityText",
-            "content-desc",
-            "hintText",
-            "value",
-            "label",
-            "title",
-            "placeholder",
-        )
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/HierarchySnapshotStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/HierarchySnapshotStore.kt
@@ -1,0 +1,65 @@
+package maestro.cli.mcp.hierarchy
+
+import maestro.TreeNode
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Remembers the most recent view-hierarchy snapshot per device so selector
+ * validation in [maestro.cli.mcp.tools.RunTool] can check `text:` values
+ * against what's actually on screen.
+ *
+ * `inspect_view_hierarchy` writes here; `run` reads. Snapshots live only in
+ * process memory, last-write-wins, and are never persisted across restarts.
+ */
+class HierarchySnapshotStore {
+
+    data class Snapshot(
+        val deviceId: String,
+        val texts: Set<String>,
+    )
+
+    private val snapshots = ConcurrentHashMap<String, Snapshot>()
+
+    fun record(deviceId: String, root: TreeNode?) {
+        val texts = collectTexts(root)
+        snapshots[deviceId] = Snapshot(deviceId = deviceId, texts = texts)
+    }
+
+    fun get(deviceId: String): Snapshot? = snapshots[deviceId]
+
+    fun clear() {
+        snapshots.clear()
+    }
+
+    private fun collectTexts(root: TreeNode?): Set<String> {
+        if (root == null) return emptySet()
+        val out = linkedSetOf<String>()
+        walk(root, out)
+        return out
+    }
+
+    private fun walk(node: TreeNode, out: MutableSet<String>) {
+        TEXT_BEARING_KEYS.forEach { key ->
+            node.attributes[key]
+                ?.takeIf { it.isNotBlank() }
+                ?.let { out.add(it) }
+        }
+        node.children.forEach { walk(it, out) }
+    }
+
+    companion object {
+        // Every attribute a Maestro `text:` selector might plausibly match
+        // against. Sourced from the same fields the CSV/compact formatters
+        // emit for TreeNode.attributes.
+        private val TEXT_BEARING_KEYS = listOf(
+            "text",
+            "accessibilityText",
+            "content-desc",
+            "hintText",
+            "value",
+            "label",
+            "title",
+            "placeholder",
+        )
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
@@ -6,14 +6,18 @@ import maestro.Filters
 import maestro.TreeNode
 
 // Cross-checks `text:` selectors in a flow's YAML against the latest
-// hierarchy snapshot. Matching delegates to Filters.textMatches so the
-// validator agrees with the runner — same attributes (text / hintText /
-// accessibilityText), same full-string regex semantics.
+// hierarchy snapshot. Matching delegates to Filters.textMatches with the
+// same RegexOptions Orchestra uses (IGNORE_CASE, DOT_MATCHES_ALL,
+// MULTILINE), so a verdict here matches the runner. Selectors containing
+// ${...} env interpolation are skipped — they'll be resolved by Orchestra
+// before the real match runs.
 object SelectorValidator {
 
     sealed interface Result {
         data object Ok : Result
-        data class Miss(val findings: List<Finding>) : Result
+        data class Miss(val findings: List<Finding>) : Result {
+            init { require(findings.isNotEmpty()) { "Miss must carry at least one finding" } }
+        }
     }
 
     data class Finding(
@@ -22,7 +26,9 @@ object SelectorValidator {
     )
 
     fun validate(yaml: String, snapshot: HierarchySnapshotStore.Snapshot): Result {
-        val selectors = extractTextSelectors(yaml).distinct()
+        val selectors = extractTextSelectors(yaml)
+            .filterNot(::hasEnvInterpolation)
+            .distinct()
         if (selectors.isEmpty()) return Result.Ok
 
         val nodes = snapshot.root.aggregate()
@@ -33,12 +39,14 @@ object SelectorValidator {
         return if (findings.isEmpty()) Result.Ok else Result.Miss(findings)
     }
 
+    private fun hasEnvInterpolation(selector: String): Boolean = ENV_INTERPOLATION.containsMatchIn(selector)
+
     private fun extractTextSelectors(yaml: String): List<String> {
         val root = try {
             YAML.readTree(yaml)
         } catch (e: Exception) {
-            // Malformed YAML will surface a better error from YamlCommandReader
-            // downstream — don't second-guess it here.
+            // Malformed YAML surfaces a better error from YamlCommandReader
+            // downstream; don't second-guess it here.
             return emptyList()
         }
         val out = mutableListOf<String>()
@@ -62,12 +70,11 @@ object SelectorValidator {
 
     private fun selectorMatches(selector: String, nodes: List<TreeNode>): Boolean {
         val regex = try {
-            Regex(selector)
+            Regex(selector, REGEX_OPTIONS)
         } catch (e: Exception) {
-            // Selector isn't a valid regex. Filters.textMatches already handles
-            // this via its `regex.pattern == value` literal-equality branch, but
-            // we can't construct a Regex to hand it — fall back to a plain
-            // equality check on the same three attributes.
+            // Selector isn't a valid regex (e.g. "foo("). Filters.textMatches
+            // has a `regex.pattern == value` literal-equality branch for this,
+            // but we can't construct a Regex to hand it — mimic it directly.
             return nodes.any { node ->
                 TEXT_ATTRIBUTES.any { attr -> node.attributes[attr] == selector }
             }
@@ -84,6 +91,9 @@ object SelectorValidator {
         }
         if (candidates.isEmpty()) return emptyList()
 
+        // Cheap bidirectional substring match — catches typos like "Loign"/"Login"
+        // and truncations like "RNR 352"/"RNR 352 - Expo Launch..." without
+        // needing a Levenshtein dependency.
         val lowered = selector.lowercase()
         val partial = candidates
             .filter { it.lowercase().contains(lowered) || lowered.contains(it.lowercase()) }
@@ -94,9 +104,18 @@ object SelectorValidator {
         return candidates.take(FALLBACK_PEEK).toList()
     }
 
-    // Mirrors the attributes Filters.textMatches inspects. Keep in sync with
-    // maestro-client/Filters.kt::textMatches.
+    // Mirrors the attributes Filters.textMatches inspects in
+    // maestro-client/Filters.kt::textMatches. Keep the two in sync.
     private val TEXT_ATTRIBUTES = listOf("text", "hintText", "accessibilityText")
+
+    // Mirrors maestro-orchestra/Orchestra.kt::REGEX_OPTIONS.
+    private val REGEX_OPTIONS = setOf(
+        RegexOption.IGNORE_CASE,
+        RegexOption.DOT_MATCHES_ALL,
+        RegexOption.MULTILINE,
+    )
+
+    private val ENV_INTERPOLATION = Regex("""\$\{[^}]+}""")
 
     private const val MAX_SUGGESTIONS = 5
     private const val FALLBACK_PEEK = 10

--- a/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
@@ -2,17 +2,13 @@ package maestro.cli.mcp.hierarchy
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import maestro.Filters
+import maestro.TreeNode
 
-/**
- * Walks the YAML of a Maestro flow for `text:` selectors and checks whether
- * each appears in the latest hierarchy snapshot. The goal is catching
- * hallucinated strings (e.g. text read off a screenshot that isn't actually
- * in the accessibility tree) before they reach Maestro's runner and produce
- * a less-informative "element not found" at runtime.
- *
- * Per MA-4029, only `text:` is validated in v1. Maestro's `text` matcher is a
- * regex; the validator honours that — partial matches count as hits.
- */
+// Cross-checks `text:` selectors in a flow's YAML against the latest
+// hierarchy snapshot. Matching delegates to Filters.textMatches so the
+// validator agrees with the runner — same attributes (text / hintText /
+// accessibilityText), same full-string regex semantics.
 object SelectorValidator {
 
     sealed interface Result {
@@ -26,12 +22,13 @@ object SelectorValidator {
     )
 
     fun validate(yaml: String, snapshot: HierarchySnapshotStore.Snapshot): Result {
-        val selectors = extractTextSelectors(yaml)
+        val selectors = extractTextSelectors(yaml).distinct()
         if (selectors.isEmpty()) return Result.Ok
 
+        val nodes = snapshot.root.aggregate()
         val findings = selectors
-            .filterNot { selectorMatchesAnyCandidate(it, snapshot.texts) }
-            .map { Finding(selector = it, suggestions = suggestFor(it, snapshot.texts)) }
+            .filterNot { selectorMatches(it, nodes) }
+            .map { Finding(selector = it, suggestions = suggestFor(it, nodes)) }
 
         return if (findings.isEmpty()) Result.Ok else Result.Miss(findings)
     }
@@ -40,8 +37,8 @@ object SelectorValidator {
         val root = try {
             YAML.readTree(yaml)
         } catch (e: Exception) {
-            // Invalid YAML will be caught by YamlCommandReader downstream with a
-            // better error message; don't try to validate selectors out of it.
+            // Malformed YAML will surface a better error from YamlCommandReader
+            // downstream — don't second-guess it here.
             return emptyList()
         }
         val out = mutableListOf<String>()
@@ -52,32 +49,39 @@ object SelectorValidator {
     private fun collect(node: JsonNode?, out: MutableList<String>) {
         if (node == null || node.isNull) return
         when {
-            node.isObject -> {
-                node.fields().forEach { (key, value) ->
-                    if (key == "text" && value.isTextual) {
-                        val text = value.asText()
-                        if (text.isNotBlank()) out.add(text)
-                    } else {
-                        collect(value, out)
-                    }
+            node.isObject -> node.fields().forEach { (key, value) ->
+                if (key == "text" && value.isTextual) {
+                    value.asText().takeIf { it.isNotBlank() }?.let(out::add)
+                } else {
+                    collect(value, out)
                 }
             }
             node.isArray -> node.forEach { collect(it, out) }
         }
     }
 
-    private fun selectorMatchesAnyCandidate(selector: String, candidates: Set<String>): Boolean {
+    private fun selectorMatches(selector: String, nodes: List<TreeNode>): Boolean {
         val regex = try {
             Regex(selector)
         } catch (e: Exception) {
-            // Fall back to a plain substring check so a flow with literal text
-            // containing regex metacharacters still validates.
-            return candidates.any { it.contains(selector, ignoreCase = false) }
+            // Selector isn't a valid regex. Filters.textMatches already handles
+            // this via its `regex.pattern == value` literal-equality branch, but
+            // we can't construct a Regex to hand it — fall back to a plain
+            // equality check on the same three attributes.
+            return nodes.any { node ->
+                TEXT_ATTRIBUTES.any { attr -> node.attributes[attr] == selector }
+            }
         }
-        return candidates.any { regex.containsMatchIn(it) }
+        return Filters.textMatches(regex).invoke(nodes).isNotEmpty()
     }
 
-    private fun suggestFor(selector: String, candidates: Set<String>): List<String> {
+    private fun suggestFor(selector: String, nodes: List<TreeNode>): List<String> {
+        val candidates = linkedSetOf<String>()
+        nodes.forEach { node ->
+            TEXT_ATTRIBUTES.forEach { attr ->
+                node.attributes[attr]?.takeIf { it.isNotBlank() }?.let { candidates.add(it) }
+            }
+        }
         if (candidates.isEmpty()) return emptyList()
 
         val lowered = selector.lowercase()
@@ -87,10 +91,12 @@ object SelectorValidator {
 
         if (partial.isNotEmpty()) return partial
 
-        // No overlap found — surface a short fallback list of what IS on
-        // screen so the agent has something concrete to correct against.
-        return candidates.take(FALLBACK_PEEK)
+        return candidates.take(FALLBACK_PEEK).toList()
     }
+
+    // Mirrors the attributes Filters.textMatches inspects. Keep in sync with
+    // maestro-client/Filters.kt::textMatches.
+    private val TEXT_ATTRIBUTES = listOf("text", "hintText", "accessibilityText")
 
     private const val MAX_SUGGESTIONS = 5
     private const val FALLBACK_PEEK = 10

--- a/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
@@ -1,0 +1,99 @@
+package maestro.cli.mcp.hierarchy
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+
+/**
+ * Walks the YAML of a Maestro flow for `text:` selectors and checks whether
+ * each appears in the latest hierarchy snapshot. The goal is catching
+ * hallucinated strings (e.g. text read off a screenshot that isn't actually
+ * in the accessibility tree) before they reach Maestro's runner and produce
+ * a less-informative "element not found" at runtime.
+ *
+ * Per MA-4029, only `text:` is validated in v1. Maestro's `text` matcher is a
+ * regex; the validator honours that — partial matches count as hits.
+ */
+object SelectorValidator {
+
+    sealed interface Result {
+        data object Ok : Result
+        data class Miss(val findings: List<Finding>) : Result
+    }
+
+    data class Finding(
+        val selector: String,
+        val suggestions: List<String>,
+    )
+
+    fun validate(yaml: String, snapshot: HierarchySnapshotStore.Snapshot): Result {
+        val selectors = extractTextSelectors(yaml)
+        if (selectors.isEmpty()) return Result.Ok
+
+        val findings = selectors
+            .filterNot { selectorMatchesAnyCandidate(it, snapshot.texts) }
+            .map { Finding(selector = it, suggestions = suggestFor(it, snapshot.texts)) }
+
+        return if (findings.isEmpty()) Result.Ok else Result.Miss(findings)
+    }
+
+    private fun extractTextSelectors(yaml: String): List<String> {
+        val root = try {
+            YAML.readTree(yaml)
+        } catch (e: Exception) {
+            // Invalid YAML will be caught by YamlCommandReader downstream with a
+            // better error message; don't try to validate selectors out of it.
+            return emptyList()
+        }
+        val out = mutableListOf<String>()
+        collect(root, out)
+        return out
+    }
+
+    private fun collect(node: JsonNode?, out: MutableList<String>) {
+        if (node == null || node.isNull) return
+        when {
+            node.isObject -> {
+                node.fields().forEach { (key, value) ->
+                    if (key == "text" && value.isTextual) {
+                        val text = value.asText()
+                        if (text.isNotBlank()) out.add(text)
+                    } else {
+                        collect(value, out)
+                    }
+                }
+            }
+            node.isArray -> node.forEach { collect(it, out) }
+        }
+    }
+
+    private fun selectorMatchesAnyCandidate(selector: String, candidates: Set<String>): Boolean {
+        val regex = try {
+            Regex(selector)
+        } catch (e: Exception) {
+            // Fall back to a plain substring check so a flow with literal text
+            // containing regex metacharacters still validates.
+            return candidates.any { it.contains(selector, ignoreCase = false) }
+        }
+        return candidates.any { regex.containsMatchIn(it) }
+    }
+
+    private fun suggestFor(selector: String, candidates: Set<String>): List<String> {
+        if (candidates.isEmpty()) return emptyList()
+
+        val lowered = selector.lowercase()
+        val partial = candidates
+            .filter { it.lowercase().contains(lowered) || lowered.contains(it.lowercase()) }
+            .take(MAX_SUGGESTIONS)
+
+        if (partial.isNotEmpty()) return partial
+
+        // No overlap found — surface a short fallback list of what IS on
+        // screen so the agent has something concrete to correct against.
+        return candidates.take(FALLBACK_PEEK)
+    }
+
+    private const val MAX_SUGGESTIONS = 5
+    private const val FALLBACK_PEEK = 10
+
+    private val YAML = YAMLMapper()
+}

--- a/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/hierarchy/SelectorValidator.kt
@@ -5,120 +5,78 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import maestro.Filters
 import maestro.TreeNode
 
-// Cross-checks `text:` selectors in a flow's YAML against the latest
-// hierarchy snapshot. Matching delegates to Filters.textMatches with the
-// same RegexOptions Orchestra uses (IGNORE_CASE, DOT_MATCHES_ALL,
-// MULTILINE), so a verdict here matches the runner. Selectors containing
-// ${...} env interpolation are skipped — they'll be resolved by Orchestra
-// before the real match runs.
 object SelectorValidator {
 
     sealed interface Result {
         data object Ok : Result
         data class Miss(val findings: List<Finding>) : Result {
-            init { require(findings.isNotEmpty()) { "Miss must carry at least one finding" } }
+            init { require(findings.isNotEmpty()) }
         }
     }
 
-    data class Finding(
-        val selector: String,
-        val suggestions: List<String>,
-    )
+    data class Finding(val selector: String, val suggestions: List<String>)
 
     fun validate(yaml: String, snapshot: HierarchySnapshotStore.Snapshot): Result {
-        val selectors = extractTextSelectors(yaml)
-            .filterNot(::hasEnvInterpolation)
+        val selectors = textSelectorsIn(yaml)
+            .filterNot { ENV_INTERPOLATION.containsMatchIn(it) }
             .distinct()
         if (selectors.isEmpty()) return Result.Ok
 
         val nodes = snapshot.root.aggregate()
         val findings = selectors
-            .filterNot { selectorMatches(it, nodes) }
-            .map { Finding(selector = it, suggestions = suggestFor(it, nodes)) }
+            .filterNot { it.matchesAny(nodes) }
+            .map { Finding(it, it.suggestionsFrom(nodes)) }
 
         return if (findings.isEmpty()) Result.Ok else Result.Miss(findings)
     }
 
-    private fun hasEnvInterpolation(selector: String): Boolean = ENV_INTERPOLATION.containsMatchIn(selector)
-
-    private fun extractTextSelectors(yaml: String): List<String> {
-        val root = try {
-            YAML.readTree(yaml)
-        } catch (e: Exception) {
-            // Malformed YAML surfaces a better error from YamlCommandReader
-            // downstream; don't second-guess it here.
-            return emptyList()
-        }
+    private fun textSelectorsIn(yaml: String): List<String> {
+        val root = try { YAML.readTree(yaml) } catch (e: Exception) { return emptyList() }
         val out = mutableListOf<String>()
-        collect(root, out)
+        root.walkTextSelectors(out)
         return out
     }
 
-    private fun collect(node: JsonNode?, out: MutableList<String>) {
-        if (node == null || node.isNull) return
+    private fun JsonNode.walkTextSelectors(out: MutableList<String>) {
+        if (isNull) return
         when {
-            node.isObject -> node.fields().forEach { (key, value) ->
+            isObject -> fields().forEach { (key, value) ->
                 if (key == "text" && value.isTextual) {
                     value.asText().takeIf { it.isNotBlank() }?.let(out::add)
                 } else {
-                    collect(value, out)
+                    value.walkTextSelectors(out)
                 }
             }
-            node.isArray -> node.forEach { collect(it, out) }
+            isArray -> forEach { it.walkTextSelectors(out) }
         }
     }
 
-    private fun selectorMatches(selector: String, nodes: List<TreeNode>): Boolean {
+    private fun String.matchesAny(nodes: List<TreeNode>): Boolean {
         val regex = try {
-            Regex(selector, REGEX_OPTIONS)
+            Regex(this, REGEX_OPTIONS)
         } catch (e: Exception) {
-            // Selector isn't a valid regex (e.g. "foo("). Filters.textMatches
-            // has a `regex.pattern == value` literal-equality branch for this,
-            // but we can't construct a Regex to hand it — mimic it directly.
-            return nodes.any { node ->
-                TEXT_ATTRIBUTES.any { attr -> node.attributes[attr] == selector }
-            }
+            return nodes.any { n -> TEXT_ATTRIBUTES.any { n.attributes[it] == this } }
         }
         return Filters.textMatches(regex).invoke(nodes).isNotEmpty()
     }
 
-    private fun suggestFor(selector: String, nodes: List<TreeNode>): List<String> {
+    private fun String.suggestionsFrom(nodes: List<TreeNode>): List<String> {
         val candidates = linkedSetOf<String>()
-        nodes.forEach { node ->
-            TEXT_ATTRIBUTES.forEach { attr ->
-                node.attributes[attr]?.takeIf { it.isNotBlank() }?.let { candidates.add(it) }
-            }
-        }
+        nodes.forEach { n -> TEXT_ATTRIBUTES.forEach { n.attributes[it]?.takeIf(String::isNotBlank)?.let(candidates::add) } }
         if (candidates.isEmpty()) return emptyList()
 
-        // Cheap bidirectional substring match — catches typos like "Loign"/"Login"
-        // and truncations like "RNR 352"/"RNR 352 - Expo Launch..." without
-        // needing a Levenshtein dependency.
-        val lowered = selector.lowercase()
-        val partial = candidates
-            .filter { it.lowercase().contains(lowered) || lowered.contains(it.lowercase()) }
-            .take(MAX_SUGGESTIONS)
-
-        if (partial.isNotEmpty()) return partial
-
-        return candidates.take(FALLBACK_PEEK).toList()
+        val lowered = lowercase()
+        val overlap = candidates.filter { it.lowercase().contains(lowered) || lowered.contains(it.lowercase()) }
+        return (if (overlap.isNotEmpty()) overlap.take(MAX_SUGGESTIONS) else candidates.take(FALLBACK_PEEK)).toList()
     }
 
-    // Mirrors the attributes Filters.textMatches inspects in
-    // maestro-client/Filters.kt::textMatches. Keep the two in sync.
+    // Mirrors maestro-client/Filters.kt::textMatches and
+    // maestro-orchestra/Orchestra.kt::REGEX_OPTIONS — keep in sync.
     private val TEXT_ATTRIBUTES = listOf("text", "hintText", "accessibilityText")
-
-    // Mirrors maestro-orchestra/Orchestra.kt::REGEX_OPTIONS.
-    private val REGEX_OPTIONS = setOf(
-        RegexOption.IGNORE_CASE,
-        RegexOption.DOT_MATCHES_ALL,
-        RegexOption.MULTILINE,
-    )
+    private val REGEX_OPTIONS = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE)
 
     private val ENV_INTERPOLATION = Regex("""\$\{[^}]+}""")
-
     private const val MAX_SUGGESTIONS = 5
     private const val FALLBACK_PEEK = 10
-
     private val YAML = YAMLMapper()
 }

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
@@ -3,12 +3,16 @@ package maestro.cli.mcp.tools
 import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.serialization.json.*
+import maestro.cli.mcp.hierarchy.HierarchySnapshotStore
 import maestro.cli.session.MaestroSessionManager
 import maestro.TreeNode
 import kotlinx.coroutines.runBlocking
 
 object InspectViewHierarchyTool {
-    fun create(sessionManager: MaestroSessionManager): RegisteredTool {
+    fun create(
+        sessionManager: MaestroSessionManager,
+        snapshotStore: HierarchySnapshotStore,
+    ): RegisteredTool {
         return RegisteredTool(
             Tool(
                 name = "inspect_view_hierarchy",
@@ -50,11 +54,13 @@ object InspectViewHierarchyTool {
                     val maestro = session.maestro
                     val viewHierarchy = runBlocking { maestro.viewHierarchy() }
                     val tree = viewHierarchy.root
-                    
+
+                    snapshotStore.record(deviceId, tree)
+
                     // Return CSV format (original format for compatibility)
                     ViewHierarchyFormatters.extractCsvOutput(tree)
                 }
-                
+
                 CallToolResult(content = listOf(TextContent(result)))
             } catch (e: Exception) {
                 CallToolResult(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
@@ -55,7 +55,7 @@ object InspectViewHierarchyTool {
                     val viewHierarchy = runBlocking { maestro.viewHierarchy() }
                     val tree = viewHierarchy.root
 
-                    snapshotStore.record(deviceId, tree)
+                    tree?.let { snapshotStore.record(deviceId, it) }
 
                     // Return CSV format (original format for compatibility)
                     ViewHierarchyFormatters.extractCsvOutput(tree)

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
@@ -44,9 +44,8 @@ object RunTool {
         `env` is optional in all modes and injects environment variables available to the flow.
 
         Syntax is validated as part of this call; no separate pre-check is needed.
-        `text:` selectors are also cross-checked against the latest `inspect_view_hierarchy`
-        snapshot for the target device; misses surface before Maestro parses the flow. Pass
-        `skip_selector_validation: true` to bypass (e.g. flows that target dynamically-rendered text).
+        `text:` selectors are cross-checked against the latest `inspect_view_hierarchy`
+        snapshot for the device. Pass `skip_selector_validation: true` for dynamically-rendered text.
 
         If no device is running, ask the user to start one first.
         Use `inspect_view_hierarchy` to get the current screen before guessing at commands.
@@ -166,12 +165,7 @@ object RunTool {
             }
             putJsonObject("skip_selector_validation") {
                 put("type", "boolean")
-                put(
-                    "description",
-                    "Skip cross-checking `text:` selectors against the latest hierarchy snapshot. " +
-                        "Default false. Set true when the flow targets text that renders dynamically and " +
-                        "wasn't present in the last `inspect_view_hierarchy`.",
-                )
+                put("description", "Skip cross-checking `text:` selectors against the hierarchy snapshot. Default false.")
             }
         },
         required = listOf("device_id"),
@@ -313,71 +307,53 @@ object RunTool {
         executable: Executable,
         snapshot: HierarchySnapshotStore.Snapshot,
     ): CallToolResult? {
-        for (source in collectYamlSources(executable)) {
-            if (source.yaml.isBlank()) continue
-            val result = SelectorValidator.validate(source.yaml, snapshot)
-            if (result is SelectorValidator.Result.Miss) {
-                return selectorValidationError(deviceId, source.label, result.findings)
-            }
+        yamlSourcesOf(executable).forEach { (label, yaml) ->
+            if (yaml.isBlank()) return@forEach
+            val miss = SelectorValidator.validate(yaml, snapshot) as? SelectorValidator.Result.Miss ?: return@forEach
+            return selectorMissError(deviceId, label, miss.findings)
         }
         return null
     }
 
-    private fun collectYamlSources(executable: Executable): List<YamlSource> = when (executable) {
-        is Executable.Inline -> listOf(YamlSource(label = "inline", yaml = executable.yaml))
-        is Executable.Plan -> buildList {
-            executable.plan.sequence.flows.forEach { add(yamlSourceForFile(it)) }
-            executable.plan.flowsToRun.forEach { add(yamlSourceForFile(it)) }
-        }
+    private fun yamlSourcesOf(executable: Executable): List<Pair<String, String>> = when (executable) {
+        is Executable.Inline -> listOf("inline" to executable.yaml)
+        is Executable.Plan -> (executable.plan.sequence.flows + executable.plan.flowsToRun).map { it.toString() to readYaml(it) }
     }
 
-    private fun yamlSourceForFile(path: Path): YamlSource {
-        // Best-effort read. An unreadable file just skips validation for that
-        // source; YamlCommandReader will produce the real error when it tries
-        // to run the flow. We still log at warn so a puzzled maintainer sees
-        // why the pre-check didn't fire.
-        val yaml = try {
-            path.toFile().readText()
-        } catch (e: Exception) {
-            logger.warn("Failed to read {} for selector validation: {}", path, e.message)
-            ""
-        }
-        return YamlSource(label = path.toString(), yaml = yaml)
+    private fun readYaml(path: Path): String = try {
+        path.toFile().readText()
+    } catch (e: Exception) {
+        logger.warn("Failed to read {} for selector validation: {}", path, e.message)
+        ""
     }
 
-    private fun selectorValidationError(
+    private fun selectorMissError(
         deviceId: String,
-        label: String,
+        source: String,
         findings: List<SelectorValidator.Finding>,
     ): CallToolResult {
         val payload = buildJsonObject {
             put("success", false)
             put("device_id", deviceId)
-            put("error", ERROR_SELECTOR_NOT_ON_SCREEN)
-            put("source", label)
+            put("error", "selector_not_on_screen")
+            put("source", source)
             put(
                 "message",
                 "One or more `text:` selectors don't appear in the latest `inspect_view_hierarchy` " +
-                    "snapshot for this device. Re-inspect the screen and use the exact text on display, " +
-                    "or pass `skip_selector_validation: true` if the text renders dynamically.",
+                    "snapshot. Re-inspect and copy the exact on-screen text, or pass " +
+                    "`skip_selector_validation: true` if the text renders dynamically.",
             )
             putJsonArray("findings") {
                 findings.forEach { finding ->
                     addJsonObject {
                         put("selector", finding.selector)
-                        putJsonArray("closest_texts_on_screen") {
-                            finding.suggestions.forEach { add(it) }
-                        }
+                        putJsonArray("closest_texts_on_screen") { finding.suggestions.forEach { add(it) } }
                     }
                 }
             }
         }
         return CallToolResult(content = listOf(TextContent(payload.toString())), isError = true)
     }
-
-    private const val ERROR_SELECTOR_NOT_ON_SCREEN = "selector_not_on_screen"
-
-    private data class YamlSource(val label: String, val yaml: String)
 
     private data class RunResult(val payload: JsonObject, val success: Boolean)
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
@@ -17,11 +17,14 @@ import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner.ExecutionPlan
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner.FlowSequence
 import maestro.orchestra.yaml.YamlCommandReader
+import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 
 object RunTool {
+
+    private val logger = LoggerFactory.getLogger(RunTool::class.java)
 
     private const val TOOL_NAME = "run"
     private const val TOOL_DESCRIPTION = """
@@ -331,8 +334,14 @@ object RunTool {
     private fun yamlSourceForFile(path: Path): YamlSource {
         // Best-effort read. An unreadable file just skips validation for that
         // source; YamlCommandReader will produce the real error when it tries
-        // to run the flow.
-        val yaml = try { path.toFile().readText() } catch (e: Exception) { "" }
+        // to run the flow. We still log at warn so a puzzled maintainer sees
+        // why the pre-check didn't fire.
+        val yaml = try {
+            path.toFile().readText()
+        } catch (e: Exception) {
+            logger.warn("Failed to read {} for selector validation: {}", path, e.message)
+            ""
+        }
         return YamlSource(label = path.toString(), yaml = yaml)
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
@@ -84,11 +84,9 @@ object RunTool {
         }
 
         if (!args.skipSelectorValidation) {
-            val snapshot = snapshotStore.get(args.deviceId)
-            if (snapshot != null) {
-                val yamlSources = collectYamlSources(executable)
-                val miss = findFirstMiss(yamlSources, snapshot)
-                if (miss != null) return selectorValidationErrorResult(args.deviceId, miss)
+            snapshotStore.get(args.deviceId)?.let { snapshot ->
+                val validationError = validateSelectors(args.deviceId, executable, snapshot)
+                if (validationError != null) return validationError
             }
         }
 
@@ -307,6 +305,21 @@ object RunTool {
     private fun errorResult(message: String): CallToolResult =
         CallToolResult(content = listOf(TextContent(message)), isError = true)
 
+    private fun validateSelectors(
+        deviceId: String,
+        executable: Executable,
+        snapshot: HierarchySnapshotStore.Snapshot,
+    ): CallToolResult? {
+        for (source in collectYamlSources(executable)) {
+            if (source.yaml.isBlank()) continue
+            val result = SelectorValidator.validate(source.yaml, snapshot)
+            if (result is SelectorValidator.Result.Miss) {
+                return selectorValidationError(deviceId, source.label, result.findings)
+            }
+        }
+        return null
+    }
+
     private fun collectYamlSources(executable: Executable): List<YamlSource> = when (executable) {
         is Executable.Inline -> listOf(YamlSource(label = "inline", yaml = executable.yaml))
         is Executable.Plan -> buildList {
@@ -315,31 +328,24 @@ object RunTool {
         }
     }
 
-    private fun yamlSourceForFile(path: Path): YamlSource = YamlSource(
-        label = path.toString(),
-        yaml = try { path.toFile().readText() } catch (e: Exception) { "" },
-    )
-
-    private fun findFirstMiss(
-        sources: List<YamlSource>,
-        snapshot: HierarchySnapshotStore.Snapshot,
-    ): SelectorMiss? {
-        for (source in sources) {
-            if (source.yaml.isBlank()) continue
-            val result = SelectorValidator.validate(source.yaml, snapshot)
-            if (result is SelectorValidator.Result.Miss) {
-                return SelectorMiss(label = source.label, findings = result.findings)
-            }
-        }
-        return null
+    private fun yamlSourceForFile(path: Path): YamlSource {
+        // Best-effort read. An unreadable file just skips validation for that
+        // source; YamlCommandReader will produce the real error when it tries
+        // to run the flow.
+        val yaml = try { path.toFile().readText() } catch (e: Exception) { "" }
+        return YamlSource(label = path.toString(), yaml = yaml)
     }
 
-    private fun selectorValidationErrorResult(deviceId: String, miss: SelectorMiss): CallToolResult {
+    private fun selectorValidationError(
+        deviceId: String,
+        label: String,
+        findings: List<SelectorValidator.Finding>,
+    ): CallToolResult {
         val payload = buildJsonObject {
             put("success", false)
             put("device_id", deviceId)
-            put("error", "selector_not_on_screen")
-            put("source", miss.label)
+            put("error", ERROR_SELECTOR_NOT_ON_SCREEN)
+            put("source", label)
             put(
                 "message",
                 "One or more `text:` selectors don't appear in the latest `inspect_view_hierarchy` " +
@@ -347,7 +353,7 @@ object RunTool {
                     "or pass `skip_selector_validation: true` if the text renders dynamically.",
             )
             putJsonArray("findings") {
-                miss.findings.forEach { finding ->
+                findings.forEach { finding ->
                     addJsonObject {
                         put("selector", finding.selector)
                         putJsonArray("closest_texts_on_screen") {
@@ -360,12 +366,9 @@ object RunTool {
         return CallToolResult(content = listOf(TextContent(payload.toString())), isError = true)
     }
 
-    private data class YamlSource(val label: String, val yaml: String)
+    private const val ERROR_SELECTOR_NOT_ON_SCREEN = "selector_not_on_screen"
 
-    private data class SelectorMiss(
-        val label: String,
-        val findings: List<SelectorValidator.Finding>,
-    )
+    private data class YamlSource(val label: String, val yaml: String)
 
     private data class RunResult(val payload: JsonObject, val success: Boolean)
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
@@ -4,6 +4,8 @@ import io.modelcontextprotocol.kotlin.sdk.types.*
 import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
+import maestro.cli.mcp.hierarchy.HierarchySnapshotStore
+import maestro.cli.mcp.hierarchy.SelectorValidator
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.util.WorkingDirectory
 import maestro.orchestra.Orchestra
@@ -39,13 +41,19 @@ object RunTool {
         `env` is optional in all modes and injects environment variables available to the flow.
 
         Syntax is validated as part of this call; no separate pre-check is needed.
+        `text:` selectors are also cross-checked against the latest `inspect_view_hierarchy`
+        snapshot for the target device; misses surface before Maestro parses the flow. Pass
+        `skip_selector_validation: true` to bypass (e.g. flows that target dynamically-rendered text).
 
         If no device is running, ask the user to start one first.
         Use `inspect_view_hierarchy` to get the current screen before guessing at commands.
         Use `cheat_sheet` for Maestro flow syntax.
     """
 
-    fun create(sessionManager: MaestroSessionManager): RegisteredTool {
+    fun create(
+        sessionManager: MaestroSessionManager,
+        snapshotStore: HierarchySnapshotStore,
+    ): RegisteredTool {
         return RegisteredTool(
             Tool(
                 name = TOOL_NAME,
@@ -53,13 +61,14 @@ object RunTool {
                 inputSchema = buildInputSchema(),
             )
         ) { request ->
-            handle(request, sessionManager)
+            handle(request, sessionManager, snapshotStore)
         }
     }
 
     internal fun handle(
         request: CallToolRequest,
         sessionManager: MaestroSessionManager,
+        snapshotStore: HierarchySnapshotStore,
     ): CallToolResult {
         val args = when (val parsed = RunToolArgs.parse(request.arguments)) {
             is ParseResult.Failure -> return errorResult(parsed.message)
@@ -72,6 +81,15 @@ object RunTool {
             return errorResult(e.message ?: "Invalid input")
         } catch (e: ValidationError) {
             return errorResult(e.message ?: "Invalid workspace")
+        }
+
+        if (!args.skipSelectorValidation) {
+            val snapshot = snapshotStore.get(args.deviceId)
+            if (snapshot != null) {
+                val yamlSources = collectYamlSources(executable)
+                val miss = findFirstMiss(yamlSources, snapshot)
+                if (miss != null) return selectorValidationErrorResult(args.deviceId, miss)
+            }
         }
 
         return try {
@@ -144,6 +162,15 @@ object RunTool {
                 put("type", "object")
                 put("description", "Environment variables to inject into the flow(s).")
                 putJsonObject("additionalProperties") { put("type", "string") }
+            }
+            putJsonObject("skip_selector_validation") {
+                put("type", "boolean")
+                put(
+                    "description",
+                    "Skip cross-checking `text:` selectors against the latest hierarchy snapshot. " +
+                        "Default false. Set true when the flow targets text that renders dynamically and " +
+                        "wasn't present in the last `inspect_view_hierarchy`.",
+                )
             }
         },
         required = listOf("device_id"),
@@ -280,6 +307,66 @@ object RunTool {
     private fun errorResult(message: String): CallToolResult =
         CallToolResult(content = listOf(TextContent(message)), isError = true)
 
+    private fun collectYamlSources(executable: Executable): List<YamlSource> = when (executable) {
+        is Executable.Inline -> listOf(YamlSource(label = "inline", yaml = executable.yaml))
+        is Executable.Plan -> buildList {
+            executable.plan.sequence.flows.forEach { add(yamlSourceForFile(it)) }
+            executable.plan.flowsToRun.forEach { add(yamlSourceForFile(it)) }
+        }
+    }
+
+    private fun yamlSourceForFile(path: Path): YamlSource = YamlSource(
+        label = path.toString(),
+        yaml = try { path.toFile().readText() } catch (e: Exception) { "" },
+    )
+
+    private fun findFirstMiss(
+        sources: List<YamlSource>,
+        snapshot: HierarchySnapshotStore.Snapshot,
+    ): SelectorMiss? {
+        for (source in sources) {
+            if (source.yaml.isBlank()) continue
+            val result = SelectorValidator.validate(source.yaml, snapshot)
+            if (result is SelectorValidator.Result.Miss) {
+                return SelectorMiss(label = source.label, findings = result.findings)
+            }
+        }
+        return null
+    }
+
+    private fun selectorValidationErrorResult(deviceId: String, miss: SelectorMiss): CallToolResult {
+        val payload = buildJsonObject {
+            put("success", false)
+            put("device_id", deviceId)
+            put("error", "selector_not_on_screen")
+            put("source", miss.label)
+            put(
+                "message",
+                "One or more `text:` selectors don't appear in the latest `inspect_view_hierarchy` " +
+                    "snapshot for this device. Re-inspect the screen and use the exact text on display, " +
+                    "or pass `skip_selector_validation: true` if the text renders dynamically.",
+            )
+            putJsonArray("findings") {
+                miss.findings.forEach { finding ->
+                    addJsonObject {
+                        put("selector", finding.selector)
+                        putJsonArray("closest_texts_on_screen") {
+                            finding.suggestions.forEach { add(it) }
+                        }
+                    }
+                }
+            }
+        }
+        return CallToolResult(content = listOf(TextContent(payload.toString())), isError = true)
+    }
+
+    private data class YamlSource(val label: String, val yaml: String)
+
+    private data class SelectorMiss(
+        val label: String,
+        val findings: List<SelectorValidator.Finding>,
+    )
+
     private data class RunResult(val payload: JsonObject, val success: Boolean)
 
     private sealed interface Executable {
@@ -311,6 +398,7 @@ internal data class RunToolArgs(
     val deviceId: String,
     val input: RunInput,
     val env: Map<String, String>,
+    val skipSelectorValidation: Boolean,
 ) {
     companion object {
         fun parse(arguments: JsonObject?): ParseResult {
@@ -327,6 +415,8 @@ internal data class RunToolArgs(
                 ?: emptyList()
             val excludeTags = arguments["exclude_tags"]?.jsonArray?.map { it.jsonPrimitive.content }
                 ?: emptyList()
+            val skipSelectorValidation = arguments["skip_selector_validation"]
+                ?.jsonPrimitive?.booleanOrNull ?: false
 
             val modesProvided = listOfNotNull(
                 yaml?.let { "yaml" },
@@ -367,7 +457,14 @@ internal data class RunToolArgs(
                 ?.mapValues { it.value.jsonPrimitive.content }
                 ?: emptyMap()
 
-            return ParseResult.Success(RunToolArgs(deviceId, input, env))
+            return ParseResult.Success(
+                RunToolArgs(
+                    deviceId = deviceId,
+                    input = input,
+                    env = env,
+                    skipSelectorValidation = skipSelectorValidation,
+                )
+            )
         }
     }
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
@@ -34,12 +34,6 @@ class HierarchySnapshotStoreTest {
         assertThat(store.get("nope")).isNull()
     }
 
-    @Test
-    fun `record ignores null root`() {
-        val store = HierarchySnapshotStore()
-        store.record("device-1", null)
-        assertThat(store.get("device-1")).isNull()
-    }
 
     private fun node(
         attributes: Map<String, String> = emptyMap(),

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
@@ -7,36 +7,25 @@ import org.junit.jupiter.api.Test
 class HierarchySnapshotStoreTest {
 
     @Test
-    fun `stores the tree root for later matching`() {
+    fun `stores the tree root`() {
         val store = HierarchySnapshotStore()
-        val tree = node(attributes = mapOf("text" to "Sign in"))
-
+        val tree = TreeNode(attributes = mutableMapOf("text" to "Sign in"))
         store.record("device-1", tree)
-
         assertThat(store.get("device-1")?.root).isSameInstanceAs(tree)
     }
 
     @Test
     fun `last write wins per device`() {
         val store = HierarchySnapshotStore()
-        val first = node(attributes = mapOf("text" to "First"))
-        val second = node(attributes = mapOf("text" to "Second"))
-
+        val first = TreeNode(attributes = mutableMapOf("text" to "First"))
+        val second = TreeNode(attributes = mutableMapOf("text" to "Second"))
         store.record("device-1", first)
         store.record("device-1", second)
-
         assertThat(store.get("device-1")?.root).isSameInstanceAs(second)
     }
 
     @Test
-    fun `get returns null for unknown device`() {
-        val store = HierarchySnapshotStore()
-        assertThat(store.get("nope")).isNull()
+    fun `unknown device returns null`() {
+        assertThat(HierarchySnapshotStore().get("nope")).isNull()
     }
-
-
-    private fun node(
-        attributes: Map<String, String> = emptyMap(),
-        children: List<TreeNode> = emptyList(),
-    ): TreeNode = TreeNode(attributes = attributes.toMutableMap(), children = children)
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
@@ -1,0 +1,55 @@
+package maestro.cli.mcp.hierarchy
+
+import com.google.common.truth.Truth.assertThat
+import maestro.TreeNode
+import org.junit.jupiter.api.Test
+
+class HierarchySnapshotStoreTest {
+
+    @Test
+    fun `records text-bearing attributes from the tree`() {
+        val store = HierarchySnapshotStore()
+        val tree = node(
+            attributes = mapOf("text" to "Sign in", "bounds" to "[0,0][100,50]"),
+            children = listOf(
+                node(attributes = mapOf("accessibilityText" to "Favorite button")),
+                node(attributes = mapOf("content-desc" to "Share", "hintText" to "Tap to share")),
+            ),
+        )
+
+        store.record("device-1", tree)
+
+        val snapshot = store.get("device-1")
+        assertThat(snapshot).isNotNull()
+        assertThat(snapshot!!.texts).containsExactly(
+            "Sign in", "Favorite button", "Share", "Tap to share",
+        )
+    }
+
+    @Test
+    fun `last write wins per device`() {
+        val store = HierarchySnapshotStore()
+        store.record("device-1", node(attributes = mapOf("text" to "First")))
+        store.record("device-1", node(attributes = mapOf("text" to "Second")))
+
+        assertThat(store.get("device-1")!!.texts).containsExactly("Second")
+    }
+
+    @Test
+    fun `get returns null for unknown device`() {
+        val store = HierarchySnapshotStore()
+        assertThat(store.get("nope")).isNull()
+    }
+
+    @Test
+    fun `null or empty attribute values are skipped`() {
+        val store = HierarchySnapshotStore()
+        store.record("device-1", node(attributes = mapOf("text" to "", "accessibilityText" to "   ")))
+        assertThat(store.get("device-1")!!.texts).isEmpty()
+    }
+
+    private fun node(
+        attributes: Map<String, String> = emptyMap(),
+        children: List<TreeNode> = emptyList(),
+    ): TreeNode = TreeNode(attributes = attributes.toMutableMap(), children = children)
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/HierarchySnapshotStoreTest.kt
@@ -7,32 +7,25 @@ import org.junit.jupiter.api.Test
 class HierarchySnapshotStoreTest {
 
     @Test
-    fun `records text-bearing attributes from the tree`() {
+    fun `stores the tree root for later matching`() {
         val store = HierarchySnapshotStore()
-        val tree = node(
-            attributes = mapOf("text" to "Sign in", "bounds" to "[0,0][100,50]"),
-            children = listOf(
-                node(attributes = mapOf("accessibilityText" to "Favorite button")),
-                node(attributes = mapOf("content-desc" to "Share", "hintText" to "Tap to share")),
-            ),
-        )
+        val tree = node(attributes = mapOf("text" to "Sign in"))
 
         store.record("device-1", tree)
 
-        val snapshot = store.get("device-1")
-        assertThat(snapshot).isNotNull()
-        assertThat(snapshot!!.texts).containsExactly(
-            "Sign in", "Favorite button", "Share", "Tap to share",
-        )
+        assertThat(store.get("device-1")?.root).isSameInstanceAs(tree)
     }
 
     @Test
     fun `last write wins per device`() {
         val store = HierarchySnapshotStore()
-        store.record("device-1", node(attributes = mapOf("text" to "First")))
-        store.record("device-1", node(attributes = mapOf("text" to "Second")))
+        val first = node(attributes = mapOf("text" to "First"))
+        val second = node(attributes = mapOf("text" to "Second"))
 
-        assertThat(store.get("device-1")!!.texts).containsExactly("Second")
+        store.record("device-1", first)
+        store.record("device-1", second)
+
+        assertThat(store.get("device-1")?.root).isSameInstanceAs(second)
     }
 
     @Test
@@ -42,10 +35,10 @@ class HierarchySnapshotStoreTest {
     }
 
     @Test
-    fun `null or empty attribute values are skipped`() {
+    fun `record ignores null root`() {
         val store = HierarchySnapshotStore()
-        store.record("device-1", node(attributes = mapOf("text" to "", "accessibilityText" to "   ")))
-        assertThat(store.get("device-1")!!.texts).isEmpty()
+        store.record("device-1", null)
+        assertThat(store.get("device-1")).isNull()
     }
 
     private fun node(

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
@@ -137,6 +137,28 @@ class SelectorValidatorTest {
     }
 
     @Test
+    fun `matches case-insensitively (same as runner)`() {
+        val snapshot = snapshotOfAll("Favorite")
+        val yaml = """
+            - tapOn:
+                text: "favorite"
+        """.trimIndent()
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
+    fun `skips selectors containing env-var interpolation`() {
+        val snapshot = snapshotOfAll("Welcome, Pedro")
+        val yaml = """
+            - assertVisible:
+                text: "Welcome, ${'$'}{USER}"
+        """.trimIndent()
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
     fun `matches against hintText and accessibilityText the same as text`() {
         val root = TreeNode(
             children = listOf(

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
@@ -7,68 +7,51 @@ import org.junit.jupiter.api.Test
 class SelectorValidatorTest {
 
     @Test
-    fun `passes when every text selector matches some on-screen text`() {
-        val snapshot = snapshotOfAll("Sign in", "Create account")
-        val yaml = """
-            - launchApp
-            - tapOn:
-                text: "Sign in"
-        """.trimIndent()
-
+    fun `passes when every text selector matches on-screen text`() {
+        val snapshot = snapshotOf("Sign in", "Create account")
+        val yaml = "- tapOn:\n    text: \"Sign in\""
         assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
     }
 
     @Test
-    fun `flags truncated text that only partially matches (matches runner's full-string semantics)`() {
-        // Matches Simon's RNR 352 failure: Maestro's text matcher uses
-        // regex.matches (full-string), so "RNR 352" does NOT hit an element
-        // whose text is "RNR 352 - Expo Launch with Cedric van Putten".
-        val snapshot = snapshotOfAll("RNR 352 - Expo Launch with Cedric van Putten")
-        val yaml = """
-            - tapOn:
-                text: "RNR 352"
-        """.trimIndent()
+    fun `flags truncated text (Maestro uses full-string regex matches)`() {
+        val snapshot = snapshotOf("RNR 352 - Expo Launch with Cedric van Putten")
+        val yaml = "- tapOn:\n    text: \"RNR 352\""
 
         val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
         assertThat(result.findings.single().selector).isEqualTo("RNR 352")
-        assertThat(result.findings.single().suggestions)
-            .contains("RNR 352 - Expo Launch with Cedric van Putten")
+        assertThat(result.findings.single().suggestions).contains("RNR 352 - Expo Launch with Cedric van Putten")
     }
 
     @Test
-    fun `flags selectors that do not appear anywhere in the snapshot`() {
-        val snapshot = snapshotOfAll("Sign in", "Create account", "Help")
-        val yaml = """
-            - tapOn:
-                text: "Favorite"
-        """.trimIndent()
+    fun `flags selectors not present in the snapshot`() {
+        val snapshot = snapshotOf("Sign in", "Create account", "Help")
+        val yaml = "- tapOn:\n    text: \"Favorite\""
 
         val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
         assertThat(result.findings.single().selector).isEqualTo("Favorite")
     }
 
     @Test
-    fun `suggests close matches via case-insensitive substring overlap`() {
-        val snapshot = snapshotOfAll(
-            "Add to favorites",
-            "Remove from favorites",
-            "Unrelated string",
-        )
-        // Capital F in selector — case-sensitive regex against lowercase
-        // "favorites" misses, so we surface substring matches.
-        val yaml = """
-            - tapOn:
-                text: "Favorite"
-        """.trimIndent()
+    fun `matches case-insensitively like the runner`() {
+        val snapshot = snapshotOf("Favorite")
+        val yaml = "- tapOn:\n    text: \"favorite\""
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
+    fun `suggests close matches via bidirectional substring overlap`() {
+        val snapshot = snapshotOf("Add to favorites page", "Remove from favorites", "Unrelated")
+        val yaml = "- tapOn:\n    text: \"favorite\""
 
         val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
         assertThat(result.findings.single().suggestions)
-            .containsExactly("Add to favorites", "Remove from favorites").inOrder()
+            .containsExactly("Add to favorites page", "Remove from favorites").inOrder()
     }
 
     @Test
     fun `recurses through nested selectors like below`() {
-        val snapshot = snapshotOfAll("Email", "Password")
+        val snapshot = snapshotOf("Email", "Password")
         val yaml = """
             - tapOn:
                 text: "Ghost"
@@ -82,7 +65,7 @@ class SelectorValidatorTest {
 
     @Test
     fun `deduplicates repeated selectors`() {
-        val snapshot = snapshotOfAll("Sign in")
+        val snapshot = snapshotOf("Sign in")
         val yaml = """
             - tapOn:
                 text: "Ghost"
@@ -95,92 +78,57 @@ class SelectorValidatorTest {
     }
 
     @Test
-    fun `falls back to literal equality when selector is invalid regex`() {
-        val snapshot = snapshotOfAll("Price: \$9.99")
-        val yaml = """
-            - assertVisible:
-                text: "Price: \${'$'}9.99"
-        """.trimIndent()
-
+    fun `skips selectors containing env-var interpolation`() {
+        val snapshot = snapshotOf("Welcome, Pedro")
+        val yaml = "- assertVisible:\n    text: \"Welcome, ${'$'}{USER}\""
         assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
     }
 
     @Test
-    fun `snapshot with no textual overlap surfaces a fallback peek list`() {
-        val snapshot = snapshotOfAll("One", "Two", "Three")
-        val yaml = """
-            - tapOn:
-                text: "xyz-nowhere"
-        """.trimIndent()
+    fun `falls back to literal equality when selector is invalid regex`() {
+        val snapshot = snapshotOf("Price: \$9.99")
+        val yaml = "- assertVisible:\n    text: \"Price: \${'$'}9.99\""
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
+    fun `peek list surfaces when selector has no textual overlap`() {
+        val snapshot = snapshotOf("One", "Two", "Three")
+        val yaml = "- tapOn:\n    text: \"xyz-nowhere\""
 
         val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
         assertThat(result.findings.single().suggestions).containsExactly("One", "Two", "Three")
     }
 
     @Test
-    fun `no text selectors in the flow is Ok`() {
-        val snapshot = snapshotOfAll("whatever")
-        val yaml = """
-            - launchApp
-            - scroll
-        """.trimIndent()
-
+    fun `flow without text selectors is Ok`() {
+        val snapshot = snapshotOf("whatever")
+        val yaml = "- launchApp\n- scroll"
         assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
     }
 
     @Test
-    fun `invalid yaml falls through cleanly instead of throwing`() {
-        val snapshot = snapshotOfAll("whatever")
-        val yaml = ": : ::"
-
-        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    fun `invalid yaml falls through`() {
+        assertThat(SelectorValidator.validate(": : ::", snapshotOf("x"))).isEqualTo(SelectorValidator.Result.Ok)
     }
 
     @Test
-    fun `matches case-insensitively (same as runner)`() {
-        val snapshot = snapshotOfAll("Favorite")
-        val yaml = """
-            - tapOn:
-                text: "favorite"
-        """.trimIndent()
-
-        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
-    }
-
-    @Test
-    fun `skips selectors containing env-var interpolation`() {
-        val snapshot = snapshotOfAll("Welcome, Pedro")
-        val yaml = """
-            - assertVisible:
-                text: "Welcome, ${'$'}{USER}"
-        """.trimIndent()
-
-        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
-    }
-
-    @Test
-    fun `matches against hintText and accessibilityText the same as text`() {
-        val root = TreeNode(
-            children = listOf(
-                TreeNode(attributes = mutableMapOf("hintText" to "Search here")),
-                TreeNode(attributes = mutableMapOf("accessibilityText" to "Menu button")),
-            ),
-        )
-        val snapshot = HierarchySnapshotStore.Snapshot(root)
+    fun `matches hintText and accessibilityText`() {
+        val root = TreeNode(children = listOf(
+            TreeNode(attributes = mutableMapOf("hintText" to "Search here")),
+            TreeNode(attributes = mutableMapOf("accessibilityText" to "Menu button")),
+        ))
         val yaml = """
             - tapOn:
                 text: "Search here"
             - tapOn:
                 text: "Menu button"
         """.trimIndent()
-
-        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+        assertThat(SelectorValidator.validate(yaml, HierarchySnapshotStore.Snapshot(root)))
+            .isEqualTo(SelectorValidator.Result.Ok)
     }
 
-    private fun snapshotOfAll(vararg texts: String): HierarchySnapshotStore.Snapshot {
-        val root = TreeNode(
-            children = texts.map { TreeNode(attributes = mutableMapOf("text" to it)) },
-        )
-        return HierarchySnapshotStore.Snapshot(root)
-    }
+    private fun snapshotOf(vararg texts: String) = HierarchySnapshotStore.Snapshot(
+        TreeNode(children = texts.map { TreeNode(attributes = mutableMapOf("text" to it)) }),
+    )
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
@@ -1,13 +1,14 @@
 package maestro.cli.mcp.hierarchy
 
 import com.google.common.truth.Truth.assertThat
+import maestro.TreeNode
 import org.junit.jupiter.api.Test
 
 class SelectorValidatorTest {
 
     @Test
     fun `passes when every text selector matches some on-screen text`() {
-        val snapshot = snapshotOf("Sign in", "Create account")
+        val snapshot = snapshotOfAll("Sign in", "Create account")
         val yaml = """
             - launchApp
             - tapOn:
@@ -18,41 +19,43 @@ class SelectorValidatorTest {
     }
 
     @Test
-    fun `treats text selector as regex with partial matching`() {
-        val snapshot = snapshotOf("RNR 352 - Expo Launch with Cedric van Putten")
+    fun `flags truncated text that only partially matches (matches runner's full-string semantics)`() {
+        // Matches Simon's RNR 352 failure: Maestro's text matcher uses
+        // regex.matches (full-string), so "RNR 352" does NOT hit an element
+        // whose text is "RNR 352 - Expo Launch with Cedric van Putten".
+        val snapshot = snapshotOfAll("RNR 352 - Expo Launch with Cedric van Putten")
         val yaml = """
             - tapOn:
                 text: "RNR 352"
         """.trimIndent()
 
-        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+        val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
+        assertThat(result.findings.single().selector).isEqualTo("RNR 352")
+        assertThat(result.findings.single().suggestions)
+            .contains("RNR 352 - Expo Launch with Cedric van Putten")
     }
 
     @Test
     fun `flags selectors that do not appear anywhere in the snapshot`() {
-        val snapshot = snapshotOf("Sign in", "Create account", "Help")
+        val snapshot = snapshotOfAll("Sign in", "Create account", "Help")
         val yaml = """
             - tapOn:
                 text: "Favorite"
         """.trimIndent()
 
-        val result = SelectorValidator.validate(yaml, snapshot)
-        assertThat(result).isInstanceOf(SelectorValidator.Result.Miss::class.java)
-        val findings = (result as SelectorValidator.Result.Miss).findings
-        assertThat(findings).hasSize(1)
-        assertThat(findings.single().selector).isEqualTo("Favorite")
+        val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
+        assertThat(result.findings.single().selector).isEqualTo("Favorite")
     }
 
     @Test
     fun `suggests close matches via case-insensitive substring overlap`() {
-        val snapshot = snapshotOf(
+        val snapshot = snapshotOfAll(
             "Add to favorites",
             "Remove from favorites",
             "Unrelated string",
         )
         // Capital F in selector — case-sensitive regex against lowercase
-        // "favorites" in the snapshot misses, so we surface the case-insensitive
-        // substring matches as suggestions.
+        // "favorites" misses, so we surface substring matches.
         val yaml = """
             - tapOn:
                 text: "Favorite"
@@ -65,7 +68,7 @@ class SelectorValidatorTest {
 
     @Test
     fun `recurses through nested selectors like below`() {
-        val snapshot = snapshotOf("Email", "Password")
+        val snapshot = snapshotOfAll("Email", "Password")
         val yaml = """
             - tapOn:
                 text: "Ghost"
@@ -78,8 +81,22 @@ class SelectorValidatorTest {
     }
 
     @Test
-    fun `falls back to literal substring when selector is invalid regex`() {
-        val snapshot = snapshotOf("Price: \$9.99")
+    fun `deduplicates repeated selectors`() {
+        val snapshot = snapshotOfAll("Sign in")
+        val yaml = """
+            - tapOn:
+                text: "Ghost"
+            - tapOn:
+                text: "Ghost"
+        """.trimIndent()
+
+        val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
+        assertThat(result.findings).hasSize(1)
+    }
+
+    @Test
+    fun `falls back to literal equality when selector is invalid regex`() {
+        val snapshot = snapshotOfAll("Price: \$9.99")
         val yaml = """
             - assertVisible:
                 text: "Price: \${'$'}9.99"
@@ -89,8 +106,8 @@ class SelectorValidatorTest {
     }
 
     @Test
-    fun `empty snapshot with no on-screen overlap surfaces a peek list`() {
-        val snapshot = snapshotOf("One", "Two", "Three")
+    fun `snapshot with no textual overlap surfaces a fallback peek list`() {
+        val snapshot = snapshotOfAll("One", "Two", "Three")
         val yaml = """
             - tapOn:
                 text: "xyz-nowhere"
@@ -102,7 +119,7 @@ class SelectorValidatorTest {
 
     @Test
     fun `no text selectors in the flow is Ok`() {
-        val snapshot = snapshotOf("whatever")
+        val snapshot = snapshotOfAll("whatever")
         val yaml = """
             - launchApp
             - scroll
@@ -113,14 +130,35 @@ class SelectorValidatorTest {
 
     @Test
     fun `invalid yaml falls through cleanly instead of throwing`() {
-        val snapshot = snapshotOf("whatever")
+        val snapshot = snapshotOfAll("whatever")
         val yaml = ": : ::"
 
         assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
     }
 
-    private fun snapshotOf(vararg texts: String) = HierarchySnapshotStore.Snapshot(
-        deviceId = "device-1",
-        texts = texts.toSet(),
-    )
+    @Test
+    fun `matches against hintText and accessibilityText the same as text`() {
+        val root = TreeNode(
+            children = listOf(
+                TreeNode(attributes = mutableMapOf("hintText" to "Search here")),
+                TreeNode(attributes = mutableMapOf("accessibilityText" to "Menu button")),
+            ),
+        )
+        val snapshot = HierarchySnapshotStore.Snapshot(root)
+        val yaml = """
+            - tapOn:
+                text: "Search here"
+            - tapOn:
+                text: "Menu button"
+        """.trimIndent()
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    private fun snapshotOfAll(vararg texts: String): HierarchySnapshotStore.Snapshot {
+        val root = TreeNode(
+            children = texts.map { TreeNode(attributes = mutableMapOf("text" to it)) },
+        )
+        return HierarchySnapshotStore.Snapshot(root)
+    }
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/hierarchy/SelectorValidatorTest.kt
@@ -1,0 +1,126 @@
+package maestro.cli.mcp.hierarchy
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class SelectorValidatorTest {
+
+    @Test
+    fun `passes when every text selector matches some on-screen text`() {
+        val snapshot = snapshotOf("Sign in", "Create account")
+        val yaml = """
+            - launchApp
+            - tapOn:
+                text: "Sign in"
+        """.trimIndent()
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
+    fun `treats text selector as regex with partial matching`() {
+        val snapshot = snapshotOf("RNR 352 - Expo Launch with Cedric van Putten")
+        val yaml = """
+            - tapOn:
+                text: "RNR 352"
+        """.trimIndent()
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
+    fun `flags selectors that do not appear anywhere in the snapshot`() {
+        val snapshot = snapshotOf("Sign in", "Create account", "Help")
+        val yaml = """
+            - tapOn:
+                text: "Favorite"
+        """.trimIndent()
+
+        val result = SelectorValidator.validate(yaml, snapshot)
+        assertThat(result).isInstanceOf(SelectorValidator.Result.Miss::class.java)
+        val findings = (result as SelectorValidator.Result.Miss).findings
+        assertThat(findings).hasSize(1)
+        assertThat(findings.single().selector).isEqualTo("Favorite")
+    }
+
+    @Test
+    fun `suggests close matches via case-insensitive substring overlap`() {
+        val snapshot = snapshotOf(
+            "Add to favorites",
+            "Remove from favorites",
+            "Unrelated string",
+        )
+        // Capital F in selector — case-sensitive regex against lowercase
+        // "favorites" in the snapshot misses, so we surface the case-insensitive
+        // substring matches as suggestions.
+        val yaml = """
+            - tapOn:
+                text: "Favorite"
+        """.trimIndent()
+
+        val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
+        assertThat(result.findings.single().suggestions)
+            .containsExactly("Add to favorites", "Remove from favorites").inOrder()
+    }
+
+    @Test
+    fun `recurses through nested selectors like below`() {
+        val snapshot = snapshotOf("Email", "Password")
+        val yaml = """
+            - tapOn:
+                text: "Ghost"
+                below:
+                  text: "Email"
+        """.trimIndent()
+
+        val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
+        assertThat(result.findings.map { it.selector }).containsExactly("Ghost")
+    }
+
+    @Test
+    fun `falls back to literal substring when selector is invalid regex`() {
+        val snapshot = snapshotOf("Price: \$9.99")
+        val yaml = """
+            - assertVisible:
+                text: "Price: \${'$'}9.99"
+        """.trimIndent()
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
+    fun `empty snapshot with no on-screen overlap surfaces a peek list`() {
+        val snapshot = snapshotOf("One", "Two", "Three")
+        val yaml = """
+            - tapOn:
+                text: "xyz-nowhere"
+        """.trimIndent()
+
+        val result = SelectorValidator.validate(yaml, snapshot) as SelectorValidator.Result.Miss
+        assertThat(result.findings.single().suggestions).containsExactly("One", "Two", "Three")
+    }
+
+    @Test
+    fun `no text selectors in the flow is Ok`() {
+        val snapshot = snapshotOf("whatever")
+        val yaml = """
+            - launchApp
+            - scroll
+        """.trimIndent()
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    @Test
+    fun `invalid yaml falls through cleanly instead of throwing`() {
+        val snapshot = snapshotOf("whatever")
+        val yaml = ": : ::"
+
+        assertThat(SelectorValidator.validate(yaml, snapshot)).isEqualTo(SelectorValidator.Result.Ok)
+    }
+
+    private fun snapshotOf(vararg texts: String) = HierarchySnapshotStore.Snapshot(
+        deviceId = "device-1",
+        texts = texts.toSet(),
+    )
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/tools/RunToolTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/tools/RunToolTest.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+import maestro.TreeNode
 import maestro.cli.mcp.hierarchy.HierarchySnapshotStore
 import maestro.cli.session.MaestroSessionManager
 import org.junit.jupiter.api.Test
@@ -194,6 +195,35 @@ class RunToolTest {
             }
         )
         assertThat(args.skipSelectorValidation).isTrue()
+    }
+
+    @Test
+    fun `handle short-circuits with selector_not_on_screen when snapshot has no matching text`() {
+        val store = HierarchySnapshotStore()
+        val root = TreeNode(
+            children = listOf(TreeNode(attributes = mutableMapOf("text" to "Sign in"))),
+        )
+        store.record("device-1", root)
+
+        val result = RunTool.handle(
+            CallToolRequest(
+                CallToolRequestParams(
+                    name = "run",
+                    arguments = buildArgs {
+                        put("device_id", "device-1")
+                        put("yaml", "- tapOn:\n    text: \"Hallucinated\"")
+                    },
+                )
+            ),
+            MaestroSessionManager,
+            store,
+        )
+
+        assertThat(result.isError).isTrue()
+        val text = (result.content.single() as TextContent).text
+        assertThat(text).contains("selector_not_on_screen")
+        assertThat(text).contains("Hallucinated")
+        assertThat(text).contains("Sign in")
     }
 
     private fun expectParseSuccess(arguments: JsonObject): RunToolArgs {

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/tools/RunToolTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/tools/RunToolTest.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+import maestro.cli.mcp.hierarchy.HierarchySnapshotStore
 import maestro.cli.session.MaestroSessionManager
 import org.junit.jupiter.api.Test
 
@@ -164,11 +165,35 @@ class RunToolTest {
         val result = RunTool.handle(
             CallToolRequest(CallToolRequestParams(name = "run", arguments = buildArgs { put("yaml", "- tapOn: x") })),
             MaestroSessionManager,
+            HierarchySnapshotStore(),
         )
 
         assertThat(result.isError).isTrue()
         val text = (result.content.single() as TextContent).text
         assertThat(text).contains("device_id")
+    }
+
+    @Test
+    fun `parse defaults skip_selector_validation to false`() {
+        val args = expectParseSuccess(
+            buildArgs {
+                put("device_id", "device-1")
+                put("yaml", "- tapOn: Search")
+            }
+        )
+        assertThat(args.skipSelectorValidation).isFalse()
+    }
+
+    @Test
+    fun `parse captures skip_selector_validation flag`() {
+        val args = expectParseSuccess(
+            buildArgs {
+                put("device_id", "device-1")
+                put("yaml", "- tapOn: Search")
+                put("skip_selector_validation", true)
+            }
+        )
+        assertThat(args.skipSelectorValidation).isTrue()
     }
 
     private fun expectParseSuccess(arguments: JsonObject): RunToolArgs {


### PR DESCRIPTION
Closes [MA-4029](https://linear.app/mobile-dev/issue/MA-4029/mcp-validate-text-selectors-against-the-latest-view-hierarchy-before).

## Why

Simon hit two failure modes authoring flows through the MCP:

1. **Hallucinated text.** `tapOn: { text: "Favorite" }` on the podcast screen — no element on iOS carries that label (the agent read it off a screenshot). Runtime error was the unhelpful "element not found."
2. **Truncated text.** `tapOn: { text: "RNR 352" }` when the actual element text is `"RNR 352 - Expo Launch with Cedric van Putten"`. Maestro's `text:` matcher uses full-string `regex.matches`, so the partial string misses — and the runtime error again is just "element not found."

Both failures waste an agent cycle (or several) before the caller figures out the selector is wrong. Instructions-only nudges help but don't catch this deterministically. This PR adds a server-side pre-flight that catches both cases with a structured error pointing at the actual texts on screen.

## What this does

- `inspect_view_hierarchy` records the current `TreeNode` root into a per-device `HierarchySnapshotStore`. In-memory, last-write-wins, no persistence.
- `run` cross-checks every `text:` selector in the flow (inline YAML + `files` + `dir` modes, including nested `below` / `above` / `leftOf` / `rightOf`) against the latest snapshot for the target device. Matching delegates to `Filters.textMatches` with the same `RegexOption`s Orchestra uses (`IGNORE_CASE`, `DOT_MATCHES_ALL`, `MULTILINE`) — so a verdict here matches the runner's verdict.
- On miss, returns `isError=true` with a structured JSON payload naming the missing selectors and the closest on-screen texts (bidirectional substring overlap, falling back to a peek list of what *is* on screen). Agent can self-correct and re-run.
- Selectors containing `${...}` env-var interpolation are skipped — those get resolved downstream and can't be matched against a raw snapshot.
- Opt-out: `skip_selector_validation: true` for flows that legitimately target dynamically-rendered text.
- No snapshot for the device → validation silently skipped (the instructions already tell the agent to inspect first).

## Scope

v1 validates `text:` only. `id:` and accessibility-identifier selectors are out of scope; they have platform-split semantics that warrant their own follow-up.

## Refactors prompted by review

- Initial pass used a hand-rolled matcher with 8 attributes and `containsMatchIn` (partial). Maestro's real `Filters.textMatches` only looks at `text` / `hintText` / `accessibilityText` and uses full-string `regex.matches`. Reusing the real filter eliminated semantic drift; as a side effect it started catching the `RNR 352` truncation case too.
- Review also flagged: mismatched `RegexOption`s vs the runner, env-var interpolation false positives, a silent file-read catch, and empty-findings invariant on `Result.Miss`. All addressed.

## Verified

- `./gradlew :maestro-cli:test` — green.
- Smoke on a booted iPhone 17 sim: inspect home screen → run with `text: "AbsolutelyNotOnScreen"` returns `selector_not_on_screen` with suggestions drawn from the real home screen (`["Fitness","Watch","Contacts","Files","Preview",...]`); same flow with `skip_selector_validation: true` bypasses the validator and falls through to Maestro's own parser.
- MCP `instructions` string stays under the 2KB cap.