### PR TITLE
Fix detection of successful emulator installation in start-device

### DIFF
--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -608,11 +608,7 @@ object DeviceService {
                 throw TimeoutException()
             }
 
-            if (process.exitValue() == 0) {
-                val output = String(process.inputStream.readBytes()).trim()
-
-                return output.contains(image)
-            }
+            return process.exitValue() == 0 && isAndroidSystemImageInstalled(image)
         } catch (e: Exception) {
             logger.error("Unable to install if SDK package is installed", e)
         }


### PR DESCRIPTION
## Proposed changes

When running start-device with an Android SDK version that you didn't have a matching emulator image for, it'd prompt to install, succeed at installing, but fail.

This change fixes the detection logic.

## Testing

```
sdkmanager --uninstall "system-images;android-35;google_apis;arm64-v8a"
./installLocally.sh
maestro start-device --platform android --device-os android-35
```

gives:

```
% maestro start-device --platform android --device-os android-35

The required system image system-images;android-35;google_apis;arm64-v8a is not installed.

Would you like to install it? y/n
y

Attempting to install system-images;android-35;google_apis;arm64-v8a via Android SDK Manager...

Warning: This version only understands SDK XML versions up to 3 but an SDK XML file of version 4 was encountered. This can happen if you use versions of Android Studio and the command-line tools that were released at different times.
[=======================================] 100% Unzipping... arm64-v8a/data/misc/


Attempting to create Android emulator: Maestro_ANDROID_pixel_6_android-35 

Created Android emulator: Maestro_ANDROID_pixel_6_android-35 (system-images;android-35;google_apis;arm64-v8a)
Launching Emulator...
Waiting for emulator ( Maestro_ANDROID_pixel_6_android-35 ) to boot...
Setting the device locale to en_US...
[Done] Setting the device locale to en_US...
```

The warning that appears:
> Warning: This version only understands SDK XML ....
appears to be a local issue in my commandline tools setup.

## Issues fixed

Fixes #2722
