### PR TITLE
Fix the mutation setting of hierarchy-inert commands

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -598,7 +598,7 @@ class Orchestra(
         val diffFile = expectedFile.parentFile?.resolve(diffFileName) ?: File(diffFileName)
 
         when (val result = ScreenshotMatch.compare(expectedImage, actualImage, command.thresholdPercentage, diffFile)) {
-            is ScreenshotMatch.Result.Match -> return true
+            is ScreenshotMatch.Result.Match -> return false // Screenshots are non-interactive
             is ScreenshotMatch.Result.SizeMismatch -> throw MaestroException.AssertionFailure(
                 message = "Screenshot size mismatch: ${command.description()} - expected ${result.expectedWidth}x${result.expectedHeight}, actual ${result.actualWidth}x${result.actualHeight}. Screenshots must have the same dimensions to compare.",
                 hierarchyRoot = maestro.viewHierarchy().root,
@@ -616,7 +616,9 @@ class Orchestra(
     private fun evalScriptCommand(command: EvalScriptCommand): Boolean {
         command.scriptString.evaluateScripts(jsEngine)
 
-        // We do not actually know if there were any mutations, but we assume there were
+        // Scripts can trigger HTTP requests that cause the app to receive a state change
+        // (e.g. via WebSocket or push notification), mutating the hierarchy. We conservatively
+        // treat these as mutating.
         return true
     }
 
@@ -629,7 +631,9 @@ class Orchestra(
                 runInSubScope = true,
             )
 
-            // We do not actually know if there were any mutations, but we assume there were
+            // Scripts can trigger HTTP requests that cause the app to receive a state change
+            // (e.g. via WebSocket or push notification), mutating the hierarchy. We conservatively
+            // treat these as mutating.
             true
         } else {
             throw CommandSkipped
@@ -1151,13 +1155,16 @@ class Orchestra(
             throw MaestroException.UnableToSetPermissions("Unable to set permissions for app ${command.appId}: ${e.message}", e)
         }
 
-        return true
+        // Setting permissions occurs behind the scenes and won't alter screen state.
+        // Android and iOS provide no mechanism for subscribing to permissions events.
+        return false
     }
 
     private suspend fun clearKeychainCommand(): Boolean {
         maestro.clearKeychain()
 
-        return true
+        // No UI effect
+        return false
     }
 
     private suspend fun inputTextCommand(command: InputTextCommand): Boolean {
@@ -1573,14 +1580,16 @@ class Orchestra(
 
         jsEngine.setCopiedText(copiedText)
 
-        return true
+        // Hierarchy read and internal variable setting - no UI effect
+        return false
     }
 
     private fun setClipboardCommand(command: SetClipboardCommand): Boolean {
         copiedText = command.text
         jsEngine.setCopiedText(copiedText)
 
-        return true
+        // Internal variable setting - no UI effect
+        return false
     }
 
     private fun resolveText(attributes: MutableMap<String, String>): String? {


### PR DESCRIPTION
## Proposed changes

Performance improvement.

Maestro performs assertions like assertNotVisible based on a timer tied to the last command that altered the hierarchy. We track that through a return value on a command that indicates whether the command mutated the hierarchy (or may have).

This change updates a few inert commands, marking them as non-mutating, which will speed up assertions that immediately follow them.

In the below example, assertNotVisible's timer should be from the tapOn, not from the last copyTextFrom.

```
- tapOn: Remove Foo
- copyTextFrom:
    id: thing1
- copyTextFrom:
    id: thing2
- copyTextFrom:
    id: thing3
- assertNotVisible: Foo
```

I've added comments on justifications, so that the next person visiting this code might be able to think a little less about these :)

## Testing

e2e 🤞 

## Issues fixed

Fixes #3117