### PR TITLE
feat(mcp): nudge on assertScreenshot + broaden cheat_sheet guidance

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -28,7 +28,7 @@ internal val INSTRUCTIONS = """
 
     Every local tool (`take_screenshot`, `inspect_view_hierarchy`, `run`) needs a `device_id` from `list_devices` first.
 
-    Docs: https://docs.maestro.dev/llms.txt - call `cheat_sheet` before authoring any flow with assertions, conditionals, nested properties, or multiple screens.
+    Docs: https://docs.maestro.dev/llms.txt. Call `cheat_sheet` before authoring unfamiliar commands, required args, nested properties, conditionals, or multi-screen flows.
 
     ## Local workflow
 

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
@@ -40,6 +40,10 @@ object RunTool {
 
         Syntax is validated as part of this call; no separate pre-check is needed.
 
+        Some commands require arguments and fail to parse when written bare. `assertScreenshot`
+        needs a name (e.g. `assertScreenshot: home_screen` or `assertScreenshot: { path: home_screen }`);
+        never emit `- assertScreenshot` on its own. When in doubt, check `cheat_sheet`.
+
         If no device is running, ask the user to start one first.
         Use `inspect_view_hierarchy` to get the current screen before guessing at commands.
         Use `cheat_sheet` for Maestro flow syntax.


### PR DESCRIPTION
Follow-up from Simon's demo-prep feedback in Slack: the agent emitted a bare `- assertScreenshot`, which fails Maestro's YAML parser since the command needs a name/path.

## Two related nudges

**1. Targeted (pre-webinar insurance):** one line in the `run` tool description explaining `assertScreenshot` requires a name with both YAML forms. Deterministic protection against the exact failure Simon hit.

**2. General (slows the per-command growth of the run description):** tightens the existing `cheat_sheet` line in server INSTRUCTIONS so it also covers "unfamiliar commands" and "required args", not just assertions/conditionals/nested props/multi-screen flows. Aims to make the next command-shape mistake (swipeUp, runScript, whatever) get caught by the cheat_sheet nudge instead of needing yet another line in the `run` description.

## Why both

The whack-a-mole concern is real: adding one nudge per failure Simon reports doesn't scale. Ideally the fix is at the Maestro YAML parser layer (the "Missing Command Options" error could list the required fields or show an example) so every consumer benefits, not just MCP.

For the webinar we want deterministic coverage of the specific case, plus a general nudge that slows the pattern.

## A/B test

Fresh subagents given the prompt "launch the app and screenshot test it":

**Without the nudge:**
```yaml
appId: com.mobile.podcast
---
- launchApp
- takeScreenshot: screenshot
```
Confused `takeScreenshot` (capture-only) with `assertScreenshot` (screenshot test).

**With the nudge:**
```yaml
appId: com.mobile.podcast
---
- launchApp
- assertScreenshot: home_screen
```
Picked the correct command and supplied a name.

## Verified

- `./gradlew :maestro-cli:test` green.
- MCP `tools/list` returns both the new `run` description text and the tightened INSTRUCTIONS.
- INSTRUCTIONS stays under 2KB cap (2024 bytes).
- Total diff: 5 lines across 2 files.

## Follow-ups (deliberately deferred)

- **Improve maestro-orchestra's "Missing Command Options" error** to list required fields / show an example. This is the actually-right root fix and it helps every consumer (CLI, Studio, cloud, MCP), not just MCP. Holding it off now because (a) it touches the YAML parser, a hot path every Maestro user hits, and the soak time before Simon's webinar is short, (b) it's its own ticket with its own review surface, and (c) mixing a parser change into this 5-line MCP nudge PR would muddy the diff and slow the demo-prep path.
- **Audit the `run` description for nudges that can fold into the tightened `cheat_sheet` rule.** Intentionally done after the fact: we want to observe whether the broader `cheat_sheet` nudge actually catches future command-shape mistakes before we start collapsing existing lines. Collapsing prematurely could undo the deterministic protection we just added. Will revisit once we've seen a week or two of agent behavior post-merge.