### PR TITLE
fix: skip broken cross-origin iframe hierarchy reads

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -681,10 +681,7 @@ class CdpWebDriver(
         } catch (e: Exception) {
             logWebHierarchyFailure("Could not find iframe element with src $iframeSrc", e)
             return null
-        } ?: run {
-            LOGGER.debug("No iframe element found with src $iframeSrc")
-            return null
-        }
+        } ?: return null
 
         // Get the iframe's scaled viewport params (accounts for parent viewportWidth/Height scaling)
         val paramsJson = try {
@@ -695,10 +692,7 @@ class CdpWebDriver(
         } catch (e: Exception) {
             logWebHierarchyFailure("Could not get viewport params for iframe $iframeSrc", e)
             return null
-        } ?: run {
-            LOGGER.debug("No viewport params returned for iframe $iframeSrc")
-            return null
-        }
+        } ?: return null
 
         val params = WebHierarchy.parseIframeViewportParams(paramsJson, iframeSrc) ?: return null
 

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -133,8 +133,10 @@ class CdpWebDriver(
             }
         )
 
-        val options = driver.capabilities.getCapability("goog:chromeOptions") as Map<String, Any>
-        val debuggerAddress = options["debuggerAddress"] as String
+        val options = driver.capabilities.getCapability("goog:chromeOptions") as? Map<*, *>
+            ?: error("Chrome debugger options are unavailable")
+        val debuggerAddress = options["debuggerAddress"] as? String
+            ?: error("Chrome debugger address is unavailable")
         val parts = debuggerAddress.split(":")
 
         cdpClient = CdpClient(
@@ -256,6 +258,7 @@ class CdpWebDriver(
         ensureOpen()
 
         detectWindowChange()
+        switchToDefaultContent("before web hierarchy fetch")
 
         // retrieve view hierarchy from DOM
         // There are edge cases where executeJS returns null, and we cannot get the hierarchy. In this situation
@@ -272,7 +275,8 @@ class CdpWebDriver(
             }
         }
 
-        val rawMap = contentDesc as Map<String, Any>
+        val rawMap = WebHierarchy.normalizeDomNode(contentDesc, "web content description")
+            ?: throw IllegalStateException("Could not parse hierarchy returned by maestro.getContentDescription()")
         val enrichedMap = injectCrossOriginIframes(rawMap)
         val root = parseDomAsTreeNodes(enrichedMap)
         seleniumDriver?.currentUrl?.let { url ->
@@ -282,45 +286,57 @@ class CdpWebDriver(
     }
 
     fun parseDomAsTreeNodes(domRepresentation: Map<String, Any>): TreeNode {
-        val attrs = domRepresentation["attributes"] as Map<String, Any>
-
-        val attributes = mutableMapOf(
-            "text" to attrs["text"] as String,
-            "bounds" to attrs["bounds"] as String,
-        )
-        if (attrs.containsKey("resource-id") && attrs["resource-id"] != null) {
-            attributes["resource-id"] = attrs["resource-id"] as String
-        }
-        if (attrs.containsKey("selected") && attrs["selected"] != null) {
-            attributes["selected"] = (attrs["selected"] as Boolean).toString()
-        }
-        if (attrs.containsKey("synthetic") && attrs["synthetic"] != null) {
-            attributes["synthetic"] = (attrs["synthetic"] as Boolean).toString()
-        }
-        if (attrs.containsKey("ignoreBoundsFiltering") && attrs["ignoreBoundsFiltering"] != null) {
-            attributes["ignoreBoundsFiltering"] = (attrs["ignoreBoundsFiltering"] as Boolean).toString()
-        }
-
-        val children = domRepresentation["children"] as List<Map<String, Any>>
-
-        return TreeNode(attributes = attributes, children = children.map { parseDomAsTreeNodes(it) })
+        return WebHierarchy.parseDomAsTreeNodes(domRepresentation)
     }
 
     private fun detectWindowChange() {
         // Checks whether there are any new window handles available and, if so, switches Selenium driver focus to it
         val driver = ensureOpen()
+        val windowHandles = try {
+            driver.windowHandles
+        } catch (e: Exception) {
+            logIframeFetchFailure("Failed to read window handles while detecting window change", e)
+            return
+        }
 
-        if (lastSeenWindowHandles != driver.windowHandles) {
-            val newHandles = driver.windowHandles - lastSeenWindowHandles
-            lastSeenWindowHandles = driver.windowHandles
+        if (lastSeenWindowHandles != windowHandles) {
+            val newHandles = windowHandles - lastSeenWindowHandles
+            lastSeenWindowHandles = windowHandles
 
             if (newHandles.isNotEmpty()) {
                 val newHandle = newHandles.first()
                 LOGGER.info("Detected a window change, switching to new window handle $newHandle")
 
-                driver.switchTo().window(newHandle)
+                try {
+                    driver.switchTo().window(newHandle)
+                } catch (e: Exception) {
+                    logIframeFetchFailure("Failed to switch to new window handle $newHandle", e)
+                    return
+                }
 
                 webScreenRecorder?.onWindowChange()
+            }
+        }
+        if (windowHandles.isNotEmpty()) {
+            val currentHandle = try {
+                driver.windowHandle
+            } catch (e: Exception) {
+                null
+            }
+
+            if (currentHandle == null || currentHandle !in windowHandles) {
+                val fallbackHandle = lastSeenWindowHandles.firstOrNull { it in windowHandles }
+                    ?: windowHandles.first()
+                LOGGER.info("Switching to available window handle $fallbackHandle before web hierarchy fetch")
+
+                try {
+                    driver.switchTo().window(fallbackHandle)
+                    lastSeenWindowHandles = windowHandles
+                    webScreenRecorder?.onWindowChange()
+                } catch (e: Exception) {
+                    logIframeFetchFailure("Failed to switch to available window handle $fallbackHandle before web hierarchy fetch", e)
+                    return
+                }
             }
         }
     }
@@ -638,35 +654,25 @@ class CdpWebDriver(
 
         if (jsResult is List<*>) {
             return jsResult
-                .mapNotNull { it as? Map<*, *> }
-                .map { parseDomAsTreeNodes(it as Map<String, Any>) }
+                .mapNotNull { WebHierarchy.normalizeDomNode(it, "queryCss result") }
+                .map { parseDomAsTreeNodes(it) }
         } else {
             LOGGER.error("Unexpected result type from queryCss: ${jsResult.javaClass.name}")
             return emptyList()
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun injectCrossOriginIframes(node: Map<String, Any>): Map<String, Any> {
-        val attrs = node["attributes"] as Map<String, Any>
-        val iframeSrc = attrs["__crossOriginIframe"] as? String
-
-        if (iframeSrc != null) {
-            val iframeContent = fetchCrossOriginIframeContent(iframeSrc)
-            if (iframeContent != null) return iframeContent
-            val cleanAttrs = attrs - "__crossOriginIframe"
-            return mapOf("attributes" to cleanAttrs, "children" to emptyList<Any>())
-        }
-
-        val children = (node["children"] as List<Map<String, Any>>)
-            .map { injectCrossOriginIframes(it) }
-        return mapOf("attributes" to attrs, "children" to children)
+        return WebHierarchy.injectCrossOriginIframes(node, ::fetchCrossOriginIframeContent)
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun fetchCrossOriginIframeContent(iframeSrc: String): Map<String, Any>? {
         val driver = seleniumDriver ?: return null
         val jsExecutor = driver as? JavascriptExecutor ?: return null
+
+        if (!switchToDefaultContent("before locating cross-origin iframe $iframeSrc")) {
+            return null
+        }
 
         // Find the iframe element by its resolved src property (absolute URL)
         val iframeElement = try {
@@ -675,10 +681,10 @@ class CdpWebDriver(
                 iframeSrc
             ) as? WebElement
         } catch (e: Exception) {
-            LOGGER.warn("Could not find iframe element with src $iframeSrc", e)
+            logIframeFetchFailure("Could not find iframe element with src $iframeSrc", e)
             return null
         } ?: run {
-            LOGGER.warn("No iframe element found with src $iframeSrc")
+            LOGGER.debug("No iframe element found with src $iframeSrc")
             return null
         }
 
@@ -689,34 +695,52 @@ class CdpWebDriver(
                 iframeSrc
             ) as? String
         } catch (e: Exception) {
-            LOGGER.warn("Could not get viewport params for iframe $iframeSrc", e)
+            logIframeFetchFailure("Could not get viewport params for iframe $iframeSrc", e)
             return null
-        } ?: return null
+        } ?: run {
+            LOGGER.debug("No viewport params returned for iframe $iframeSrc")
+            return null
+        }
 
-        val params = jacksonObjectMapper().readValue(paramsJson, Map::class.java) as Map<String, Any>
-        val iframeX = (params["viewportX"]      as? Number)?.toDouble() ?: 0.0
-        val iframeY = (params["viewportY"]      as? Number)?.toDouble() ?: 0.0
-        val iframeW = (params["viewportWidth"]  as? Number)?.toDouble() ?: 0.0
-        val iframeH = (params["viewportHeight"] as? Number)?.toDouble() ?: 0.0
+        val params = WebHierarchy.parseIframeViewportParams(paramsJson, iframeSrc) ?: return null
 
         // ChromeDriver can execute scripts inside cross-origin iframes via switchTo().frame()
-        driver.switchTo().frame(iframeElement)
         return try {
+            driver.switchTo().frame(iframeElement)
             val resultJson = jsExecutor.executeScript("""
                 $maestroWebScript
-                window.maestro.viewportX = $iframeX;
-                window.maestro.viewportY = $iframeY;
-                window.maestro.viewportWidth = $iframeW;
-                window.maestro.viewportHeight = $iframeH;
+                window.maestro.viewportX = ${params.viewportX};
+                window.maestro.viewportY = ${params.viewportY};
+                window.maestro.viewportWidth = ${params.viewportWidth};
+                window.maestro.viewportHeight = ${params.viewportHeight};
                 return JSON.stringify(window.maestro.getContentDescription());
             """.trimIndent()) as? String ?: return null
-            jacksonObjectMapper().readValue(resultJson, Map::class.java) as? Map<String, Any>
+            WebHierarchy.parseDomJson(resultJson, "cross-origin iframe $iframeSrc")
         } catch (e: Exception) {
-            LOGGER.warn("Failed to get content description from cross-origin iframe $iframeSrc", e)
+            logIframeFetchFailure("Failed to get content description from cross-origin iframe $iframeSrc", e)
             null
         } finally {
             try { driver.switchTo().defaultContent() }
-            catch (e: Exception) { LOGGER.warn("Failed to switch back to default content", e) }
+            catch (e: Exception) { logIframeFetchFailure("Failed to switch back to default content", e) }
+        }
+    }
+
+    private fun logIframeFetchFailure(message: String, e: Exception) {
+        if (WebHierarchy.isTransientIframeFetchError(e)) {
+            LOGGER.debug(message, e)
+        } else {
+            LOGGER.warn(message, e)
+        }
+    }
+
+    private fun switchToDefaultContent(context: String): Boolean {
+        val driver = seleniumDriver ?: return false
+        return try {
+            driver.switchTo().defaultContent()
+            true
+        } catch (e: Exception) {
+            logIframeFetchFailure("Failed to switch to default content $context", e)
+            false
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -258,7 +258,7 @@ class CdpWebDriver(
         ensureOpen()
 
         detectWindowChange()
-        switchToDefaultContent("before web hierarchy fetch")
+        val canFetchIframeContent = switchToDefaultContent("before web hierarchy fetch")
 
         // retrieve view hierarchy from DOM
         // There are edge cases where executeJS returns null, and we cannot get the hierarchy. In this situation
@@ -277,7 +277,7 @@ class CdpWebDriver(
 
         val rawMap = WebHierarchy.normalizeDomNode(contentDesc, "web content description")
             ?: throw IllegalStateException("Could not parse hierarchy returned by maestro.getContentDescription()")
-        val enrichedMap = injectCrossOriginIframes(rawMap)
+        val enrichedMap = injectCrossOriginIframes(rawMap, canFetchIframeContent)
         val root = parseDomAsTreeNodes(enrichedMap)
         seleniumDriver?.currentUrl?.let { url ->
             root.attributes["url"] = url
@@ -637,9 +637,10 @@ class CdpWebDriver(
     }
 
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {
-        return when (query) {
-            is OnDeviceElementQuery.Css -> queryCss(query)
+        if (query is OnDeviceElementQuery.Css) {
+            return queryCss(query)
         }
+        return super.queryOnDeviceElements(query)
     }
 
     private fun queryCss(query: OnDeviceElementQuery.Css): List<TreeNode> {
@@ -661,8 +662,14 @@ class CdpWebDriver(
         }
     }
 
-    private fun injectCrossOriginIframes(node: Map<String, Any>): Map<String, Any> {
-        return WebHierarchy.injectCrossOriginIframes(node, ::fetchCrossOriginIframeContent)
+    private fun injectCrossOriginIframes(node: Map<String, Any>, canFetchIframeContent: Boolean): Map<String, Any> {
+        return WebHierarchy.injectCrossOriginIframes(node) { iframeSrc ->
+            if (canFetchIframeContent) {
+                fetchCrossOriginIframeContent(iframeSrc)
+            } else {
+                null
+            }
+        }
     }
 
     private fun fetchCrossOriginIframeContent(iframeSrc: String): Map<String, Any>? {
@@ -725,7 +732,7 @@ class CdpWebDriver(
     }
 
     private fun logWebHierarchyFailure(message: String, e: Exception) {
-        if (WebHierarchy.isTransientIframeFetchError(e)) {
+        if (WebHierarchy.isTransientBrowserContextError(e)) {
             LOGGER.debug(message, e)
         } else {
             LOGGER.warn(message, e)

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -295,7 +295,7 @@ class CdpWebDriver(
         val windowHandles = try {
             driver.windowHandles
         } catch (e: Exception) {
-            logIframeFetchFailure("Failed to read window handles while detecting window change", e)
+            logWebHierarchyFailure("Failed to read window handles while detecting window change", e)
             return
         }
 
@@ -310,7 +310,7 @@ class CdpWebDriver(
                 try {
                     driver.switchTo().window(newHandle)
                 } catch (e: Exception) {
-                    logIframeFetchFailure("Failed to switch to new window handle $newHandle", e)
+                    logWebHierarchyFailure("Failed to switch to new window handle $newHandle", e)
                     return
                 }
 
@@ -334,7 +334,7 @@ class CdpWebDriver(
                     lastSeenWindowHandles = windowHandles
                     webScreenRecorder?.onWindowChange()
                 } catch (e: Exception) {
-                    logIframeFetchFailure("Failed to switch to available window handle $fallbackHandle before web hierarchy fetch", e)
+                    logWebHierarchyFailure("Failed to switch to available window handle $fallbackHandle before web hierarchy fetch", e)
                     return
                 }
             }
@@ -639,7 +639,6 @@ class CdpWebDriver(
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {
         return when (query) {
             is OnDeviceElementQuery.Css -> queryCss(query)
-            else -> super.queryOnDeviceElements(query)
         }
     }
 
@@ -681,7 +680,7 @@ class CdpWebDriver(
                 iframeSrc
             ) as? WebElement
         } catch (e: Exception) {
-            logIframeFetchFailure("Could not find iframe element with src $iframeSrc", e)
+            logWebHierarchyFailure("Could not find iframe element with src $iframeSrc", e)
             return null
         } ?: run {
             LOGGER.debug("No iframe element found with src $iframeSrc")
@@ -695,7 +694,7 @@ class CdpWebDriver(
                 iframeSrc
             ) as? String
         } catch (e: Exception) {
-            logIframeFetchFailure("Could not get viewport params for iframe $iframeSrc", e)
+            logWebHierarchyFailure("Could not get viewport params for iframe $iframeSrc", e)
             return null
         } ?: run {
             LOGGER.debug("No viewport params returned for iframe $iframeSrc")
@@ -717,15 +716,15 @@ class CdpWebDriver(
             """.trimIndent()) as? String ?: return null
             WebHierarchy.parseDomJson(resultJson, "cross-origin iframe $iframeSrc")
         } catch (e: Exception) {
-            logIframeFetchFailure("Failed to get content description from cross-origin iframe $iframeSrc", e)
+            logWebHierarchyFailure("Failed to get content description from cross-origin iframe $iframeSrc", e)
             null
         } finally {
             try { driver.switchTo().defaultContent() }
-            catch (e: Exception) { logIframeFetchFailure("Failed to switch back to default content", e) }
+            catch (e: Exception) { logWebHierarchyFailure("Failed to switch back to default content", e) }
         }
     }
 
-    private fun logIframeFetchFailure(message: String, e: Exception) {
+    private fun logWebHierarchyFailure(message: String, e: Exception) {
         if (WebHierarchy.isTransientIframeFetchError(e)) {
             LOGGER.debug(message, e)
         } else {
@@ -739,7 +738,7 @@ class CdpWebDriver(
             driver.switchTo().defaultContent()
             true
         } catch (e: Exception) {
-            logIframeFetchFailure("Failed to switch to default content $context", e)
+            logWebHierarchyFailure("Failed to switch to default content $context", e)
             false
         }
     }

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -277,16 +277,18 @@ class CdpWebDriver(
 
         val rawMap = WebHierarchy.normalizeDomNode(contentDesc, "web content description")
             ?: throw IllegalStateException("Could not parse hierarchy returned by maestro.getContentDescription()")
-        val enrichedMap = injectCrossOriginIframes(rawMap, canFetchIframeContent)
-        val root = parseDomAsTreeNodes(enrichedMap)
+        val enrichedMap = WebHierarchy.injectCrossOriginIframes(rawMap) { iframeSrc ->
+            if (canFetchIframeContent) {
+                fetchCrossOriginIframeContent(iframeSrc)
+            } else {
+                null
+            }
+        }
+        val root = WebHierarchy.parseDomAsTreeNodes(enrichedMap)
         seleniumDriver?.currentUrl?.let { url ->
             root.attributes["url"] = url
         }
         return root
-    }
-
-    fun parseDomAsTreeNodes(domRepresentation: Map<String, Any>): TreeNode {
-        return WebHierarchy.parseDomAsTreeNodes(domRepresentation)
     }
 
     private fun detectWindowChange() {
@@ -655,20 +657,10 @@ class CdpWebDriver(
         if (jsResult is List<*>) {
             return jsResult
                 .mapNotNull { WebHierarchy.normalizeDomNode(it, "queryCss result") }
-                .map { parseDomAsTreeNodes(it) }
+                .map { WebHierarchy.parseDomAsTreeNodes(it) }
         } else {
             LOGGER.error("Unexpected result type from queryCss: ${jsResult.javaClass.name}")
             return emptyList()
-        }
-    }
-
-    private fun injectCrossOriginIframes(node: Map<String, Any>, canFetchIframeContent: Boolean): Map<String, Any> {
-        return WebHierarchy.injectCrossOriginIframes(node) { iframeSrc ->
-            if (canFetchIframeContent) {
-                fetchCrossOriginIframeContent(iframeSrc)
-            } else {
-                null
-            }
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -656,7 +656,7 @@ class CdpWebDriver(
 
         if (jsResult is List<*>) {
             return jsResult
-                .mapNotNull { WebHierarchy.normalizeDomNode(it, "queryCss result") }
+                .mapNotNull { it as? Map<*, *> }
                 .map { WebHierarchy.parseDomAsTreeNodes(it) }
         } else {
             LOGGER.error("Unexpected result type from queryCss: ${jsResult.javaClass.name}")

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -638,7 +638,7 @@ class WebDriver(
 
         if (jsResult is List<*>) {
             return jsResult
-                .mapNotNull { WebHierarchy.normalizeDomNode(it, "queryCss result") }
+                .mapNotNull { it as? Map<*, *> }
                 .map { WebHierarchy.parseDomAsTreeNodes(it) }
         } else {
             LOGGER.error("Unexpected result type from queryCss: ${jsResult.javaClass.name}")

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -260,7 +260,7 @@ class WebDriver(
         val windowHandles = try {
             driver.windowHandles
         } catch (e: Exception) {
-            logIframeFetchFailure("Failed to read window handles while detecting window change", e)
+            logWebHierarchyFailure("Failed to read window handles while detecting window change", e)
             return
         }
 
@@ -269,13 +269,13 @@ class WebDriver(
             lastSeenWindowHandles = windowHandles
 
             if (newHandles.isNotEmpty()) {
-                val newHandle = newHandles.first()
+                val newHandle = newHandles.first();
                 LOGGER.info("Detected a window change, switching to new window handle $newHandle")
 
                 try {
                     driver.switchTo().window(newHandle)
                 } catch (e: Exception) {
-                    logIframeFetchFailure("Failed to switch to new window handle $newHandle", e)
+                    logWebHierarchyFailure("Failed to switch to new window handle $newHandle", e)
                     return
                 }
 
@@ -299,7 +299,7 @@ class WebDriver(
                     lastSeenWindowHandles = windowHandles
                     webScreenRecorder?.onWindowChange()
                 } catch (e: Exception) {
-                    logIframeFetchFailure("Failed to switch to available window handle $fallbackHandle before web hierarchy fetch", e)
+                    logWebHierarchyFailure("Failed to switch to available window handle $fallbackHandle before web hierarchy fetch", e)
                     return
                 }
             }
@@ -621,7 +621,6 @@ class WebDriver(
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {
         return when (query) {
             is OnDeviceElementQuery.Css -> queryCss(query)
-            else -> super.queryOnDeviceElements(query)
         }
     }
 
@@ -663,7 +662,7 @@ class WebDriver(
                 iframeSrc
             ) as? WebElement
         } catch (e: Exception) {
-            logIframeFetchFailure("Could not find iframe element with src $iframeSrc", e)
+            logWebHierarchyFailure("Could not find iframe element with src $iframeSrc", e)
             return null
         } ?: run {
             LOGGER.debug("No iframe element found with src $iframeSrc")
@@ -677,7 +676,7 @@ class WebDriver(
                 iframeSrc
             ) as? String
         } catch (e: Exception) {
-            logIframeFetchFailure("Could not get viewport params for iframe $iframeSrc", e)
+            logWebHierarchyFailure("Could not get viewport params for iframe $iframeSrc", e)
             return null
         } ?: run {
             LOGGER.debug("No viewport params returned for iframe $iframeSrc")
@@ -699,15 +698,15 @@ class WebDriver(
             """.trimIndent()) as? String ?: return null
             WebHierarchy.parseDomJson(resultJson, "cross-origin iframe $iframeSrc")
         } catch (e: Exception) {
-            logIframeFetchFailure("Failed to get content description from cross-origin iframe $iframeSrc", e)
+            logWebHierarchyFailure("Failed to get content description from cross-origin iframe $iframeSrc", e)
             null
         } finally {
             try { driver.switchTo().defaultContent() }
-            catch (e: Exception) { logIframeFetchFailure("Failed to switch back to default content", e) }
+            catch (e: Exception) { logWebHierarchyFailure("Failed to switch back to default content", e) }
         }
     }
 
-    private fun logIframeFetchFailure(message: String, e: Exception) {
+    private fun logWebHierarchyFailure(message: String, e: Exception) {
         if (WebHierarchy.isTransientIframeFetchError(e)) {
             LOGGER.debug(message, e)
         } else {
@@ -721,7 +720,7 @@ class WebDriver(
             driver.switchTo().defaultContent()
             true
         } catch (e: Exception) {
-            logIframeFetchFailure("Failed to switch to default content $context", e)
+            logWebHierarchyFailure("Failed to switch to default content $context", e)
             false
         }
     }

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -269,7 +269,7 @@ class WebDriver(
             lastSeenWindowHandles = windowHandles
 
             if (newHandles.isNotEmpty()) {
-                val newHandle = newHandles.first();
+                val newHandle = newHandles.first()
                 LOGGER.info("Detected a window change, switching to new window handle $newHandle")
 
                 try {

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -242,16 +242,18 @@ class WebDriver(
 
         val rawMap = WebHierarchy.normalizeDomNode(contentDesc, "web content description")
             ?: throw IllegalStateException("Could not parse hierarchy returned by maestro.getContentDescription()")
-        val enrichedMap = injectCrossOriginIframes(rawMap, canFetchIframeContent)
-        val root = parseDomAsTreeNodes(enrichedMap)
+        val enrichedMap = WebHierarchy.injectCrossOriginIframes(rawMap) { iframeSrc ->
+            if (canFetchIframeContent) {
+                fetchCrossOriginIframeContent(iframeSrc)
+            } else {
+                null
+            }
+        }
+        val root = WebHierarchy.parseDomAsTreeNodes(enrichedMap)
         seleniumDriver?.currentUrl?.let { url ->
             root.attributes["url"] = url
         }
         return root
-    }
-
-    fun parseDomAsTreeNodes(domRepresentation: Map<String, Any>): TreeNode {
-        return WebHierarchy.parseDomAsTreeNodes(domRepresentation)
     }
 
     private fun detectWindowChange() {
@@ -637,20 +639,10 @@ class WebDriver(
         if (jsResult is List<*>) {
             return jsResult
                 .mapNotNull { WebHierarchy.normalizeDomNode(it, "queryCss result") }
-                .map { parseDomAsTreeNodes(it) }
+                .map { WebHierarchy.parseDomAsTreeNodes(it) }
         } else {
             LOGGER.error("Unexpected result type from queryCss: ${jsResult.javaClass.name}")
             return emptyList()
-        }
-    }
-
-    private fun injectCrossOriginIframes(node: Map<String, Any>, canFetchIframeContent: Boolean): Map<String, Any> {
-        return WebHierarchy.injectCrossOriginIframes(node) { iframeSrc ->
-            if (canFetchIframeContent) {
-                fetchCrossOriginIframeContent(iframeSrc)
-            } else {
-                null
-            }
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -20,7 +20,6 @@ import maestro.web.selenium.ChromeSeleniumFactory
 import maestro.web.selenium.SeleniumFactory
 import okio.Sink
 import okio.buffer
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.openqa.selenium.By
 import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.Keys
@@ -224,6 +223,7 @@ class WebDriver(
         ensureOpen()
 
         detectWindowChange()
+        switchToDefaultContent("before web hierarchy fetch")
 
         // retrieve view hierarchy from DOM
         // There are edge cases where executeJS returns null, and we cannot get the hierarchy. In this situation
@@ -240,7 +240,8 @@ class WebDriver(
             }
         }
 
-        val rawMap = contentDesc as Map<String, Any>
+        val rawMap = WebHierarchy.normalizeDomNode(contentDesc, "web content description")
+            ?: throw IllegalStateException("Could not parse hierarchy returned by maestro.getContentDescription()")
         val enrichedMap = injectCrossOriginIframes(rawMap)
         val root = parseDomAsTreeNodes(enrichedMap)
         seleniumDriver?.currentUrl?.let { url ->
@@ -250,45 +251,57 @@ class WebDriver(
     }
 
     fun parseDomAsTreeNodes(domRepresentation: Map<String, Any>): TreeNode {
-        val attrs = domRepresentation["attributes"] as Map<String, Any>
-
-        val attributes = mutableMapOf(
-            "text" to attrs["text"] as String,
-            "bounds" to attrs["bounds"] as String,
-        )
-        if (attrs.containsKey("resource-id") && attrs["resource-id"] != null) {
-            attributes["resource-id"] = attrs["resource-id"] as String
-        }
-        if (attrs.containsKey("selected") && attrs["selected"] != null) {
-            attributes["selected"] = (attrs["selected"] as Boolean).toString()
-        }
-        if (attrs.containsKey("synthetic") && attrs["synthetic"] != null) {
-            attributes["synthetic"] = (attrs["synthetic"] as Boolean).toString()
-        }
-        if (attrs.containsKey("ignoreBoundsFiltering") && attrs["ignoreBoundsFiltering"] != null) {
-            attributes["ignoreBoundsFiltering"] = (attrs["ignoreBoundsFiltering"] as Boolean).toString()
-        }
-
-        val children = domRepresentation["children"] as List<Map<String, Any>>
-
-        return TreeNode(attributes = attributes, children = children.map { parseDomAsTreeNodes(it) })
+        return WebHierarchy.parseDomAsTreeNodes(domRepresentation)
     }
 
     private fun detectWindowChange() {
         // Checks whether there are any new window handles available and, if so, switches Selenium driver focus to it
         val driver = ensureOpen()
+        val windowHandles = try {
+            driver.windowHandles
+        } catch (e: Exception) {
+            logIframeFetchFailure("Failed to read window handles while detecting window change", e)
+            return
+        }
 
-        if (lastSeenWindowHandles != driver.windowHandles) {
-            val newHandles = driver.windowHandles - lastSeenWindowHandles
-            lastSeenWindowHandles = driver.windowHandles
+        if (lastSeenWindowHandles != windowHandles) {
+            val newHandles = windowHandles - lastSeenWindowHandles
+            lastSeenWindowHandles = windowHandles
 
             if (newHandles.isNotEmpty()) {
-                val newHandle = newHandles.first();
+                val newHandle = newHandles.first()
                 LOGGER.info("Detected a window change, switching to new window handle $newHandle")
 
-                driver.switchTo().window(newHandle)
+                try {
+                    driver.switchTo().window(newHandle)
+                } catch (e: Exception) {
+                    logIframeFetchFailure("Failed to switch to new window handle $newHandle", e)
+                    return
+                }
 
                 webScreenRecorder?.onWindowChange()
+            }
+        }
+        if (windowHandles.isNotEmpty()) {
+            val currentHandle = try {
+                driver.windowHandle
+            } catch (e: Exception) {
+                null
+            }
+
+            if (currentHandle == null || currentHandle !in windowHandles) {
+                val fallbackHandle = lastSeenWindowHandles.firstOrNull { it in windowHandles }
+                    ?: windowHandles.first()
+                LOGGER.info("Switching to available window handle $fallbackHandle before web hierarchy fetch")
+
+                try {
+                    driver.switchTo().window(fallbackHandle)
+                    lastSeenWindowHandles = windowHandles
+                    webScreenRecorder?.onWindowChange()
+                } catch (e: Exception) {
+                    logIframeFetchFailure("Failed to switch to available window handle $fallbackHandle before web hierarchy fetch", e)
+                    return
+                }
             }
         }
     }
@@ -623,35 +636,25 @@ class WebDriver(
 
         if (jsResult is List<*>) {
             return jsResult
-                .mapNotNull { it as? Map<*, *> }
-                .map { parseDomAsTreeNodes(it as Map<String, Any>) }
+                .mapNotNull { WebHierarchy.normalizeDomNode(it, "queryCss result") }
+                .map { parseDomAsTreeNodes(it) }
         } else {
             LOGGER.error("Unexpected result type from queryCss: ${jsResult.javaClass.name}")
             return emptyList()
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun injectCrossOriginIframes(node: Map<String, Any>): Map<String, Any> {
-        val attrs = node["attributes"] as Map<String, Any>
-        val iframeSrc = attrs["__crossOriginIframe"] as? String
-
-        if (iframeSrc != null) {
-            val iframeContent = fetchCrossOriginIframeContent(iframeSrc)
-            if (iframeContent != null) return iframeContent
-            val cleanAttrs = attrs - "__crossOriginIframe"
-            return mapOf("attributes" to cleanAttrs, "children" to emptyList<Any>())
-        }
-
-        val children = (node["children"] as List<Map<String, Any>>)
-            .map { injectCrossOriginIframes(it) }
-        return mapOf("attributes" to attrs, "children" to children)
+        return WebHierarchy.injectCrossOriginIframes(node, ::fetchCrossOriginIframeContent)
     }
 
-    @Suppress("UNCHECKED_CAST")
     private fun fetchCrossOriginIframeContent(iframeSrc: String): Map<String, Any>? {
         val driver = seleniumDriver ?: return null
         val jsExecutor = driver as? JavascriptExecutor ?: return null
+
+        if (!switchToDefaultContent("before locating cross-origin iframe $iframeSrc")) {
+            return null
+        }
 
         // Find the iframe element by its resolved src property (absolute URL)
         val iframeElement = try {
@@ -660,10 +663,10 @@ class WebDriver(
                 iframeSrc
             ) as? WebElement
         } catch (e: Exception) {
-            LOGGER.warn("Could not find iframe element with src $iframeSrc", e)
+            logIframeFetchFailure("Could not find iframe element with src $iframeSrc", e)
             return null
         } ?: run {
-            LOGGER.warn("No iframe element found with src $iframeSrc")
+            LOGGER.debug("No iframe element found with src $iframeSrc")
             return null
         }
 
@@ -674,34 +677,52 @@ class WebDriver(
                 iframeSrc
             ) as? String
         } catch (e: Exception) {
-            LOGGER.warn("Could not get viewport params for iframe $iframeSrc", e)
+            logIframeFetchFailure("Could not get viewport params for iframe $iframeSrc", e)
             return null
-        } ?: return null
+        } ?: run {
+            LOGGER.debug("No viewport params returned for iframe $iframeSrc")
+            return null
+        }
 
-        val params = jacksonObjectMapper().readValue(paramsJson, Map::class.java) as Map<String, Any>
-        val iframeX = (params["viewportX"]      as? Number)?.toDouble() ?: 0.0
-        val iframeY = (params["viewportY"]      as? Number)?.toDouble() ?: 0.0
-        val iframeW = (params["viewportWidth"]  as? Number)?.toDouble() ?: 0.0
-        val iframeH = (params["viewportHeight"] as? Number)?.toDouble() ?: 0.0
+        val params = WebHierarchy.parseIframeViewportParams(paramsJson, iframeSrc) ?: return null
 
         // ChromeDriver can execute scripts inside cross-origin iframes via switchTo().frame()
-        driver.switchTo().frame(iframeElement)
         return try {
+            driver.switchTo().frame(iframeElement)
             val resultJson = jsExecutor.executeScript("""
                 $maestroWebScript
-                window.maestro.viewportX = $iframeX;
-                window.maestro.viewportY = $iframeY;
-                window.maestro.viewportWidth = $iframeW;
-                window.maestro.viewportHeight = $iframeH;
+                window.maestro.viewportX = ${params.viewportX};
+                window.maestro.viewportY = ${params.viewportY};
+                window.maestro.viewportWidth = ${params.viewportWidth};
+                window.maestro.viewportHeight = ${params.viewportHeight};
                 return JSON.stringify(window.maestro.getContentDescription());
             """.trimIndent()) as? String ?: return null
-            jacksonObjectMapper().readValue(resultJson, Map::class.java) as? Map<String, Any>
+            WebHierarchy.parseDomJson(resultJson, "cross-origin iframe $iframeSrc")
         } catch (e: Exception) {
-            LOGGER.warn("Failed to get content description from cross-origin iframe $iframeSrc", e)
+            logIframeFetchFailure("Failed to get content description from cross-origin iframe $iframeSrc", e)
             null
         } finally {
             try { driver.switchTo().defaultContent() }
-            catch (e: Exception) { LOGGER.warn("Failed to switch back to default content", e) }
+            catch (e: Exception) { logIframeFetchFailure("Failed to switch back to default content", e) }
+        }
+    }
+
+    private fun logIframeFetchFailure(message: String, e: Exception) {
+        if (WebHierarchy.isTransientIframeFetchError(e)) {
+            LOGGER.debug(message, e)
+        } else {
+            LOGGER.warn(message, e)
+        }
+    }
+
+    private fun switchToDefaultContent(context: String): Boolean {
+        val driver = seleniumDriver ?: return false
+        return try {
+            driver.switchTo().defaultContent()
+            true
+        } catch (e: Exception) {
+            logIframeFetchFailure("Failed to switch to default content $context", e)
+            false
         }
     }
 

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -663,10 +663,7 @@ class WebDriver(
         } catch (e: Exception) {
             logWebHierarchyFailure("Could not find iframe element with src $iframeSrc", e)
             return null
-        } ?: run {
-            LOGGER.debug("No iframe element found with src $iframeSrc")
-            return null
-        }
+        } ?: return null
 
         // Get the iframe's scaled viewport params (accounts for parent viewportWidth/Height scaling)
         val paramsJson = try {
@@ -677,10 +674,7 @@ class WebDriver(
         } catch (e: Exception) {
             logWebHierarchyFailure("Could not get viewport params for iframe $iframeSrc", e)
             return null
-        } ?: run {
-            LOGGER.debug("No viewport params returned for iframe $iframeSrc")
-            return null
-        }
+        } ?: return null
 
         val params = WebHierarchy.parseIframeViewportParams(paramsJson, iframeSrc) ?: return null
 

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -223,7 +223,7 @@ class WebDriver(
         ensureOpen()
 
         detectWindowChange()
-        switchToDefaultContent("before web hierarchy fetch")
+        val canFetchIframeContent = switchToDefaultContent("before web hierarchy fetch")
 
         // retrieve view hierarchy from DOM
         // There are edge cases where executeJS returns null, and we cannot get the hierarchy. In this situation
@@ -242,7 +242,7 @@ class WebDriver(
 
         val rawMap = WebHierarchy.normalizeDomNode(contentDesc, "web content description")
             ?: throw IllegalStateException("Could not parse hierarchy returned by maestro.getContentDescription()")
-        val enrichedMap = injectCrossOriginIframes(rawMap)
+        val enrichedMap = injectCrossOriginIframes(rawMap, canFetchIframeContent)
         val root = parseDomAsTreeNodes(enrichedMap)
         seleniumDriver?.currentUrl?.let { url ->
             root.attributes["url"] = url
@@ -619,9 +619,10 @@ class WebDriver(
     }
 
     override fun queryOnDeviceElements(query: OnDeviceElementQuery): List<TreeNode> {
-        return when (query) {
-            is OnDeviceElementQuery.Css -> queryCss(query)
+        if (query is OnDeviceElementQuery.Css) {
+            return queryCss(query)
         }
+        return super.queryOnDeviceElements(query)
     }
 
     private fun queryCss(query: OnDeviceElementQuery.Css): List<TreeNode> {
@@ -643,8 +644,14 @@ class WebDriver(
         }
     }
 
-    private fun injectCrossOriginIframes(node: Map<String, Any>): Map<String, Any> {
-        return WebHierarchy.injectCrossOriginIframes(node, ::fetchCrossOriginIframeContent)
+    private fun injectCrossOriginIframes(node: Map<String, Any>, canFetchIframeContent: Boolean): Map<String, Any> {
+        return WebHierarchy.injectCrossOriginIframes(node) { iframeSrc ->
+            if (canFetchIframeContent) {
+                fetchCrossOriginIframeContent(iframeSrc)
+            } else {
+                null
+            }
+        }
     }
 
     private fun fetchCrossOriginIframeContent(iframeSrc: String): Map<String, Any>? {
@@ -707,7 +714,7 @@ class WebDriver(
     }
 
     private fun logWebHierarchyFailure(message: String, e: Exception) {
-        if (WebHierarchy.isTransientIframeFetchError(e)) {
+        if (WebHierarchy.isTransientBrowserContextError(e)) {
             LOGGER.debug(message, e)
         } else {
             LOGGER.warn(message, e)

--- a/maestro-client/src/main/java/maestro/drivers/WebHierarchy.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebHierarchy.kt
@@ -1,0 +1,201 @@
+package maestro.drivers
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import maestro.TreeNode
+import org.openqa.selenium.NoSuchFrameException
+import org.openqa.selenium.NoSuchWindowException
+import org.openqa.selenium.StaleElementReferenceException
+import org.slf4j.LoggerFactory
+
+internal data class IframeViewportParams(
+    val viewportX: Double,
+    val viewportY: Double,
+    val viewportWidth: Double,
+    val viewportHeight: Double,
+)
+
+internal object WebHierarchy {
+
+    private const val CROSS_ORIGIN_IFRAME_ATTRIBUTE = "__crossOriginIframe"
+
+    private val objectMapper = jacksonObjectMapper()
+    private val logger = LoggerFactory.getLogger(WebHierarchy::class.java)
+
+    fun normalizeDomNode(value: Any?, context: String): Map<String, Any>? {
+        val node = value as? Map<*, *> ?: return malformed(context, "expected object")
+        val attrs = normalizeAttributes(node["attributes"], context) ?: return null
+        val rawChildren = node["children"] as? List<*> ?: return malformed(context, "missing children")
+        val children = rawChildren.mapNotNull {
+            normalizeDomNode(it, "$context child")
+        }
+
+        return mapOf(
+            "attributes" to attrs,
+            "children" to children,
+        )
+    }
+
+    fun parseDomJson(json: String?, context: String): Map<String, Any>? {
+        val decoded = parseJson(json, context) ?: return null
+        return normalizeDomNode(decoded, context)
+    }
+
+    fun parseIframeViewportParams(json: String?, iframeSrc: String): IframeViewportParams? {
+        val context = "iframe viewport params for $iframeSrc"
+        val params = parseJson(json, context) as? Map<*, *> ?: return malformed(context, "expected object")
+
+        val viewportX = (params["viewportX"] as? Number)?.toDouble()
+            ?: return malformed(context, "missing viewportX")
+        val viewportY = (params["viewportY"] as? Number)?.toDouble()
+            ?: return malformed(context, "missing viewportY")
+        val viewportWidth = (params["viewportWidth"] as? Number)?.toDouble()
+            ?: return malformed(context, "missing viewportWidth")
+        val viewportHeight = (params["viewportHeight"] as? Number)?.toDouble()
+            ?: return malformed(context, "missing viewportHeight")
+
+        return IframeViewportParams(
+            viewportX = viewportX,
+            viewportY = viewportY,
+            viewportWidth = viewportWidth,
+            viewportHeight = viewportHeight,
+        )
+    }
+
+    fun injectCrossOriginIframes(
+        node: Map<String, Any>,
+        fetchIframeContent: (String) -> Map<String, Any>?,
+    ): Map<String, Any> {
+        val attrs = node["attributes"] as? Map<*, *> ?: return node
+        val iframeSrc = attrs[CROSS_ORIGIN_IFRAME_ATTRIBUTE] as? String
+
+        if (iframeSrc != null) {
+            val iframeContent = try {
+                fetchIframeContent(iframeSrc)
+            } catch (e: Exception) {
+                logIframeFetchFailure("Failed to fetch cross-origin iframe $iframeSrc", e)
+                null
+            }
+            if (iframeContent != null) {
+                normalizeDomNode(iframeContent, "cross-origin iframe $iframeSrc")?.let {
+                    return it
+                }
+            }
+
+            return mapOf(
+                "attributes" to copyAttributes(attrs, includeIframeMarker = false),
+                "children" to emptyList<Map<String, Any>>(),
+            )
+        }
+
+        val children = (node["children"] as? List<*>)
+            .orEmpty()
+            .mapNotNull { normalizeDomNode(it, "web hierarchy child") }
+            .map { injectCrossOriginIframes(it, fetchIframeContent) }
+
+        return mapOf(
+            "attributes" to copyAttributes(attrs),
+            "children" to children,
+        )
+    }
+
+    fun parseDomAsTreeNodes(domRepresentation: Map<String, Any>): TreeNode {
+        val attrs = domRepresentation["attributes"] as? Map<*, *> ?: emptyMap<String, Any>()
+
+        val attributes = mutableMapOf(
+            "text" to ((attrs["text"] as? String) ?: ""),
+        )
+        (attrs["bounds"] as? String)?.let {
+            attributes["bounds"] = it
+        }
+        (attrs["resource-id"] as? String)?.let {
+            attributes["resource-id"] = it
+        }
+        (attrs["selected"] as? Boolean)?.let {
+            attributes["selected"] = it.toString()
+        }
+        (attrs["synthetic"] as? Boolean)?.let {
+            attributes["synthetic"] = it.toString()
+        }
+        (attrs["ignoreBoundsFiltering"] as? Boolean)?.let {
+            attributes["ignoreBoundsFiltering"] = it.toString()
+        }
+
+        val children = (domRepresentation["children"] as? List<*>)
+            .orEmpty()
+            .mapNotNull { normalizeDomNode(it, "web hierarchy child") }
+            .map { parseDomAsTreeNodes(it) }
+
+        return TreeNode(attributes = attributes, children = children)
+    }
+
+    fun isTransientIframeFetchError(e: Throwable): Boolean {
+        return e is StaleElementReferenceException ||
+            e is NoSuchFrameException ||
+            e is NoSuchWindowException
+    }
+
+    private fun logIframeFetchFailure(message: String, e: Exception) {
+        if (isTransientIframeFetchError(e)) {
+            logger.debug(message, e)
+        } else {
+            logger.warn(message, e)
+        }
+    }
+
+    private fun parseJson(json: String?, context: String): Any? {
+        if (json == null) {
+            return malformed(context, "empty JSON")
+        }
+
+        return try {
+            objectMapper.readValue(json, Any::class.java)
+        } catch (e: Exception) {
+            logger.debug("Skipping malformed web hierarchy data from $context", e)
+            null
+        }
+    }
+
+    private fun normalizeAttributes(value: Any?, context: String): Map<String, Any>? {
+        val attrs = value as? Map<*, *> ?: return malformed(context, "missing attributes")
+        val text = attrs["text"] as? String ?: return malformed(context, "missing text")
+        val bounds = attrs["bounds"] as? String ?: return malformed(context, "missing bounds")
+
+        val normalized = mutableMapOf<String, Any>(
+            "text" to text,
+            "bounds" to bounds,
+        )
+
+        (attrs["resource-id"] as? String)?.let {
+            normalized["resource-id"] = it
+        }
+        (attrs["selected"] as? Boolean)?.let {
+            normalized["selected"] = it
+        }
+        (attrs["synthetic"] as? Boolean)?.let {
+            normalized["synthetic"] = it
+        }
+        (attrs["ignoreBoundsFiltering"] as? Boolean)?.let {
+            normalized["ignoreBoundsFiltering"] = it
+        }
+        (attrs[CROSS_ORIGIN_IFRAME_ATTRIBUTE] as? String)?.let {
+            normalized[CROSS_ORIGIN_IFRAME_ATTRIBUTE] = it
+        }
+
+        return normalized
+    }
+
+    private fun copyAttributes(attrs: Map<*, *>, includeIframeMarker: Boolean = true): Map<String, Any> {
+        return attrs.entries
+            .mapNotNull { (key, value) ->
+                if (key !is String || value == null) return@mapNotNull null
+                if (!includeIframeMarker && key == CROSS_ORIGIN_IFRAME_ATTRIBUTE) return@mapNotNull null
+                key to value
+            }
+            .toMap()
+    }
+
+    private fun <T> malformed(context: String, reason: String): T? {
+        logger.debug("Skipping malformed web hierarchy data from $context: $reason")
+        return null
+    }
+}

--- a/maestro-client/src/main/java/maestro/drivers/WebHierarchy.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebHierarchy.kt
@@ -25,8 +25,8 @@ internal object WebHierarchy {
         val node = value as? Map<*, *> ?: return malformed(context, "expected object")
         val attrs = normalizeAttributes(node["attributes"], context) ?: return null
         val rawChildren = node["children"] as? List<*> ?: return malformed(context, "missing children")
-        val children = rawChildren.mapNotNull {
-            normalizeDomNode(it, "$context child")
+        val children = rawChildren.mapIndexedNotNull { index, child ->
+            normalizeDomNode(child, "$context child $index")
         }
 
         return mapOf(
@@ -89,7 +89,7 @@ internal object WebHierarchy {
 
         val children = (node["children"] as? List<*>)
             .orEmpty()
-            .mapNotNull { normalizeDomNode(it, "web hierarchy child") }
+            .mapIndexedNotNull { index, child -> normalizeDomNode(child, "web hierarchy child $index") }
             .map { injectCrossOriginIframes(it, fetchIframeContent) }
 
         return mapOf(
@@ -122,20 +122,20 @@ internal object WebHierarchy {
 
         val children = (domRepresentation["children"] as? List<*>)
             .orEmpty()
-            .mapNotNull { normalizeDomNode(it, "web hierarchy child") }
+            .mapIndexedNotNull { index, child -> normalizeDomNode(child, "web hierarchy child $index") }
             .map { parseDomAsTreeNodes(it) }
 
         return TreeNode(attributes = attributes, children = children)
     }
 
-    fun isTransientIframeFetchError(e: Throwable): Boolean {
+    fun isTransientBrowserContextError(e: Throwable): Boolean {
         return e is StaleElementReferenceException ||
             e is NoSuchFrameException ||
             e is NoSuchWindowException
     }
 
     private fun logIframeFetchFailure(message: String, e: Exception) {
-        if (isTransientIframeFetchError(e)) {
+        if (isTransientBrowserContextError(e)) {
             logger.debug(message, e)
         } else {
             logger.warn(message, e)

--- a/maestro-client/src/main/java/maestro/drivers/WebHierarchy.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebHierarchy.kt
@@ -98,7 +98,7 @@ internal object WebHierarchy {
         )
     }
 
-    fun parseDomAsTreeNodes(domRepresentation: Map<String, Any>): TreeNode {
+    fun parseDomAsTreeNodes(domRepresentation: Map<*, *>): TreeNode {
         val attrs = domRepresentation["attributes"] as? Map<*, *> ?: emptyMap<String, Any>()
 
         val attributes = mutableMapOf(
@@ -122,7 +122,7 @@ internal object WebHierarchy {
 
         val children = (domRepresentation["children"] as? List<*>)
             .orEmpty()
-            .mapIndexedNotNull { index, child -> normalizeDomNode(child, "web hierarchy child $index") }
+            .mapNotNull { it as? Map<*, *> }
             .map { parseDomAsTreeNodes(it) }
 
         return TreeNode(attributes = attributes, children = children)

--- a/maestro-client/src/test/java/maestro/drivers/WebHierarchyTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/WebHierarchyTest.kt
@@ -60,6 +60,33 @@ class WebHierarchyTest {
         assertThat(tree.children[1].children[0].attributes["resource-id"]).isEqualTo("chat-input")
     }
 
+    @Test
+    fun `malformed top-level child is skipped and siblings are preserved`() {
+        val normalized = requireNotNull(
+            WebHierarchy.normalizeDomNode(parentHierarchyWithMalformedChild(), "test parent hierarchy")
+        )
+        val tree = WebHierarchy.parseDomAsTreeNodes(normalized)
+
+        assertThat(tree.children).hasSize(2)
+        assertThat(tree.children[0].attributes["resource-id"]).isEqualTo("parent-button")
+        assertThat(tree.children[1].attributes["resource-id"]).isEqualTo("second-button")
+    }
+
+    @Test
+    fun `missing iframe viewport params skip iframe fetch`() {
+        val params = WebHierarchy.parseIframeViewportParams(
+            """
+            {
+              "viewportX": 20,
+              "viewportY": 80
+            }
+            """.trimIndent(),
+            IFRAME_SRC,
+        )
+
+        assertThat(params).isNull()
+    }
+
     private fun injectIframeContent(fetchIframeContent: (String) -> Map<String, Any>?): TreeNode {
         val normalized = requireNotNull(WebHierarchy.normalizeDomNode(parentHierarchy(), "test parent hierarchy"))
         val enriched = WebHierarchy.injectCrossOriginIframes(normalized, fetchIframeContent)
@@ -93,6 +120,39 @@ class WebHierarchyTest {
                         "text" to "",
                         "bounds" to "[20,80][380,700]",
                         "__crossOriginIframe" to IFRAME_SRC,
+                    ),
+                    "children" to emptyList<Map<String, Any>>(),
+                ),
+            ),
+        )
+    }
+
+    private fun parentHierarchyWithMalformedChild(): Map<String, Any> {
+        return mapOf(
+            "attributes" to mapOf(
+                "text" to "Parent page",
+                "bounds" to "[0,0][400,800]",
+            ),
+            "children" to listOf(
+                mapOf(
+                    "attributes" to mapOf(
+                        "text" to "Parent button",
+                        "bounds" to "[10,10][120,60]",
+                        "resource-id" to "parent-button",
+                    ),
+                    "children" to emptyList<Map<String, Any>>(),
+                ),
+                mapOf(
+                    "attributes" to mapOf(
+                        "text" to "Malformed child",
+                    ),
+                    "children" to emptyList<Map<String, Any>>(),
+                ),
+                mapOf(
+                    "attributes" to mapOf(
+                        "text" to "Second button",
+                        "bounds" to "[10,70][120,120]",
+                        "resource-id" to "second-button",
                     ),
                     "children" to emptyList<Map<String, Any>>(),
                 ),

--- a/maestro-client/src/test/java/maestro/drivers/WebHierarchyTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/WebHierarchyTest.kt
@@ -1,0 +1,134 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import maestro.TreeNode
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.openqa.selenium.NoSuchFrameException
+import org.openqa.selenium.NoSuchWindowException
+import org.openqa.selenium.StaleElementReferenceException
+
+class WebHierarchyTest {
+
+    @Test
+    fun `null iframe content result does not crash`() {
+        val tree = injectIframeContent {
+            WebHierarchy.parseDomJson("null", "cross-origin iframe")
+        }
+
+        assertParentHierarchyReturned(tree)
+        assertThat(tree.children[1].attributes["text"]).isEqualTo("")
+        assertThat(tree.children[1].children).isEmpty()
+    }
+
+    @Test
+    fun `malformed iframe content result does not crash`() {
+        val tree = injectIframeContent {
+            mapOf(
+                "attributes" to emptyMap<String, Any>(),
+                "children" to emptyList<Map<String, Any>>(),
+            )
+        }
+
+        assertParentHierarchyReturned(tree)
+        assertThat(tree.children[1].attributes["text"]).isEqualTo("")
+        assertThat(tree.children[1].children).isEmpty()
+    }
+
+    @ParameterizedTest
+    @MethodSource("transientIframeErrors")
+    fun `transient iframe fetch errors are swallowed and traversal continues`(exception: Exception) {
+        val tree = injectIframeContent {
+            throw exception
+        }
+
+        assertParentHierarchyReturned(tree)
+        assertThat(tree.children[1].attributes["text"]).isEqualTo("")
+        assertThat(tree.children[1].children).isEmpty()
+    }
+
+    @Test
+    fun `readable iframe content is preserved`() {
+        val tree = injectIframeContent {
+            iframeContent()
+        }
+
+        assertParentHierarchyReturned(tree)
+        assertThat(tree.children[1].attributes["text"]).isEqualTo("Support chat")
+        assertThat(tree.children[1].children).hasSize(1)
+        assertThat(tree.children[1].children[0].attributes["resource-id"]).isEqualTo("chat-input")
+    }
+
+    private fun injectIframeContent(fetchIframeContent: (String) -> Map<String, Any>?): TreeNode {
+        val normalized = requireNotNull(WebHierarchy.normalizeDomNode(parentHierarchy(), "test parent hierarchy"))
+        val enriched = WebHierarchy.injectCrossOriginIframes(normalized, fetchIframeContent)
+        return WebHierarchy.parseDomAsTreeNodes(enriched)
+    }
+
+    private fun assertParentHierarchyReturned(tree: TreeNode) {
+        assertThat(tree.attributes["text"]).isEqualTo("Parent page")
+        assertThat(tree.children).hasSize(2)
+        assertThat(tree.children[0].attributes["text"]).isEqualTo("Parent button")
+        assertThat(tree.children[0].attributes["resource-id"]).isEqualTo("parent-button")
+    }
+
+    private fun parentHierarchy(): Map<String, Any> {
+        return mapOf(
+            "attributes" to mapOf(
+                "text" to "Parent page",
+                "bounds" to "[0,0][400,800]",
+            ),
+            "children" to listOf(
+                mapOf(
+                    "attributes" to mapOf(
+                        "text" to "Parent button",
+                        "bounds" to "[10,10][120,60]",
+                        "resource-id" to "parent-button",
+                    ),
+                    "children" to emptyList<Map<String, Any>>(),
+                ),
+                mapOf(
+                    "attributes" to mapOf(
+                        "text" to "",
+                        "bounds" to "[20,80][380,700]",
+                        "__crossOriginIframe" to IFRAME_SRC,
+                    ),
+                    "children" to emptyList<Map<String, Any>>(),
+                ),
+            ),
+        )
+    }
+
+    private fun iframeContent(): Map<String, Any> {
+        return mapOf(
+            "attributes" to mapOf(
+                "text" to "Support chat",
+                "bounds" to "[20,80][380,700]",
+            ),
+            "children" to listOf(
+                mapOf(
+                    "attributes" to mapOf(
+                        "text" to "Message",
+                        "bounds" to "[40,600][360,680]",
+                        "resource-id" to "chat-input",
+                    ),
+                    "children" to emptyList<Map<String, Any>>(),
+                ),
+            ),
+        )
+    }
+
+    companion object {
+        private const val IFRAME_SRC = "https://support.example/chat"
+
+        @JvmStatic
+        fun transientIframeErrors(): List<Exception> {
+            return listOf(
+                StaleElementReferenceException("iframe is stale"),
+                NoSuchFrameException("iframe is gone"),
+                NoSuchWindowException("window is closed"),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Proposed changes

fixes a Maestro web hierarchy crash when cross-origin iframe enrichment hits transient browser state or malformed JS/CDP results.

see:
```json
"status" : "FAILED",
  "error" : {
    "stackTrace" : [ {
      "methodName" : "fetchCrossOriginIframeContent",
      "fileName" : "CdpWebDriver.kt",
      "lineNumber" : 696,
      "className" : "maestro.drivers.CdpWebDriver"
    }, {
      "methodName" : "injectCrossOriginIframes",
      "fileName" : "CdpWebDriver.kt",
      "lineNumber" : 655,
      "className" : "maestro.drivers.CdpWebDriver"
    }, {
      "methodName" : "contentDescriptor",
      "fileName" : "CdpWebDriver.kt",
      "lineNumber" : 276,
      "className" : "maestro.drivers.CdpWebDriver"
    }, {
      "methodName" : "from-8JJjmZI",
      "fileName" : "ViewHierarchy.kt",
      "lineNumber" : 29,
      "className" : "maestro.ViewHierarchy$Companion"
    } ],
    "message" : "null cannot be cast to non-null type kotlin.collections.Map<kotlin.String, kotlin.Any>"
  }
```

from my understanding this usually happens after navigation, popup return, or iframe reload. the parent page is still usable, but a third-party iframe can be stale/closed/still loading/detached, or return null/malformed hierarchy data. 

previously, that path used unsafe casts into `Map<String, Any>` and numeric fields, so one broken iframe could crash the whole hierarchy build.

this patch tries keeps the hierarchy path best-effort, see flow below 
1. parse js/cdp hierarchy payloads with checked maps/lists instead of unsafe casts
2. reset selenium to default content before hierarchy and iframe reads
3. preserve readable cross-origin iframe content
4. keep the parent iframe node with empty children when iframe content is bad
5. treat stale frame, missing frame, and closed window errors as transient during iframe enrichment
6. keep the parent page hierarchy usable when a third-party iframe is broken

## Testing

unit tests should cover:
- null iframe content does not crash hierarchy construction
- malformed iframe content does not crash hierarchy construction
- transient iframe/window errors are swallowed and traversal continues
- readable iframe content is still preserved and injected
- malformed child nodes are skipped while valid siblings are preserved
- missing iframe viewport params skip iframe content fetch

ran the following:
```bash
./gradlew :maestro-client:test --tests maestro.drivers.WebHierarchyTest -x :maestro-ios-driver:buildIosDriver
./gradlew :maestro-client:check -x :maestro-ios-driver:buildIosDriver
./gradlew detektMain
```

idt e2e is needed because there already is one for iframes

### Issues fixed
- fixes #3271
- potentially related to #3136