### PR TITLE
feat: filter active sessions by platform in SessionStore

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
@@ -7,13 +7,23 @@ import java.util.concurrent.TimeUnit
 
 object SessionStore {
 
-    private val keyValueStore by lazy {
+    private val defaultKeyValueStore by lazy {
         KeyValueStore(
             dbFile = Paths
                 .get(System.getProperty("user.home"), ".maestro", "sessions")
                 .toFile()
                 .also { it.parentFile.mkdirs() }
         )
+    }
+
+    @Volatile
+    private var keyValueStoreOverride: KeyValueStore? = null
+
+    private val keyValueStore: KeyValueStore
+        get() = keyValueStoreOverride ?: defaultKeyValueStore
+
+    internal fun setKeyValueStoreForTest(store: KeyValueStore?) {
+        keyValueStoreOverride = store
     }
 
     fun heartbeat(sessionId: String, platform: Platform) {
@@ -61,8 +71,10 @@ object SessionStore {
         platform: Platform
     ): Boolean {
         synchronized(keyValueStore) {
+            val currentKey = key(sessionId, platform)
+            val platformPrefix = "${platform}_"
             return activeSessions()
-                .any { it != key(sessionId, platform) }
+                .any { it != currentKey && it.startsWith(platformPrefix) }
         }
     }
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/session/SessionStoreTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/session/SessionStoreTest.kt
@@ -1,0 +1,55 @@
+package maestro.cli.session
+
+import com.google.common.truth.Truth.assertThat
+import maestro.cli.db.KeyValueStore
+import maestro.device.Platform
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class SessionStoreTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @BeforeEach
+    fun setUp() {
+        SessionStore.setKeyValueStoreForTest(
+            KeyValueStore(tempDir.resolve("sessions").toFile())
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SessionStore.setKeyValueStoreForTest(null)
+    }
+
+    @Test
+    fun `iOS heartbeat does not make Android session see another active session`() {
+        SessionStore.heartbeat("ios-session", Platform.IOS)
+
+        val seesOther = SessionStore.hasActiveSessions("android-session", Platform.ANDROID)
+
+        assertThat(seesOther).isFalse()
+    }
+
+    @Test
+    fun `another active session on the same platform is detected`() {
+        SessionStore.heartbeat("android-1", Platform.ANDROID)
+
+        val seesOther = SessionStore.hasActiveSessions("android-2", Platform.ANDROID)
+
+        assertThat(seesOther).isTrue()
+    }
+
+    @Test
+    fun `own session entry is not counted as another active session`() {
+        SessionStore.heartbeat("self", Platform.ANDROID)
+
+        val seesOther = SessionStore.hasActiveSessions("self", Platform.ANDROID)
+
+        assertThat(seesOther).isFalse()
+    }
+}


### PR DESCRIPTION
 ## Proposed changes

  Fix `SessionStore.hasActiveSessions` so that it only considers sessions on the **same platform** as the caller. Previously, an active iOS session would cause `hasActiveSessions(..., Platform.ANDROID)` to return `true` (and vice versa), because the check simply
  compared against any key other than the caller's own.

  - `SessionStore.hasActiveSessions` now filters entries by a `"${platform}_"` key prefix, so iOS and Android sessions no longer interfere with each other.
  - Refactored the `keyValueStore` accessor to support a test-only override (`setKeyValueStoreForTest`) so the store can be redirected to a `@TempDir` in unit tests without touching the user's real `~/.maestro/sessions` DB.
  - Added `SessionStoreTest` covering three cases:
    - iOS heartbeat does not surface as an active session for an Android caller.
    - Another active session on the same platform is detected.
    - The caller's own session entry is not counted as "another" active session.

  ## Testing

  - `./gradlew :maestro-cli:test --tests "maestro.cli.session.SessionStoreTest"` — all three new unit tests pass.
  - Manually verified that running an Android flow no longer warns about an "active session" left over from a previous iOS run on the same machine.

  No e2e test added: this is a pure CLI-internal session bookkeeping change with no user-visible UI surface in `e2e/demo_app/` to exercise. Unit tests in `SessionStoreTest` cover the behavior.

  ## Issues fixed

  - iOS/Android sessions cross-contaminating `hasActiveSessions` checks, causing spurious "another session is active" warnings when switching platforms on the same machine.