### PR TITLE
Don't assume lowercase .yaml extension when parsing flownames

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
@@ -18,6 +18,7 @@ import java.util.zip.ZipError
 import java.util.zip.ZipException
 import kotlin.io.path.exists
 import kotlin.io.path.name
+import kotlin.io.path.nameWithoutExtension
 
 data class ValidatedFlow(
     val filePath: String,
@@ -108,7 +109,7 @@ object WorkspaceValidator {
                     val config = applyConfigurationCommand
                         ?.evaluateScripts(jsEngine)
                         ?.config
-                    val flowName = config?.name ?: path.name.removeSuffix(".yaml")
+                    val flowName = config?.name ?: path.nameWithoutExtension
                     allFlows.add(ValidatedFlow(path.toString(), flowName, commands, config?.appId))
                 }
             }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceValidatorTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceValidatorTest.kt
@@ -47,6 +47,20 @@ class WorkspaceValidatorTest {
     }
 
     @Test
+    fun `validate strips yml extension from flow name`() {
+        val result = WorkspaceValidator.validate(
+            workspace = makeWorkspaceZip("my_flow.yml" to baseFlowContent),
+            appId = "com.example.app",
+            envParameters = mapOf("APP_ID" to "com.example.app"),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+        )
+
+        assertThat(result.isOk).isTrue()
+        assertThat(result.value.flows.first().name).isEqualTo("my_flow")
+    }
+
+    @Test
     fun `validate returns workspaceConfig and matching flows for appId`() {
         val result = WorkspaceValidator.validate(
             workspace = makeWorkspaceZip("flow.yaml" to baseFlowContent),


### PR DESCRIPTION
## Proposed changes

When using `flowsOrder` with flows that have no `name` property, you specify the name of the flow, without the file extension.

When preparing the run order, if your file is `login.yml` instead of `login.yaml`, the flow wouldn't be included in the sequential run, due to a line that expected a case-sensitive and explicit `.yaml` extension.

This change strips the file extension completely - we already know it's a Maestro flow at this point.

## Testing

Added a unit test that failed, which now doesn't.

## Issues fixed
