### PR TITLE
feat(mcp): ground text selectors in the hierarchy, not screenshots

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
@@ -19,7 +19,7 @@ object InspectViewHierarchyTool {
                     "Those attribute keys are NOT valid Maestro selector keys. `tapOn` / `assertVisible` / etc. accept " +
                     "`text`, `id`, `index`, and position matchers (`below`, `above`, `leftOf`, `rightOf`). " +
                     "Map `accessibilityText=Foo` to `text: Foo`; never pass `accessibilityText` as a selector. " +
-                    "Always copy `text:` values verbatim from this output — never author them from a screenshot, " +
+                    "Always copy `text:` values verbatim from this output; never author them from a screenshot, " +
                     "which is a common source of hallucinated strings (e.g. an element showing a heart icon " +
                     "looks like a \"Favorite\" button in a screenshot but has no such text in the hierarchy). " +
                     "Maestro's `text:` matcher is full-string regex with IGNORE_CASE, so a partial string does " +

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/InspectViewHierarchyTool.kt
@@ -18,7 +18,14 @@ object InspectViewHierarchyTool {
                     "the `attributes` cell holds semicolon-separated `key=value` pairs (e.g. `text=Submit; accessibilityText=Submit button; resource_id=btn_submit`). " +
                     "Those attribute keys are NOT valid Maestro selector keys. `tapOn` / `assertVisible` / etc. accept " +
                     "`text`, `id`, `index`, and position matchers (`below`, `above`, `leftOf`, `rightOf`). " +
-                    "Map `accessibilityText=Foo` to `text: Foo`; never pass `accessibilityText` as a selector.",
+                    "Map `accessibilityText=Foo` to `text: Foo`; never pass `accessibilityText` as a selector. " +
+                    "Always copy `text:` values verbatim from this output — never author them from a screenshot, " +
+                    "which is a common source of hallucinated strings (e.g. an element showing a heart icon " +
+                    "looks like a \"Favorite\" button in a screenshot but has no such text in the hierarchy). " +
+                    "Maestro's `text:` matcher is full-string regex with IGNORE_CASE, so a partial string does " +
+                    "NOT match: `text: \"RNR 352\"` will miss an element whose real text is " +
+                    "`\"RNR 352 - Expo Launch with Cedric van Putten\"`. Use the full on-screen string, or " +
+                    "anchor with a regex like `\"RNR 352.*\"`.",
                 inputSchema = ToolSchema(
                     properties = buildJsonObject {
                         putJsonObject("device_id") {


### PR DESCRIPTION
Follow-up from Simon's latest feedback in Slack and the discussion on #3205.

## Why

Two failures Simon hit authoring flows through the MCP:

1. **Hallucinated text from screenshots.** `tapOn: { text: "Favorite" }` when no element in the iOS hierarchy carries that label — the agent read it off a screenshot of a heart icon.
2. **Truncated text selector.** `tapOn: { text: "RNR 352" }` against an element whose real text is `"RNR 352 - Expo Launch with Cedric van Putten"`. Maestro's `text:` matcher uses full-string `regex.matches`, so partial strings miss.

Both are authoring mistakes the agent can avoid if it knows the rules.

## What this does

Two additions to the `inspect_view_hierarchy` tool description:

- "Always copy `text:` values verbatim from this output; never author them from a screenshot" with the heart-icon / "Favorite" example.
- "Maestro's `text:` matcher is full-string regex with IGNORE_CASE" with the RNR 352 example plus the `"RNR 352.*"` anchor option.

## Why instructions, not validation

Same approach as #3204 which landed three instruction nudges based on Simon's earlier round of feedback — all three stuck in practice. A pre-flight validator was drafted in #3205 and closed after @lelandjrichardson flagged that it introduces multi-screen regression risk without an eval to measure net impact. Revisiting as warning-mode once evals are in place (MA-4029).

## A/B test on Simon's exact scenario

Two fresh subagents, same prompt ("write a flow that favorites episode 352 on this podcast app"), screenshot-only context, user framed as "in a hurry, no extra tool calls". One subagent got the original tool description, the other got the new one.

**Without the new rules** (reproduced both of Simon's failures):

```yaml
- scrollUntilVisible:
    element:
      text: "RNR 352"
- tapOn:
    text: "Favorite"
```

**With the new rules** (refused to shortcut, cited both rules by name):

> (b) Call `inspect_view_hierarchy` first. The tool description explicitly warns that screenshots are a common source of hallucinated selectors: a heart icon looks like "Favorite" visually but likely has no such text, and "RNR 352" is probably a truncated prefix of a longer full title that won't match Maestro's full-string regex.

Then authored an anchored regex (`"RNR 352.*"`) and said it would look up the real `id` for the heart button post-inspect.

**What this proves:** the nudges change behavior in the exact scenario Simon hit. Agent without them reproduces his failures; agent with them pushes back and authors a correct flow.

**What it doesn't prove:** frequency at scale (one A/B pair, not a volume eval) and over-caution cost (agent refusing to proceed when a shortcut would have been fine). Both questions are for the eval work, not this PR.

## Verified

- `./gradlew :maestro-cli:test` — green.
- Diff is 8 insertions, 1 deletion (plus 1-char em-dash → semicolon fixup).