### PR TITLE
Route xctest runner logs into per-run debug output

### DIFF
--- a/.github/workflows/test-e2e-ios-intel.yaml
+++ b/.github/workflows/test-e2e-ios-intel.yaml
@@ -119,15 +119,6 @@ jobs:
           retention-days: 7
           include-hidden-files: true
 
-      - name: Upload xctest runner logs
-        uses: actions/upload-artifact@v7
-        if: success() || failure()
-        with:
-          name: xctest_runner_logs
-          path: ~/Library/Logs/maestro/xctest_runner_logs
-          retention-days: 7
-          include-hidden-files: true
-
       - name: Upload screen recording of Simulator
         uses: actions/upload-artifact@v7
         if: success() || failure()

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -499,15 +499,6 @@ jobs:
           retention-days: 7
           include-hidden-files: true
 
-      - name: Upload xctest runner logs
-        uses: actions/upload-artifact@v7
-        if: success() || failure()
-        with:
-          name: xctest_runner_logs
-          path: ~/Library/Logs/maestro/xctest_runner_logs
-          retention-days: 7
-          include-hidden-files: true
-
       - name: Upload screen recording of Simulator
         uses: actions/upload-artifact@v7
         if: success() || failure()

--- a/e2e/alert-repro-swiftui/verify_preflight_suppressed.sh
+++ b/e2e/alert-repro-swiftui/verify_preflight_suppressed.sh
@@ -5,8 +5,9 @@
 #   1. Generates + builds the minimal AlertRepro SwiftUI app for iOS Simulator.
 #   2. Installs it on the given simulator and runs the Maestro flow that
 #      opens a real UIAlertController via SwiftUI `.alert(...)` and swipes.
-#   3. Greps the latest xctest_runner log for Apple's preflight signature.
-#      If any signature fires, the swizzle in
+#   3. Greps the most recently modified xctest_runner log under the per-run
+#      Maestro debug-output tree for Apple's preflight signature. If any
+#      signature fires, the swizzle in
 #      maestro-ios-xctest-runner/maestro-driver-iosUITests/Categories/XCUIApplication+Helper.m
 #      (+load method) regressed.
 #
@@ -28,7 +29,11 @@ fi
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 REPO="$(cd "$HERE/../.." && pwd)"
-LOG_DIR="$HOME/Library/Logs/maestro/xctest_runner_logs"
+# Maestro writes per-run debug output (including the xctest runner log) under
+# this tree by default; honor XDG_STATE_HOME if set, matching EnvUtils.kt.
+DEBUG_ROOT="${XDG_STATE_HOME:+$XDG_STATE_HOME/maestro}"
+DEBUG_ROOT="${DEBUG_ROOT:-$HOME/.maestro}"
+LOG_GLOB="$DEBUG_ROOT/tests/*/xctest_runner_*.log"
 FLOW="$HERE/flows/ui_interruption_preflight.yaml"
 
 echo "[1/4] Generating + building AlertRepro for simulator $SIM_UDID"
@@ -56,7 +61,12 @@ else
     exit 2
 fi
 
