### PR TITLE
Improve device info help in maestro cloud --help

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -158,16 +158,16 @@ class CloudCommand : Callable<Int> {
     private var deviceLocale: String? = null
 
     @Option(order = 20, names = ["--device-model"], description = [
-      "Device model to run your flow against. " +
-              "iOS: iPhone-11, iPhone-11-Pro, etc. Run command: maestro list-cloud-devices" +
-              "Android: pixel_6, etc. Run command: maestro list-cloud-devices"
+      "Device model to run your flow against.",
+      "  iOS: iPhone-11, iPhone-17-Pro, etc. Run command: maestro list-cloud-devices",
+      "  Android: pixel_6, pixel_7, etc. Run command: maestro list-cloud-devices"
     ])
     private var deviceModel: String? = null
 
     @Option(order = 21, names = ["--device-os"], description = [
-      "OS version to run your flow against. " +
-              "iOS: iOS-16-2, iOS-17-5, iOS-18-2, etc. maestro list-devices" +
-              "Android: android-33, android-34, etc. maestro list-cloud-devices"
+      "OS version to run your flow against.",
+      "  iOS: iOS-18-2, iOS-26-2, etc. maestro list-cloud-devices",
+      "  Android: android-33, android-34, etc. maestro list-cloud-devices"
     ])
     private var deviceOs: String? = null
 


### PR DESCRIPTION
## Proposed changes

Text changes to match what was done in #3228 

## Testing

```
./installLocally.sh
maestro cloud --help
```

gives the following (I've pointed at the changes)

```
% maestro cloud --help
Usage: maestro cloud [-h] [--async] [--[no-]ansi] [--apiKey=<apiKey>] [--apiUrl=<apiUrl>] [--app-file=<appFile>] [--appBinaryId=<appBinaryId>]
                     [--branch=<branch>] [--commitSha=<commitSha>] [--config=<configFile>] [--device-locale=<deviceLocale>] [--device-model=<deviceModel>]
                     [--device-os=<deviceOs>] [--flows=<flowsFile>] [--format=<format>] [--mapping=<mapping>] [--name=<uploadName>] [--output=<output>]
                     [--projectId=<projectId>] [--pullRequestId=<pullRequestId>] [--repoName=<repoName>] [--repoOwner=<repoOwner>]
                     [--test-suite-name=<testSuiteName>] [-e=<String=String>]... [--exclude-tags=<excludeTags>[,<excludeTags>...]]...
                     [--include-tags=<includeTags>[,<includeTags>...]]...
Upload your flows on Cloud by using `maestro cloud sample/app.apk flows_folder/` (https://app.maestro.dev)
Provide your application file and a folder with Maestro flows to run them in parallel on multiple devices in the cloud
By default, the command will block until all analyses have completed. You can use the --async flag to run the command asynchronously and exit immediately.
      --apiKey, --api-key=<apiKey>
                             API key
      --apiUrl, --api-url=<apiUrl>
                             API base URL
      --app-file=<appFile>   App binary to run your Flows against
      --appBinaryId, --app-binary-id=<appBinaryId>
                             The ID of the app binary previously uploaded to Maestro Cloud
      --async                Run the upload asynchronously
      --branch=<branch>      The branch this upload originated from
      --commitSha, --commit-sha=<commitSha>
                             The commit SHA of this upload
      --config=<configFile>  Optional .yaml configuration file for Flows. If not provided, Maestro will look for a config.yaml file in the root directory.
      --device-locale=<deviceLocale>
                             Locale that will be set to a device, ISO-639-1 code and uppercase ISO-3166-1 code i.e. "de_DE" for Germany

< -- BELOW IS THE BIT THAT CHANGED -->

      --device-model=<deviceModel>
                             Device model to run your flow against.
                               iOS: iPhone-11, iPhone-17-Pro, etc. Run command: maestro list-cloud-devices
                               Android: pixel_6, pixel_7, etc. Run command: maestro list-cloud-devices
      --device-os=<deviceOs> OS version to run your flow against.
                               iOS: iOS-18-2, iOS-26-2, etc. maestro list-cloud-devices
                               Android: android-33, android-34, etc. maestro list-cloud-devices

< -- ABOVE IS THE BIT THAT CHANGED -->

  -e, --env=<String=String>  Environment variables to inject into your Flows
      --exclude-tags=<excludeTags>[,<excludeTags>...]
                             List of tags that will remove the Flows containing the provided tags
      --flows=<flowsFile>    A Flow filepath or a folder path that contains Flows
      --format=<format>      Test report format (default=NOOP): JUNIT, HTML, HTML-DETAILED, NOOP
  -h, --help                 Display help message
      --include-tags=<includeTags>[,<includeTags>...]
                             List of tags that will remove the Flows that does not have the provided tags
      --mapping=<mapping>    dSYM file (iOS) or Proguard mapping file (Android)
      --name=<uploadName>    Name of the upload
      --[no-]ansi, --[no-]color
                             Enable / disable colors and ansi output
      --output=<output>      File to write report into (default=report.xml)
      --projectId, --project-id=<projectId>
                             Project Id
      --pullRequestId, --pull-request-id=<pullRequestId>
                             The ID of the pull request this upload originated from
      --repoName, --repo-name=<repoName>
                             Repository name (ie: GitHub repo slug)
      --repoOwner, --repo-owner=<repoOwner>
                             Repository owner (ie: GitHub organization or user slug)
      --test-suite-name=<testSuiteName>
                             Test suite name
```

## Issues fixed

n/a