### PR TITLE
Adds a soft CLI warning when the workspace zip produced by maestro cloud exceeds 20 MB

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -1,4 +1,4 @@
-maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.ktpackage maestro.cli.cloud
+package maestro.cli.cloud
 
 import maestro.cli.CliError
 import maestro.cli.analytics.Analytics

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -132,6 +132,7 @@ class CloudInteractor(
                 out = workspaceZip,
                 configOverride = configFile?.toPath()?.absolute(),
             )
+            warnIfWorkspaceIsLarge(workspaceZip.toFile().length())
             val progressBar = ProgressBar(20)
 
             // Binary id or Binary file
@@ -247,6 +248,14 @@ class CloudInteractor(
                 else -> 1
             }
         }
+    }
+
+    private fun warnIfWorkspaceIsLarge(sizeBytes: Long) {
+        if (sizeBytes < WORKSPACE_WARN_THRESHOLD_BYTES) return
+        val sizeMb = sizeBytes / 1024 / 1024
+        PrintUtils.warn(
+            "Workspace zip is ${sizeMb} MB. Large workspaces are downloaded by every device on every run and will slow down your tests. Common causes: app binaries (.apk/.ipa/.app/.aab) bundled with flows (use --app-binary-id instead), .git directories, build outputs (build/, .gradle/, node_modules/, Pods/), test artifacts from previous runs (reports/, recordings/, artifacts/), or duplicated fixtures."
+        )
     }
 
     private fun selectProject(authToken: String): String {
@@ -692,5 +701,9 @@ class CloudInteractor(
             PrintUtils.err("Unexpected error while analyzing Flow(s): ${error.message}")
             return 1
         }
+    }
+
+    companion object {
+        private const val WORKSPACE_WARN_THRESHOLD_BYTES = 10L * 1024 * 1024
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -1,4 +1,4 @@
-package maestro.cli.cloud
+maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.ktpackage maestro.cli.cloud
 
 import maestro.cli.CliError
 import maestro.cli.analytics.Analytics
@@ -704,6 +704,6 @@ class CloudInteractor(
     }
 
     companion object {
-        private const val WORKSPACE_WARN_THRESHOLD_BYTES = 50L * 1024 * 1024
+        private const val WORKSPACE_WARN_THRESHOLD_BYTES = 20L * 1024 * 1024
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -704,6 +704,6 @@ class CloudInteractor(
     }
 
     companion object {
-        private const val WORKSPACE_WARN_THRESHOLD_BYTES = 10L * 1024 * 1024
+        private const val WORKSPACE_WARN_THRESHOLD_BYTES = 50L * 1024 * 1024
     }
 }


### PR DESCRIPTION
A sweep of the last 20 days of cloud uploads showed 37 orgs shipping workspaces over 20 MB, with several in the 300–670 MB range. Because every device downloads the full workspace on every run, oversized uploads directly slow down queue and run times across the fleet.

The dominant causes were app binaries (.apk / .ipa / .app / .aab) bundled alongside flows, .git/ directories, build outputs (build/, .gradle/, node_modules/, Pods/), re-uploaded test artifacts (reports/, recordings/, artifacts/), and duplicated fixtures.

It will be very tricky to either blacklist or whitelist the file behind the scene, so we would just warn users and its upto users how they wanna maintain the workspace, knowing larger size will slow things down.

<img width="868" height="245" alt="Screenshot 2026-04-22 at 10 34 07 AM" src="https://github.com/user-attachments/assets/31a2a7b5-500d-4ed8-85f2-8a01cd764c97" />
