### PR TITLE
fix(js): convert PolyglotException to JsEvaluationException at the engine boundary

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -7,6 +7,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import org.graalvm.polyglot.Context
 import org.graalvm.polyglot.HostAccess
+import org.graalvm.polyglot.PolyglotException
 import org.graalvm.polyglot.Source
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyObject
@@ -131,7 +132,13 @@ class GraalJsEngine(
             .replace("\${", "\\\${")
         val wrappedScript = "(function(){ return eval(`$escapedScript`) })()"
         val source = Source.newBuilder("js", wrappedScript, sourceName).build()
-        return context.eval(source)
+        return try {
+            context.eval(source)
+        } catch (e: PolyglotException) {
+            // Convert to a fully detached JsEvaluationException so live polyglot
+            // frames never escape the engine boundary. See JsScriptError.kt.
+            throw JsEvaluationException(e.toJsScriptError())
+        }
     }
 
     /**
@@ -185,25 +192,30 @@ class GraalJsEngine(
             .allowHostAccess(hostAccess)
             .build()
 
-        context.eval(
-            "js", """
-            // Prevent a reference error on referencing undeclared variables. Enables patterns like {MY_ENV_VAR || 'default-value'}.
-            // Instead of throwing an error, undeclared variables will evaluate to undefined.
-            Object.setPrototypeOf(globalThis, new Proxy(Object.prototype, {
-                has(target, key) {
-                    return true;
+        try {
+            context.eval(
+                "js", """
+                // Prevent a reference error on referencing undeclared variables. Enables patterns like {MY_ENV_VAR || 'default-value'}.
+                // Instead of throwing an error, undeclared variables will evaluate to undefined.
+                Object.setPrototypeOf(globalThis, new Proxy(Object.prototype, {
+                    has(target, key) {
+                        return true;
+                    }
+                }))
+                function json(text) {
+                    return JSON.parse(text)
                 }
-            }))
-            function json(text) {
-                return JSON.parse(text)
-            }
-            function relativePoint(x, y) {
-                var xPercent = Math.ceil(x * 100) + '%'
-                var yPercent = Math.ceil(y * 100) + '%'
-                return xPercent + ',' + yPercent
-            }
-        """.trimIndent()
-        )
+                function relativePoint(x, y) {
+                    var xPercent = Math.ceil(x * 100) + '%'
+                    var yPercent = Math.ceil(y * 100) + '%'
+                    return xPercent + ',' + yPercent
+                }
+            """.trimIndent()
+            )
+        } catch (e: PolyglotException) {
+            // Boundary applies to the bootstrap script too — same reasoning as evalWithIIFE.
+            throw JsEvaluationException(e.toJsScriptError())
+        }
 
         sharedContext = context
         return context

--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -135,8 +135,6 @@ class GraalJsEngine(
         return try {
             context.eval(source)
         } catch (e: PolyglotException) {
-            // Convert to a fully detached JsEvaluationException so live polyglot
-            // frames never escape the engine boundary. See JsScriptError.kt.
             throw JsEvaluationException(e.toJsScriptError())
         }
     }
@@ -213,7 +211,6 @@ class GraalJsEngine(
             """.trimIndent()
             )
         } catch (e: PolyglotException) {
-            // Boundary applies to the bootstrap script too — same reasoning as evalWithIIFE.
             throw JsEvaluationException(e.toJsScriptError())
         }
 

--- a/maestro-client/src/main/java/maestro/js/JsScriptError.kt
+++ b/maestro-client/src/main/java/maestro/js/JsScriptError.kt
@@ -1,0 +1,48 @@
+package maestro.js
+
+import org.graalvm.polyglot.PolyglotException
+
+/**
+ * Plain-data view of a JavaScript evaluation error. All fields are JVM-safe
+ * (String / List<String> / Boolean) and resolved while the originating Polyglot
+ * engine is still open, so this object can outlive the engine and survive
+ * downstream serialization (Jackson, etc.) without re-entering the closed runtime.
+ */
+data class JsScriptError(
+    val message: String,
+    val causeMessage: String?,
+    val sourceClass: String,
+    val stackFrames: List<String>,
+    val isHostException: Boolean,
+    val isGuestException: Boolean,
+)
+
+/**
+ * Thrown by [JsEngine.evaluateScript] when script evaluation fails. Replaces the
+ * raw [PolyglotException] previously propagated by the GraalJS implementation,
+ * so callers — and any downstream code that retains exceptions on result models —
+ * never observe live polyglot internals.
+ */
+class JsEvaluationException(val error: JsScriptError) : RuntimeException(error.message)
+
+/**
+ * Convert a [PolyglotException] into a fully detached [JsScriptError]. Every
+ * field is resolved to a plain JVM type before this returns; after the call,
+ * the original exception can be released and the engine closed without
+ * affecting the resulting object.
+ */
+fun PolyglotException.toJsScriptError(): JsScriptError = JsScriptError(
+    message = this.message ?: "(no message)",
+    causeMessage = this.cause?.message,
+    sourceClass = this::class.java.name,
+    stackFrames = runCatching {
+        this.polyglotStackTrace.map { frame ->
+            val lang = frame.language?.id ?: "?"
+            val name = frame.rootName ?: "?"
+            val loc = frame.sourceLocation?.toString() ?: "?"
+            "$lang $name ($loc)"
+        }
+    }.getOrElse { emptyList() },
+    isHostException = this.isHostException,
+    isGuestException = this.isGuestException,
+)

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -1,10 +1,12 @@
 package maestro.test
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.truth.Truth.assertThat
 import maestro.js.GraalJsEngine
