### PR TITLE
fix(ios-driver): fail-fast on transport failure instead of rethrowing raw SocketTimeoutException

### DIFF
--- a/maestro-client/build.gradle.kts
+++ b/maestro-client/build.gradle.kts
@@ -170,6 +170,7 @@ dependencies {
     testImplementation(libs.google.truth)
     testImplementation(libs.square.mock.server)
     testImplementation(libs.junit.jupiter.params)
+    testImplementation(libs.mockk)
 }
 
 java {

--- a/maestro-client/src/main/java/maestro/DeviceUnreachableException.kt
+++ b/maestro-client/src/main/java/maestro/DeviceUnreachableException.kt
@@ -1,0 +1,15 @@
+package maestro
+
+/**
+ * Thrown when a driver call fails because the underlying device transport (e.g. the iOS XCTest
+ * runner's HTTP socket) has stopped responding. Distinct from [MaestroException] — this is an
+ * infrastructure failure, not a test failure, and consumers should treat it accordingly
+ * (no test-error reporting, no flow-level retry).
+ *
+ * Once a driver records a transport failure it should fail-fast on subsequent calls instead of
+ * issuing fresh requests against the same dead transport.
+ */
+class DeviceUnreachableException(
+    val callName: String,
+    cause: Throwable,
+) : RuntimeException("Device became unreachable during $callName", cause)

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -26,6 +26,7 @@ import ios.IOSDeviceErrors
 import maestro.Capability
 import maestro.DeviceInfo
 import maestro.device.DeviceOrientation
+import maestro.DeviceUnreachableException
 import maestro.Driver
 import maestro.Filters
 import maestro.KeyCode
@@ -67,6 +68,14 @@ class IOSDriver(
     private var appId: String? = null
     private var proxySet = false
     private val xcRunnerCLIUtils = XCRunnerCLIUtils(tempFileHandler = TempFileHandler())
+
+    // Set on the first transport-level failure (socket timeout against the XCTest runner).
+    // Subsequent runDeviceCalls fail-fast against this instead of issuing fresh HTTP requests
+    // to a runner we already know isn't answering. Volatile because runDeviceCall executes on
+    // Dispatchers.IO worker threads (via runInterruptible in maestro.Maestro) — the writer and
+    // any future reader may be different pool workers, so JMM visibility matters.
+    @Volatile
+    private var transportFailure: DeviceUnreachableException? = null
 
     override fun name(): String {
         return metrics.measured("name") {
@@ -542,11 +551,17 @@ class IOSDriver(
     }
 
     private fun <T> runDeviceCall(callName: String, call: () -> T): T {
+        transportFailure?.let { throw it }
         return try {
             call()
         } catch (socketTimeoutException: SocketTimeoutException) {
-            LOGGER.error("Got socket timeout processing $callName command", socketTimeoutException)
-            throw socketTimeoutException
+            val tripped = DeviceUnreachableException(callName, socketTimeoutException)
+            transportFailure = tripped
+            LOGGER.error(
+                "Got socket timeout processing $callName command, marking driver unreachable",
+                socketTimeoutException
+            )
+            throw tripped
         } catch (appCrashException: IOSDeviceErrors.AppCrash) {
             LOGGER.error("Detected app crash during $callName command", appCrashException)
             throw MaestroException.AppCrash(appCrashException.errorMessage)

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -54,7 +54,6 @@ import okio.source
 import org.slf4j.LoggerFactory
 import util.XCRunnerCLIUtils
 import java.io.File
-import java.net.SocketTimeoutException
 import kotlin.collections.set
 
 class IOSDriver(
@@ -68,14 +67,6 @@ class IOSDriver(
     private var appId: String? = null
     private var proxySet = false
     private val xcRunnerCLIUtils = XCRunnerCLIUtils(tempFileHandler = TempFileHandler())
-
-    // Set on the first transport-level failure (socket timeout against the XCTest runner).
-    // Subsequent runDeviceCalls fail-fast against this instead of issuing fresh HTTP requests
-    // to a runner we already know isn't answering. Volatile because runDeviceCall executes on
-    // Dispatchers.IO worker threads (via runInterruptible in maestro.Maestro) — the writer and
-    // any future reader may be different pool workers, so JMM visibility matters.
-    @Volatile
-    private var transportFailure: DeviceUnreachableException? = null
 
     override fun name(): String {
         return metrics.measured("name") {
@@ -551,29 +542,11 @@ class IOSDriver(
     }
 
     private fun <T> runDeviceCall(callName: String, call: () -> T): T {
-        transportFailure?.let { throw it }
         return try {
             call()
-        } catch (socketTimeoutException: SocketTimeoutException) {
-            val tripped = DeviceUnreachableException(callName, socketTimeoutException)
-            transportFailure = tripped
-            LOGGER.error(
-                "Got socket timeout processing $callName command, marking driver unreachable",
-                socketTimeoutException
-            )
-            throw tripped
-        } catch (unreachable: maestro.utils.network.XCUITestServerError.Unreachable) {
-            // The transport-layer latch in XCTestDriverClient now traps SocketTimeoutException
-            // closer to OkHttp and surfaces it as Unreachable. Mirror it into the driver-level
-            // DeviceUnreachableException so callers see one shape. Will be replaced by an
-            // IOSDeviceErrors.Unreachable catch once XCTestIOSDevice does the translation.
-            val tripped = DeviceUnreachableException(unreachable.callName, unreachable)
-            transportFailure = tripped
-            LOGGER.error(
-                "Transport unreachable while processing ${unreachable.callName}, marking driver unreachable",
-                unreachable
-            )
-            throw tripped
+        } catch (unreachable: IOSDeviceErrors.Unreachable) {
+            LOGGER.error("Device unreachable while processing $callName command", unreachable)
+            throw DeviceUnreachableException(unreachable.callName, unreachable)
         } catch (appCrashException: IOSDeviceErrors.AppCrash) {
             LOGGER.error("Detected app crash during $callName command", appCrashException)
             throw MaestroException.AppCrash(appCrashException.errorMessage)

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -562,6 +562,18 @@ class IOSDriver(
                 socketTimeoutException
             )
             throw tripped
+        } catch (unreachable: maestro.utils.network.XCUITestServerError.Unreachable) {
+            // The transport-layer latch in XCTestDriverClient now traps SocketTimeoutException
+            // closer to OkHttp and surfaces it as Unreachable. Mirror it into the driver-level
+            // DeviceUnreachableException so callers see one shape. Will be replaced by an
+            // IOSDeviceErrors.Unreachable catch once XCTestIOSDevice does the translation.
+            val tripped = DeviceUnreachableException(unreachable.callName, unreachable)
+            transportFailure = tripped
+            LOGGER.error(
+                "Transport unreachable while processing ${unreachable.callName}, marking driver unreachable",
+                unreachable
+            )
+            throw tripped
         } catch (appCrashException: IOSDeviceErrors.AppCrash) {
             LOGGER.error("Detected app crash during $callName command", appCrashException)
             throw MaestroException.AppCrash(appCrashException.errorMessage)

--- a/maestro-client/src/test/java/maestro/drivers/IOSDriverTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/IOSDriverTest.kt
@@ -1,0 +1,75 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import device.IOSDevice
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import ios.IOSDeviceErrors
+import maestro.DeviceUnreachableException
+import maestro.MaestroException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xcuitest.api.DeviceInfo
+import java.net.SocketTimeoutException
+
+class IOSDriverTest {
+
+    @Test
+    fun `socket timeout trips the driver and short-circuits subsequent calls without re-invoking the device`() {
+        val iosDevice = mockk<IOSDevice>(relaxed = true)
+        every { iosDevice.deviceInfo() } throws SocketTimeoutException("Read timed out")
+
+        val driver = IOSDriver(iosDevice)
+
+        // First call: real call, hits the device, gets timeout, wraps to DeviceUnreachableException
+        val first = assertThrows<DeviceUnreachableException> { driver.deviceInfo() }
+        assertThat(first.callName).isEqualTo("deviceInfo")
+        assertThat(first.cause).isInstanceOf(SocketTimeoutException::class.java)
+        verify(exactly = 1) { iosDevice.deviceInfo() }
+
+        // Second call: trip flag short-circuits, device is NOT invoked again
+        val second = assertThrows<DeviceUnreachableException> { driver.deviceInfo() }
+        assertThat(second).isSameInstanceAs(first)
+        verify(exactly = 1) { iosDevice.deviceInfo() }
+
+        // A different driver method also short-circuits without invoking the device
+        assertThrows<DeviceUnreachableException> { driver.isKeyboardVisible() }
+        verify(exactly = 0) { iosDevice.isKeyboardVisible() }
+    }
+
+    @Test
+    fun `non-transport exceptions do not trip the driver`() {
+        val iosDevice = mockk<IOSDevice>(relaxed = true)
+        every { iosDevice.deviceInfo() } throws IOSDeviceErrors.AppCrash("crashed")
+
+        val driver = IOSDriver(iosDevice)
+
+        // First call: AppCrash maps to MaestroException.AppCrash, NOT DeviceUnreachableException
+        assertThrows<MaestroException.AppCrash> { driver.deviceInfo() }
+
+        // Second call: trip flag is NOT set, the device is invoked again
+        assertThrows<MaestroException.AppCrash> { driver.deviceInfo() }
+        verify(exactly = 2) { iosDevice.deviceInfo() }
+    }
+
+    @Test
+    fun `successful calls do not trip the driver`() {
+        val iosDevice = mockk<IOSDevice>(relaxed = true)
+        every { iosDevice.deviceInfo() } returns DeviceInfo(
+            widthPixels = 1170,
+            heightPixels = 2532,
+            widthPoints = 390,
+            heightPoints = 844,
+        )
+
+        val driver = IOSDriver(iosDevice)
+
+        driver.deviceInfo()
+        driver.deviceInfo()
+        driver.deviceInfo()
+
+        verify(exactly = 3) { iosDevice.deviceInfo() }
+    }
+}

--- a/maestro-client/src/test/java/maestro/drivers/IOSDriverTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/IOSDriverTest.kt
@@ -2,7 +2,6 @@ package maestro.drivers
 
 import com.google.common.truth.Truth.assertThat
 import device.IOSDevice
-import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -17,45 +16,50 @@ import java.net.SocketTimeoutException
 class IOSDriverTest {
 
     @Test
-    fun `socket timeout trips the driver and short-circuits subsequent calls without re-invoking the device`() {
+    fun `IOSDeviceErrors Unreachable from the device is translated to DeviceUnreachableException`() {
+        val cause = SocketTimeoutException("Read timed out")
         val iosDevice = mockk<IOSDevice>(relaxed = true)
-        every { iosDevice.deviceInfo() } throws SocketTimeoutException("Read timed out")
+        every { iosDevice.deviceInfo() } throws IOSDeviceErrors.Unreachable("deviceInfo", cause)
 
         val driver = IOSDriver(iosDevice)
 
-        // First call: real call, hits the device, gets timeout, wraps to DeviceUnreachableException
-        val first = assertThrows<DeviceUnreachableException> { driver.deviceInfo() }
-        assertThat(first.callName).isEqualTo("deviceInfo")
-        assertThat(first.cause).isInstanceOf(SocketTimeoutException::class.java)
-        verify(exactly = 1) { iosDevice.deviceInfo() }
-
-        // Second call: trip flag short-circuits, device is NOT invoked again
-        val second = assertThrows<DeviceUnreachableException> { driver.deviceInfo() }
-        assertThat(second).isSameInstanceAs(first)
-        verify(exactly = 1) { iosDevice.deviceInfo() }
-
-        // A different driver method also short-circuits without invoking the device
-        assertThrows<DeviceUnreachableException> { driver.isKeyboardVisible() }
-        verify(exactly = 0) { iosDevice.isKeyboardVisible() }
+        val thrown = assertThrows<DeviceUnreachableException> { driver.deviceInfo() }
+        assertThat(thrown.callName).isEqualTo("deviceInfo")
+        assertThat(thrown.cause).isInstanceOf(IOSDeviceErrors.Unreachable::class.java)
+        assertThat(thrown.cause?.cause).isSameInstanceAs(cause)
     }
 
     @Test
-    fun `non-transport exceptions do not trip the driver`() {
+    fun `IOSDriver does not cache - subsequent calls invoke the device again`() {
+        // Fail-fast for the dead-runner case lives at the transport layer (XCTestDriverClient).
+        // IOSDriver is now a thin translator: it converts each IOSDeviceErrors.Unreachable into
+        // a DeviceUnreachableException without short-circuiting on its own. When the underlying
+        // device keeps throwing (mimicking a still-tripped transport latch), the driver translates
+        // each call independently.
+        val iosDevice = mockk<IOSDevice>(relaxed = true)
+        every { iosDevice.deviceInfo() } throws IOSDeviceErrors.Unreachable("deviceInfo", SocketTimeoutException())
+
+        val driver = IOSDriver(iosDevice)
+
+        assertThrows<DeviceUnreachableException> { driver.deviceInfo() }
+        assertThrows<DeviceUnreachableException> { driver.deviceInfo() }
+        verify(exactly = 2) { iosDevice.deviceInfo() }
+    }
+
+    @Test
+    fun `non-transport exceptions still translate to their MaestroException counterparts`() {
         val iosDevice = mockk<IOSDevice>(relaxed = true)
         every { iosDevice.deviceInfo() } throws IOSDeviceErrors.AppCrash("crashed")
 
         val driver = IOSDriver(iosDevice)
 
-        // First call: AppCrash maps to MaestroException.AppCrash, NOT DeviceUnreachableException
         assertThrows<MaestroException.AppCrash> { driver.deviceInfo() }
-
-        // Second call: trip flag is NOT set, the device is invoked again
         assertThrows<MaestroException.AppCrash> { driver.deviceInfo() }
         verify(exactly = 2) { iosDevice.deviceInfo() }
     }
 
     @Test
-    fun `successful calls do not trip the driver`() {
+    fun `successful calls pass through unchanged`() {
         val iosDevice = mockk<IOSDevice>(relaxed = true)
         every { iosDevice.deviceInfo() } returns DeviceInfo(
             widthPixels = 1170,

--- a/maestro-client/src/test/java/maestro/ios/MockXCTestInstaller.kt
+++ b/maestro-client/src/test/java/maestro/ios/MockXCTestInstaller.kt
@@ -6,6 +6,7 @@ import xcuitest.installer.XCTestInstaller
 
 class MockXCTestInstaller(
     private val simulator: Simulator,
+    private val port: Int = 22807,
 ) : XCTestInstaller {
 
     private var attempts = 0
@@ -16,7 +17,7 @@ class MockXCTestInstaller(
             assertThat(simulator.runningApps()).doesNotContain("dev.mobile.maestro-driver-iosUITests.xctrunner")
         }
         simulator.installXCTestDriver()
-        return XCTestClient("localhost", 22807)
+        return XCTestClient("localhost", port)
     }
 
     override fun uninstall(): Boolean {

--- a/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
+++ b/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.truth.Truth.assertThat
 import maestro.ios.MockXCTestInstaller
 import maestro.utils.network.XCUITestServerError
+import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy
@@ -15,7 +16,9 @@ import xcuitest.XCTestClient
 import xcuitest.XCTestDriverClient
 import xcuitest.api.DeviceInfo
 import xcuitest.api.Error
+import java.io.InterruptedIOException
 import java.net.InetAddress
+import java.util.concurrent.TimeUnit
 
 class XCTestDriverClientTest {
 
@@ -110,6 +113,132 @@ class XCTestDriverClientTest {
         mockXCTestInstaller.assertInstallationRetries(0)
         mockWebServer.shutdown()
     }
+
+    @Test
+    fun `transport timeout is reported as Unreachable wrapping the underlying cause`() {
+        val mockWebServer = MockWebServer()
+        mockWebServer.enqueue(MockResponse().apply { socketPolicy = SocketPolicy.NO_RESPONSE })
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
+        val port = mockWebServer.port
+        val httpUrl = mockWebServer.url("/deviceInfo")
+
+        val xcTestDriverClient = XCTestDriverClient(
+            installer = MockXCTestInstaller(MockXCTestInstaller.Simulator(), port = port),
+            client = XCTestClient("localhost", port),
+            okHttpClient = fastTimeoutOkHttpClient(),
+        )
+
+        val thrown = assertThrows<XCUITestServerError.Unreachable> {
+            xcTestDriverClient.deviceInfo(httpUrl)
+        }
+        assertThat(thrown.callName).isEqualTo("deviceInfo")
+        // SocketTimeoutException is a subclass of InterruptedIOException; OkHttp's callTimeout
+        // can also surface as raw InterruptedIOException, so accept either.
+        assertThat(thrown.cause).isInstanceOf(InterruptedIOException::class.java)
+
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `subsequent calls short-circuit without issuing another HTTP request`() {
+        val mockWebServer = MockWebServer()
+        mockWebServer.enqueue(MockResponse().apply { socketPolicy = SocketPolicy.NO_RESPONSE })
+        // intentionally no second response: a non-short-circuited call would dispatch an HTTP
+        // request and either time out again (slow) or get an EOF once the queue is exhausted.
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
+        val port = mockWebServer.port
+        val httpUrl = mockWebServer.url("/deviceInfo")
+
+        val xcTestDriverClient = XCTestDriverClient(
+            installer = MockXCTestInstaller(MockXCTestInstaller.Simulator(), port = port),
+            client = XCTestClient("localhost", port),
+            okHttpClient = fastTimeoutOkHttpClient(),
+        )
+
+        val first = assertThrows<XCUITestServerError.Unreachable> {
+            xcTestDriverClient.deviceInfo(httpUrl)
+        }
+        val second = assertThrows<XCUITestServerError.Unreachable> {
+            xcTestDriverClient.deviceInfo(httpUrl)
+        }
+
+        assertThat(second).isSameInstanceAs(first)
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
+
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `restartXCTestRunner clears the latch and the next call hits the runner again`() {
+        val mockWebServer = MockWebServer()
+        val mapper = jacksonObjectMapper()
+        val expectedDeviceInfo = DeviceInfo(1, 2, 3, 4)
+        mockWebServer.enqueue(MockResponse().apply { socketPolicy = SocketPolicy.NO_RESPONSE })
+        mockWebServer.enqueue(MockResponse().apply {
+            setResponseCode(200)
+            setBody(mapper.writeValueAsString(expectedDeviceInfo))
+        })
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
+        val port = mockWebServer.port
+        val httpUrl = mockWebServer.url("/deviceInfo")
+
+        // Pin the post-restart XCTestClient to the same mock-server port so the second call lands here.
+        val xcTestDriverClient = XCTestDriverClient(
+            installer = MockXCTestInstaller(MockXCTestInstaller.Simulator(), port = port),
+            client = XCTestClient("localhost", port),
+            okHttpClient = fastTimeoutOkHttpClient(),
+            reinstallDriver = false,
+        )
+
+        assertThrows<XCUITestServerError.Unreachable> {
+            xcTestDriverClient.deviceInfo(httpUrl)
+        }
+
+        xcTestDriverClient.restartXCTestRunner()
+
+        val actual = xcTestDriverClient.deviceInfo(httpUrl)
+        assertThat(actual).isEqualTo(expectedDeviceInfo)
+        assertThat(mockWebServer.requestCount).isEqualTo(2)
+
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `non-transport failures do not trip the latch`() {
+        val mockWebServer = MockWebServer()
+        val mapper = jacksonObjectMapper()
+        val error = Error(errorMessage = "bad request", errorCode = "bad-request")
+        repeat(2) {
+            mockWebServer.enqueue(MockResponse().apply {
+                setResponseCode(401)
+                setBody(mapper.writeValueAsString(error))
+            })
+        }
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
+        val port = mockWebServer.port
+        val httpUrl = mockWebServer.url("/deviceInfo")
+
+        val xcTestDriverClient = XCTestDriverClient(
+            installer = MockXCTestInstaller(MockXCTestInstaller.Simulator(), port = port),
+            client = XCTestClient("localhost", port),
+            okHttpClient = fastTimeoutOkHttpClient(),
+        )
+
+        assertThrows<XCUITestServerError.BadRequest> { xcTestDriverClient.deviceInfo(httpUrl) }
+        assertThrows<XCUITestServerError.BadRequest> { xcTestDriverClient.deviceInfo(httpUrl) }
+
+        // Both calls must have reached the server: a tripped latch would have short-circuited the second.
+        assertThat(mockWebServer.requestCount).isEqualTo(2)
+
+        mockWebServer.shutdown()
+    }
+
+    // Mirrors production: the 200s readTimeout is the bound that fires first in the observed
+    // incident, surfacing as a SocketTimeoutException. We don't set callTimeout because OkHttp
+    // wraps the cause in a plain InterruptedIOException, which is a different kind of signal.
+    private fun fastTimeoutOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .readTimeout(500, TimeUnit.MILLISECONDS)
+        .build()
 
     companion object {
 

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -11,6 +11,7 @@ import okhttp3.RequestBody.Companion.toRequestBody
 import org.slf4j.LoggerFactory
 import xcuitest.api.*
 import xcuitest.installer.XCTestInstaller
+import java.net.SocketTimeoutException
 import kotlin.time.Duration.Companion.seconds
 
 class XCTestDriverClient(
@@ -27,7 +28,24 @@ class XCTestDriverClient(
 
     private lateinit var client: XCTestClient
 
+    // Latched on the first transport-level failure (socket timeout against the runner's
+    // OkHttp socket). Subsequent HTTP calls fail-fast against this instead of issuing fresh
+    // requests to a runner we already know isn't answering. Volatile because OkHttp callers
+    // run on Dispatchers.IO worker threads (via runInterruptible in maestro.Maestro) — the
+    // writer and any future reader may be different pool workers, so JMM visibility matters.
+    @Volatile
+    private var transportDead: XCUITestServerError.Unreachable? = null
+
     constructor(installer: XCTestInstaller, client: XCTestClient, reinstallDriver: Boolean = true): this(installer, reinstallDriver = reinstallDriver) {
+        this.client = client
+    }
+
+    constructor(
+        installer: XCTestInstaller,
+        client: XCTestClient,
+        okHttpClient: OkHttpClient,
+        reinstallDriver: Boolean = true,
+    ): this(installer, okHttpClient, reinstallDriver) {
         this.client = client
     }
 
@@ -39,6 +57,19 @@ class XCTestDriverClient(
         }
 
         client = installer.start()
+        transportDead = null
+    }
+
+    private fun <T> transportCall(callName: String, call: () -> T): T {
+        transportDead?.let { throw it }
+        return try {
+            call()
+        } catch (e: SocketTimeoutException) {
+            val tripped = XCUITestServerError.Unreachable(callName, e)
+            transportDead = tripped
+            logger.error("Transport unreachable while processing $callName, latching", e)
+            throw tripped
+        }
     }
 
     private val mapper = jacksonObjectMapper()
@@ -181,62 +212,68 @@ class XCTestDriverClient(
         executeJsonRequest("setPermissions", SetPermissionsRequest(permissions))
     }
 
-    private fun executeJsonRequest(httpUrl: HttpUrl, body: Any): String {
-        val mediaType = "application/json; charset=utf-8".toMediaType()
-        val bodyData = mapper.writeValueAsString(body).toRequestBody(mediaType)
+    private fun executeJsonRequest(httpUrl: HttpUrl, body: Any): String =
+        transportCall(httpUrl.callName()) {
+            val mediaType = "application/json; charset=utf-8".toMediaType()
+            val bodyData = mapper.writeValueAsString(body).toRequestBody(mediaType)
 
-        val requestBuilder = Request.Builder()
-            .addHeader("Content-Type", "application/json")
-            .url(httpUrl)
-            .post(bodyData)
+            val requestBuilder = Request.Builder()
+                .addHeader("Content-Type", "application/json")
+                .url(httpUrl)
+                .post(bodyData)
 
-        return okHttpClient
-            .newCall(requestBuilder.build())
-            .execute().use { processResponse(it, httpUrl.toString()) }
-    }
+            okHttpClient
+                .newCall(requestBuilder.build())
+                .execute().use { processResponse(it, httpUrl.toString()) }
+        }
 
-    private fun executeJsonRequest(httpUrl: HttpUrl): ByteArray {
-        val request = Request.Builder()
-            .get()
-            .url(httpUrl)
-            .build()
+    private fun executeJsonRequest(httpUrl: HttpUrl): ByteArray =
+        transportCall(httpUrl.callName()) {
+            val request = Request.Builder()
+                .get()
+                .url(httpUrl)
+                .build()
 
-        return okHttpClient
-            .newCall(request)
-            .execute().use {
-                val bytes = it.body?.bytes() ?: ByteArray(0)
-                if (!it.isSuccessful) {
-                    //handle exception
-                    val responseBodyAsString = String(bytes)
-                    handleExceptions(it.code, request.url.pathSegments.first(), responseBodyAsString)
+            okHttpClient
+                .newCall(request)
+                .execute().use {
+                    val bytes = it.body?.bytes() ?: ByteArray(0)
+                    if (!it.isSuccessful) {
+                        //handle exception
+                        val responseBodyAsString = String(bytes)
+                        handleExceptions(it.code, request.url.pathSegments.first(), responseBodyAsString)
+                    }
+                    bytes
                 }
-                bytes
-            }
-    }
+        }
 
-    private fun executeJsonRequest(pathSegment: String, body: Any): String {
-        val mediaType = "application/json; charset=utf-8".toMediaType()
-        val bodyData = mapper.writeValueAsString(body).toRequestBody(mediaType)
+    private fun executeJsonRequest(pathSegment: String, body: Any): String =
+        transportCall(pathSegment) {
+            val mediaType = "application/json; charset=utf-8".toMediaType()
+            val bodyData = mapper.writeValueAsString(body).toRequestBody(mediaType)
 
-        val requestBuilder = Request.Builder()
-            .addHeader("Content-Type", "application/json")
-            .url(client.xctestAPIBuilder(pathSegment).build())
-            .post(bodyData)
+            val requestBuilder = Request.Builder()
+                .addHeader("Content-Type", "application/json")
+                .url(client.xctestAPIBuilder(pathSegment).build())
+                .post(bodyData)
 
-        return okHttpClient
-            .newCall(requestBuilder.build())
-            .execute().use { processResponse(it, pathSegment) }
-    }
+            okHttpClient
+                .newCall(requestBuilder.build())
+                .execute().use { processResponse(it, pathSegment) }
+        }
 
-    private fun executeJsonRequest(pathSegment: String): String {
-        val requestBuilder = Request.Builder()
-            .url(client.xctestAPIBuilder(pathSegment).build())
-            .get()
+    private fun executeJsonRequest(pathSegment: String): String =
+        transportCall(pathSegment) {
+            val requestBuilder = Request.Builder()
+                .url(client.xctestAPIBuilder(pathSegment).build())
+                .get()
 
-        return okHttpClient
-            .newCall(requestBuilder.build())
-            .execute().use { processResponse(it, pathSegment) }
-    }
+            okHttpClient
+                .newCall(requestBuilder.build())
+                .execute().use { processResponse(it, pathSegment) }
+        }
+
+    private fun HttpUrl.callName(): String = pathSegments.firstOrNull().orEmpty().ifEmpty { "unknown" }
 
     private fun processResponse(response: Response, url: String): String {
         val responseBodyAsString = response.body?.bytes()?.let { bytes -> String(bytes) } ?: ""

--- a/maestro-ios/src/main/java/ios/IOSDeviceErrors.kt
+++ b/maestro-ios/src/main/java/ios/IOSDeviceErrors.kt
@@ -3,4 +3,12 @@ package ios
 sealed class IOSDeviceErrors : Throwable() {
     data class AppCrash(val errorMessage: String): IOSDeviceErrors()
     data class OperationTimeout(val errorMessage: String): IOSDeviceErrors()
+
+    // Surfaced when the underlying transport (e.g. the XCTest runner's HTTP socket) is
+    // unreachable. Translated from XCUITestServerError.Unreachable inside XCTestIOSDevice
+    // so callers above the device-abstraction layer don't need to know about OkHttp types.
+    class Unreachable(val callName: String, cause: Throwable): IOSDeviceErrors() {
+        init { initCause(cause) }
+        override val message: String = "Device became unreachable while processing $callName"
+    }
 }

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -237,6 +237,8 @@ class XCTestIOSDevice(
             )
         } catch (timeout: XCUITestServerError.OperationTimeout) {
             throw IOSDeviceErrors.OperationTimeout(timeout.errorResponse)
+        } catch (unreachable: XCUITestServerError.Unreachable) {
+            throw IOSDeviceErrors.Unreachable(unreachable.callName, unreachable)
         }
     }
 

--- a/maestro-ios/src/test/kotlin/ios/xctest/XCTestIOSDeviceTest.kt
+++ b/maestro-ios/src/test/kotlin/ios/xctest/XCTestIOSDeviceTest.kt
@@ -1,0 +1,71 @@
+package ios.xctest
+
+import com.google.common.truth.Truth.assertThat
+import ios.IOSDeviceErrors
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import xcuitest.XCTestClient
+import xcuitest.XCTestDriverClient
+import xcuitest.installer.XCTestInstaller
+import java.net.SocketTimeoutException
+
+class XCTestIOSDeviceTest {
+
+    @Test
+    fun `transport unreachable from XCTestDriverClient is translated to IOSDeviceErrors Unreachable`() {
+        val cause = SocketTimeoutException("simulated read timeout")
+        val driverClient = XCTestDriverClient(
+            installer = NoopInstaller,
+            // The interceptor short-circuits before any socket use, so the port is never reached.
+            client = XCTestClient("localhost", 1),
+            okHttpClient = throwingOkHttpClient(cause),
+        )
+        val device = XCTestIOSDevice(
+            deviceId = "test-device",
+            client = driverClient,
+            getInstalledApps = { emptySet() },
+        )
+
+        val thrown = assertThrows<IOSDeviceErrors.Unreachable> {
+            device.tap(x = 10, y = 20)
+        }
+
+        assertThat(thrown.callName).isEqualTo("touch")
+        assertThat(thrown.cause).isInstanceOf(maestro.utils.network.XCUITestServerError.Unreachable::class.java)
+        assertThat(thrown.cause?.cause).isSameInstanceAs(cause)
+    }
+
+    @Test
+    fun `subsequent calls also throw Unreachable because the underlying latch short-circuits`() {
+        val cause = SocketTimeoutException("simulated read timeout")
+        val driverClient = XCTestDriverClient(
+            installer = NoopInstaller,
+            // The interceptor short-circuits before any socket use, so the port is never reached.
+            client = XCTestClient("localhost", 1),
+            okHttpClient = throwingOkHttpClient(cause),
+        )
+        val device = XCTestIOSDevice(
+            deviceId = "test-device",
+            client = driverClient,
+            getInstalledApps = { emptySet() },
+        )
+
+        assertThrows<IOSDeviceErrors.Unreachable> { device.tap(10, 20) }
+        // A second call must also surface as Unreachable — proves the translation arm catches
+        // the cached Unreachable that the latch in XCTestDriverClient re-throws on every call.
+        assertThrows<IOSDeviceErrors.Unreachable> { device.tap(30, 40) }
+    }
+
+    private fun throwingOkHttpClient(cause: Throwable): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor { _ -> throw cause }
+            .build()
+
+    private object NoopInstaller : XCTestInstaller {
+        override fun start(): XCTestClient = error("not used in this test")
+        override fun uninstall(): Boolean = error("not used in this test")
+        override fun isChannelAlive(): Boolean = error("not used in this test")
+        override fun close() {}
+    }
+}

--- a/maestro-utils/src/main/kotlin/network/Errors.kt
+++ b/maestro-utils/src/main/kotlin/network/Errors.kt
@@ -14,4 +14,12 @@ sealed class XCUITestServerError: Throwable() {
     data class AppCrash(val errorResponse: String): XCUITestServerError()
     data class OperationTimeout(val errorResponse: String, val operation: String): XCUITestServerError()
     data class BadRequest(val errorResponse: String, val clientMessage: String): XCUITestServerError()
+
+    // Transport-layer failure: the XCTest runner stopped answering its HTTP socket.
+    // Latched in XCTestDriverClient so subsequent calls fail-fast instead of issuing
+    // fresh requests against a dead runner. Cleared on restartXCTestRunner().
+    class Unreachable(val callName: String, cause: Throwable): XCUITestServerError() {
+        init { initCause(cause) }
+        override val message: String = "Transport unreachable while processing $callName"
+    }
 }


### PR DESCRIPTION
## Problem

Investigation during #3206 surfaced this: the iOS XCTest driver can deadlock mid-job (a `swipe` in our case). Although it's fixed elsewhere, it revealed issues in our driver client.

The client receives `SocketTimeoutException` after the 200s `readTimeout`, but every subsequent driver HTTP call hits the same dead runner and eats another 200s — wasting ~10 min of compute.

Two compounding behaviours feed the cascade:

- `onCommandStart` / `onCommandFailed` (screenshot, hierarchy) re-issue HTTP to the dead runner, each burning another 200s
- Flow-level `retry` in Orchestra replays on any throwable, including transport failures, so each retry attempt starts fresh HTTP calls against the same dead runner

Concrete sequence we observed:

1. `driver.swipe` → `runDeviceCall` → 200s `SocketTimeoutException`
2. `onCommandFailed` calls `deviceInfo` to snapshot hierarchy → 200s
3. `retry` wrapper replays the subflow
4. `onCommandStart` calls `screenshot` on the replayed command → 200s
5. ...repeats until the 15-min cooperative `withTimeout` fires and `runInterruptible` interrupts the IO-pool worker, unsticking `socket.read()`

## Fix

Treat unreachable driver as a first-class exception that consumers can catch. Fail fast and short-circuit subsequent HTTP calls instead of wasting ~10 min of compute on dead runners.

The latch lives at the **transport layer** (`XCTestDriverClient`), where the `OkHttpClient` and `restartXCTestRunner()` already live. Translation propagates up through the existing exception vocabulary so each layer only speaks its own language and `SocketTimeoutException` never leaks above OkHttp.

| Layer | Catches | Throws | Owns |
| --- | --- | --- | --- |
| `XCTestDriverClient` | `SocketTimeoutException` | `XCUITestServerError.Unreachable` | OkHttp client, `@Volatile` latch, `restartXCTestRunner()` reset |
| `XCTestIOSDevice.execute` | `XCUITestServerError.Unreachable` | `IOSDeviceErrors.Unreachable` | Device-abstraction translation |
| `IOSDriver.runDeviceCall` | `IOSDeviceErrors.Unreachable` | `DeviceUnreachableException` | Maestro-facing driver contract |

What this buys:

- **Coverage gap closed.** `launchApp`, `stopApp`, `clearAppState`, `clearKeychain`, `close` all go through the same OkHttp client now, so they trip the latch automatically — they couldn't trip the previous IOSDriver-level latch because they bypassed `runDeviceCall`.
- **Recovery story.** `restartXCTestRunner()` clears the latch (recovery is the only thing that should). `close()` deliberately does not — the transport really is gone, and the reopen path goes through `restartXCTestRunner()` anyway.
- **No cross-layer types.** `SocketTimeoutException` is no longer imported above `XCTestDriverClient`. The OkHttp dependency stops at the layer that actually talks to OkHttp.
- **`DeviceUnreachableException`** stays a plain `RuntimeException`, not a `MaestroException`, since it's an infra failure — consumers (worker-level `INFRA_ERROR` classification, Orchestra's retry) can decide how to handle it.

## Verify

- [x] `:maestro-utils:test` — `XCUITestServerError.Unreachable` sealed variant
- [x] `:maestro-ios:test` — new `XCTestIOSDeviceTest` pins the translation `XCUITestServerError.Unreachable` → `IOSDeviceErrors.Unreachable`
- [x] `:maestro-client:test` — `XCTestDriverClientTest` pins trip-on-timeout, short-circuit-without-HTTP, restart-clears-latch, non-transport-doesn't-trip; `IOSDriverTest` pins the final `IOSDeviceErrors.Unreachable` → `DeviceUnreachableException` translation