### PR TITLE
fix(ios): fall back to SpringBoard hierarchy when DockFolderViewService is foreground (iOS 26 iPad)

### DIFF
--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
@@ -45,6 +45,14 @@ struct ViewHierarchyHandler: HTTPHandler {
     }
 
     func getAppViewHierarchy(foregroundApp: XCUIApplication, excludeKeyboardElements: Bool) async throws -> AXElement {
+        // On iOS 26 iPad, com.apple.DocumentManager.DockFolderViewService is reported as the
+        // foreground process on the home screen, but its AX hierarchy is empty. The actual
+        // home screen content lives in SpringBoard. Fall back to SpringBoard when detected.
+        var foregroundApp = foregroundApp
+        if foregroundApp.bundleID == "com.apple.DocumentManager.DockFolderViewService" {
+            NSLog("DockFolderViewService detected as foreground, using SpringBoard hierarchy instead")
+            foregroundApp = springboardApplication
+        }
         let appHierarchy = try getHierarchyWithFallback(foregroundApp)
         await SystemPermissionHelper.handleSystemPermissionAlertIfNeeded(appHierarchy: appHierarchy, foregroundApp: foregroundApp)
                 


### PR DESCRIPTION
In Maestro Studio Desktop (the view hierarchy), on iPad + iOS 26, nothing is clickable on the home screen except the status bar.

It looks like on the home screen, springboard is not the foreground app, it's now `com.apple.DocumentManager.DockFolderViewService` which has no hierarchy.

This change detects that service and instead falls back to springboard. The end result is you can click the icons on the home screen.

**Issue:**

(In Maestro Studio Desktop)

https://github.com/user-attachments/assets/fe360346-69a9-4935-bf96-b898535492ef

**Fix:**

(In the locally built web view UI)

https://github.com/user-attachments/assets/6c96c34e-b813-49f0-a21a-fd8191479dc7

## Remaining issues

- The highlights are completely off in landscape, but that's a larger / separate fix

<img width="836" height="637" alt="image" src="https://github.com/user-attachments/assets/983acdcd-4acf-4ec8-93bf-942e83c92141" />

## Proposed changes

copilot:summary

## Testing

I have manually tested that the home screen / springboard now has an hierarchy associated and is clickable in the home screen.

## Issues fixed