-import org.graalvm.polyglot.PolyglotException
+import maestro.js.JsEvaluationException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class GraalJsEngineTest : JsEngineTest() {
 
@@ -44,12 +46,10 @@ class GraalJsEngineTest : JsEngineTest() {
 
     @Test
     fun `sandboxing works`() {
-        try {
+        val ex = assertThrows<JsEvaluationException> {
             engine.evaluateScript("require('fs')")
-            assert(false)
-        } catch (e: PolyglotException) {
-            assertThat(e.message).contains("undefined is not a function")
         }
+        assertThat(ex.message).contains("undefined is not a function")
     }
 
     @Test
@@ -230,4 +230,52 @@ class GraalJsEngineTest : JsEngineTest() {
         assertThat(platform.toString()).isNotEqualTo("should_not_override")
     }
 
+    // --- Polyglot-safe boundary --------------------------------------------------------------
+
+    @Test
+    fun `script error is wrapped in JsEvaluationException, not PolyglotException`() {
+        val ex = assertThrows<JsEvaluationException> {
+            engine.evaluateScript("throw new Error('boom')")
+        }
+        // The exception that escapes must be a plain JVM type, not the closed class
+        // PolyglotException — Jackson reflection on retained PolyglotException frames was the
+        // crash mode this boundary is preventing.
+        assertThat(ex::class.java.name).doesNotContain("Polyglot")
+        assertThat(ex.message).contains("boom")
+    }
+
+    @Test
+    fun `JsScriptError captures message, stack, and cause as plain strings`() {
+        val ex = assertThrows<JsEvaluationException> {
+            engine.evaluateScript("throw new Error('captured')")
+        }
+        val err = ex.error
+        assertThat(err.message).contains("captured")
+        assertThat(err.sourceClass).contains("PolyglotException")
+        assertThat(err.stackFrames).isNotEmpty()
+        // All stack frames are Strings — none are live polyglot StackFrame objects
+        err.stackFrames.forEach { assertThat(it).isInstanceOf(String::class.java) }
+        assertThat(err.isGuestException).isTrue()
+    }
+
+    @Test
+    fun `JsEvaluationException round-trips through Jackson without touching polyglot fields`() {
+        val ex = assertThrows<JsEvaluationException> {
+            engine.evaluateScript("throw new Error('serialise me')")
+        }
+        engine.close() // simulate engine closure before serialisation — the original crash mode
+
+        val mapper = jacksonObjectMapper()
+        // The act of writing must not crash. Pre-fix, Jackson would walk
+        // PolyglotException's polyglotStackTrace and call .getLanguage() on a
+        // closed engine, hitting ShouldNotReachHere.
+        val json = mapper.writeValueAsString(ex.error)
+
+        assertThat(json).contains("\"message\"")
+        assertThat(json).contains("serialise me")
+        assertThat(json).contains("\"stackFrames\"")
+        // The polyglot-typed property that produced the original crash isn't
+        // serialised — JsScriptError captures everything as plain Strings.
+        assertThat(json).doesNotContain("polyglotStackTrace")
+    }
 }


### PR DESCRIPTION
## Summary

`GraalJsEngine` now catches `PolyglotException` at `context.eval()` call site and rethrows a plain `JsEvaluationException(JsScriptError)`. 

Live polyglot internals never escape the engine, the needs JS engine context. 

## Why

`PolyglotException` exposes a `polyglotStackTrace: List<StackFrame>` property whose `getLanguage()` callback re-enters the originating `PolyglotContext`. 

If a caller retains the exception on a model, happened with our FlowDebugOutput model [here](https://github.com/mobile-dev-inc/Maestro/blob/main/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/FlowDebugOutput.kt#L13). 

This is later walked by a reflective serializer libraries (Jackson) after the engine has closed, that can cause errors causing `ShouldNotReachHere` and the JVM dies.

## Shape of the new types

```kotlin
data class JsScriptError(
    val message: String,
    val causeMessage: String?,
    val sourceClass: String,
    val stackFrames: List<String>,   // formatted, not live frames
    val isHostException: Boolean,
    val isGuestException: Boolean,
)

class JsEvaluationException(val error: JsScriptError) : RuntimeException(error.message)
```

Resolved entirely while the engine is still open. After the constructor returns, the original `PolyglotException` can be released and the engine closed without affecting the wrapper.

## Behaviour change for library users

Callers like our worker and studio, previously caught `PolyglotException` from `JsEngine.evaluateScript` now catch `JsEvaluationException`.

## Migration

```kotlin
// before
} catch (e: PolyglotException) { ... }

// after
} catch (e: JsEvaluationException) {
    // e.message — the JS error message
    // e.error.causeMessage — host cause message, if any
    // e.error.stackFrames — formatted strings, no live frames
}
```

## Verify

- [x] `./gradlew test` passes across all modules.
- [x] New tests in `GraalJsEngineTest` cover the wrapping behaviour, JsScriptError shape, and Jackson round-trip with the engine closed.
- [x] Existing `sandboxing works` test updated to expect the new exception type.