### PR TITLE
Use emoji on Windows

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -48,7 +48,6 @@ import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.runner.resultview.PlainTextResultView
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.util.CiUtils
-import maestro.cli.util.EnvUtils
 import maestro.cli.util.FileUtils.isWebFlow
 import maestro.cli.util.PrintUtils
 import maestro.cli.insights.TestAnalysisManager
@@ -548,7 +547,7 @@ class TestCommand : Callable<Int> {
     ): Triple<Int, Int, Nothing?> {
         val resultView =
             if (DisableAnsiMixin.ansiEnabled) {
-                AnsiResultView(useEmojis = !EnvUtils.isWindows())
+                AnsiResultView()
             } else {
                 PlainTextResultView()
             }

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -15,7 +15,6 @@ import maestro.cli.report.TestDebugReporter
 import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.runner.resultview.ResultView
 import maestro.cli.runner.resultview.UiState
-import maestro.cli.util.EnvUtils
 import maestro.cli.util.PrintUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.orchestra.MaestroCommand
@@ -129,7 +128,7 @@ object TestRunner {
         testOutputDir: Path?,
         deviceId: String?,
     ): Nothing {
-        val resultView = AnsiResultView("> Press [ENTER] to restart the Flow\n\n", useEmojis = !EnvUtils.isWindows())
+        val resultView = AnsiResultView("> Press [ENTER] to restart the Flow\n\n")
 
         val fileWatcher = FileWatcher()
 


### PR DESCRIPTION
Now that Windows 10 is EOL and Windows 11 has PowerShell by default, we can remove the check that disabled emoji by default on Windows

## Proposed changes

Remove Windows-specific emoji disabling

## Testing

Ran it on Windows. Saw emojis.

## Issues fixed
