### PR TITLE
fix(env): fail fast with helpful message when env value is null

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -33,13 +33,20 @@ object Env {
         // Fail fast with the offending keys so the user knows exactly what to fix.
         @Suppress("UNCHECKED_CAST")
         val nullKeys = (env as Map<String, String?>).filterValues { it == null }.keys
-        require(nullKeys.isEmpty()) {
-            "Environment variable(s) ${nullKeys.joinToString(", ")} have no value. " +
-                "Set an explicit value (e.g. `${nullKeys.first()}: \"\"` for an empty string) " +
-                "or remove the key."
-        }
+        if (nullKeys.isNotEmpty()) throw EnvVariableMissingValueError(nullKeys)
         return listOf(MaestroCommand(DefineVariablesCommand(env))) + this
     }
+
+    /**
+     * Raised by [withEnv] when the env map carries one or more null values. Caught by
+     * `MaestroFlowParser.wrapException` so the rendered error names the missing key(s)
+     * instead of surfacing a generic "Parsing Failed" summary.
+     */
+    class EnvVariableMissingValueError(val keys: Set<String>) : IllegalArgumentException(
+        "Environment variable(s) ${keys.joinToString(", ")} have no value. " +
+            "Set an explicit value (e.g. `${keys.first()}: \"\"` for an empty string) " +
+            "or remove the key."
+    )
 
     /**
      * Reserved internal env vars that are controlled exclusively by Maestro.

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -25,9 +25,21 @@ object Env {
             }
     }
 
-    fun List<MaestroCommand>.withEnv(env: Map<String, String>): List<MaestroCommand> =
-        if (env.isEmpty()) this
-        else listOf(MaestroCommand(DefineVariablesCommand(env))) + this
+    fun List<MaestroCommand>.withEnv(env: Map<String, String>): List<MaestroCommand> {
+        if (env.isEmpty()) return this
+        // Jackson's KotlinModule allows null values into Map<String, String> (generic erasure),
+        // so a YAML entry like `KEY:` with no value lands here as null and later crashes
+        // DefineVariablesCommand.evaluateScripts with an opaque Kotlin null-intrinsics error.
+        // Fail fast with the offending keys so the user knows exactly what to fix.
+        @Suppress("UNCHECKED_CAST")
+        val nullKeys = (env as Map<String, String?>).filterValues { it == null }.keys
+        require(nullKeys.isEmpty()) {
+            "Environment variable(s) ${nullKeys.joinToString(", ")} have no value. " +
+                "Set an explicit value (e.g. `${nullKeys.first()}: \"\"` for an empty string) " +
+                "or remove the key."
+        }
+        return listOf(MaestroCommand(DefineVariablesCommand(env))) + this
+    }
 
     /**
      * Reserved internal env vars that are controlled exclusively by Maestro.

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
@@ -130,4 +130,48 @@ class EnvTest {
 
         assertThat(withEnv).containsExactly(defineVariables, applyConfig)
     }
+
+    @Test
+    fun `withEnv fails with a helpful message when an env value is null`() {
+        // YAML `AUTOMATED_EMAIL:` (no value) deserializes to null inside Map<String, String>
+        // due to Kotlin generic type erasure; simulate that here with an unchecked cast.
+        @Suppress("UNCHECKED_CAST")
+        val envWithNull = mapOf(
+            "AUTOMATED_EMAIL" to null,
+            "COUNTRY" to "United Kingdom",
+        ) as Map<String, String>
+
+        val error = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException::class.java) {
+            emptyList<MaestroCommand>().withEnv(envWithNull)
+        }
+        assertThat(error.message).contains("AUTOMATED_EMAIL")
+        assertThat(error.message).doesNotContain("COUNTRY")
+    }
+
+    @Test
+    fun `withEnv fails when the only env key has a null value`() {
+        @Suppress("UNCHECKED_CAST")
+        val envWithNull = mapOf("AUTOMATED_EMAIL" to null) as Map<String, String>
+
+        val error = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException::class.java) {
+            emptyList<MaestroCommand>().withEnv(envWithNull)
+        }
+        assertThat(error.message).contains("AUTOMATED_EMAIL")
+    }
+
+    @Test
+    fun `withEnv lists every null env key`() {
+        @Suppress("UNCHECKED_CAST")
+        val envWithNulls = mapOf(
+            "AUTOMATED_EMAIL" to null,
+            "COUNTRY" to "United Kingdom",
+            "REGION" to null,
+        ) as Map<String, String>
+
+        val error = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException::class.java) {
+            emptyList<MaestroCommand>().withEnv(envWithNulls)
+        }
+        assertThat(error.message).contains("AUTOMATED_EMAIL")
+        assertThat(error.message).contains("REGION")
+    }
 }

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
@@ -141,7 +141,7 @@ class EnvTest {
             "COUNTRY" to "United Kingdom",
         ) as Map<String, String>
 
-        val error = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException::class.java) {
+        val error = org.junit.jupiter.api.Assertions.assertThrows(maestro.orchestra.util.Env.EnvVariableMissingValueError::class.java) {
             emptyList<MaestroCommand>().withEnv(envWithNull)
         }
         assertThat(error.message).contains("AUTOMATED_EMAIL")
@@ -153,7 +153,7 @@ class EnvTest {
         @Suppress("UNCHECKED_CAST")
         val envWithNull = mapOf("AUTOMATED_EMAIL" to null) as Map<String, String>
 
-        val error = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException::class.java) {
+        val error = org.junit.jupiter.api.Assertions.assertThrows(maestro.orchestra.util.Env.EnvVariableMissingValueError::class.java) {
             emptyList<MaestroCommand>().withEnv(envWithNull)
         }
         assertThat(error.message).contains("AUTOMATED_EMAIL")
@@ -168,7 +168,7 @@ class EnvTest {
             "REGION" to null,
         ) as Map<String, String>
 
-        val error = org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException::class.java) {
+        val error = org.junit.jupiter.api.Assertions.assertThrows(maestro.orchestra.util.Env.EnvVariableMissingValueError::class.java) {
             emptyList<MaestroCommand>().withEnv(envWithNulls)
         }
         assertThat(error.message).contains("AUTOMATED_EMAIL")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
@@ -39,6 +39,7 @@ import maestro.orchestra.SourceInfo
 import maestro.orchestra.WorkspaceConfig
 import maestro.orchestra.error.InvalidFlowFile
 import maestro.orchestra.error.MediaFileNotFound
+import maestro.orchestra.util.Env.EnvVariableMissingValueError
 import maestro.orchestra.util.Env.withEnv
 import org.intellij.lang.annotations.Language
 import java.nio.file.Path
@@ -194,6 +195,16 @@ private fun SourceInfo.asJsonLocation(): JsonLocation =
 
 private fun wrapException(error: Throwable, parser: JsonParser, contentPath: Path, content: String): Exception {
     findException<FlowParseException>(error)?.let { return it }
+    findException<EnvVariableMissingValueError>(error)?.let { e ->
+        val keys = e.keys.joinToString(", ")
+        return FlowParseException(
+            parser = parser,
+            contentPath = contentPath,
+            content = content,
+            title = "Environment variable has no value: $keys",
+            errorMessage = e.message ?: "Environment variable has no value",
+        )
+    }
     findException<ToCommandsException>(error)?.let { e ->
         val location = e.sourceInfo.asJsonLocation()
         return when (e.cause) {


### PR DESCRIPTION
A YAML entry like `KEY:` with no value deserializes to `null` inside `Map<String, String>` (Kotlin generic erasure) and later crashes `DefineVariablesCommand.evaluateScripts` with an opaque `Parameter specified as non-null is null` error after retries. `withEnv` now validates and names the offending key(s) so the failure surfaces at YAML-parse time.

## Example:

What a flow with empty variable `AUTOMATED_EMAIL` cause before and after the change in PR:

<img width="389" height="86" alt="Screenshot 2026-05-07 at 2 25 26 PM" src="https://github.com/user-attachments/assets/304e3060-34d5-47f5-b520-0ebb093915c9" />

---

Before:
<img width="1212" height="702" alt="Screenshot 2026-05-07 at 2 18 09 PM" src="https://github.com/user-attachments/assets/dbfb274f-60ea-4fb9-a349-d528b16be8ae" />

After:
<img width="1215" height="68" alt="Screenshot 2026-05-07 at 2 22 20 PM" src="https://github.com/user-attachments/assets/28d2b46c-38f1-49af-ba30-0bb9422cbd34" />

