### PR TITLE
Add support for MANAGE_EXTERNAL_STORAGE permission on Android

### DIFF
--- a/e2e/demo_app/.maestro/all_files_permission.yaml
+++ b/e2e/demo_app/.maestro/all_files_permission.yaml
@@ -1,0 +1,29 @@
+appId: com.example.example
+tags:
+  - passing
+  - android
+---
+- launchApp:
+    clearState: true
+    permissions:
+      allFiles: allow
+
+# Verify the permission is granted via the Settings app
+- launchApp: com.android.settings
+- tapOn: Search settings
+- inputText: "all files access"
+- tapOn: "Apps > Special app access"
+- tapOn: "All files access"
+- assertVisible: "demo_app"
+- assertVisible: "Allowed"
+
+# Clear state should revoke the permission
+- clearState: com.example.example
+
+- launchApp: com.android.settings
+- tapOn: Search settings
+- inputText: "all files access"
+- tapOn: "Apps > Special app access"
+- tapOn: "All files access"
+- assertVisible: "demo_app"
+- assertVisible: "Not allowed"

--- a/e2e/demo_app/.maestro/all_files_permission.yaml
+++ b/e2e/demo_app/.maestro/all_files_permission.yaml
@@ -6,7 +6,7 @@ tags:
 - launchApp:
     clearState: true
     permissions:
-      allFiles: allow
+      externalstorage: allow
 
 # Verify the permission is granted via the Settings app
 - launchApp: com.android.settings

--- a/e2e/demo_app/.maestro/all_files_permission.yaml
+++ b/e2e/demo_app/.maestro/all_files_permission.yaml
@@ -20,10 +20,38 @@ tags:
 # Clear state should revoke the permission
 - clearState: com.example.example
 
-- launchApp: com.android.settings
-- tapOn: Search settings
-- inputText: "all files access"
-- tapOn: "Apps > Special app access"
+- tapOn: "Navigate up"
 - tapOn: "All files access"
 - assertVisible: "demo_app"
 - assertVisible: "Not allowed"
+
+# SetPermissions command should set the permission via 'all'
+- setPermissions:
+    permissions:
+      all: allow
+
+- tapOn: "Navigate up"
+- tapOn: "All files access"
+- assertVisible: "demo_app"
+- assertVisible: "Allowed"
+
+# SetPermissions command should revoke the permission explicitly
+- setPermissions:
+    permissions:
+      externalstorage: deny
+
+- tapOn: "Navigate up"
+- tapOn: "All files access"
+- assertVisible: "demo_app"
+- assertVisible: "Not allowed"
+
+# Launch app should grant all by default
+- launchApp
+
+- launchApp: 
+    appId: com.android.settings
+    stopApp: false
+- tapOn: "Apps > Special app access"
+- tapOn: "All files access"
+- assertVisible: "demo_app"
+- assertVisible: "Allowed"

--- a/e2e/demo_app/.maestro/all_files_permission.yaml
+++ b/e2e/demo_app/.maestro/all_files_permission.yaml
@@ -48,9 +48,9 @@ tags:
 # Launch app should grant all by default
 - launchApp
 
-- launchApp: 
-    appId: com.android.settings
-    stopApp: false
+- launchApp: com.android.settings
+- tapOn: Search settings
+- inputText: "all files access"
 - tapOn: "Apps > Special app access"
 - tapOn: "All files access"
 - assertVisible: "demo_app"

--- a/e2e/demo_app/.maestro/all_files_permission.yaml
+++ b/e2e/demo_app/.maestro/all_files_permission.yaml
@@ -6,7 +6,7 @@ tags:
 - launchApp:
     clearState: true
     permissions:
-      externalstorage: allow
+      android.permission.MANAGE_EXTERNAL_STORAGE: allow
 
 # Verify the permission is granted via the Settings app
 - launchApp: com.android.settings
@@ -38,7 +38,7 @@ tags:
 # SetPermissions command should revoke the permission explicitly
 - setPermissions:
     permissions:
-      externalstorage: deny
+      android.permission.MANAGE_EXTERNAL_STORAGE: deny
 
 - tapOn: "Navigate up"
 - tapOn: "All files access"

