### PR TITLE
Warn when deprecated --android-api-level / --ios-version flags are used

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -193,6 +193,13 @@ class CloudCommand : Callable<Int> {
             printToConsole = parent?.verbose == true,
         )
 
+        if (androidApiLevel != null) {
+            PrintUtils.warn("--android-api-level is deprecated and will be removed in a future release. Use --device-os instead (e.g. --device-os=android-34).")
+        }
+        if (iOSVersion != null) {
+            PrintUtils.warn("--ios-version is deprecated and will be removed in a future release. Use --device-os instead (e.g. --device-os=iOS-18-2).")
+        }
+
         validateFiles()
         validateWorkSpace()
 


### PR DESCRIPTION
## Summary
`--android-api-level` and `--ios-version` on `maestro cloud` are marked `@Deprecated` and hidden from `--help`, but were silently accepted with no user-facing feedback. This adds a runtime warning that points users to `--device-os`.

## Test plan
- [x] `maestro cloud --android-api-level=33 ...` prints the deprecation warning
- [x] `maestro cloud --ios-version=17.0 ...` prints the deprecation warning
- [x] Runs without either flag are unchanged