### PR TITLE
Fix emulator discovery on Windows, fixes start-device

### DIFF
--- a/maestro-client/src/main/java/maestro/device/util/AndroidEnvUtils.kt
+++ b/maestro-client/src/main/java/maestro/device/util/AndroidEnvUtils.kt
@@ -148,10 +148,11 @@ object AndroidEnvUtils {
     fun requireEmulatorBinary(): File {
         val androidHome = androidHome
             ?: throw DeviceError("Could not detect Android home environment variable is not set. Ensure that either ANDROID_HOME or ANDROID_SDK_ROOT is set.")
-        val firstChoice = File(androidHome, "emulator/emulator")
-        val secondChoice = File(androidHome, "tools/emulator")
+        val binaryName = if (EnvUtils.isWindows()) "emulator.exe" else "emulator"
+        val firstChoice = File(androidHome, "emulator/$binaryName")
+        val secondChoice = File(androidHome, "tools/$binaryName")
         return firstChoice.takeIf { it.exists() } ?: secondChoice.takeIf { it.exists() }
-        ?: throw DeviceError("Could not find emulator binary at either of the following paths:\n$firstChoice\n$secondChoice")
+            ?: throw DeviceError("Could not find emulator binary at either of the following paths:\n$firstChoice\n$secondChoice")
     }
 }
 


### PR DESCRIPTION
## Proposed changes

This fixes `maestro start-device --platform android ...` on Windows.

It was all sorts of wonky after failing to find emulator.exe (although there's good existing logic to find .bat variants of executables)

## Testing

Ran locally. Can now successfully create and launch emulators.

## Issues fixed

Fixes #3237 