--- a/e2e/demo_app/android/app/src/main/AndroidManifest.xml
+++ b/e2e/demo_app/android/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and
          https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -973,8 +973,6 @@ class AndroidDriver(
                 "android.permission.WRITE_CONTACTS"
             )
 
-            "externalstorage" -> listOf("android.permission.MANAGE_EXTERNAL_STORAGE")
-
             "location" -> listOf(
                 "android.permission.ACCESS_FINE_LOCATION",
                 "android.permission.ACCESS_COARSE_LOCATION",

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -954,40 +954,28 @@ class AndroidDriver(
 
     private fun translatePermissionName(name: String): List<String> {
         return when (name) {
-            "location" -> listOf(
-                "android.permission.ACCESS_FINE_LOCATION",
-                "android.permission.ACCESS_COARSE_LOCATION",
-            )
-
-            "camera" -> listOf("android.permission.CAMERA")
-            "contacts" -> listOf(
-                "android.permission.READ_CONTACTS",
-                "android.permission.WRITE_CONTACTS"
-            )
-
-            "phone" -> listOf(
-                "android.permission.CALL_PHONE",
-                "android.permission.ANSWER_PHONE_CALLS",
-            )
-
-            "microphone" -> listOf(
-                "android.permission.RECORD_AUDIO"
-            )
-
             "bluetooth" -> listOf(
                 "android.permission.BLUETOOTH_CONNECT",
                 "android.permission.BLUETOOTH_SCAN",
             )
 
-            "storage" -> listOf(
-                "android.permission.WRITE_EXTERNAL_STORAGE",
-                "android.permission.READ_EXTERNAL_STORAGE"
+            "calendar" -> listOf(
+                "android.permission.WRITE_CALENDAR",
+                "android.permission.READ_CALENDAR"
+            )
+
+            "camera" -> listOf("android.permission.CAMERA")
+
+            "contacts" -> listOf(
+                "android.permission.READ_CONTACTS",
+                "android.permission.WRITE_CONTACTS"
             )
 
             "externalstorage" -> listOf("android.permission.MANAGE_EXTERNAL_STORAGE")
 
-            "notifications" -> listOf(
-                "android.permission.POST_NOTIFICATIONS"
+            "location" -> listOf(
+                "android.permission.ACCESS_FINE_LOCATION",
+                "android.permission.ACCESS_COARSE_LOCATION",
             )
 
             "medialibrary" -> listOf(
@@ -998,15 +986,28 @@ class AndroidDriver(
                 "android.permission.READ_MEDIA_VIDEO"
             )
 
-            "calendar" -> listOf(
-                "android.permission.WRITE_CALENDAR",
-                "android.permission.READ_CALENDAR"
+            "microphone" -> listOf(
+                "android.permission.RECORD_AUDIO"
+            )
+
+            "notifications" -> listOf(
+                "android.permission.POST_NOTIFICATIONS"
+            )
+
+            "phone" -> listOf(
+                "android.permission.CALL_PHONE",
+                "android.permission.ANSWER_PHONE_CALLS",
             )
 
             "sms" -> listOf(
                 "android.permission.READ_SMS",
                 "android.permission.RECEIVE_SMS",
                 "android.permission.SEND_SMS"
+            )
+
+            "storage" -> listOf(
+                "android.permission.WRITE_EXTERNAL_STORAGE",
+                "android.permission.READ_EXTERNAL_STORAGE"
             )
 
             else -> listOf(name.replace("[^A-Za-z0-9._]+".toRegex(), ""))

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -984,7 +984,7 @@ class AndroidDriver(
                 "android.permission.READ_EXTERNAL_STORAGE"
             )
 
-            "allFiles" -> listOf("android.permission.MANAGE_EXTERNAL_STORAGE")
+            "externalstorage" -> listOf("android.permission.MANAGE_EXTERNAL_STORAGE")
 
             "notifications" -> listOf(
                 "android.permission.POST_NOTIFICATIONS"

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -920,9 +920,17 @@ class AndroidDriver(
         }
     }
 
+    private val appOpsPermissions = setOf(
+        "android.permission.MANAGE_EXTERNAL_STORAGE"
+    )
+
     private fun setPermissionInternal(appId: String, permission: String, permissionValue: String) {
         try {
-            shell("pm $permissionValue $appId $permission")
+            if (permission in appOpsPermissions) {
+                setAppOp(appId, permission, permissionValue)
+            } else {
+                shell("pm $permissionValue $appId $permission")
+            }
         } catch (exception: Exception) {
             // Ignore if it's something that the user doesn't have control over (e.g. you can't grant / deny INTERNET)
             if (exception.message?.contains("is not a changeable permission type") == false) {
@@ -932,6 +940,16 @@ class AndroidDriver(
                 logger.debug("Failed to set permission $permission for app $appId: ${exception.message}")
             }
         }
+    }
+
+    private fun setAppOp(appId: String, op: String, permissionValue: String) {
+        // appops uses the bare operation name (e.g. MANAGE_EXTERNAL_STORAGE), not the full permission string
+        val opName = op.removePrefix("android.permission.")
+
+        // appops set expects "allow"/"deny"; permissionValue has already been translated to "grant"/"revoke"
+        val appOpsValue = if (permissionValue == "grant") "allow" else "deny"
+
+        shell("appops set --uid $appId $opName $appOpsValue")
     }
 
     private fun translatePermissionName(name: String): List<String> {
@@ -965,6 +983,8 @@ class AndroidDriver(
                 "android.permission.WRITE_EXTERNAL_STORAGE",
                 "android.permission.READ_EXTERNAL_STORAGE"
             )
+
+            "allFiles" -> listOf("android.permission.MANAGE_EXTERNAL_STORAGE")
 
             "notifications" -> listOf(
                 "android.permission.POST_NOTIFICATIONS"

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -787,9 +787,8 @@ class AndroidDriver(
             }
 
             mutable.forEach { permission ->
-                val permissionValue = translatePermissionValue(permission.value)
                 translatePermissionName(permission.key).forEach { permissionName ->
-                    setPermissionInternal(appId, permissionName, permissionValue)
+                    setPermissionInternal(appId, permissionName, permission.value)
                 }
             }
         }
@@ -914,7 +913,7 @@ class AndroidDriver(
         if (permissionsResult.isSuccess) {
             permissionsResult.getOrNull()?.let {
                 it.forEach { permission ->
-                    setPermissionInternal(appId, permission, translatePermissionValue(permissionValue))
+                    setPermissionInternal(appId, permission, permissionValue)
                 }
             }
         }
@@ -924,12 +923,12 @@ class AndroidDriver(
         "android.permission.MANAGE_EXTERNAL_STORAGE"
     )
 
-    private fun setPermissionInternal(appId: String, permission: String, permissionValue: String) {
+    private fun setPermissionInternal(appId: String, permission: String, rawValue: String) {
         try {
             if (permission in appOpsPermissions) {
-                setAppOp(appId, permission, permissionValue)
+                setAppOp(appId, permission, rawValue)
             } else {
-                shell("pm $permissionValue $appId $permission")
+                shell("pm ${translatePermissionValue(rawValue)} $appId $permission")
             }
         } catch (exception: Exception) {
             // Ignore if it's something that the user doesn't have control over (e.g. you can't grant / deny INTERNET)
@@ -942,12 +941,15 @@ class AndroidDriver(
         }
     }
 
-    private fun setAppOp(appId: String, op: String, permissionValue: String) {
+    private fun setAppOp(appId: String, op: String, rawValue: String) {
         // appops uses the bare operation name (e.g. MANAGE_EXTERNAL_STORAGE), not the full permission string
         val opName = op.removePrefix("android.permission.")
 
-        // appops set expects "allow"/"deny"; permissionValue has already been translated to "grant"/"revoke"
-        val appOpsValue = if (permissionValue == "grant") "allow" else "deny"
+        val appOpsValue = when (rawValue) {
+            "allow" -> "allow"
+            "deny" -> "deny"
+            else -> "default" // "unset" resets to system default
+        }
 
         shell("appops set --uid $appId $opName $appOpsValue")
     }


### PR DESCRIPTION
## Proposed changes

MANAGE_EXTERNAL_STORAGE is a special permission ([docs](https://developer.android.com/training/data-storage/manage-all-files)).

This adds the first permission granted via `appops` rather than via `pm grant`.

## Testing

Added permission declaration to demo_app, and added an e2e test.


## Issues fixed
