### PR TITLE
Restructure the reporting metadata + properties

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
+++ b/maestro-cli/src/main/java/maestro/cli/model/TestExecutionSummary.kt
@@ -25,6 +25,11 @@ data class TestExecutionSummary(
         fun failures(): List<FlowResult> = flows.filter { it.status == FlowStatus.ERROR }
     }
 
+    data class ReportingMetadata(
+        val id: String? = null,
+        val classname: String? = null,
+    )
+
     data class FlowResult(
         val name: String,
         val fileName: String?,
@@ -32,6 +37,7 @@ data class TestExecutionSummary(
         val failure: Failure? = null,
         val duration: Duration? = null,
         val startTime: Long? = null,
+        val reportingMetadata: ReportingMetadata? = null,
         val properties: Map<String, String>? = null,
         val tags: List<String>? = null,
         val steps: List<StepResult> = emptyList(),

--- a/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/JUnitTestSuiteReporter.kt
@@ -33,8 +33,7 @@ class JUnitTestSuiteReporter(
                 // Combine flow properties and tags into a single properties list
                 val allProperties = mutableListOf<TestCaseProperty>()
 
-                // Add custom properties (excluding JUnit-specific reserved keys)
-                flow.properties?.filterKeys { it !in JUNIT_RESERVED_PROPERTY_KEYS }?.forEach { (key, value) ->
+                flow.properties?.forEach { (key, value) ->
                     allProperties.add(TestCaseProperty(key, value))
                 }
 
@@ -44,9 +43,9 @@ class JUnitTestSuiteReporter(
                 }
 
                 TestCase(
-                    id = flow.properties?.get("junitId") ?: flow.name,
+                    id = flow.reportingMetadata?.id ?: flow.name,
                     name = flow.name,
-                    classname = flow.properties?.get("junitClassname") ?: flow.name,
+                    classname = flow.reportingMetadata?.classname ?: flow.name,
                     file = flow.filePath,
                     failure = flow.failure?.let { failure ->
                         Failure(
@@ -122,8 +121,6 @@ class JUnitTestSuiteReporter(
     )
 
     companion object {
-
-        private val JUNIT_RESERVED_PROPERTY_KEYS = setOf("junitId", "junitClassname")
 
         fun xml(testSuiteName: String? = null) = JUnitTestSuiteReporter(
             mapper = XmlMapper().apply {

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -310,7 +310,10 @@ class TestSuiteInteractor(
                     )
                 } else null,
                 duration = flowDuration,
-                properties = maestroConfig?.properties,
+                reportingMetadata = maestroConfig?.reporting?.let {
+                    TestExecutionSummary.ReportingMetadata(id = it.id, classname = it.classname)
+                },
+                properties = maestroConfig?.reporting?.properties?.takeIf { it.isNotEmpty() },
                 tags = maestroConfig?.tags,
                 steps = steps,
             ),

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestSuiteReporterTest.kt
@@ -234,9 +234,9 @@ abstract class TestSuiteReporterTest {
                         status = FlowStatus.SUCCESS,
                         duration = 2500.milliseconds,
                         startTime = nowPlus1.toInstant().toEpochMilli(),
-                        properties = mapOf(
-                            "junitId" to "TC-LOGIN-001",
-                            "junitClassname" to "com.example.tests.LoginTest"
+                        reportingMetadata = TestExecutionSummary.ReportingMetadata(
+                            id = "TC-LOGIN-001",
+                            classname = "com.example.tests.LoginTest",
                         )
                     ),
                     TestExecutionSummary.FlowResult(

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -3,6 +3,12 @@ package maestro.orchestra
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
 
+data class MaestroReportingConfig(
+    val id: String? = null,
+    val classname: String? = null,
+    val properties: Map<String, String> = emptyMap(),
+)
+
 // Note: The appId config is only a yaml concept for now. It'll be a larger migration to get to a point
 // where appId is part of MaestroConfig (and factored out of MaestroCommands - eg: LaunchAppCommand).
 data class MaestroConfig(
@@ -12,14 +18,16 @@ data class MaestroConfig(
     val ext: Map<String, Any?> = emptyMap(),
     val onFlowStart: MaestroOnFlowStart? = null,
     val onFlowComplete: MaestroOnFlowComplete? = null,
-    val properties: Map<String, String> = emptyMap(),
+    val reporting: MaestroReportingConfig = MaestroReportingConfig(),
 ) {
 
     fun evaluateScripts(jsEngine: JsEngine): MaestroConfig {
         return copy(
             appId = appId?.evaluateScripts(jsEngine),
             name = name?.evaluateScripts(jsEngine),
-            properties = properties.mapValues { (_, v) -> v.evaluateScripts(jsEngine) },
+            reporting = reporting.copy(
+                properties = reporting.properties.mapValues { (_, v) -> v.evaluateScripts(jsEngine) },
+            ),
             onFlowComplete = onFlowComplete?.evaluateScripts(jsEngine),
             onFlowStart = onFlowStart?.evaluateScripts(jsEngine),
         )

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -8,6 +8,7 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroOnFlowComplete
 import maestro.orchestra.MaestroOnFlowStart
+import maestro.orchestra.MaestroReportingConfig
 import java.nio.file.Path
 
 // Exception for config field validation errors
@@ -15,6 +16,12 @@ class ConfigParseError(
     val errorType: String,
     val location: JsonLocation? = null
 ) : RuntimeException("Config validation error: $errorType")
+
+data class YamlReportingConfig(
+    val id: String? = null,
+    val classname: String? = null,
+    val properties: Map<String, String> = emptyMap(),
+)
 
 data class YamlConfig(
     val name: String?,
@@ -25,7 +32,7 @@ data class YamlConfig(
     val env: Map<String, String> = emptyMap(),
     val onFlowStart: YamlOnFlowStart?,
     val onFlowComplete: YamlOnFlowComplete?,
-    val properties: Map<String, String> = emptyMap(),
+    val reporting: YamlReportingConfig = YamlReportingConfig(),
     private val ext: MutableMap<String, Any?> = mutableMapOf<String, Any?>()
 ) {
 
@@ -53,7 +60,11 @@ data class YamlConfig(
             ext = ext.toMap(),
             onFlowStart = onFlowStart(flowPath),
             onFlowComplete = onFlowComplete(flowPath),
-            properties = properties
+            reporting = MaestroReportingConfig(
+                id = reporting.id,
+                classname = reporting.classname,
+                properties = reporting.properties,
+            ),
         )
         return MaestroCommand(ApplyConfigurationCommand(config))
     }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/MaestroCommandSerializationTest.kt
@@ -407,7 +407,9 @@ internal class MaestroCommandSerializationTest {
                   "name" : "Twitter",
                   "tags" : [ ],
                   "ext" : { },
-                  "properties" : { }
+                  "reporting" : {
+                    "properties" : { }
+                  }
                 },
                 "optional" : false
               }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -31,6 +31,7 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroOnFlowComplete
 import maestro.orchestra.MaestroOnFlowStart
+import maestro.orchestra.MaestroReportingConfig
 import maestro.orchestra.OpenLinkCommand
 import maestro.orchestra.PasteTextCommand
 import maestro.orchestra.PressKeyCommand
@@ -176,9 +177,9 @@ internal class YamlCommandReaderTest {
             ApplyConfigurationCommand(MaestroConfig(
                 appId = "com.example.app",
                 name = "Login Test",
-                properties = mapOf(
-                    "junitId" to "TC-LOGIN-001",
-                    "junitClassname" to "com.example.tests.LoginTest"
+                reporting = MaestroReportingConfig(
+                    id = "TC-LOGIN-001",
+                    classname = "com.example.tests.LoginTest",
                 )
             )),
             LaunchAppCommand(

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/033_config_junit_properties.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/033_config_junit_properties.yaml
@@ -1,7 +1,7 @@
 name: Login Test
 appId: com.example.app
-properties:
-  junitId: TC-LOGIN-001
-  junitClassname: com.example.tests.LoginTest
+reporting:
+  id: TC-LOGIN-001
+  classname: com.example.tests.LoginTest
 ---
 - launchApp


### PR DESCRIPTION
## Context

BREAKING CHANGE

#2737 introduced a `properties` key to flow config that added the contents to JUnit (and later HTML) reports. This was released in v2.1.0.

#3235 adds specific property names that are for the id and classname used in reports. Currently unreleased.

## Proposed changes

- Moves properties under `reporting` - this is a breaking change for existing flows
- Separates the report config from the report content

Before:
```
appId: com.example
properties:
  junitId: TC-01
  junitClassname: LoginTests
  priority: "High"
---
- launchApp
```

After:
```
appId: com.example
reporting:
  id: TC-01
  classname: LoginTests
  properties:
    priority: "High"
---
- launchApp
``` 

## Testing



## Issues fixed
