### PR TITLE
feat: Plugin architecture for extensibility

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -28,10 +28,13 @@ import maestro.cli.command.CheckSyntaxCommand
 import maestro.cli.command.CloudCommand
 import maestro.cli.command.DownloadSamplesCommand
 import maestro.cli.command.DriverCommand
+import maestro.cli.command.AddPluginCommand
 import maestro.cli.command.ListCloudDevicesCommand
 import maestro.cli.command.ListDevicesCommand
+import maestro.cli.command.ListPluginsCommand
 import maestro.cli.command.LoginCommand
 import maestro.cli.command.LogoutCommand
+import maestro.cli.command.RemovePluginCommand
 import maestro.cli.command.McpCommand
 import maestro.cli.command.PrintHierarchyCommand
 import maestro.cli.command.QueryCommand
@@ -69,6 +72,9 @@ import kotlin.system.exitProcess
         StartDeviceCommand::class,
         ListDevicesCommand::class,
         ListCloudDevicesCommand::class,
+        AddPluginCommand::class,
+        ListPluginsCommand::class,
+        RemovePluginCommand::class,
         GenerateCompletion::class,
         ChatCommand::class,
         CheckSyntaxCommand::class,

--- a/maestro-cli/src/main/java/maestro/cli/command/AddPluginCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/AddPluginCommand.kt
@@ -1,0 +1,40 @@
+package maestro.cli.command
+
+import maestro.cli.CliError
+import maestro.cli.util.PrintUtils.message
+import maestro.orchestra.plugin.PluginManager
+import picocli.CommandLine
+import java.io.File
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+    name = "add-plugin",
+    description = ["Add a Maestro plugin from a JAR file"],
+)
+class AddPluginCommand : Callable<Int> {
+
+    @CommandLine.Parameters(
+        description = ["Plugin JAR file to add"],
+        arity = "1"
+    )
+    private lateinit var pluginFile: File
+
+    override fun call(): Int {
+        try {
+            val installedFile = PluginManager.installPlugin(pluginFile)
+            val pluginName = installedFile.nameWithoutExtension
+
+            message("✓ Added plugin: ${installedFile.name}")
+            message("  Location: ${installedFile.absolutePath}")
+            message("")
+            message("To use this plugin:")
+            message("  maestro test flow.yaml --plugin $pluginName")
+
+            return 0
+        } catch (e: IllegalArgumentException) {
+            throw CliError(e.message ?: "Failed to add plugin")
+        } catch (e: Exception) {
+            throw CliError("Failed to add plugin: ${e.message}")
+        }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/command/ListPluginsCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/ListPluginsCommand.kt
@@ -1,0 +1,40 @@
+package maestro.cli.command
+
+import maestro.cli.util.PrintUtils.message
+import maestro.orchestra.plugin.PluginManager
+import picocli.CommandLine
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+    name = "list-plugins",
+    description = ["List installed Maestro plugins"],
+)
+class ListPluginsCommand : Callable<Int> {
+
+    override fun call(): Int {
+        val plugins = PluginManager.listPlugins()
+
+        if (plugins.isEmpty()) {
+            message("No plugins installed.")
+            message("")
+            message("Add a plugin:")
+            message("  maestro add-plugin <plugin.jar>")
+            return 0
+        }
+
+        message("Installed plugins (${plugins.size}):")
+        message("")
+
+        plugins.sortedBy { it.name }.forEach { plugin ->
+            val pluginName = plugin.nameWithoutExtension
+            message("  • $pluginName")
+            message("    ${plugin.absolutePath}")
+        }
+
+        message("")
+        message("Usage:")
+        message("  maestro test flow.yaml --plugin <plugin-name>")
+
+        return 0
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/command/RemovePluginCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RemovePluginCommand.kt
@@ -1,0 +1,31 @@
+package maestro.cli.command
+
+import maestro.cli.CliError
+import maestro.cli.util.PrintUtils.message
+import maestro.orchestra.plugin.PluginManager
+import picocli.CommandLine
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+    name = "remove-plugin",
+    description = ["Remove a Maestro plugin"],
+)
+class RemovePluginCommand : Callable<Int> {
+
+    @CommandLine.Parameters(
+        description = ["Plugin name to remove (without .jar extension)"],
+        arity = "1"
+    )
+    private lateinit var pluginName: String
+
+    override fun call(): Int {
+        val removed = PluginManager.uninstallPlugin(pluginName)
+
+        if (removed) {
+            message("✓ Removed plugin: $pluginName")
+            return 0
+        } else {
+            throw CliError("Plugin not found: $pluginName\nUse 'maestro list-plugins' to see installed plugins.")
+        }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -308,7 +308,7 @@ class TestCommand : Callable<Int> {
         val deviceCount = getDeviceCount(executionPlan)
 
         val result = try {
-            handleSessions(debugOutputPath, executionPlan, resolvedTestOutputDir)
+            handleSessions(debugOutputPath, executionPlan, resolvedTestOutputDir, pluginRegistry)
         } catch (e: Exception) {
             // Track workspace failure for runtime errors
             if (flowCount > 1) {
@@ -369,7 +369,7 @@ class TestCommand : Callable<Int> {
         return null
     }
 
-    private fun handleSessions(debugOutputPath: Path, plan: ExecutionPlan, testOutputDir: Path?): Int = runBlocking(Dispatchers.IO) {
+    private fun handleSessions(debugOutputPath: Path, plan: ExecutionPlan, testOutputDir: Path?, pluginRegistry: PluginRegistry?): Int = runBlocking(Dispatchers.IO) {
         val requestedShards = shardSplit ?: shardAll ?: 1
         if (requestedShards > 1 && plan.sequence.flows.isNotEmpty()) {
             error("Cannot run sharded tests with sequential execution")
@@ -456,6 +456,7 @@ class TestCommand : Callable<Int> {
                     chunkPlans = chunkPlans,
                     debugOutputPath = debugOutputPath,
                     testOutputDir = testOutputDir,
+                    pluginRegistry = pluginRegistry,
                 )
             }
         }.awaitAll()
@@ -483,6 +484,7 @@ class TestCommand : Callable<Int> {
         chunkPlans: List<ExecutionPlan>,
         debugOutputPath: Path,
         testOutputDir: Path?,
+        pluginRegistry: PluginRegistry?,
     ): Triple<Int?, Int?, TestExecutionSummary?> {
         val driverHostPort = selectPort(effectiveShards)
         val deviceId = deviceIds[shardIndex]

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -61,6 +61,8 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.view.cyan
 import maestro.cli.promotion.PromotionStateManager
 import maestro.orchestra.error.ValidationError
+import maestro.orchestra.plugin.PluginLoader
+import maestro.orchestra.plugin.PluginRegistry
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner.ExecutionPlan
 import maestro.utils.isSingleFile
@@ -141,6 +143,12 @@ class TestCommand : Callable<Int> {
 
     @Option(names = ["--output"])
     private var output: File? = null
+
+    @Option(
+        names = ["--plugin"],
+        description = ["Plugin(s) to load (name or path). Can be specified multiple times."],
+    )
+    private var plugins: List<String> = emptyList()
 
     @Option(
         names = ["--debug-output"],
@@ -249,6 +257,15 @@ class TestCommand : Callable<Int> {
             flattenDebugOutput = flattenDebugOutput,
             printToConsole = parent?.verbose == true,
         )
+
+        val pluginRegistry = if (plugins.isNotEmpty()) {
+            val loadedPlugins = PluginLoader.loadPlugins(plugins)
+            PluginRegistry().apply {
+                loadedPlugins.forEach { register(it) }
+            }
+        } else {
+            null
+        }
 
         if (shardSplit != null && shardAll != null) {
             throw CliError("Options --shard-split and --shard-all are mutually exclusive.")
@@ -507,6 +524,7 @@ class TestCommand : Callable<Int> {
                         debugOutputPath,
                         testOutputDir,
                         deviceId,
+                        pluginRegistry,
                     )
                 }
             } else {
@@ -524,9 +542,10 @@ class TestCommand : Callable<Int> {
                         authToken,
                         testOutputDir,
                         deviceId,
+                        pluginRegistry,
                     )
                 } else {
-                    runSingleFlow(maestro, device, flowFile, debugOutputPath, testOutputDir, deviceId)
+                    runSingleFlow(maestro, device, flowFile, debugOutputPath, testOutputDir, deviceId, pluginRegistry)
                 }
             }
         }
@@ -545,6 +564,7 @@ class TestCommand : Callable<Int> {
         debugOutputPath: Path,
         testOutputDir: Path?,
         deviceId: String?,
+        pluginRegistry: PluginRegistry?,
     ): Triple<Int, Int, Nothing?> {
         val resultView =
             if (DisableAnsiMixin.ansiEnabled) {
@@ -569,6 +589,7 @@ class TestCommand : Callable<Int> {
             apiKey = authToken,
             testOutputDir = testOutputDir,
             deviceId = deviceId,
+            pluginRegistry = pluginRegistry,
         )
         val duration = System.currentTimeMillis() - startTime
 
@@ -601,6 +622,7 @@ class TestCommand : Callable<Int> {
         debugOutputPath: Path,
         testOutputDir: Path?,
         deviceId: String?,
+        pluginRegistry: PluginRegistry?,
     ): Triple<Int?, Int?, TestExecutionSummary> {
         val startTime = System.currentTimeMillis()
         val totalFlowCount = chunkPlans.sumOf { it.flowsToRun.size }
@@ -623,6 +645,7 @@ class TestCommand : Callable<Int> {
             debugOutputPath = debugOutputPath,
             testOutputDir = testOutputDir,
             deviceId = deviceId,
+            pluginRegistry = pluginRegistry,
         )
 
         val duration = System.currentTimeMillis() - startTime

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -34,6 +34,7 @@ import maestro.orchestra.Orchestra
 import maestro.orchestra.debug.CommandDebugMetadata
 import maestro.orchestra.debug.CommandStatus
 import maestro.orchestra.debug.FlowDebugOutput
+import maestro.orchestra.plugin.PluginRegistry
 
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.utils.CliInsights
@@ -63,7 +64,8 @@ object MaestroCommandRunner {
         aiOutput: FlowAIOutput,
         apiKey: String? = null,
         analyze: Boolean = false,
-        testOutputDir: Path?
+        testOutputDir: Path?,
+        pluginRegistry: PluginRegistry? = null,
     ): Boolean {
         val config = YamlCommandReader.getConfig(commands)
         val onFlowComplete = config?.onFlowComplete
@@ -108,6 +110,7 @@ object MaestroCommandRunner {
             maestro = maestro,
             screenshotsDir = testOutputDir?.resolve("screenshots"),
             insights = CliInsights,
+            pluginRegistry = pluginRegistry,
             onCommandStart = { _, command ->
                 logger.info("${command.description()} RUNNING")
                 commandStatuses[command] = CommandStatus.RUNNING

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -20,6 +20,7 @@ import maestro.cli.util.PrintUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.debug.FlowDebugOutput
+import maestro.orchestra.plugin.PluginRegistry
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
@@ -52,6 +53,7 @@ object TestRunner {
         apiKey: String? = null,
         testOutputDir: Path?,
         deviceId: String?,
+        pluginRegistry: PluginRegistry? = null,
     ): Int {
         val debugOutput = FlowDebugOutput()
         var aiOutput = FlowAIOutput(
@@ -84,6 +86,7 @@ object TestRunner {
                     analyze = analyze,
                     apiKey = apiKey,
                     testOutputDir = testOutputDir,
+                    pluginRegistry = pluginRegistry,
                 )
             }
         }
@@ -128,6 +131,7 @@ object TestRunner {
         apiKey: String? = null,
         testOutputDir: Path?,
         deviceId: String?,
+        pluginRegistry: PluginRegistry? = null,
     ): Nothing {
         val resultView = AnsiResultView("> Press [ENTER] to restart the Flow\n\n", useEmojis = !EnvUtils.isWindows())
 
@@ -174,7 +178,8 @@ object TestRunner {
                                     ),
                                     analyze = analyze,
                                     apiKey = apiKey,
-                                    testOutputDir = testOutputDir
+                                    testOutputDir = testOutputDir,
+                                    pluginRegistry = pluginRegistry,
                                 )
                             }
                         }.get()

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -19,6 +19,7 @@ import maestro.orchestra.Orchestra
 import maestro.orchestra.debug.CommandDebugMetadata
 import maestro.orchestra.debug.CommandStatus
 import maestro.orchestra.debug.FlowDebugOutput
+import maestro.orchestra.plugin.PluginRegistry
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.yaml.YamlCommandReader
@@ -57,6 +58,7 @@ class TestSuiteInteractor(
         debugOutputPath: Path,
         testOutputDir: Path? = null,
         deviceId: String? = null,
+        pluginRegistry: PluginRegistry? = null,
     ): TestExecutionSummary {
         if (executionPlan.flowsToRun.isEmpty() && executionPlan.sequence.flows.isEmpty()) {
             throw CliError("${shardPrefix}No flows returned from the tag filter used")
@@ -76,7 +78,7 @@ class TestSuiteInteractor(
             val updatedEnv = env
                 .withInjectedShellEnvVars()
                 .withDefaultEnvVars(flowFile, deviceId, shardIndex)
-            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir)
+            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir, pluginRegistry)
             flowResults.add(result)
             aiOutputs.add(aiOutput)
 
@@ -96,7 +98,7 @@ class TestSuiteInteractor(
             val updatedEnv = env
                 .withInjectedShellEnvVars()
                 .withDefaultEnvVars(flowFile, deviceId, shardIndex)
-            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir)
+            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir, pluginRegistry)
             aiOutputs.add(aiOutput)
 
             if (result.status == FlowStatus.ERROR) {
@@ -157,7 +159,8 @@ class TestSuiteInteractor(
         env: Map<String, String>,
         maestro: Maestro,
         debugOutputPath: Path,
-        testOutputDir: Path? = null
+        testOutputDir: Path? = null,
+        pluginRegistry: PluginRegistry? = null,
     ): Pair<TestExecutionSummary.FlowResult, FlowAIOutput> {
         // TODO(bartekpacia): merge TestExecutionSummary with AI suggestions
         //  (i.e. consider them also part of the test output)
@@ -186,6 +189,7 @@ class TestSuiteInteractor(
                 val orchestra = Orchestra(
                     maestro = maestro,
                     screenshotsDir = testOutputDir?.resolve("screenshots"),
+                    pluginRegistry = pluginRegistry,
                     onCommandStart = { _, command ->
                         logger.info("${shardPrefix}${command.description()} RUNNING")
                         debugOutput.commands[command] = CommandDebugMetadata(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -48,6 +48,8 @@ import maestro.orchestra.error.UnicodeNotSupportedError
 import maestro.orchestra.filter.FilterWithDescription
 import maestro.orchestra.filter.TraitFilters
 import maestro.orchestra.geo.Traveller
+import maestro.orchestra.plugin.MaestroContext
+import maestro.orchestra.plugin.PluginRegistry
 import maestro.orchestra.util.calculateElementRelativePoint
 import maestro.orchestra.util.Env.evaluateScripts
 import maestro.orchestra.yaml.YamlCommandReader
@@ -125,11 +127,13 @@ class DefaultFlowController : FlowController {
  */
 class Orchestra(
     private val maestro: Maestro,
+    private val outputDirectory: Path? = null,
     private val screenshotsDir: Path? = null, // TODO(bartekpacia): Orchestra shouldn't interact with files directly.
     private val lookupTimeoutMs: Long = 17000L,
     private val optionalLookupTimeoutMs: Long = 7000L,
     private val httpClient: OkHttpClient? = null,
     private val insights: Insights = NoopInsights,
+    private val pluginRegistry: PluginRegistry? = null,
     private val onFlowStart: (List<MaestroCommand>) -> Unit = {},
     private val onCommandStart: (Int, MaestroCommand) -> Unit = { _, _ -> },
     private val onCommandComplete: (Int, MaestroCommand) -> Unit = { _, _ -> },
@@ -170,8 +174,10 @@ class Orchestra(
 
         initJsEngine(config)
         initAndroidChromeDevTools(config)
+        initPlugins(config)
 
         onFlowStart(commands)
+        pluginRegistry?.notifyFlowStart(commands)
 
         executeDefineVariablesCommands(commands, config)
         // filter out DefineVariablesCommand to not execute it twice
@@ -217,6 +223,10 @@ class Orchestra(
 
             jsEngine.close()
 
+            // Notify plugins of flow completion and shutdown
+            pluginRegistry?.notifyFlowComplete(config, flowSuccess && onCompleteSuccess)
+            pluginRegistry?.shutdownAll()
+
             exception?.let { throw it }
 
             return onCompleteSuccess && flowSuccess
@@ -243,6 +253,7 @@ class Orchestra(
                 flowController.waitIfPaused()
 
                 onCommandStart(index, command)
+                pluginRegistry?.notifyCommandStart(index, command)
 
                 jsEngine.onLogMessage { msg ->
                     val metadata = getMetadata(command)
@@ -274,6 +285,7 @@ class Orchestra(
                     try {
                         executeCommand(evaluatedCommand, config)
                         onCommandComplete(index, command)
+                        pluginRegistry?.notifyCommandComplete(index, command)
                     } catch (e: MaestroException) {
                         val isOptional =
                             command.asCommand()?.optional == true || command.elementSelector()?.optional == true
@@ -289,10 +301,12 @@ class Orchestra(
                     logger.info("[Command execution] CommandSkipped: ${ignored.message}")
                     // Swallow exception
                     onCommandSkipped(index, command)
+                    pluginRegistry?.notifyCommandSkipped(index, command)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Throwable) {
                     logger.error("[Command execution] CommandFailed: ${e.message}")
+                    pluginRegistry?.notifyCommandFailed(index, command, e)
                     val errorResolution = onCommandFailed(index, command, e)
                     when (errorResolution) {
                         ErrorResolution.FAIL -> return false
@@ -317,6 +331,24 @@ class Orchestra(
         if (config == null) return
         val shouldEnableAndroidChromeDevTools = config.ext["androidWebViewHierarchy"] == "devtools"
         maestro.setAndroidChromeDevToolsEnabled(shouldEnableAndroidChromeDevTools)
+    }
+
+    private fun initPlugins(config: MaestroConfig?) {
+        pluginRegistry?.let {
+            // Derive output directory: use explicit outputDirectory if provided,
+            // otherwise use parent of screenshotsDir, fallback to temp directory
+            val resolvedOutputDirectory = outputDirectory
+                ?: screenshotsDir?.parent
+                ?: Files.createTempDirectory("maestro-output")
+
+            val context = MaestroContext(
+                maestro = maestro,
+                outputDirectory = resolvedOutputDirectory,
+                config = config,
+                screenshotsDir = screenshotsDir
+            )
+            it.initializeAll(context)
+        }
     }
 
     /**

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroContext.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroContext.kt
@@ -1,0 +1,47 @@
+package maestro.orchestra.plugin
+
+import maestro.Maestro
+import java.nio.file.Path
+
+/**
+ * Context provided to plugins during initialization.
+ *
+ * Contains access to Maestro's device driver, output directories,
+ * and plugin-specific configuration.
+ */
+data class MaestroContext(
+    /**
+     * The Maestro driver instance for interacting with the device.
+     *
+     * Plugins can use this to:
+     * - Query view hierarchy: maestro.viewHierarchy()
+     * - Take screenshots: maestro.takeScreenshot()
+     * - Get device info: maestro.deviceInfo
+     */
+    val maestro: Maestro,
+
+    /**
+     * Directory where the plugin can write output files (reports, screenshots, etc.)
+     *
+     * This directory is created by Maestro and is typically under the test output directory.
+     */
+    val outputDirectory: Path,
+
+    /**
+     * Plugin-specific configuration provided by the user.
+     *
+     * Configuration can come from:
+     * - Environment variables
+     * - Config files (.maestro/config.yaml)
+     * - CLI flags
+     *
+     * Example: For ARIA plugin, might contain {"severity": "error", "outputFormat": "html"}
+     */
+    val config: Map<String, Any>,
+
+    /**
+     * Optional directory where Maestro saves screenshots.
+     * May be null if screenshot saving is disabled.
+     */
+    val screenshotsDir: Path?
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroContext.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroContext.kt
@@ -1,6 +1,7 @@
 package maestro.orchestra.plugin
 
 import maestro.Maestro
+import maestro.orchestra.MaestroConfig
 import java.nio.file.Path
 
 /**
@@ -28,16 +29,18 @@ data class MaestroContext(
     val outputDirectory: Path,
 
     /**
-     * Plugin-specific configuration provided by the user.
+     * The flow configuration from the YAML file.
      *
-     * Configuration can come from:
-     * - Environment variables
-     * - Config files (.maestro/config.yaml)
-     * - CLI flags
+     * Contains:
+     * - appId: The application ID being tested
+     * - name: The flow name
+     * - tags: Tags for categorizing flows (e.g., ["smoke", "production"])
+     * - ext: Custom plugin-specific configuration
+     * - properties: Flow properties
      *
-     * Example: For ARIA plugin, might contain {"severity": "error", "outputFormat": "html"}
+     * May be null if no config was provided.
      */
-    val config: Map<String, Any>,
+    val config: MaestroConfig?,
 
     /**
      * Optional directory where Maestro saves screenshots.

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroPlugin.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroPlugin.kt
@@ -2,6 +2,7 @@ package maestro.orchestra.plugin
 
 import maestro.Maestro
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
 import java.nio.file.Path
 
 /**
@@ -76,10 +77,10 @@ interface MaestroPlugin {
     /**
      * Called when a flow completes (success or failure).
      *
-     * @param flowName The name of the flow that completed
+     * @param config The flow configuration (contains name, tags, appId, ext, etc.). May be null if no config was provided.
      * @param success True if the flow completed successfully, false if it failed
      */
-    fun onFlowComplete(flowName: String, success: Boolean) {}
+    fun onFlowComplete(config: MaestroConfig?, success: Boolean) {}
 
     /**
      * Called when the plugin is being unloaded (e.g., CLI shutdown).

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroPlugin.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/MaestroPlugin.kt
@@ -1,0 +1,89 @@
+package maestro.orchestra.plugin
+
+import maestro.Maestro
+import maestro.orchestra.MaestroCommand
+import java.nio.file.Path
+
+/**
+ * Base interface for Maestro plugins.
+ *
+ * Plugins can hook into Maestro's execution lifecycle to add custom functionality
+ * like accessibility scanning, performance monitoring, or custom reporting.
+ *
+ * All lifecycle hook methods have default empty implementations - plugins only need
+ * to override the hooks they care about.
+ */
+interface MaestroPlugin {
+
+    /**
+     * Unique identifier for this plugin (e.g., "aria-accessibility", "perf-monitor")
+     */
+    val id: String
+
+    /**
+     * Human-readable name for this plugin (e.g., "ARIA Accessibility Scanner")
+     */
+    val name: String
+
+    /**
+     * Called once when the plugin is loaded, before any flows execute.
+     * Use this to initialize resources, validate configuration, etc.
+     *
+     * @param context Plugin initialization context with access to Maestro and configuration
+     */
+    fun onInit(context: MaestroContext) {}
+
+    /**
+     * Called when a flow starts, before any commands execute.
+     *
+     * @param commands The list of commands that will be executed in this flow
+     */
+    fun onFlowStart(commands: List<MaestroCommand>) {}
+
+    /**
+     * Called before each command executes.
+     *
+     * @param index The zero-based index of the command in the flow
+     * @param command The command that is about to execute
+     */
+    fun onCommandStart(index: Int, command: MaestroCommand) {}
+
+    /**
+     * Called after each command completes successfully.
+     *
+     * @param index The zero-based index of the command in the flow
+     * @param command The command that just executed
+     */
+    fun onCommandComplete(index: Int, command: MaestroCommand) {}
+
+    /**
+     * Called when a command fails with an exception.
+     *
+     * @param index The zero-based index of the command in the flow
+     * @param command The command that failed
+     * @param error The exception that was thrown
+     */
+    fun onCommandFailed(index: Int, command: MaestroCommand, error: Throwable) {}
+
+    /**
+     * Called when a command is skipped (e.g., due to conditional logic).
+     *
+     * @param index The zero-based index of the command in the flow
+     * @param command The command that was skipped
+     */
+    fun onCommandSkipped(index: Int, command: MaestroCommand) {}
+
+    /**
+     * Called when a flow completes (success or failure).
+     *
+     * @param flowName The name of the flow that completed
+     * @param success True if the flow completed successfully, false if it failed
+     */
+    fun onFlowComplete(flowName: String, success: Boolean) {}
+
+    /**
+     * Called when the plugin is being unloaded (e.g., CLI shutdown).
+     * Use this to clean up resources, close connections, etc.
+     */
+    fun onShutdown() {}
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginLoader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginLoader.kt
@@ -1,0 +1,90 @@
+package maestro.orchestra.plugin
+
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.net.URLClassLoader
+import java.util.ServiceLoader
+
+/**
+ * Loads plugins from specific JAR files using Java's ServiceLoader mechanism.
+ *
+ * Each plugin JAR must contain a META-INF/services/maestro.orchestra.plugin.MaestroPlugin
+ * file listing the fully-qualified class names of plugin implementations.
+ */
+object PluginLoader {
+
+    private val logger = LoggerFactory.getLogger(PluginLoader::class.java)
+
+    /**
+     * Loads plugins from specified references (file paths or installed plugin names).
+     *
+     * @param pluginRefs List of plugin references (paths or names)
+     * @return List of loaded plugin instances
+     */
+    fun loadPlugins(pluginRefs: List<String>): List<MaestroPlugin> {
+        if (pluginRefs.isEmpty()) {
+            logger.info("No plugins specified")
+            return emptyList()
+        }
+
+        // Resolve all plugin references to actual JAR files
+        val jarFiles = pluginRefs.map { ref ->
+            try {
+                PluginManager.resolvePlugin(ref)
+            } catch (e: IllegalArgumentException) {
+                logger.error("Failed to resolve plugin: $ref - ${e.message}")
+                throw e
+            }
+        }
+
+        return loadPluginJars(jarFiles)
+    }
+
+    /**
+     * Loads plugins from specified JAR files.
+     *
+     * @param jarFiles List of plugin JAR files to load
+     * @return List of loaded plugin instances
+     */
+    fun loadPluginJars(jarFiles: List<File>): List<MaestroPlugin> {
+        if (jarFiles.isEmpty()) {
+            logger.info("No plugin JARs specified")
+            return emptyList()
+        }
+
+        val plugins = mutableListOf<MaestroPlugin>()
+
+        // Validate all files exist and are JARs
+        jarFiles.forEach { jarFile ->
+            if (!jarFile.exists()) {
+                logger.error("Plugin JAR not found: ${jarFile.absolutePath}")
+                throw IllegalArgumentException("Plugin JAR not found: ${jarFile.absolutePath}")
+            }
+            if (jarFile.extension != "jar") {
+                logger.error("Not a JAR file: ${jarFile.absolutePath}")
+                throw IllegalArgumentException("Plugin file must be a JAR: ${jarFile.absolutePath}")
+            }
+            logger.info("Loading plugin from: ${jarFile.absolutePath}")
+        }
+
+        // Create a class loader with all plugin JARs
+        val urls = jarFiles.map { it.toURI().toURL() }.toTypedArray()
+        val classLoader = URLClassLoader(urls, this.javaClass.classLoader)
+
+        // Use ServiceLoader to discover plugin implementations
+        val serviceLoader = ServiceLoader.load(MaestroPlugin::class.java, classLoader)
+
+        serviceLoader.forEach { plugin ->
+            try {
+                logger.info("Loaded plugin: ${plugin.name} (id: ${plugin.id})")
+                plugins.add(plugin)
+            } catch (e: Exception) {
+                logger.error("Failed to load plugin: ${e.message}", e)
+                throw RuntimeException("Failed to load plugin: ${e.message}", e)
+            }
+        }
+
+        logger.info("Successfully loaded ${plugins.size} plugin(s)")
+        return plugins
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginManager.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginManager.kt
@@ -1,0 +1,159 @@
+package maestro.orchestra.plugin
+
+import org.slf4j.LoggerFactory
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+
+/**
+ * Manages plugin installation, listing, and removal.
+ *
+ * Plugins are stored in ~/.maestro/plugins/ directory.
+ */
+object PluginManager {
+
+    private val logger = LoggerFactory.getLogger(PluginManager::class.java)
+
+    /**
+     * Get the plugins directory (~/.maestro/plugins/)
+     */
+    fun getPluginsDirectory(): Path {
+        val homeDir = System.getProperty("user.home")
+        return Paths.get(homeDir, ".maestro", "plugins")
+    }
+
+    /**
+     * Ensure the plugins directory exists
+     */
+    fun ensurePluginsDirectory(): Path {
+        val pluginsDir = getPluginsDirectory()
+        if (!Files.exists(pluginsDir)) {
+            Files.createDirectories(pluginsDir)
+            logger.info("Created plugins directory: ${pluginsDir.toAbsolutePath()}")
+        }
+        return pluginsDir
+    }
+
+    /**
+     * Install a plugin from a JAR file.
+     *
+     * @param sourceFile The plugin JAR file to install
+     * @return The installed plugin file
+     * @throws IllegalArgumentException if source file doesn't exist or isn't a JAR
+     */
+    fun installPlugin(sourceFile: File): File {
+        if (!sourceFile.exists()) {
+            throw IllegalArgumentException("Plugin file not found: ${sourceFile.absolutePath}")
+        }
+
+        if (sourceFile.extension != "jar") {
+            throw IllegalArgumentException("Plugin file must be a JAR: ${sourceFile.absolutePath}")
+        }
+
+        val pluginsDir = ensurePluginsDirectory()
+        val targetFile = pluginsDir.resolve(sourceFile.name).toFile()
+
+        if (targetFile.exists()) {
+            logger.warn("Plugin ${sourceFile.name} already exists, overwriting")
+        }
+
+        Files.copy(
+            sourceFile.toPath(),
+            targetFile.toPath(),
+            StandardCopyOption.REPLACE_EXISTING
+        )
+
+        logger.info("Installed plugin: ${sourceFile.name}")
+        return targetFile
+    }
+
+    /**
+     * List all installed plugins.
+     *
+     * @return List of installed plugin files
+     */
+    fun listPlugins(): List<File> {
+        val pluginsDir = getPluginsDirectory()
+
+        if (!Files.exists(pluginsDir)) {
+            return emptyList()
+        }
+
+        return pluginsDir.toFile()
+            .listFiles { file -> file.extension == "jar" }
+            ?.toList()
+            ?: emptyList()
+    }
+
+    /**
+     * Uninstall a plugin by name.
+     *
+     * @param pluginName The plugin name (without .jar extension) or filename
+     * @return true if plugin was removed, false if not found
+     */
+    fun uninstallPlugin(pluginName: String): Boolean {
+        val pluginsDir = getPluginsDirectory()
+
+        if (!Files.exists(pluginsDir)) {
+            return false
+        }
+
+        // Support both "aria-plugin" and "aria-plugin.jar"
+        val fileName = if (pluginName.endsWith(".jar")) pluginName else "$pluginName.jar"
+        val pluginFile = pluginsDir.resolve(fileName).toFile()
+
+        if (!pluginFile.exists()) {
+            logger.warn("Plugin not found: $fileName")
+            return false
+        }
+
+        val deleted = pluginFile.delete()
+        if (deleted) {
+            logger.info("Uninstalled plugin: $fileName")
+        } else {
+            logger.error("Failed to delete plugin: $fileName")
+        }
+
+        return deleted
+    }
+
+    /**
+     * Resolve a plugin reference to a file.
+     *
+     * Can resolve:
+     * - Direct file paths: /path/to/plugin.jar
+     * - Installed plugin names: aria-plugin
+     *
+     * @param pluginRef Plugin reference (path or name)
+     * @return Resolved plugin file
+     * @throws IllegalArgumentException if plugin cannot be resolved
+     */
+    fun resolvePlugin(pluginRef: String): File {
+        // First try as direct file path
+        val directFile = File(pluginRef)
+        if (directFile.exists() && directFile.extension == "jar") {
+            return directFile
+        }
+
+        // Try as installed plugin name
+        val pluginsDir = getPluginsDirectory()
+
+        // Support both "aria-plugin" and "aria-plugin.jar"
+        val fileName = if (pluginRef.endsWith(".jar")) pluginRef else "$pluginRef.jar"
+        val installedFile = pluginsDir.resolve(fileName).toFile()
+
+        if (installedFile.exists()) {
+            return installedFile
+        }
+
+        throw IllegalArgumentException(
+            "Plugin not found: $pluginRef\n" +
+            "Searched:\n" +
+            "  - Direct path: ${directFile.absolutePath}\n" +
+            "  - Installed plugins: ${installedFile.absolutePath}\n" +
+            "Use 'maestro list-plugins' to see installed plugins."
+        )
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginRegistry.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginRegistry.kt
@@ -1,6 +1,7 @@
 package maestro.orchestra.plugin
 
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
 import org.slf4j.LoggerFactory
 
 /**
@@ -119,13 +120,13 @@ class PluginRegistry {
     /**
      * Notify all plugins that a flow has completed.
      *
-     * @param flowName The name of the flow
+     * @param config The flow configuration
      * @param success Whether the flow completed successfully
      */
-    fun notifyFlowComplete(flowName: String, success: Boolean) {
+    fun notifyFlowComplete(config: MaestroConfig?, success: Boolean) {
         plugins.forEach { plugin ->
             safeExecute(plugin, "onFlowComplete") {
-                plugin.onFlowComplete(flowName, success)
+                plugin.onFlowComplete(config, success)
             }
         }
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginRegistry.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/plugin/PluginRegistry.kt
@@ -1,0 +1,158 @@
+package maestro.orchestra.plugin
+
+import maestro.orchestra.MaestroCommand
+import org.slf4j.LoggerFactory
+
+/**
+ * Registry that manages all loaded plugins and broadcasts lifecycle events to them.
+ *
+ * This class acts as a hub between Orchestra and individual plugins. When Orchestra
+ * executes commands, it calls methods on this registry, which then broadcasts
+ * those events to all registered plugins.
+ *
+ * Plugin errors are isolated - if one plugin throws an exception, it won't crash
+ * the test or affect other plugins.
+ */
+class PluginRegistry {
+
+    private val plugins = mutableListOf<MaestroPlugin>()
+    private val logger = LoggerFactory.getLogger(PluginRegistry::class.java)
+
+    /**
+     * Register a plugin to receive lifecycle hooks.
+     *
+     * @param plugin The plugin to register
+     */
+    fun register(plugin: MaestroPlugin) {
+        plugins.add(plugin)
+        logger.info("Registered plugin: ${plugin.name} (${plugin.id})")
+    }
+
+    /**
+     * Get all registered plugins.
+     */
+    fun getPlugins(): List<MaestroPlugin> = plugins.toList()
+
+    /**
+     * Initialize all registered plugins.
+     *
+     * @param context The context to pass to each plugin's onInit method
+     */
+    fun initializeAll(context: MaestroContext) {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onInit") {
+                plugin.onInit(context)
+            }
+        }
+    }
+
+    /**
+     * Notify all plugins that a flow is starting.
+     *
+     * @param commands The list of commands in this flow
+     */
+    fun notifyFlowStart(commands: List<MaestroCommand>) {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onFlowStart") {
+                plugin.onFlowStart(commands)
+            }
+        }
+    }
+
+    /**
+     * Notify all plugins that a command is starting.
+     *
+     * @param index The index of the command
+     * @param command The command that is starting
+     */
+    fun notifyCommandStart(index: Int, command: MaestroCommand) {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onCommandStart") {
+                plugin.onCommandStart(index, command)
+            }
+        }
+    }
+
+    /**
+     * Notify all plugins that a command has completed successfully.
+     *
+     * @param index The index of the command
+     * @param command The command that completed
+     */
+    fun notifyCommandComplete(index: Int, command: MaestroCommand) {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onCommandComplete") {
+                plugin.onCommandComplete(index, command)
+            }
+        }
+    }
+
+    /**
+     * Notify all plugins that a command has failed.
+     *
+     * @param index The index of the command
+     * @param command The command that failed
+     * @param error The exception that was thrown
+     */
+    fun notifyCommandFailed(index: Int, command: MaestroCommand, error: Throwable) {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onCommandFailed") {
+                plugin.onCommandFailed(index, command, error)
+            }
+        }
+    }
+
+    /**
+     * Notify all plugins that a command was skipped.
+     *
+     * @param index The index of the command
+     * @param command The command that was skipped
+     */
+    fun notifyCommandSkipped(index: Int, command: MaestroCommand) {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onCommandSkipped") {
+                plugin.onCommandSkipped(index, command)
+            }
+        }
+    }
+
+    /**
+     * Notify all plugins that a flow has completed.
+     *
+     * @param flowName The name of the flow
+     * @param success Whether the flow completed successfully
+     */
+    fun notifyFlowComplete(flowName: String, success: Boolean) {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onFlowComplete") {
+                plugin.onFlowComplete(flowName, success)
+            }
+        }
+    }
+
+    /**
+     * Shutdown all plugins (cleanup resources).
+     */
+    fun shutdownAll() {
+        plugins.forEach { plugin ->
+            safeExecute(plugin, "onShutdown") {
+                plugin.onShutdown()
+            }
+        }
+    }
+
+    /**
+     * Execute a plugin hook safely, catching and logging any exceptions.
+     * This ensures one plugin's errors don't crash the test or affect other plugins.
+     */
+    private fun safeExecute(plugin: MaestroPlugin, hookName: String, block: () -> Unit) {
+        try {
+            block()
+        } catch (e: Exception) {
+            logger.error(
+                "Plugin '${plugin.name}' (${plugin.id}) failed in $hookName: ${e.message}",
+                e
+            )
+        }
+    }
+}

--- a/maestro-orchestra/src/test/java/maestro/orchestra/plugin/PluginSystemTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/plugin/PluginSystemTest.kt
@@ -1,0 +1,143 @@
+package maestro.orchestra.plugin
+
+import io.mockk.mockk
+import maestro.Maestro
+import maestro.orchestra.ElementSelector
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.TapOnElementCommand
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class PluginSystemTest {
+
+    @Test
+    fun `PluginRegistry should register and notify plugins`(@TempDir tempDir: Path) {
+        // Create a mock plugin
+        var initCalled = false
+        var flowStartCalled = false
+        var commandStartCount = 0
+        var commandCompleteCount = 0
+        var flowCompleteCalled = false
+        var shutdownCalled = false
+
+        val plugin = object : MaestroPlugin {
+            override val id = "test-plugin"
+            override val name = "Test Plugin"
+
+            override fun onInit(context: MaestroContext) {
+                initCalled = true
+            }
+
+            override fun onFlowStart(commands: List<MaestroCommand>) {
+                flowStartCalled = true
+            }
+
+            override fun onCommandStart(index: Int, command: MaestroCommand) {
+                commandStartCount++
+            }
+
+            override fun onCommandComplete(index: Int, command: MaestroCommand) {
+                commandCompleteCount++
+            }
+
+            override fun onFlowComplete(config: maestro.orchestra.MaestroConfig?, success: Boolean) {
+                flowCompleteCalled = true
+            }
+
+            override fun onShutdown() {
+                shutdownCalled = true
+            }
+        }
+
+        // Create registry and register plugin
+        val registry = PluginRegistry()
+        registry.register(plugin)
+
+        // Verify plugin is registered
+        assertEquals(1, registry.getPlugins().size)
+        assertEquals("test-plugin", registry.getPlugins()[0].id)
+
+        // Initialize plugins
+        val maestro = mockk<Maestro>(relaxed = true)
+        val context = MaestroContext(
+            maestro = maestro,
+            outputDirectory = tempDir,
+            config = null,
+            screenshotsDir = null
+        )
+        registry.initializeAll(context)
+        assertTrue(initCalled, "onInit should be called")
+
+        // Notify flow start
+        val selector = ElementSelector(textRegex = "test")
+        val commands = listOf(MaestroCommand(tapOnElement = TapOnElementCommand(selector = selector)))
+        registry.notifyFlowStart(commands)
+        assertTrue(flowStartCalled, "onFlowStart should be called")
+
+        // Notify command lifecycle
+        registry.notifyCommandStart(0, commands[0])
+        assertEquals(1, commandStartCount)
+
+        registry.notifyCommandComplete(0, commands[0])
+        assertEquals(1, commandCompleteCount)
+
+        // Notify flow complete
+        registry.notifyFlowComplete(null, true)
+        assertTrue(flowCompleteCalled, "onFlowComplete should be called")
+
+        // Shutdown
+        registry.shutdownAll()
+        assertTrue(shutdownCalled, "onShutdown should be called")
+    }
+
+    @Test
+    fun `PluginRegistry should isolate plugin errors`(@TempDir tempDir: Path) {
+        // Create plugins where one throws an exception
+        var plugin1Called = false
+        var plugin2Called = false
+
+        val plugin1 = object : MaestroPlugin {
+            override val id = "failing-plugin"
+            override val name = "Failing Plugin"
+
+            override fun onCommandStart(index: Int, command: MaestroCommand) {
+                plugin1Called = true
+                throw RuntimeException("Plugin failure!")
+            }
+        }
+
+        val plugin2 = object : MaestroPlugin {
+            override val id = "working-plugin"
+            override val name = "Working Plugin"
+
+            override fun onCommandStart(index: Int, command: MaestroCommand) {
+                plugin2Called = true
+            }
+        }
+
+        val registry = PluginRegistry()
+        registry.register(plugin1)
+        registry.register(plugin2)
+
+        // Notify command start - plugin1 will fail but plugin2 should still be called
+        val selector = ElementSelector(textRegex = "test")
+        val command = MaestroCommand(tapOnElement = TapOnElementCommand(selector = selector))
+        registry.notifyCommandStart(0, command)
+
+        assertTrue(plugin1Called, "Failing plugin should be called")
+        assertTrue(plugin2Called, "Working plugin should still be called after first plugin fails")
+    }
+
+    @Test
+    fun `PluginLoader should load plugins from JAR files`() {
+        // This test verifies PluginLoader can load from specific JAR files
+        // In a real scenario, you would pass actual JAR files
+        val plugins = PluginLoader.loadPlugins(emptyList())
+
+        // With empty list, should return empty
+        assertTrue(plugins.isEmpty(), "Should return empty list when no JARs provided")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a complete plugin system to Maestro that allows extending functionality through JAR-based plugins with lifecycle hooks.

### Plugin Management Commands
- `maestro add-plugin <plugin.jar>` - Install plugin to ~/.maestro/plugins/
- `maestro list-plugins` - List installed plugins  
- `maestro remove-plugin <name>` - Remove plugin

### Plugin Loading
- `--plugin` flag supports plugin names or direct paths
- Example: `maestro test flow.yaml --plugin aria-plugin`
- Multiple plugins: `--plugin plugin1 --plugin plugin2`
- ServiceLoader-based discovery from JAR files

### Plugin Lifecycle Hooks
- `onInit()` - Initialize plugin with context (Maestro instance, output dirs, config)
- `onFlowStart()` - Called when flow starts
- `onCommandStart/Complete/Failed/Skipped()` - Command lifecycle hooks
- `onFlowComplete()` - Called when flow completes (with success/failure status)
- `onShutdown()` - Cleanup resources

### Architecture
- **PluginRegistry** - Manages plugin lifecycle, broadcasts events, isolates errors
- **PluginLoader** - Resolves and loads plugins from JAR files using ServiceLoader
- **PluginManager** - Handles installation/removal in ~/.maestro/plugins/
- **MaestroContext** - Provides plugins access to Maestro driver, output directories, flow config

### Integration
- Integrated with TestRunner, MaestroCommandRunner, TestSuiteInteractor
- Works with single flow, multiple flows, continuous mode, and sharded execution
- Plugin errors are isolated - failures don't crash tests or affect other plugins

## Problem Statement

Currently, extending Maestro requires forking the repository. For example, we built an accessibility scanner that needed to:
- Hook into command execution lifecycle
- Add custom CLI flags
- Integrate native SDKs (Swift/Kotlin) to extract view properties
- Generate custom reports

This forking approach creates maintenance burden and prevents ecosystem growth.

## Implementation Details

**What's Included:**
- ✅ Core plugin interfaces (MaestroPlugin, MaestroContext)
- ✅ Plugin registry with error isolation
- ✅ Orchestra integration with lifecycle hooks
- ✅ ServiceLoader-based plugin discovery
- ✅ CLI commands (add-plugin, list-plugins, remove-plugin)
- ✅ --plugin flag integration across all test modes
- ✅ Plugin manager for ~/.maestro/plugins/ directory
- ✅ Unit tests with error isolation verification

**Files Changed:**
- 15 files modified
- 599 insertions, 18 deletions
- New commands: AddPluginCommand, ListPluginsCommand, RemovePluginCommand
- Core plugin system: PluginLoader, PluginManager, PluginRegistry
- Integration across: TestRunner, MaestroCommandRunner, TestSuiteInteractor, Orchestra

## Use Cases Enabled

- **Accessibility scanning:** WCAG compliance checks during test runs (our use case)
- **Performance monitoring:** Track command execution timing, memory usage
- **Visual regression:** Capture and compare screenshots automatically
- **Custom analytics:** Send test metrics to external dashboards
- **Custom reporters:** Generate specialized test reports

## Example Plugin

```kotlin
class AccessibilityPlugin : MaestroPlugin {
    override val id = "aria-scanner"
    override val name = "ARIA Accessibility Scanner"
    
    private lateinit var context: MaestroContext
    
    override fun onInit(context: MaestroContext) {
        this.context = context
        // Initialize ARIA SDK
    }
    
    override fun onCommandComplete(index: Int, command: MaestroCommand) {
        // Scan after UI commands
        val hierarchy = context.maestro.viewHierarchy()
        val screenshot = context.maestro.takeScreenshot()
        // Run WCAG checks and record violations
    }
    
    override fun onFlowComplete(config: MaestroConfig?, success: Boolean) {
        // Generate HTML report to context.outputDirectory
    }
}
```

Package as JAR with META-INF/services/maestro.orchestra.plugin.MaestroPlugin file listing implementation.

## Usage

```bash
# Install plugin
maestro add-plugin aria-scanner-1.0.0.jar

# List installed plugins
maestro list-plugins

# Run tests with plugin
maestro test flow.yaml --plugin aria-scanner

# Use multiple plugins
maestro test flow.yaml --plugin aria-scanner --plugin perf-monitor

# Use plugin by path (for development)
maestro test flow.yaml --plugin /path/to/plugin.jar

# Remove plugin
maestro remove-plugin aria-scanner
```

## Testing

- ✅ Unit tests for PluginRegistry (lifecycle, error isolation)
- ✅ Tests verify plugin errors don't crash tests
- ✅ Tests verify multiple plugin coordination
- ✅ Manual testing with example plugin stub

## Questions for Maintainers

1. **Distribution:** Should we support Phase 2/3 features like URL-based installation or a plugin registry?
2. **Native SDK integration:** Plugins may need native code (Swift/Kotlin). Current approach: plugin JARs can include SDK communication logic, native SDK installed separately
3. **API stability:** Should we mark the plugin API as experimental initially?
4. **Documentation:** Where should plugin development guide live?

---

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>