### PR TITLE
fix(android): suppress GMS Location Accuracy dialog + bypass Chrome FRE

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -247,6 +247,16 @@ jobs:
             sleep 1
           done
 
+      - name: Bypass Chrome first-run experience
+        # Chrome's FRE blocks web-link flows on a fresh emulator. The command-line
+        # file is honored because of `am set-debug-app` on userdebug builds.
+        # https://stackoverflow.com/q/33408138
+        run: |
+          adb shell 'echo "chrome --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
+          adb shell chmod 644 /data/local/tmp/chrome-command-line
+          adb shell am set-debug-app --persistent com.android.chrome
+          adb shell am force-stop com.android.chrome
+
       - name: Install apps
         working-directory: ${{ github.workspace }}/e2e
         run: ./install_apps android

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -667,6 +667,12 @@ class AndroidDriver(
                 shell("pm grant dev.mobile.maestro android.permission.ACCESS_FINE_LOCATION")
                 shell("pm grant dev.mobile.maestro android.permission.ACCESS_COARSE_LOCATION")
                 shell("appops set dev.mobile.maestro android:mock_location allow")
+
+                // Pre-consent so Play Services doesn't show its "Location Accuracy"
+                // dialog when FusedLocationProviderClient is constructed below.
+                shell("settings put secure location_mode 3")
+                shell("settings put secure network_location_opt_in 1")
+
                 runDeviceCall("enableMockLocationProviders") {
                     blockingStubWithTimeout.enableMockLocationProviders(emptyRequest {  })
                 }


### PR DESCRIPTION
## Summary

Two independent fixes for the Android E2E suite. Both surfaced in the failing run linked below — six flows cascaded from a Play Services dialog and one from a Chrome onboarding screen.

### 1. `setLocation` triggers Play Services "Location Accuracy" dialog

`setLocation` on Android constructs a real `FusedLocationProviderClient` to install the mock provider. On a clean emulator (where `Settings.Secure.location_mode != 3` and the user hasn't opted into network location), Google Play Services responds with its **"Location Accuracy"** consent dialog as a system overlay. `permissions: allow all` cannot dismiss it — it isn't an Android runtime permission, so `pm grant` doesn't apply. The dialog floats above the app and is **not cleared by `clearState`, `stopApp`, or `launchApp`** on subsequent flows, so a single `setLocation` cascades into failures across every flow that runs after it.

Patch in `AndroidDriver.setLocation()` writes the secure settings that the dialog's "Turn on" button would write, before the GMS client is constructed:

```kotlin
shell("settings put secure location_mode 3")            // HIGH_ACCURACY
shell("settings put secure network_location_opt_in 1")  // network location consent
```

Gated by the existing `isLocationMocked` guard, so it runs once per session.

### 2. Chrome first-run experience blocks web-link flows

A separate failure (`openLink`) hit because Chrome's modern FRE variant ("Make Chrome your own") wasn't covered by the existing `runFlow when:` guards in `e2e/demo_app/.maestro/commands/openLink.yaml`. Rather than chase Chrome heading variants, this PR disables Chrome FRE at the **CI emulator level** by writing Chrome's command-line file with `--no-first-run` and marking Chrome as a debug app so userdebug Chrome honors the flag file. This eliminates Chrome FRE as a flake source across every web-link flow forever, not just `openLink`.

```yaml
adb shell 'echo "chrome --disable-fre --no-default-browser-check --no-first-run" > /data/local/tmp/chrome-command-line'
adb shell chmod 644 /data/local/tmp/chrome-command-line
adb shell am set-debug-app --persistent com.android.chrome
adb shell am force-stop com.android.chrome
```

Inserted in `test-e2e.yaml` between AVD boot and `install_apps`. Reference: https://stackoverflow.com/q/33408138.

## Evidence

Failing CI run: https://github.com/mobile-dev-inc/Maestro/actions/runs/24981897142

| Order | Flow | Failed assertion / tap | Cause |
|---|---|---|---|
| 1 | `openLink` | "Swag Labs" visible | Chrome "Make Chrome your own" FRE blocking saucedemo |
| 2 | `setLocation` | "Latitude: 48.857807" | GMS Location Accuracy dialog raised on first FusedLocationProviderClient call |
| 3 | `inputRandomEmail` | tap "Input/Keyboard" | dialog persists; demo app not foregrounded (Pixel launcher behind dialog) |
| 4 | `inputRandomNumber` | tap "Input/Keyboard" | same |
| 5 | `stopApp` | "Form Test" visible | same |
| 6 | `travel` | "Latitude: 48.857807" | same |
| 7 | `copyTextFrom` | tap id `fabAddIcon` | same |

Screenshots in the artifact confirm the same GMS dialog ("For a better experience, your device will need to use Location Accuracy" / "No thanks" / "Turn on") for failures 2-7, and the Chrome "Make Chrome your own" / "Use without an account" sign-in screen for failure 1. All commands timed out at ~17s — the default wait — confirming UI-blocked state, not crashes.

## Side-effect notes

- The `setLocation` patch writes a secure setting on the device. On CI emulators that's ephemeral. On a real device run it persists across reboot, but `setLocation` is already invasively mocking the user's location, so the location-mode change is consistent with the command's intent. The original mode is not restored on cleanup; happy to add save/restore in `clearState` if reviewers prefer.
- The Chrome flag file requires a userdebug build for `am set-debug-app` to take effect — fine for the CI AVD (`google_apis` system image is userdebug). If we ever switch to a user-build image, we'd need to fall back to handling FRE in flows.

## Test plan

- [ ] Re-run the demo_app `passing/` suite on a fresh Android emulator (same matrix as the linked failing run) and confirm `openLink`, `setLocation`, `travel`, `inputRandomEmail`, `inputRandomNumber`, `stopApp`, `copyTextFrom` pass.
- [ ] Confirm no Location Accuracy dialog and no Chrome FRE during the run.
- [ ] Confirm flows that don't use `setLocation` are unaffected by the driver change (the gated `if (!isLocationMocked)` block doesn't run).
