### PR TITLE
fix(maestro-client): remove redundant proto srcDirs to unblock sourcesJar

### DIFF
--- a/maestro-client/build.gradle.kts
+++ b/maestro-client/build.gradle.kts
@@ -122,18 +122,6 @@ kotlin.sourceSets.all {
     languageSettings.optIn("kotlin.RequiresOptIn")
 }
 
-sourceSets {
-    main {
-        java {
-            srcDirs(
-                "build/generated/source/proto/main/grpc",
-                "build/generated/source/proto/main/java",
-                "build/generated/source/proto/main/kotlin"
-            )
-        }
-    }
-}
-
 dependencies {
     protobuf(project(":maestro-proto"))
     implementation(project(":maestro-utils"))


### PR DESCRIPTION
## Summary

The 2.5.0 publish workflow failed with:

```
Execution failed for task ':maestro-client:sourcesJar'.
> Entry maestro_android/MaestroDriverGrpc.java is a duplicate
  but no duplicate handling strategy has been set.
```

`maestro-client/build.gradle.kts` was registering the proto-generated source dirs onto `sourceSets.main.java` manually:

```kotlin
sourceSets {
    main {
        java {
            srcDirs(
                "build/generated/source/proto/main/grpc",
                "build/generated/source/proto/main/java",
                "build/generated/source/proto/main/kotlin"
            )
        }
    }
}
```

…but the `protobuf-gradle-plugin` already registers those exact dirs onto the same source set. The plugin's registration plus the manual one stacks, so `sourcesJar` (which builds from `sourceSets.main.allSource`) walks the same physical files through two registrations, producing duplicate jar entries. With Gradle 8.13's stricter default (no implicit `duplicatesStrategy`), this now fails the build instead of silently de-duping.

`getSrcDirs()` returns a deduped `Set<File>`, which is why the duplication wasn't obvious from a quick inspection — the second registration is only visible in the underlying `from(...)` wiring, not in the resolved set.

## Why it surfaced now

`sourcesJar` is only invoked by `publishToMavenCentral`, which only runs from `.github/workflows/publish-release.yaml` on a release tag. So this has been latent — `./gradlew build` and PR CI never exercise it. The first release after the Gradle / plugin bumps that tightened duplicate handling is the first time anyone sees the failure.

## Fix

Delete the manual `sourceSets { main { java { srcDirs(...) } } }` block. The protobuf plugin already wires the generated sources into the main source set, so compilation, IDE indexing, and `sourcesJar` all keep working — without the second registration that was tripping the duplicate check.

## Test plan

- [x] `./gradlew :maestro-client:sourcesJar` reproduces the failure on `main`
- [x] After the fix, `./gradlew :maestro-client:sourcesJar` → `BUILD SUCCESSFUL`
- [x] `unzip -l maestro-client/build/libs/maestro-client-sources.jar | grep -c MaestroDriverGrpc.java` returns `1`
- [x] `./gradlew :maestro-client:compileKotlin :maestro-client:compileJava` still succeeds — the proto sources are still discoverable through the plugin's own registration
- [ ] Confirm `:maestro-client:publishToMavenCentral` succeeds on the release workflow (will validate on next release)