### PR TITLE
Add file attribute to JUnit report

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -35,6 +35,7 @@ data class TestExecutionSummary(
         val properties: Map<String, String>? = null,
         val tags: List<String>? = null,
         val steps: List<StepResult> = emptyList(),
+        val filePath: String? = null,
     )
 
     data class StepResult(

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -47,6 +47,7 @@ class JUnitTestSuiteReporter(
                     id = flow.properties?.get("junitId") ?: flow.name,
                     name = flow.name,
                     classname = flow.properties?.get("junitClassname") ?: flow.name,
+                    file = flow.filePath,
                     failure = flow.failure?.let { failure ->
                         Failure(
                             message = failure.message,
@@ -101,6 +102,7 @@ class JUnitTestSuiteReporter(
         @JacksonXmlProperty(isAttribute = true) val id: String,
         @JacksonXmlProperty(isAttribute = true) val name: String,
         @JacksonXmlProperty(isAttribute = true) val classname: String,
+        @JacksonXmlProperty(isAttribute = true) val file: String? = null,
         @JacksonXmlProperty(isAttribute = true) val time: String? = null,
         @JacksonXmlProperty(isAttribute = true) val timestamp: String? = null,
         @JacksonXmlProperty(isAttribute = true) val status: FlowStatus,

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -10,6 +10,7 @@ import maestro.cli.report.SingleScreenFlowAIOutput
 import maestro.cli.report.FlowAIOutput
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.report.TestSuiteReporter
+import maestro.cli.util.FileUtils.toCwdRelativeOrAbsoluteString
 import maestro.cli.util.PrintUtils
 import maestro.cli.util.TimeUtils
 import maestro.cli.view.ErrorViewUtils
@@ -301,6 +302,7 @@ class TestSuiteInteractor(
             first = TestExecutionSummary.FlowResult(
                 name = flowName,
                 fileName = flowFile.nameWithoutExtension,
+                filePath = flowFile.toPath().toCwdRelativeOrAbsoluteString(),
                 status = flowStatus,
                 failure = if (flowStatus == FlowStatus.ERROR) {
                     TestExecutionSummary.Failure(

--- a/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/FileUtils.kt
@@ -4,6 +4,7 @@ import maestro.orchestra.workspace.isWorkspaceConfigFile
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.utils.StringUtils.toRegexSafe
 import java.io.File
+import java.nio.file.Path
 import java.util.zip.ZipInputStream
 
 object FileUtils {
@@ -34,6 +35,17 @@ object FileUtils {
 
         val config = YamlCommandReader.readConfig(toPath())
         return config.url != null
+    }
+
+    /** Returns this path relative to [WorkingDirectory.baseDir] when possible, otherwise the absolute path string. */
+    fun Path.toCwdRelativeOrAbsoluteString(): String {
+        val absolute = toAbsolutePath().normalize()
+        val cwd = WorkingDirectory.baseDir.toPath().toAbsolutePath().normalize()
+        val relative = runCatching { cwd.relativize(absolute) }.getOrNull()
+        return relative
+            ?.takeIf { it.toString().isNotEmpty() && !it.startsWith("..") }
+            ?.toString()
+            ?: absolute.toString()
     }
 
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/JUnitTestSuiteReporterTest.kt
@@ -25,11 +25,11 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" device="iPhone 15" tests="2" failures="0" time="1915.947" timestamp="$nowAsIso">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494.749" timestamp="$nowPlus2AsIso" status="WARNING"/>
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" file=".maestro/flow_a.yaml" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" file=".maestro/sub/flow_b.yaml" time="1494.749" timestamp="$nowPlus2AsIso" status="WARNING"/>
                   </testsuite>
                 </testsuites>
-                
+
             """.trimIndent()
         )
     }
@@ -53,13 +53,13 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" tests="2" failures="1" time="552.743" timestamp="$nowAsIso">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="131.846" timestamp="$nowPlus2AsIso" status="ERROR">
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" file=".maestro/flow_a.yaml" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" file=".maestro/sub/flow_b.yaml" time="131.846" timestamp="$nowPlus2AsIso" status="ERROR">
                       <failure>Error message</failure>
                     </testcase>
                   </testsuite>
                 </testsuites>
-                
+
             """.trimIndent()
         )
     }
@@ -83,11 +83,11 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Custom test suite name" device="iPhone 15" tests="2" failures="0" time="1915.947" timestamp="$nowAsIso">
-                    <testcase id="Flow A" name="Flow A" classname="Flow A" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
-                    <testcase id="Flow B" name="Flow B" classname="Flow B" time="1494.749" timestamp="$nowPlus2AsIso" status="WARNING"/>
+                    <testcase id="Flow A" name="Flow A" classname="Flow A" file=".maestro/flow_a.yaml" time="421.573" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
+                    <testcase id="Flow B" name="Flow B" classname="Flow B" file=".maestro/sub/flow_b.yaml" time="1494.749" timestamp="$nowPlus2AsIso" status="WARNING"/>
                   </testsuite>
                 </testsuites>
-                
+
             """.trimIndent()
         )
     }
@@ -111,7 +111,7 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
                 <?xml version='1.0' encoding='UTF-8'?>
                 <testsuites>
                   <testsuite name="Test Suite" tests="2" failures="0" time="6.0" timestamp="$nowAsIso">
-                    <testcase id="Login Flow" name="Login Flow" classname="Login Flow" time="2.5" timestamp="$nowPlus1AsIso" status="SUCCESS">
+                    <testcase id="Login Flow" name="Login Flow" classname="Login Flow" file=".maestro/auth/login.yaml" time="2.5" timestamp="$nowPlus1AsIso" status="SUCCESS">
                       <properties>
                         <property name="testCaseId" value="TC-001"/>
                         <property name="xray-test-key" value="PROJ-123"/>
@@ -119,7 +119,7 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
                         <property name="tags" value="smoke, critical, auth"/>
                       </properties>
                     </testcase>
-                    <testcase id="Checkout Flow" name="Checkout Flow" classname="Checkout Flow" time="3.5" timestamp="$nowPlus2AsIso" status="SUCCESS">
+                    <testcase id="Checkout Flow" name="Checkout Flow" classname="Checkout Flow" file=".maestro/checkout.yaml" time="3.5" timestamp="$nowPlus2AsIso" status="SUCCESS">
                       <properties>
                         <property name="testCaseId" value="TC-002"/>
                         <property name="testrail-case-id" value="C456"/>
@@ -128,7 +128,34 @@ class JUnitTestSuiteReporterTest : TestSuiteReporterTest() {
                     </testcase>
                   </testsuite>
                 </testsuites>
-                
+
+            """.trimIndent()
+        )
+    }
+
+    @Test
+    fun `XML - file attribute is omitted when filePath is null`() {
+        // Given
+        val testee = JUnitTestSuiteReporter.xml()
+        val sink = Buffer()
+
+        // When
+        testee.report(
+            summary = testSuccessWithoutFilePath,
+            out = sink
+        )
+        val resultStr = sink.readUtf8()
+
+        // Then
+        assertThat(resultStr).isEqualTo(
+            """
+                <?xml version='1.0' encoding='UTF-8'?>
+                <testsuites>
+                  <testsuite name="Test Suite" device="iPhone 15" tests="1" failures="0" time="1.0" timestamp="$nowAsIso">
+                    <testcase id="Cloud Flow" name="Cloud Flow" classname="Cloud Flow" time="1.0" timestamp="$nowPlus1AsIso" status="SUCCESS"/>
+                  </testsuite>
+                </testsuites>
+
             """.trimIndent()
         )
     }

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
@@ -30,6 +30,7 @@ abstract class TestSuiteReporterTest {
                     TestExecutionSummary.FlowResult(
                         name = "Flow A",
                         fileName = "flow_a",
+                        filePath = ".maestro/flow_a.yaml",
                         status = FlowStatus.SUCCESS,
                         duration = 421573.milliseconds,
                         startTime = nowPlus1.toInstant().toEpochMilli()
@@ -37,6 +38,7 @@ abstract class TestSuiteReporterTest {
                     TestExecutionSummary.FlowResult(
                         name = "Flow B",
                         fileName = "flow_b",
+                        filePath = ".maestro/sub/flow_b.yaml",
                         status = FlowStatus.WARNING,
                         duration = 1494749.milliseconds,
                         startTime = nowPlus2.toInstant().toEpochMilli()
@@ -57,6 +59,7 @@ abstract class TestSuiteReporterTest {
                     TestExecutionSummary.FlowResult(
                         name = "Flow A",
                         fileName = "flow_a",
+                        filePath = ".maestro/flow_a.yaml",
                         status = FlowStatus.SUCCESS,
                         duration = 421573.milliseconds,
                         startTime = nowPlus1.toInstant().toEpochMilli()
@@ -64,6 +67,7 @@ abstract class TestSuiteReporterTest {
                     TestExecutionSummary.FlowResult(
                         name = "Flow B",
                         fileName = "flow_b",
+                        filePath = ".maestro/sub/flow_b.yaml",
                         status = FlowStatus.ERROR,
                         failure = TestExecutionSummary.Failure("Error message"),
                         duration = 131846.milliseconds,
@@ -71,6 +75,28 @@ abstract class TestSuiteReporterTest {
                     ),
                 ),
                 duration = 552743.milliseconds,
+                startTime = now.toInstant().toEpochMilli()
+            )
+        )
+    )
+
+    val testSuccessWithoutFilePath = TestExecutionSummary(
+        passed = true,
+        suites = listOf(
+            TestExecutionSummary.SuiteResult(
+                passed = true,
+                deviceName = "iPhone 15",
+                flows = listOf(
+                    TestExecutionSummary.FlowResult(
+                        name = "Cloud Flow",
+                        fileName = null,
+                        filePath = null,
+                        status = FlowStatus.SUCCESS,
+                        duration = 1000.milliseconds,
+                        startTime = nowPlus1.toInstant().toEpochMilli()
+                    ),
+                ),
+                duration = 1000.milliseconds,
                 startTime = now.toInstant().toEpochMilli()
             )
         )
@@ -165,6 +191,7 @@ abstract class TestSuiteReporterTest {
                     TestExecutionSummary.FlowResult(
                         name = "Login Flow",
                         fileName = "login_flow",
+                        filePath = ".maestro/auth/login.yaml",
                         status = FlowStatus.SUCCESS,
                         duration = 2500.milliseconds,
                         startTime = nowPlus1.toInstant().toEpochMilli(),
@@ -178,6 +205,7 @@ abstract class TestSuiteReporterTest {
                     TestExecutionSummary.FlowResult(
                         name = "Checkout Flow",
                         fileName = "checkout_flow",
+                        filePath = ".maestro/checkout.yaml",
                         status = FlowStatus.SUCCESS,
                         duration = 3500.milliseconds,
                         startTime = nowPlus2.toInstant().toEpochMilli(),

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/FileUtilsTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/FileUtilsTest.kt
@@ -1,0 +1,46 @@
+package maestro.cli.util
+
+import com.google.common.truth.Truth.assertThat
+import maestro.cli.util.FileUtils.toCwdRelativeOrAbsoluteString
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.nio.file.Paths
+
+class FileUtilsTest {
+
+    @Test
+    fun `path under CWD is relativised against CWD`() {
+        val cwd = Paths.get("").toAbsolutePath()
+        val target = cwd.resolve(".maestro").resolve("aaa").resolve("bbb.yaml")
+
+        val expected = listOf(".maestro", "aaa", "bbb.yaml").joinToString(File.separator)
+        assertThat(target.toCwdRelativeOrAbsoluteString()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `path outside CWD falls back to absolute`() {
+        val cwd = Paths.get("").toAbsolutePath()
+        val parent = cwd.parent ?: return
+        val outside = parent.resolve("definitely-not-under-cwd.yaml")
+
+        assertThat(outside.toCwdRelativeOrAbsoluteString())
+            .isEqualTo(outside.toAbsolutePath().toString())
+    }
+
+    @Test
+    fun `non-absolute input is absolutised before relativising`() {
+        val relative = Paths.get(".maestro", "x.yaml")
+        val expected = listOf(".maestro", "x.yaml").joinToString(File.separator)
+
+        assertThat(relative.toCwdRelativeOrAbsoluteString()).isEqualTo(expected)
+    }
+
+    @Test
+    fun `path equal to CWD falls back to the absolute CWD string`() {
+        // relativize(self) returns an empty path; the helper guards against that
+        // and falls back to the absolute path so callers never see a blank value.
+        val cwd = Paths.get("").toAbsolutePath()
+
+        assertThat(cwd.toCwdRelativeOrAbsoluteString()).isEqualTo(cwd.toString())
+    }
+}


### PR DESCRIPTION
## Proposed changes

Adds a `file` attribute to each `<testcase>` entry in the JUnit XML report (`maestro test --format junit`). The value is the flow's source path rendered relative to the working directory (or absolute when the file lives outside the workspace), e.g. `file=".maestro/auth/login.yaml"`.

### Why

`JUnitTestSuiteReporter` currently writes `<testcase id="X" name="X" classname="X" .../>` with all three identifiers sourced from `flow.name` (the YAML `name:` field, falling back to the filename without extension). When two flow files declare the same `name:` — or two YAML files share a basename across sub-directories and rely on the fallback — the resulting `<testcase>` entries are indistinguishable. CI dashboards (GitHub Actions test reporters, Allure, Jenkins, ReportPortal, etc.) typically key off `classname` + `name` and either silently merge the colliding rows or surface them as flakes.

The new `file` attribute follows the de facto JUnit convention used by pytest-junit, jest-junit, and Maven Surefire. It is purely additive — consumers that ignore unknown attributes are unaffected — and gives downstream tooling (and humans reading the raw XML) a reliable way to tell colliding flows apart.

### Design notes

- **Strictly additive.** `id`, `name`, and `classname` are unchanged. No breaking change to existing test history, dashboard groupings, or Allure attachments.
- **Local runs only.** `maestro cloud --format junit` keeps the existing report shape — `CloudInteractor` builds `FlowResult` from upload results that don't carry source paths today, so `filePath` stays null and the attribute is omitted.
- **Path base.** Renders relative to `WorkingDirectory.baseDir` (the same base used by `mcp --working-dir` and other CLI path resolution), with an absolute-path fallback when the flow file lives outside the base or on a different filesystem root (e.g. a different Windows drive).
- **Field placement.** `FlowResult.filePath: String?` is appended at the end of the data class so any positional constructor calls keep compiling.

## Testing

- New `Path.toCwdRelativeOrAbsoluteString()` helper has unit tests covering: relative-to-CWD path, path outside CWD subtree, non-absolute input, and the `relativize(self)` empty-path edge case.
- `JUnitTestSuiteReporterTest` updated with `file=` in expected XML across the four existing tests, plus a new test asserting the attribute is omitted when `filePath` is null (cloud-style result).
- `./gradlew :maestro-cli:test` is green (FileUtilsTest 4/4, JUnitTestSuiteReporterTest 5/5, other reporter tests unaffected).
- Manual smoke: built the CLI, ran two flows with identical YAML `name:` under `.maestro/a/` and `.maestro/b/`, confirmed the produced report has two `<testcase>` rows that differ only by `file=`.

> **Does this need e2e tests?** No — pure reporter change with no UI / device behaviour.

## Issues fixed

N/A — surfaced during local Maestro usage.