### PR TITLE
fix(orchestra): use authored path for runScript sourceDescription

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -405,7 +405,7 @@ data class YamlFluentCommand(
                         RunScriptCommand(
                             script = scriptPath.readText(),
                             env = runScript.env,
-                            sourceDescription = scriptPath.toString(),
+                            sourceDescription = runScript.file,
                             condition = runScript.`when`?.toCondition(),
                             label = runScript.label,
                             optional = runScript.optional,

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -240,10 +240,6 @@ internal class YamlCommandReaderTest {
     fun labels(
         @YamlFile("023_labels.yaml") commands: List<Command>,
     ) {
-        // Compute expected absolute path for runScript command
-        val testResourcesPath = YamlCommandReaderTest::class.java.classLoader.getResource("YamlCommandReaderTest/023_runScript_test.js")?.toURI()
-        val expectedScriptPath = testResourcesPath?.let { java.nio.file.Paths.get(it).toString() } ?: "023_runScript_test.js"
-        
         assertThat(commands).containsExactly(
             ApplyConfigurationCommand(
                 config=MaestroConfig(
@@ -387,7 +383,7 @@ internal class YamlCommandReaderTest {
             RunScriptCommand(
                 script = "const myNumber = 1 + 1;",
                 condition = null,
-                sourceDescription = expectedScriptPath,
+                sourceDescription = "023_runScript_test.js",
                 label = "Run some special calculations"
             ),
             SetOrientationCommand(


### PR DESCRIPTION
## Summary

Cloud was rendering `runScript` command descriptions with the worker's absolute tempdir path baked in, e.g.:

> `Run /var/folders/jk/29vtf9nj1nlbvzjxtxh9mdv80000gn/T/workspace3277218441292165046/auth/login/login.js`

The cause: [maestro-orchestra/.../YamlFluentCommand.kt:408](https://github.com/mobile-dev-inc/Maestro/blob/main/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt#L408) populated `RunScriptCommand.sourceDescription` with `scriptPath.toString()` — the fully resolved absolute path. `RunScriptCommand.originalDescription` then formats it as `"Run $sourceDescription"`, which is what Cloud and Studio render.

This PR switches it to `runScript.file` — the literal string the user wrote in YAML. After this change:

> `Run auth/login/login.js`

This matches how the sibling `runFlow` command at line 539 already populates its own `sourceDescription`. Existing `PlainTextResultViewTest` cases (`sourceDescription = "test1.yml"`, `"login_to_app.yml"`, etc.) already assume relative paths — the `runScript` branch was the outlier.

File resolution is unchanged: `scriptPath` is still used immediately above for `script = scriptPath.readText()`. Only the display string changes.

## Caveats

- **Older runs are not retroactively fixed.** Descriptions are persisted on the run row; only new runs after the Cloud worker rolls out will display the clean path.
- **Nested-flow corner case.** `runScript.file` is the path as written, resolved against the YAML file's directory — not the workspace root. A nested flow at `auth/login.flow.yaml` that references `runScript: login.js` will display `Run login.js` rather than `Run auth/login.js`. This exactly matches `runFlow`'s existing behavior and is acceptable as a consistent baseline.

## Test plan

- [x] `./gradlew :maestro-orchestra:test` — passes
- [x] Updated `YamlCommandReaderTest.labels` to assert `sourceDescription == "023_runScript_test.js"` (relative) instead of the computed absolute path; this is the regression test
- [ ] After merge: bump the `maestro` submodule in the consumer monorepo and verify on a real Cloud run that the rendered label is `Run auth/login/login.js` (not the tempdir path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)