-LATEST_LOG="$(ls -t "$LOG_DIR"/*.log | head -1)"
+LATEST_LOG="$(ls -t $LOG_GLOB 2>/dev/null | head -1 || true)"
+if [[ -z "$LATEST_LOG" ]]; then
+    echo "error: no xctest runner log matched $LOG_GLOB" >&2
+    echo "  Did the Maestro flow above actually start the iOS driver?" >&2
+    exit 1
+fi
 echo "[4/4] Asserting preflight signature is absent in $(basename "$LATEST_LOG")"
 
 needles=(

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -33,6 +33,7 @@ import maestro.cli.driver.RealIOSDeviceDriver
 import maestro.cli.util.PrintUtils
 import maestro.device.Platform
 import maestro.utils.CliInsights
+import maestro.cli.report.TestDebugReporter
 import maestro.cli.util.ScreenReporter
 import maestro.drivers.AndroidDriver
 import maestro.drivers.IOSDriver
@@ -413,7 +414,8 @@ object MaestroSessionManager {
             deviceType = iOSDeviceType,
             iOSDriverConfig = iOSDriverConfig,
             deviceController = deviceController,
-            tempFileHandler = tempFileHandler
+            tempFileHandler = tempFileHandler,
+            logsDir = TestDebugReporter.getDebugOutputPath().resolve("xctest_runner_logs").toFile(),
         )
 
         val xcTestDriverClient = XCTestDriverClient(

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -415,7 +415,7 @@ object MaestroSessionManager {
             iOSDriverConfig = iOSDriverConfig,
             deviceController = deviceController,
             tempFileHandler = tempFileHandler,
-            logsDir = TestDebugReporter.getDebugOutputPath().resolve("xctest_runner_logs").toFile(),
+            logsDir = TestDebugReporter.getDebugOutputPath().toFile(),
         )
 
         val xcTestDriverClient = XCTestDriverClient(

--- a/maestro-ios-driver/src/main/kotlin/util/LocalIOSDeviceController.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalIOSDeviceController.kt
@@ -8,8 +8,7 @@ import java.time.format.DateTimeFormatter
 
 object LocalIOSDeviceController {
 
-    private const val LOG_DIR_DATE_FORMAT = "yyyy-MM-dd_HHmmss"
-    private val dateFormatter by lazy { DateTimeFormatter.ofPattern(LOG_DIR_DATE_FORMAT) }
+    private val dateFormatter by lazy { DateTimeFormatter.ofPattern(XCTEST_LOG_DATE_FORMAT) }
     private val date = dateFormatter.format(LocalDateTime.now())
 
     fun install(deviceId: String, path: Path) {
@@ -27,8 +26,8 @@ object LocalIOSDeviceController {
         )
     }
 
-    fun launchRunner(deviceId: String, port: Int, snapshotKeyHonorModalViews: Boolean?) {
-        val outputFile = File(XCRunnerCLIUtils.logDirectory, "xctest_runner_$date.log")
+    fun launchRunner(deviceId: String, port: Int, snapshotKeyHonorModalViews: Boolean?, logsDir: File) {
+        val outputFile = xctestLogFile(logsDir, date)
         val params = mutableMapOf("SIMCTL_CHILD_PORT" to port.toString())
         if (snapshotKeyHonorModalViews != null) {
             params["SIMCTL_CHILD_snapshotKeyHonorModalViews"] = snapshotKeyHonorModalViews.toString()

--- a/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalSimulatorUtils.kt
@@ -343,8 +343,9 @@ class LocalSimulatorUtils(private val tempFileHandler: TempFileHandler) {
         deviceId: String,
         port: Int,
         snapshotKeyHonorModalViews: Boolean?,
+        logsDir: File,
     ) {
-        val outputFile = File(XCRunnerCLIUtils.logDirectory, "xctest_runner_$date.log")
+        val outputFile = xctestLogFile(logsDir, date)
         val params = mutableMapOf("SIMCTL_CHILD_PORT" to port.toString())
         if (snapshotKeyHonorModalViews != null) {
             params["SIMCTL_CHILD_snapshotKeyHonorModalViews"] = snapshotKeyHonorModalViews.toString()

--- a/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/XCRunnerCLIUtils.kt
@@ -2,44 +2,22 @@ package util
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import maestro.utils.TempFileHandler
-import net.harawata.appdirs.AppDirsFactory
 import java.io.File
-import java.nio.file.Files
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.absolutePathString
 
+const val XCTEST_LOG_DATE_FORMAT = "yyyy-MM-dd_HHmmss"
+
+internal fun xctestLogFile(logsDir: File, date: String): File {
+    if (!logsDir.exists()) logsDir.mkdirs()
+    return File(logsDir, "xctest_runner_$date.log")
+}
+
 class XCRunnerCLIUtils(private val tempFileHandler: TempFileHandler = TempFileHandler()) {
 
-    companion object {
-        private const val APP_NAME = "maestro"
-        private const val APP_AUTHOR = "mobile_dev"
-        private const val LOG_DIR_DATE_FORMAT = "yyyy-MM-dd_HHmmss"
-        private const val MAX_COUNT_XCTEST_LOGS = 5
-
-        internal val logDirectory by lazy {
-            val parentName = AppDirsFactory.getInstance().getUserLogDir(APP_NAME, null, APP_AUTHOR)
-            val logsDirectory = File(parentName, "xctest_runner_logs")
-            File(parentName).apply {
-                if (!exists()) mkdir()
-
-                if (!logsDirectory.exists()) logsDirectory.mkdir()
-
-                val existing = logsDirectory.listFiles() ?: emptyArray()
-                val toDelete = existing.sortedByDescending { it.name }
-                val count = toDelete.size
-                if (count > MAX_COUNT_XCTEST_LOGS) toDelete.forEach { it.deleteRecursively() }
-            }
-            logsDirectory
-        }
-    }
-
-    private val dateFormatter by lazy { DateTimeFormatter.ofPattern(LOG_DIR_DATE_FORMAT) }
-
-    fun clearLogs() {
-        logDirectory.listFiles()?.forEach { it.deleteRecursively() }
-    }
+    private val dateFormatter by lazy { DateTimeFormatter.ofPattern(XCTEST_LOG_DATE_FORMAT) }
 
     fun listApps(deviceId: String): Set<String> {
         val process = Runtime.getRuntime().exec(arrayOf("bash", "-c", "xcrun simctl listapps $deviceId | plutil -convert json - -o -"))
@@ -123,9 +101,15 @@ class XCRunnerCLIUtils(private val tempFileHandler: TempFileHandler = TempFileHa
         return runningApps(deviceId)[bundleId]
     }
 
-    fun runXcTestWithoutBuild(deviceId: String, xcTestRunFilePath: String, port: Int, snapshotKeyHonorModalViews: Boolean?): Process {
+    fun runXcTestWithoutBuild(
+        deviceId: String,
+        xcTestRunFilePath: String,
+        port: Int,
+        snapshotKeyHonorModalViews: Boolean?,
+        logsDir: File,
+    ): Process {
         val date = dateFormatter.format(LocalDateTime.now())
-        val outputFile = File(logDirectory, "xctest_runner_$date.log")
+        val outputFile = xctestLogFile(logsDir, date)
         val logOutputDir = tempFileHandler.createTempDirectory("maestro_xctestrunner_xcodebuild_output").toPath()
         val params = mutableMapOf("TEST_RUNNER_PORT" to port.toString())
         if (snapshotKeyHonorModalViews != null) {

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -36,7 +36,8 @@ class LocalXCTestInstaller(
     val reinstallDriver: Boolean = true,
     private val iOSDriverConfig: IOSDriverConfig,
     private val deviceController: IOSDevice,
-    private val tempFileHandler: TempFileHandler = TempFileHandler()
+    private val tempFileHandler: TempFileHandler = TempFileHandler(),
+    private val logsDir: File,
 ) : XCTestInstaller {
 
     private val logger = LoggerFactory.getLogger(LocalXCTestInstaller::class.java)
@@ -208,7 +209,8 @@ class LocalXCTestInstaller(
                 deviceId = this.deviceId,
                 xcTestRunFilePath = buildProducts.xctestRunPath.absolutePath,
                 port = defaultPort,
-                snapshotKeyHonorModalViews = iOSDriverConfig.snapshotKeyHonorModalViews
+                snapshotKeyHonorModalViews = iOSDriverConfig.snapshotKeyHonorModalViews,
+                logsDir = logsDir,
             )
             logger.info("[Done] Running XcUITest with `xcodebuild test-without-building`")
         }
@@ -222,7 +224,8 @@ class LocalXCTestInstaller(
                 LocalIOSDeviceController.launchRunner(
                     deviceId = deviceId,
                     port = defaultPort,
-                    snapshotKeyHonorModalViews = iOSDriverConfig.snapshotKeyHonorModalViews
+                    snapshotKeyHonorModalViews = iOSDriverConfig.snapshotKeyHonorModalViews,
+                    logsDir = logsDir,
                 )
             }
             IOSDeviceType.SIMULATOR -> {
@@ -230,7 +233,8 @@ class LocalXCTestInstaller(
                 localSimulatorUtils.launchUITestRunner(
                     deviceId = deviceId,
                     port = defaultPort,
-                    snapshotKeyHonorModalViews = iOSDriverConfig.snapshotKeyHonorModalViews
+                    snapshotKeyHonorModalViews = iOSDriverConfig.snapshotKeyHonorModalViews,
+                    logsDir = logsDir,
                 )
             }
         }

--- a/maestro-ios-driver/src/test/kotlin/util/XCRunnerCLIUtilsTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/util/XCRunnerCLIUtilsTest.kt
@@ -1,0 +1,34 @@
+package util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+
+class XCRunnerCLIUtilsTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `xctestLogFile returns file under provided logsDir with the runner-log naming convention`() {
+        val logsDir = tempDir.toFile()
+        val date = "2026-05-08_120000"
+
+        val result = xctestLogFile(logsDir, date)
+
+        assertThat(result).isEqualTo(File(logsDir, "xctest_runner_2026-05-08_120000.log"))
+    }
+
+    @Test
+    fun `xctestLogFile creates the logsDir lazily when it does not yet exist`() {
+        val notYet = File(tempDir.toFile(), "deeply/nested/dir")
+        assertThat(notYet.exists()).isFalse()
+
+        val result = xctestLogFile(notYet, "2026-05-08_120000")
+
+        assertThat(notYet.isDirectory).isTrue()
+        assertThat(result.parentFile).isEqualTo(notYet)
+    }
+}


### PR DESCRIPTION
## Summary

iOS driver writes xctest runner logs to a special separate dir (`~/Library/Logs/Maestro/xctest_runner_logs/`). Keeping that path alive forces every consumer to hardcode it, drags in its own rotation/cleanup logic, and also makes it difficult to give an agent a single coherent view of one run.

- Each iOS log producer takes a `logsDir: File` parameter at the call site.
-`LocalXCTestInstaller` threads a required `logsDir` ctor field through to all three.
- CLI points the installer at `TestDebugReporter.getDebugOutputPath()`, so the runner log lands at the run-dir root alongside `maestro.log`, `commands-*.json`, screenshots, etc.
- Dropped special logic of logging inside the internal driver.
-  Changed, our workflows for reading logs from xctest_runner_logs.

## Test plan

- [x] Unit tests
- [x] Verified xctest_runner_logs shows up along debug output: [Link](https://github.com/mobile-dev-inc/Maestro/actions/runs/25558564836)