### PR TITLE
feat(mcp-visualizer): pending-commands UX and panel redesign

### DIFF
--- a/maestro-cli/mcp-visualizer/package-lock.json
+++ b/maestro-cli/mcp-visualizer/package-lock.json
@@ -14,6 +14,8 @@
         "vite": "^6.0.0"
       },
       "devDependencies": {
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "typescript": "^5.7.0",
         "vite-plugin-singlefile": "^2.3.3"
       }
@@ -1377,6 +1379,26 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -1479,6 +1501,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {

--- a/maestro-cli/mcp-visualizer/package-lock.json
+++ b/maestro-cli/mcp-visualizer/package-lock.json
@@ -6,6 +6,8 @@
     "": {
       "name": "maestro-mcp-visualizer",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@tailwindcss/vite": "^4.0.0",
         "@vitejs/plugin-react": "^4.0.0",
         "react": "^18.3.0",
@@ -697,6 +699,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/maestro-cli/mcp-visualizer/package-lock.json
+++ b/maestro-cli/mcp-visualizer/package-lock.json
@@ -10,8 +10,8 @@
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@tailwindcss/vite": "^4.0.0",
         "@vitejs/plugin-react": "^4.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0",
+        "react": "^19.2.6",
+        "react-dom": "^19.2.6",
         "tailwindcss": "^4.0.0",
         "vite": "^6.0.0"
       },
@@ -1982,18 +1982,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2116,28 +2104,24 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-refresh": {
@@ -2194,13 +2178,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/maestro-cli/mcp-visualizer/package.json
+++ b/maestro-cli/mcp-visualizer/package.json
@@ -15,6 +15,8 @@
     "vite": "^6.0.0"
   },
   "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "typescript": "^5.7.0",
     "vite-plugin-singlefile": "^2.3.3"
   }

--- a/maestro-cli/mcp-visualizer/package.json
+++ b/maestro-cli/mcp-visualizer/package.json
@@ -11,8 +11,8 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-react": "^4.0.0",
-    "react": "^18.3.0",
-    "react-dom": "^18.3.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6",
     "tailwindcss": "^4.0.0",
     "vite": "^6.0.0"
   },

--- a/maestro-cli/mcp-visualizer/package.json
+++ b/maestro-cli/mcp-visualizer/package.json
@@ -7,6 +7,8 @@
     "build": "vite build"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@tailwindcss/vite": "^4.0.0",
     "@vitejs/plugin-react": "^4.0.0",
     "react": "^18.3.0",

--- a/maestro-cli/mcp-visualizer/src/demo.tsx
+++ b/maestro-cli/mcp-visualizer/src/demo.tsx
@@ -49,14 +49,25 @@ const DEMO_ROWS: CommandEntry[] = [
 
 export function DemoApp() {
   const [collapsed, setCollapsed] = React.useState(false);
-  const [rows, setRows] = React.useState<CommandEntry[]>(DEMO_ROWS);
+  const [running, setRunning] = React.useState(true);
+  // Derived: when "running" is off, swap any started row to pending so the panel
+  // and device-frame chrome render their idle state.
+  const rows = running
+    ? DEMO_ROWS
+    : DEMO_ROWS.map((r) => (r.status === "started" ? { ...r, status: "pending" as const } : r));
   return (
-    <VisualizerLayout
-      rows={rows}
-      collapsed={collapsed}
-      onToggle={() => setCollapsed((c) => !c)}
-      onClear={() => setRows([])}
-      deviceState={DEMO_DEVICE}
-    />
+    <>
+      <VisualizerLayout
+        rows={rows}
+        collapsed={collapsed}
+        onToggle={() => setCollapsed((c) => !c)}
+        onClear={() => {}}
+        deviceState={DEMO_DEVICE}
+      />
+      <label className="fixed bottom-4 right-4 z-10 flex cursor-pointer select-none items-center gap-2 rounded-md border border-neutral-300 bg-white/95 px-3 py-2 font-mono text-xs text-neutral-700 shadow-md backdrop-blur dark:border-neutral-700 dark:bg-neutral-900/95 dark:text-neutral-200">
+        <input type="checkbox" checked={running} onChange={(e) => setRunning(e.target.checked)} />
+        running
+      </label>
+    </>
   );
 }

--- a/maestro-cli/mcp-visualizer/src/demo.tsx
+++ b/maestro-cli/mcp-visualizer/src/demo.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { VisualizerLayout, type CommandEntry, type DeviceState } from "./main";
+
+// SVG placeholder shaped like a phone screen so the dark device frame renders at a
+// realistic size without a real simulator stream.
+const PLACEHOLDER_STREAM =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns='http://www.w3.org/2000/svg' width='320' height='700' viewBox='0 0 320 700'>` +
+      `<rect width='100%' height='100%' fill='#1c1917' />` +
+      `<text x='160' y='350' text-anchor='middle' fill='#737373' ` +
+      `font-family='monospace' font-size='14'>device placeholder</text>` +
+    `</svg>`,
+  );
+
+const DEMO_DEVICE: DeviceState = {
+  status: "streaming",
+  platform: "android",
+  streamUrl: PLACEHOLDER_STREAM,
+};
+
+// Static fixture for iterating on CommandsPanel design — visit /?demo to render
+// this instead of the live app. Cover every status plus a few layout-stress cases
+// (long lines, multi-line YAML, error messages) so visual changes can be eyeballed
+// against realistic content.
+const DEMO_ROWS: CommandEntry[] = [
+  { commandId: "1", yaml: 'launchApp: "com.example.app"', depth: 0, status: "completed" },
+  { commandId: "2", yaml: 'tapOn: "Sign in"', depth: 0, status: "completed" },
+  { commandId: "3", yaml: 'inputText: "user@example.com"', depth: 0, status: "completed" },
+  { commandId: "4", yaml: 'tapOn:\n  id: "submit_button"\n  index: 0', depth: 0, status: "completed" },
+  { commandId: "5", yaml: 'assertVisible: "Welcome back, Leland!"', depth: 0, status: "warned" },
+  { commandId: "6", yaml: 'scrollUntilVisible:\n  element:\n    text: "Settings"', depth: 0, status: "started" },
+  {
+    commandId: "7",
+    yaml: 'tapOn:\n  text: "A very very very very very long button label that should overflow the panel"',
+    depth: 0,
+    status: "pending",
+  },
+  {
+    commandId: "8",
+    yaml: 'runScript: "evaluate_response.js"',
+    depth: 0,
+    status: "failed",
+    errorMessage: "ReferenceError: response is not defined at evaluate_response.js:14",
+  },
+  { commandId: "9", yaml: 'takeScreenshot: "after_failure"', depth: 0, status: "skipped" },
+  { commandId: "10", yaml: 'stopApp: "com.example.app"', depth: 0, status: "skipped" },
+];
+
+export function DemoApp() {
+  const [collapsed, setCollapsed] = React.useState(false);
+  const [rows, setRows] = React.useState<CommandEntry[]>(DEMO_ROWS);
+  return (
+    <VisualizerLayout
+      rows={rows}
+      collapsed={collapsed}
+      onToggle={() => setCollapsed((c) => !c)}
+      onClear={() => setRows([])}
+      deviceState={DEMO_DEVICE}
+    />
+  );
+}

--- a/maestro-cli/mcp-visualizer/src/demo.tsx
+++ b/maestro-cli/mcp-visualizer/src/demo.tsx
@@ -24,32 +24,54 @@ const DEMO_DEVICE: DeviceState = {
 // (long lines, multi-line YAML, error messages) so visual changes can be eyeballed
 // against realistic content.
 const DEMO_ROWS: CommandEntry[] = [
-  { commandId: "1", yaml: 'launchApp: "com.example.app"', depth: 0, status: "completed" },
-  { commandId: "2", yaml: 'tapOn: "Sign in"', depth: 0, status: "completed" },
-  { commandId: "3", yaml: 'inputText: "user@example.com"', depth: 0, status: "completed" },
-  { commandId: "4", yaml: 'tapOn:\n  id: "submit_button"\n  index: 0', depth: 0, status: "completed" },
-  { commandId: "5", yaml: 'assertVisible: "Welcome back, Leland!"', depth: 0, status: "warned" },
-  { commandId: "6", yaml: 'scrollUntilVisible:\n  element:\n    text: "Settings"', depth: 0, status: "started" },
+  { commandId: "1", yaml: 'clearState: "com.example.app"', depth: 0, status: "completed" },
+  { commandId: "2", yaml: 'launchApp: "com.example.app"', depth: 0, status: "completed" },
+  { commandId: "3", yaml: 'tapOn: "Get started"', depth: 0, status: "completed" },
+  { commandId: "4", yaml: 'tapOn: "Continue with email"', depth: 0, status: "completed" },
+  { commandId: "5", yaml: 'assertVisible: "Create your account"', depth: 0, status: "completed" },
+  { commandId: "6", yaml: 'inputText: "Leland"', depth: 0, status: "completed" },
+  { commandId: "7", yaml: 'tapOn: "Next"', depth: 0, status: "completed" },
+  { commandId: "8", yaml: 'inputText: "user@example.com"', depth: 0, status: "completed" },
+  { commandId: "9", yaml: 'tapOn: "Next"', depth: 0, status: "completed" },
+  { commandId: "10", yaml: 'tapOn: "Accept terms"', depth: 0, status: "completed" },
+  { commandId: "11", yaml: 'launchApp: "com.example.app"', depth: 0, status: "completed" },
+  { commandId: "12", yaml: 'tapOn: "Sign in"', depth: 0, status: "completed" },
+  { commandId: "13", yaml: 'inputText: "user@example.com"', depth: 0, status: "completed" },
+  { commandId: "14", yaml: 'tapOn:\n  id: "submit_button"\n  index: 0', depth: 0, status: "completed" },
+  { commandId: "15", yaml: 'assertVisible: "Welcome back, Leland!"', depth: 0, status: "warned" },
+  { commandId: "16", yaml: 'scrollUntilVisible:\n  element:\n    text: "Settings"', depth: 0, status: "started" },
   {
-    commandId: "7",
+    commandId: "17",
     yaml: 'tapOn:\n  text: "A very very very very very long button label that should overflow the panel"',
     depth: 0,
     status: "pending",
   },
+  { commandId: "18", yaml: 'assertVisible: "Notifications"', depth: 0, status: "pending" },
+  { commandId: "19", yaml: 'tapOn: "Notifications"', depth: 0, status: "pending" },
+  { commandId: "20", yaml: 'tapOn:\n  id: "enable_push"', depth: 0, status: "pending" },
+  { commandId: "21", yaml: 'assertVisible: "All set"', depth: 0, status: "pending" },
+  { commandId: "22", yaml: 'back', depth: 0, status: "pending" },
+  { commandId: "23", yaml: 'tapOn: "Account"', depth: 0, status: "pending" },
   {
-    commandId: "8",
+    commandId: "24",
     yaml: 'runScript: "evaluate_response.js"',
     depth: 0,
     status: "failed",
     errorMessage: "ReferenceError: response is not defined at evaluate_response.js:14",
   },
-  { commandId: "9", yaml: 'takeScreenshot: "after_failure"', depth: 0, status: "skipped" },
-  { commandId: "10", yaml: 'stopApp: "com.example.app"', depth: 0, status: "skipped" },
+  { commandId: "25", yaml: 'takeScreenshot: "after_failure"', depth: 0, status: "skipped" },
+  { commandId: "26", yaml: 'stopApp: "com.example.app"', depth: 0, status: "skipped" },
 ];
+
+const NO_DEVICE: DeviceState = {
+  status: "idle",
+  message: "Maestro MCP will automatically connect when interacting with a device.",
+};
 
 export function DemoApp() {
   const [collapsed, setCollapsed] = React.useState(false);
   const [running, setRunning] = React.useState(true);
+  const [connected, setConnected] = React.useState(true);
   // Derived: when "running" is off, swap any started row to pending so the panel
   // and device-frame chrome render their idle state.
   const rows = running
@@ -58,16 +80,22 @@ export function DemoApp() {
   return (
     <>
       <VisualizerLayout
-        rows={rows}
+        rows={connected ? rows : []}
         collapsed={collapsed}
         onToggle={() => setCollapsed((c) => !c)}
         onClear={() => {}}
-        deviceState={DEMO_DEVICE}
+        deviceState={connected ? DEMO_DEVICE : NO_DEVICE}
       />
-      <label className="fixed bottom-4 right-4 z-10 flex cursor-pointer select-none items-center gap-2 rounded-md border border-neutral-300 bg-white/95 px-3 py-2 font-mono text-xs text-neutral-700 shadow-md backdrop-blur dark:border-neutral-700 dark:bg-neutral-900/95 dark:text-neutral-200">
-        <input type="checkbox" checked={running} onChange={(e) => setRunning(e.target.checked)} />
-        running
-      </label>
+      <div className="fixed bottom-4 right-4 z-10 flex flex-col gap-1.5 rounded-md border border-neutral-300 bg-white/95 px-3 py-2 text-xs text-neutral-700 shadow-md backdrop-blur dark:border-neutral-700 dark:bg-neutral-900/95 dark:text-neutral-200">
+        <label className="flex cursor-pointer select-none items-center gap-2">
+          <input type="checkbox" checked={connected} onChange={(e) => setConnected(e.target.checked)} />
+          device connected
+        </label>
+        <label className={`flex cursor-pointer select-none items-center gap-2 ${connected ? "" : "opacity-40"}`}>
+          <input type="checkbox" checked={running} disabled={!connected} onChange={(e) => setRunning(e.target.checked)} />
+          running
+        </label>
+      </div>
     </>
   );
 }

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -163,9 +163,72 @@ function StatusIcon({ status }: { status: CommandStatus }) {
   }
 }
 
-function asYamlListItem(yaml: string): string {
-  const lines = yaml.split("\n");
-  return lines.map((line, i) => (i === 0 ? `- ${line}` : `  ${line}`)).join("\n");
+// Lightweight YAML tokenizer for the rendered command rows. Recognizes the
+// shapes Maestro flows actually use — `key:`, `key: "string"`, `key: number`,
+// nested indented keys, and bare `key` (e.g. `back`). Anything outside the
+// happy path renders as plain text rather than crashing or mis-highlighting.
+function HighlightedYamlListItem({ yaml }: { yaml: string }) {
+  return (
+    <>
+      {yaml.split("\n").map((line, i) => (
+        <React.Fragment key={i}>
+          {i === 0 ? <span className="text-neutral-400 dark:text-neutral-500">- </span> : "\n  "}
+          {tokenizeYamlLine(line)}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+function tokenizeYamlLine(line: string): React.ReactNode {
+  // bare key (e.g. `back`)
+  const standalone = line.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*$/);
+  if (standalone) {
+    const [, indent, key] = standalone;
+    return <>{indent}<YamlKey>{key}</YamlKey></>;
+  }
+  // key: optional-value
+  const keyValue = line.match(/^(\s*)([A-Za-z_][A-Za-z0-9_]*)(:)(.*)$/);
+  if (keyValue) {
+    const [, indent, key, colon, rest] = keyValue;
+    return (
+      <>
+        {indent}
+        <YamlKey>{key}</YamlKey>
+        <YamlPunct>{colon}</YamlPunct>
+        {tokenizeYamlValue(rest)}
+      </>
+    );
+  }
+  return tokenizeYamlValue(line);
+}
+
+function tokenizeYamlValue(rest: string): React.ReactNode {
+  if (!rest) return null;
+  const str = rest.match(/^(\s*)("(?:[^"\\]|\\.)*")(.*)$/);
+  if (str) {
+    const [, lead, value, tail] = str;
+    return <>{lead}<YamlString>{value}</YamlString>{tail}</>;
+  }
+  const num = rest.match(/^(\s*)(-?\d+(?:\.\d+)?)(.*)$/);
+  if (num) {
+    const [, lead, value, tail] = num;
+    return <>{lead}<YamlNumber>{value}</YamlNumber>{tail}</>;
+  }
+  return rest;
+}
+
+function YamlKey({ children }: { children: React.ReactNode }) {
+  return <span className="text-indigo-700 dark:text-indigo-300">{children}</span>;
+}
+function YamlString({ children }: { children: React.ReactNode }) {
+  return <span className="text-emerald-700 dark:text-emerald-400">{children}</span>;
+}
+function YamlNumber({ children }: { children: React.ReactNode }) {
+  return <span className="text-violet-700 dark:text-violet-400">{children}</span>;
+}
+function YamlPunct({ children }: { children: React.ReactNode }) {
+  return <span className="text-neutral-400 dark:text-neutral-500">{children}</span>;
 }
 
 function CommandsPanel({
@@ -254,7 +317,7 @@ function CommandsPanel({
         {visibleRows.length === 0 ? (
           <p className="px-3 pt-2 text-neutral-400 dark:text-neutral-500">Commands executed by Maestro MCP</p>
         ) : (
-          <ol ref={listRef} className="m-0 h-full list-none overflow-y-auto px-2 pt-2 pb-8 [&>li]:mt-1 [&>li:first-child]:mt-0">
+          <ol ref={listRef} className="scrollbar-quiet m-0 h-full list-none overflow-y-auto px-2 pt-2 pb-8 [&>li]:mt-1 [&>li:first-child]:mt-0">
             {visibleRows.map((row, i) => {
               const running = row.status === "started";
               const isLast = i === visibleRows.length - 1;
@@ -286,7 +349,7 @@ function CommandsPanel({
                     )}
                   </div>
                   <div className="min-w-0 flex-1 leading-5">
-                    <pre className="m-0 whitespace-pre overflow-x-auto leading-[inherit]">{asYamlListItem(row.yaml)}</pre>
+                    <pre className="m-0 whitespace-pre overflow-x-auto leading-[inherit]"><HighlightedYamlListItem yaml={row.yaml} /></pre>
                     {row.errorMessage && row.status === "failed" ? (
                       <p className="mt-0 text-xs leading-4 text-red-600 dark:text-red-400">{row.errorMessage}</p>
                     ) : null}

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -247,13 +247,18 @@ function CommandsPanel({
   const visibleRows = rows.filter((r) => r.depth === 0);
   const listRef = React.useRef<HTMLOListElement | null>(null);
 
-  // Snap to the very bottom (past the list's bottom padding) on every rows update.
-  // `rows` reference changes on every event so status flips and late-arriving error
-  // messages also trigger a re-scroll.
+  // Keep the currently-running command in view. Scrolling to the bottom of the
+  // list isn't quite right when pending rows extend past the running one — the
+  // user wants their eye on what's executing, not what's queued.
   React.useEffect(() => {
     const el = listRef.current;
     if (!el) return;
-    el.scrollTop = el.scrollHeight;
+    const running = visibleRows.findLast((r) => r.status === "started");
+    if (!running) return;
+    const rowEl = el.querySelector(`[data-command-id="${running.commandId}"]`);
+    if (rowEl instanceof HTMLElement) {
+      rowEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
   }, [visibleRows]);
 
   if (collapsed) {

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -10,6 +10,8 @@ type Point2D = { x: number; y: number };
 type CommandEntry = {
   commandId: string;
   yaml: string;
+  /** 0 = top-level; >0 = nested. Today we only render top-level rows. */
+  depth: number;
   status: CommandStatus;
   errorMessage?: string | null;
 };
@@ -161,6 +163,9 @@ function CommandsPanel({
   onToggle: () => void;
   onClear: () => void;
 }) {
+  // The backend sends every command in the tree (top-level + nested). We only render
+  // top-level rows today; nested rendering is a future UX decision that lives here.
+  const visibleRows = rows.filter((r) => r.depth === 0);
   const listRef = React.useRef<HTMLOListElement | null>(null);
 
   // Snap to the very bottom (past the list's bottom padding) on every rows update.
@@ -170,7 +175,7 @@ function CommandsPanel({
     const el = listRef.current;
     if (!el) return;
     el.scrollTop = el.scrollHeight;
-  }, [rows]);
+  }, [visibleRows]);
 
   if (collapsed) {
     return (
@@ -206,7 +211,7 @@ function CommandsPanel({
           <button
             type="button"
             onClick={onClear}
-            disabled={rows.length === 0}
+            disabled={visibleRows.length === 0}
             aria-label="Clear log"
             title="Clear log"
             className="grid h-6 w-6 place-items-center rounded text-neutral-500 transition hover:bg-neutral-200 hover:text-neutral-800 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-500"
@@ -229,11 +234,11 @@ function CommandsPanel({
         </div>
       </header>
       <div className="min-h-0 flex-1 overflow-hidden font-mono text-sm leading-5 text-neutral-600">
-        {rows.length === 0 ? (
+        {visibleRows.length === 0 ? (
           <p className="px-3 pt-2 text-neutral-400">Commands executed by Maestro MCP</p>
         ) : (
           <ol ref={listRef} className="m-0 h-full list-none overflow-y-auto pl-2 pt-2 pb-8 [&>li]:mt-0">
-            {rows.map((row) => {
+            {visibleRows.map((row) => {
               const running = row.status === "started";
               return (
                 <li

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -329,9 +329,9 @@ function CommandsPanel({
                     // Keep rounded on every row so the running highlight's corners don't
                     // snap from rounded to square mid-fade when the status flips and
                     // transition-colors animates bg from sky-900 back to transparent.
-                    "flex gap-2 rounded-xl py-0.5 pl-1.5 pr-2 leading-5 transition-all duration-300 " +
+                    "flex gap-2 rounded-xl py-0.5 pl-1.5 pr-2 leading-5 transition-colors duration-300 " +
                     (running
-                      ? "bg-sky-100/90 text-sky-950 font-medium ring-1 ring-inset ring-sky-300/60 shadow-sm shadow-sky-300/30 dark:bg-sky-500/15 dark:text-sky-50 dark:ring-sky-400/30 dark:shadow-sky-500/20"
+                      ? "bg-sky-200 text-sky-950 ring-2 ring-inset ring-sky-500/70 shadow-md shadow-sky-500/40 dark:bg-sky-900 dark:text-sky-50 dark:ring-sky-400/70 dark:shadow-sky-500/40"
                       : row.status === "failed"
                         ? "text-neutral-900 dark:text-neutral-100"
                         : "")
@@ -343,8 +343,8 @@ function CommandsPanel({
                     {!isLast && (
                       <span
                         aria-hidden="true"
-                        className={`absolute left-1/2 w-0.5 -translate-x-1/2 rounded-full ${statusLineColor(row.status === "started" ? "pending" : row.status)}`}
-                        style={{ top: 16, bottom: -10 }}
+                        className={`absolute left-1/2 w-0.5 -translate-x-1/2 rounded-full ${statusLineColor(running ? "pending" : row.status)}`}
+                        style={{ top: running ? "100%" : 16, bottom: -10 }}
                       />
                     )}
                   </div>

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import React from "react";
 import { createRoot } from "react-dom/client";
 import "./styles.css";
@@ -7,7 +8,7 @@ type DriverStatus = "started" | "completed" | "failed";
 /** Normalized [0, 1] coordinates within the device's screen. */
 type Point2D = { x: number; y: number };
 
-type CommandEntry = {
+export type CommandEntry = {
   commandId: string;
   yaml: string;
   /** 0 = top-level; >0 = nested. Today we only render top-level rows. */
@@ -29,7 +30,7 @@ type VisualizerEvent =
     }
   | { type: "driver.input_text"; status: DriverStatus; textLength: number };
 
-type DeviceState = {
+export type DeviceState = {
   status: "idle" | "starting" | "streaming" | "error";
   platform?: string;
   deviceId?: string;
@@ -618,6 +619,118 @@ function HardwareRail({ platform }: { platform?: string }) {
   );
 }
 
+/**
+ * The right pane: dark phone frame containing whatever caller renders as `device`,
+ * the hardware rail, and the "running" background tint + ring driven by `rows`. If
+ * `device` is omitted, renders the "no device stream" placeholder card instead of
+ * the dark frame. Used by both the live App and the design demo.
+ */
+function DevicePanel({
+  rows,
+  device,
+  platform,
+  placeholderMessage,
+}: {
+  rows: CommandEntry[];
+  device?: React.ReactNode;
+  platform?: string;
+  placeholderMessage?: string;
+}) {
+  const isRunning = rows.some((r) => r.status === "started");
+  // Hold the "running" tint for a moment after the last command stops so the bg
+  // doesn't flicker between commands (which arrive ~100ms apart). Going to running
+  // is instant; leaving running is debounced.
+  const [showRunning, setShowRunning] = React.useState(false);
+  React.useEffect(() => {
+    if (isRunning) {
+      setShowRunning(true);
+      return;
+    }
+    const t = window.setTimeout(() => setShowRunning(false), 600);
+    return () => window.clearTimeout(t);
+  }, [isRunning]);
+
+  return (
+    <div
+      className={
+        "flex min-w-0 flex-1 items-start gap-4 p-4 transition-colors duration-500 " +
+        (showRunning ? "bg-sky-100" : "bg-neutral-100")
+      }
+    >
+      {device ? (
+        <>
+          <div
+            className={
+              "relative shrink-0 overflow-hidden rounded-[2rem] bg-neutral-900 shadow-xl shadow-neutral-300/60 ring-4 transition-shadow duration-500 " +
+              (showRunning ? "ring-sky-700" : "ring-transparent")
+            }
+          >
+            {device}
+          </div>
+          <HardwareRail platform={platform} />
+        </>
+      ) : (
+        <div className="grid h-[70vh] w-full max-w-sm shrink-0 place-items-center rounded-[2rem] border border-neutral-200 bg-white text-xs text-neutral-500 shadow-xl shadow-neutral-300/60">
+          <div className="text-center">
+            <div>no device stream</div>
+            {placeholderMessage && (
+              <div className="mt-2 max-w-xs whitespace-pre-wrap text-neutral-400">{placeholderMessage}</div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Top-level shell: commands panel on the left, device pane on the right. Owns the
+ * full live device rendering — img, overlays, gesture capture — so callers just
+ * pass the data they have. The design demo feeds in a synthetic DeviceState
+ * (streaming with a placeholder streamUrl) so the dark frame and running-tint
+ * chrome render against fixture rows without a real device.
+ */
+export function VisualizerLayout({
+  rows,
+  collapsed,
+  onToggle,
+  onClear,
+  deviceState,
+  overlays = [],
+}: {
+  rows: CommandEntry[];
+  collapsed: boolean;
+  onToggle: () => void;
+  onClear: () => void;
+  deviceState: DeviceState;
+  overlays?: DeviceOverlay[];
+}) {
+  const device: React.ReactNode = deviceState.status === "streaming" && deviceState.streamUrl ? (
+    <>
+      <img className="block max-h-[calc(100vh-2rem)] w-auto" src={deviceState.streamUrl} draggable={false} />
+      <div className="pointer-events-none absolute inset-0">
+        <DeviceOverlayCanvas overlays={overlays} />
+        {overlays
+          .filter((overlay): overlay is Extract<DeviceOverlay, { kind: "input_text" }> => overlay.kind === "input_text")
+          .map((overlay) => <InputTextOverlay key={overlay.id} overlay={overlay} />)}
+      </div>
+      <GestureLayer />
+    </>
+  ) : undefined;
+
+  return (
+    <main className="flex h-screen items-stretch overflow-hidden bg-neutral-100 font-mono text-neutral-700">
+      <CommandsPanel rows={rows} collapsed={collapsed} onToggle={onToggle} onClear={onClear} />
+      <DevicePanel
+        rows={rows}
+        device={device}
+        platform={deviceState.platform}
+        placeholderMessage={deviceState.message}
+      />
+    </main>
+  );
+}
+
 function App() {
   const [overlays, setOverlays] = React.useState<DeviceOverlay[]>([]);
   const [commandRows, setCommandRows] = React.useState<CommandEntry[]>([]);
@@ -703,66 +816,24 @@ function App() {
     setDeviceState(await response.json());
   }
 
-  const isRunning = commandRows.some((r) => r.status === "started");
-  // Hold the "running" tint for a moment after the last command stops so the bg
-  // doesn't flicker between commands (which arrive ~100ms apart). Going to running
-  // is instant; leaving running is debounced.
-  const [showRunning, setShowRunning] = React.useState(false);
-  React.useEffect(() => {
-    if (isRunning) {
-      setShowRunning(true);
-      return;
-    }
-    const t = window.setTimeout(() => setShowRunning(false), 600);
-    return () => window.clearTimeout(t);
-  }, [isRunning]);
-
   return (
-    <main className="flex h-screen items-stretch overflow-hidden bg-neutral-100 font-mono text-neutral-700">
-      <CommandsPanel
-        rows={commandRows}
-        collapsed={commandsCollapsed}
-        onToggle={() => setCommandsCollapsed((c) => !c)}
-        onClear={() => setCommandRows([])}
-      />
-      <div
-        className={
-          "flex min-w-0 flex-1 items-start gap-4 p-4 transition-colors duration-500 " +
-          (showRunning ? "bg-sky-100" : "bg-neutral-100")
-        }
-      >
-        {deviceState.status === "streaming" ? (
-          <>
-            <div
-              className={
-                "relative shrink-0 overflow-hidden rounded-[2rem] bg-neutral-900 shadow-xl shadow-neutral-300/60 ring-4 transition-shadow duration-500 " +
-                (showRunning ? "ring-sky-700" : "ring-transparent")
-              }
-            >
-              <img className="block max-h-[calc(100vh-2rem)] w-auto" src={deviceState.streamUrl} draggable={false} />
-              <div className="pointer-events-none absolute inset-0">
-                <DeviceOverlayCanvas overlays={overlays} />
-                {overlays
-                  .filter((overlay): overlay is Extract<DeviceOverlay, { kind: "input_text" }> => overlay.kind === "input_text")
-                  .map((overlay) => <InputTextOverlay key={overlay.id} overlay={overlay} />)}
-              </div>
-              <GestureLayer />
-            </div>
-            <HardwareRail platform={deviceState.platform} />
-          </>
-        ) : (
-          <div className="grid h-[70vh] w-full max-w-sm shrink-0 place-items-center rounded-[2rem] border border-neutral-200 bg-white text-xs text-neutral-500 shadow-xl shadow-neutral-300/60">
-            <div className="text-center">
-              <div>no device stream</div>
-              {deviceState.message && (
-                <div className="mt-2 max-w-xs whitespace-pre-wrap text-neutral-400">{deviceState.message}</div>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-    </main>
+    <VisualizerLayout
+      rows={commandRows}
+      collapsed={commandsCollapsed}
+      onToggle={() => setCommandsCollapsed((c) => !c)}
+      onClear={() => setCommandRows([])}
+      deviceState={deviceState}
+      overlays={overlays}
+    />
   );
 }
 
-createRoot(document.getElementById("root")!).render(<App />);
+// Demo is dev-only. In prod builds, `import.meta.env.DEV` is statically false, so
+// the branch (and its `./demo` dynamic import) is dead-coded out of the bundle.
+const isDemo = import.meta.env.DEV && new URLSearchParams(window.location.search).has("demo");
+const root = createRoot(document.getElementById("root")!);
+if (isDemo) {
+  import("./demo").then(({ DemoApp }) => root.render(<DemoApp />));
+} else {
+  root.render(<App />);
+}

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -2,20 +2,21 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import "./styles.css";
 
-type CommandStatus = "started" | "completed" | "failed" | "warned" | "skipped";
+type CommandStatus = "pending" | "started" | "completed" | "failed" | "warned" | "skipped";
 type DriverStatus = "started" | "completed" | "failed";
 /** Normalized [0, 1] coordinates within the device's screen. */
 type Point2D = { x: number; y: number };
 
+type CommandEntry = {
+  commandId: string;
+  yaml: string;
+  status: CommandStatus;
+  errorMessage?: string | null;
+};
+
 type VisualizerEvent =
   | { type: "maestro.connected"; platform: string; deviceId: string }
-  | {
-      type: "maestro.command";
-      status: CommandStatus;
-      callId: string;
-      yaml: string | null;
-      errorMessage?: string | null;
-    }
+  | { type: "maestro.flow_state"; commands: CommandEntry[] }
   | { type: "driver.tap"; status: DriverStatus; point: Point2D }
   | {
       type: "driver.swipe";
@@ -80,39 +81,14 @@ function clampPoint(point: Point2D): OverlayPoint {
     y: Math.max(0, Math.min(1, point.y)),
   };
 }
-type TrackedMaestroCommand = {
-  callId: string;
-  /** Monotonic insert order so multiple flows stay chronological in the log. */
-  sequence: number;
-  yaml: string;
-  status: CommandStatus;
-  errorMessage?: string;
-};
-
-function upsertMaestroCommand(rows: TrackedMaestroCommand[], event: VisualizerEvent): TrackedMaestroCommand[] {
-  if (event.type !== "maestro.command") return rows;
-  // Synthetic commands (applyConfiguration, defineVariables) have no source yaml; skip them.
-  if (!event.yaml) return rows;
-
-  const i = rows.findIndex((r) => r.callId === event.callId);
-  const maxSeq = rows.reduce((m, r) => Math.max(m, r.sequence), 0);
-  const sequence = i === -1 ? maxSeq + 1 : rows[i].sequence;
-
-  const nextRow: TrackedMaestroCommand = {
-    callId: event.callId,
-    sequence,
-    yaml: event.yaml,
-    status: event.status,
-    errorMessage: event.errorMessage ?? undefined,
-  };
-
-  if (i === -1) {
-    return [...rows, nextRow].sort((a, b) => a.sequence - b.sequence);
-  }
-
-  const copy = [...rows];
-  copy[i] = nextRow;
-  return copy.sort((a, b) => a.sequence - b.sequence);
+// Snapshot-based merge: the backend publishes the current flow's full command list
+// on every change. Rows from prior flows linger because their commandIds aren't in
+// the new snapshot — we keep what we have and overwrite anything the snapshot covers.
+// commandIds come from a process-monotonic counter, so numeric sort is chronological.
+function applyFlowState(rows: CommandEntry[], snapshot: CommandEntry[]): CommandEntry[] {
+  const next = new Map(rows.map((r) => [r.commandId, r]));
+  for (const c of snapshot) next.set(c.commandId, c);
+  return [...next.values()].sort((a, b) => Number(a.commandId) - Number(b.commandId));
 }
 
 function MaestroLogo({ className }: { className?: string }) {
@@ -129,6 +105,12 @@ function MaestroLogo({ className }: { className?: string }) {
 function StatusIcon({ status }: { status: CommandStatus }) {
   const common = "mt-[2px] h-4 w-4 shrink-0 stroke-current";
   switch (status) {
+    case "pending":
+      return (
+        <svg className={`${common} text-neutral-400`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
+          <circle cx="8" cy="8" r="5" stroke="currentColor" strokeWidth="1.5" />
+        </svg>
+      );
     case "started":
       return (
         <svg className={`${common} animate-spin text-sky-700`} viewBox="0 0 16 16" fill="none" aria-hidden="true">
@@ -174,7 +156,7 @@ function CommandsPanel({
   onToggle,
   onClear,
 }: {
-  rows: TrackedMaestroCommand[];
+  rows: CommandEntry[];
   collapsed: boolean;
   onToggle: () => void;
   onClear: () => void;
@@ -255,8 +237,8 @@ function CommandsPanel({
               const running = row.status === "started";
               return (
                 <li
-                  key={row.callId}
-                  data-call-id={row.callId}
+                  key={row.commandId}
+                  data-command-id={row.commandId}
                   className={
                     // Keep rounded-l on every row so the running highlight's left corners
                     // don't snap from rounded to square mid-fade when the status flips and
@@ -633,7 +615,7 @@ function HardwareRail({ platform }: { platform?: string }) {
 
 function App() {
   const [overlays, setOverlays] = React.useState<DeviceOverlay[]>([]);
-  const [commandRows, setCommandRows] = React.useState<TrackedMaestroCommand[]>([]);
+  const [commandRows, setCommandRows] = React.useState<CommandEntry[]>([]);
   const [deviceState, setDeviceState] = React.useState<DeviceState>({ status: "idle" });
   const [commandsCollapsed, setCommandsCollapsed] = React.useState(false);
   const didAutoStartDeviceStream = React.useRef(false);
@@ -648,7 +630,9 @@ function App() {
     stream.onmessage = (message) => {
       const event = JSON.parse(message.data) as VisualizerEvent;
 
-      setCommandRows((rows) => upsertMaestroCommand(rows, event));
+      if (event.type === "maestro.flow_state") {
+        setCommandRows((rows) => applyFlowState(rows, event.commands));
+      }
 
       const overlay = overlayFromEvent(event);
       if (overlay) {

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -105,13 +105,24 @@ function MaestroLogo({ className }: { className?: string }) {
   );
 }
 
+function statusLineColor(status: CommandStatus): string {
+  switch (status) {
+    case "completed": return "bg-gradient-to-b from-emerald-400/60 to-emerald-400/20 dark:from-emerald-500/60 dark:to-emerald-500/20";
+    case "failed": return "bg-gradient-to-b from-red-400/60 to-red-400/20 dark:from-red-500/60 dark:to-red-500/20";
+    case "warned": return "bg-gradient-to-b from-amber-400/60 to-amber-400/20 dark:from-amber-500/60 dark:to-amber-500/20";
+    case "started": return "bg-gradient-to-b from-sky-400/60 to-sky-400/20 dark:from-sky-500/60 dark:to-sky-500/20";
+    case "skipped": return "bg-gradient-to-b from-neutral-300/50 to-neutral-300/20 dark:from-neutral-600/50 dark:to-neutral-600/20";
+    case "pending": return "bg-gradient-to-b from-neutral-300/60 to-neutral-300/20 dark:from-neutral-600/60 dark:to-neutral-600/20";
+  }
+}
+
 function StatusIcon({ status }: { status: CommandStatus }) {
-  const common = "mt-[2px] h-4 w-4 shrink-0 stroke-current";
+  const common = "mt-[2px] h-3.5 w-3.5 shrink-0";
   switch (status) {
     case "pending":
       return (
         <svg className={`${common} text-neutral-400 dark:text-neutral-500`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
-          <circle cx="8" cy="8" r="5" stroke="currentColor" strokeWidth="1.5" />
+          <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" />
         </svg>
       );
     case "started":
@@ -123,26 +134,30 @@ function StatusIcon({ status }: { status: CommandStatus }) {
       );
     case "completed":
       return (
-        <svg className={`${common} text-emerald-500`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M3.75 8.25 6.75 11.25 12.25 5" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        <svg className={`${common} text-emerald-500`} viewBox="0 0 16 16" aria-hidden="true">
+          <circle cx="8" cy="8" r="7" fill="currentColor" />
+          <path d="M4.75 8.25 7 10.5 11.25 6" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
       );
     case "failed":
       return (
-        <svg className={`${common} text-red-500`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M5 11 11 5M11 11 5 5" strokeWidth="2" strokeLinecap="round" />
+        <svg className={`${common} text-red-500`} viewBox="0 0 16 16" aria-hidden="true">
+          <circle cx="8" cy="8" r="7" fill="currentColor" />
+          <path d="M5.5 10.5 10.5 5.5M10.5 10.5 5.5 5.5" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" />
         </svg>
       );
     case "warned":
       return (
-        <svg className={`${common} text-amber-500`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M8 4.5v5M8 11.5h.01" strokeWidth="2" strokeLinecap="round" />
+        <svg className={`${common} text-amber-500`} viewBox="0 0 16 16" aria-hidden="true">
+          <circle cx="8" cy="8" r="7" fill="currentColor" />
+          <path d="M8 4.5v4M8 11h.01" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" />
         </svg>
       );
     case "skipped":
       return (
-        <svg className={`${common} text-neutral-400 dark:text-neutral-500`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
-          <path d="M4 8h8" strokeWidth="2" strokeLinecap="round" />
+        <svg className={`${common} text-neutral-300 dark:text-neutral-600`} viewBox="0 0 16 16" aria-hidden="true">
+          <circle cx="8" cy="8" r="7" fill="currentColor" />
+          <path d="M5 8h6" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" />
         </svg>
       );
   }
@@ -180,7 +195,7 @@ function CommandsPanel({
 
   if (collapsed) {
     return (
-      <aside className="flex h-full shrink-0 flex-col items-center gap-2 border-r border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900 py-2">
+      <aside className="m-2 flex w-10 shrink-0 flex-col items-center gap-2 rounded-xl border border-neutral-200/70 bg-neutral-50/70 py-2 shadow-lg shadow-neutral-300/50 backdrop-blur-md dark:border-neutral-800/70 dark:bg-neutral-900/60 dark:shadow-black/40">
         <button
           type="button"
           onClick={onToggle}
@@ -192,7 +207,7 @@ function CommandsPanel({
         </button>
         <MaestroLogo className="h-4 w-4 text-neutral-700 dark:text-neutral-200" />
         <span
-          className="rotate-180 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500 dark:text-neutral-400"
+          className="rotate-180 select-none text-xs font-semibold text-neutral-500 dark:text-neutral-400"
           style={{ writingMode: "vertical-rl" }}
         >
           Maestro MCP
@@ -202,10 +217,11 @@ function CommandsPanel({
   }
 
   return (
-    <aside className="flex h-full w-80 shrink-0 flex-col border-r border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900">
+    <aside className="relative m-2 w-80 shrink-0 overflow-hidden rounded-xl border border-neutral-200/70 bg-neutral-50/70 shadow-lg shadow-neutral-300/50 backdrop-blur-md dark:border-neutral-800/70 dark:bg-neutral-900/60 dark:shadow-black/40">
+     <div className="absolute inset-0 flex flex-col">
       <header className="flex h-8 shrink-0 items-center justify-between border-b border-neutral-200 dark:border-neutral-800 px-2">
-        <h2 className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-700 dark:text-neutral-200">
-          <MaestroLogo className="h-3.5 w-3.5 text-neutral-900" />
+        <h2 className="flex items-center gap-0.5 text-xs font-semibold text-neutral-700 dark:text-neutral-200">
+          <MaestroLogo className="h-3.5 w-3.5 text-neutral-900 dark:text-neutral-100" />
           Maestro MCP
         </h2>
         <div className="flex items-center gap-0.5">
@@ -234,31 +250,41 @@ function CommandsPanel({
           </button>
         </div>
       </header>
-      <div className="min-h-0 flex-1 overflow-hidden font-mono text-sm leading-5 text-neutral-600 dark:text-neutral-300">
+      <div className="min-h-0 flex-1 overflow-hidden text-xs leading-5 text-neutral-600 dark:text-neutral-300">
         {visibleRows.length === 0 ? (
           <p className="px-3 pt-2 text-neutral-400 dark:text-neutral-500">Commands executed by Maestro MCP</p>
         ) : (
-          <ol ref={listRef} className="m-0 h-full list-none overflow-y-auto pl-2 pt-2 pb-8 [&>li]:mt-0">
-            {visibleRows.map((row) => {
+          <ol ref={listRef} className="m-0 h-full list-none overflow-y-auto px-2 pt-2 pb-8 [&>li]:mt-1 [&>li:first-child]:mt-0">
+            {visibleRows.map((row, i) => {
               const running = row.status === "started";
+              const isLast = i === visibleRows.length - 1;
               return (
                 <li
                   key={row.commandId}
                   data-command-id={row.commandId}
                   className={
-                    // Keep rounded-l on every row so the running highlight's left corners
-                    // don't snap from rounded to square mid-fade when the status flips and
+                    // Keep rounded on every row so the running highlight's corners don't
+                    // snap from rounded to square mid-fade when the status flips and
                     // transition-colors animates bg from sky-900 back to transparent.
-                    "flex gap-2 rounded-l-xl py-0.5 pl-1.5 pr-2 leading-5 transition-colors " +
+                    "flex gap-2 rounded-xl py-0.5 pl-1.5 pr-2 leading-5 transition-all duration-300 " +
                     (running
-                      ? "bg-sky-100 text-sky-900 dark:bg-sky-900/40 dark:text-sky-100"
+                      ? "bg-sky-100/90 text-sky-950 font-medium ring-1 ring-inset ring-sky-300/60 shadow-sm shadow-sky-300/30 dark:bg-sky-500/15 dark:text-sky-50 dark:ring-sky-400/30 dark:shadow-sky-500/20"
                       : row.status === "failed"
                         ? "text-neutral-900 dark:text-neutral-100"
                         : "")
                   }
                 >
                   <span className="sr-only">{row.status}</span>
-                  <StatusIcon status={row.status} />
+                  <div className="relative flex w-3.5 shrink-0 items-start justify-center self-stretch">
+                    <StatusIcon status={row.status} />
+                    {!isLast && (
+                      <span
+                        aria-hidden="true"
+                        className={`absolute left-1/2 w-0.5 -translate-x-1/2 rounded-full ${statusLineColor(row.status === "started" ? "pending" : row.status)}`}
+                        style={{ top: 16, bottom: -10 }}
+                      />
+                    )}
+                  </div>
                   <div className="min-w-0 flex-1 leading-5">
                     <pre className="m-0 whitespace-pre overflow-x-auto leading-[inherit]">{asYamlListItem(row.yaml)}</pre>
                     {row.errorMessage && row.status === "failed" ? (
@@ -271,6 +297,7 @@ function CommandsPanel({
           </ol>
         )}
       </div>
+     </div>
     </aside>
   );
 }
@@ -651,12 +678,7 @@ function DevicePanel({
   }, [isRunning]);
 
   return (
-    <div
-      className={
-        "flex min-w-0 flex-1 items-start gap-4 p-4 transition-colors duration-500 " +
-        (showRunning ? "bg-sky-100 dark:bg-sky-950/40" : "bg-neutral-100 dark:bg-neutral-950")
-      }
-    >
+    <div className="flex min-w-0 items-start gap-4 p-4">
       {device ? (
         <>
           <div
@@ -670,13 +692,15 @@ function DevicePanel({
           <HardwareRail platform={platform} />
         </>
       ) : (
-        <div className="grid h-[70vh] w-full max-w-sm shrink-0 place-items-center rounded-[2rem] border border-neutral-200 bg-white text-xs text-neutral-500 shadow-xl shadow-neutral-300/60 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-400 dark:shadow-black/40">
-          <div className="text-center">
-            <div>no device stream</div>
-            {placeholderMessage && (
-              <div className="mt-2 max-w-xs whitespace-pre-wrap text-neutral-400 dark:text-neutral-500">{placeholderMessage}</div>
-            )}
-          </div>
+        <div className="flex aspect-[9/19] h-[calc(100vh-4rem)] shrink-0 flex-col items-center justify-center gap-3 rounded-[2rem] border-2 border-dashed border-neutral-300 bg-neutral-50/40 px-6 text-center backdrop-blur-sm dark:border-neutral-700 dark:bg-neutral-900/30">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="h-10 w-10 text-neutral-400 dark:text-neutral-600">
+            <rect x="6" y="2.5" width="12" height="19" rx="2.5" />
+            <path d="M10.5 18.5h3" />
+          </svg>
+          <div className="text-sm font-medium text-neutral-700 dark:text-neutral-200">No device connected</div>
+          {placeholderMessage && (
+            <div className="max-w-[15rem] text-xs leading-relaxed whitespace-pre-wrap text-neutral-500 dark:text-neutral-400">{placeholderMessage}</div>
+          )}
         </div>
       )}
     </div>
@@ -707,7 +731,7 @@ export function VisualizerLayout({
 }) {
   const device: React.ReactNode = deviceState.status === "streaming" && deviceState.streamUrl ? (
     <>
-      <img className="block max-h-[calc(100vh-2rem)] w-auto" src={deviceState.streamUrl} draggable={false} />
+      <img className="block h-[calc(100vh-4rem)] w-auto" src={deviceState.streamUrl} draggable={false} />
       <div className="pointer-events-none absolute inset-0">
         <DeviceOverlayCanvas overlays={overlays} />
         {overlays
@@ -719,14 +743,16 @@ export function VisualizerLayout({
   ) : undefined;
 
   return (
-    <main className="flex h-screen items-stretch overflow-hidden bg-neutral-100 font-mono text-neutral-700 dark:text-neutral-200 dark:bg-neutral-950 dark:text-neutral-200">
-      <CommandsPanel rows={rows} collapsed={collapsed} onToggle={onToggle} onClear={onClear} />
-      <DevicePanel
-        rows={rows}
-        device={device}
-        platform={deviceState.platform}
-        placeholderMessage={deviceState.message}
-      />
+    <main className="flex h-screen items-center justify-center overflow-hidden bg-neutral-100 text-neutral-700 dark:bg-neutral-950 dark:text-neutral-200">
+      <div className="flex items-stretch">
+        <CommandsPanel rows={rows} collapsed={collapsed} onToggle={onToggle} onClear={onClear} />
+        <DevicePanel
+          rows={rows}
+          device={device}
+          platform={deviceState.platform}
+          placeholderMessage={deviceState.message}
+        />
+      </div>
     </main>
   );
 }

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -110,13 +110,13 @@ function StatusIcon({ status }: { status: CommandStatus }) {
   switch (status) {
     case "pending":
       return (
-        <svg className={`${common} text-neutral-400`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
+        <svg className={`${common} text-neutral-400 dark:text-neutral-500`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
           <circle cx="8" cy="8" r="5" stroke="currentColor" strokeWidth="1.5" />
         </svg>
       );
     case "started":
       return (
-        <svg className={`${common} animate-spin text-sky-700`} viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <svg className={`${common} animate-spin text-sky-700 dark:text-sky-400`} viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <circle cx="8" cy="8" r="6" stroke="currentColor" strokeWidth="2" strokeOpacity="0.25" />
           <path d="M14 8a6 6 0 0 0-6-6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
         </svg>
@@ -141,7 +141,7 @@ function StatusIcon({ status }: { status: CommandStatus }) {
       );
     case "skipped":
       return (
-        <svg className={`${common} text-neutral-400`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
+        <svg className={`${common} text-neutral-400 dark:text-neutral-500`} fill="none" viewBox="0 0 16 16" aria-hidden="true">
           <path d="M4 8h8" strokeWidth="2" strokeLinecap="round" />
         </svg>
       );
@@ -180,19 +180,19 @@ function CommandsPanel({
 
   if (collapsed) {
     return (
-      <aside className="flex h-full shrink-0 flex-col items-center gap-2 border-r border-neutral-200 bg-neutral-50 py-2">
+      <aside className="flex h-full shrink-0 flex-col items-center gap-2 border-r border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900 py-2">
         <button
           type="button"
           onClick={onToggle}
           aria-label="Expand Maestro MCP"
           title="Expand Maestro MCP"
-          className="grid h-7 w-7 place-items-center rounded text-neutral-500 transition hover:bg-neutral-200 hover:text-neutral-800"
+          className="grid h-7 w-7 place-items-center rounded text-neutral-500 dark:text-neutral-400 transition hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-100"
         >
           <ChevronIcon direction="right" />
         </button>
-        <MaestroLogo className="h-4 w-4 text-neutral-700" />
+        <MaestroLogo className="h-4 w-4 text-neutral-700 dark:text-neutral-200" />
         <span
-          className="rotate-180 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500"
+          className="rotate-180 select-none text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-500 dark:text-neutral-400"
           style={{ writingMode: "vertical-rl" }}
         >
           Maestro MCP
@@ -202,9 +202,9 @@ function CommandsPanel({
   }
 
   return (
-    <aside className="flex h-full w-80 shrink-0 flex-col border-r border-neutral-200 bg-neutral-50">
-      <header className="flex h-8 shrink-0 items-center justify-between border-b border-neutral-200 px-2">
-        <h2 className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-700">
+    <aside className="flex h-full w-80 shrink-0 flex-col border-r border-neutral-200 dark:border-neutral-800 bg-neutral-50 dark:bg-neutral-900">
+      <header className="flex h-8 shrink-0 items-center justify-between border-b border-neutral-200 dark:border-neutral-800 px-2">
+        <h2 className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-neutral-700 dark:text-neutral-200">
           <MaestroLogo className="h-3.5 w-3.5 text-neutral-900" />
           Maestro MCP
         </h2>
@@ -215,7 +215,7 @@ function CommandsPanel({
             disabled={visibleRows.length === 0}
             aria-label="Clear log"
             title="Clear log"
-            className="grid h-6 w-6 place-items-center rounded text-neutral-500 transition hover:bg-neutral-200 hover:text-neutral-800 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-500"
+            className="grid h-6 w-6 place-items-center rounded text-neutral-500 dark:text-neutral-400 transition hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-neutral-500 dark:disabled:hover:text-neutral-400"
           >
             <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="h-3.5 w-3.5">
               <path d="M3 4.5h10" />
@@ -228,15 +228,15 @@ function CommandsPanel({
             onClick={onToggle}
             aria-label="Collapse Maestro MCP"
             title="Collapse Maestro MCP"
-            className="grid h-6 w-6 place-items-center rounded text-neutral-500 transition hover:bg-neutral-200 hover:text-neutral-800"
+            className="grid h-6 w-6 place-items-center rounded text-neutral-500 dark:text-neutral-400 transition hover:bg-neutral-200 dark:hover:bg-neutral-700 hover:text-neutral-800 dark:hover:text-neutral-100"
           >
             <ChevronIcon direction="left" />
           </button>
         </div>
       </header>
-      <div className="min-h-0 flex-1 overflow-hidden font-mono text-sm leading-5 text-neutral-600">
+      <div className="min-h-0 flex-1 overflow-hidden font-mono text-sm leading-5 text-neutral-600 dark:text-neutral-300">
         {visibleRows.length === 0 ? (
-          <p className="px-3 pt-2 text-neutral-400">Commands executed by Maestro MCP</p>
+          <p className="px-3 pt-2 text-neutral-400 dark:text-neutral-500">Commands executed by Maestro MCP</p>
         ) : (
           <ol ref={listRef} className="m-0 h-full list-none overflow-y-auto pl-2 pt-2 pb-8 [&>li]:mt-0">
             {visibleRows.map((row) => {
@@ -251,9 +251,9 @@ function CommandsPanel({
                     // transition-colors animates bg from sky-900 back to transparent.
                     "flex gap-2 rounded-l-xl py-0.5 pl-1.5 pr-2 leading-5 transition-colors " +
                     (running
-                      ? "bg-sky-100 text-sky-900"
+                      ? "bg-sky-100 text-sky-900 dark:bg-sky-900/40 dark:text-sky-100"
                       : row.status === "failed"
-                        ? "text-neutral-900"
+                        ? "text-neutral-900 dark:text-neutral-100"
                         : "")
                   }
                 >
@@ -262,7 +262,7 @@ function CommandsPanel({
                   <div className="min-w-0 flex-1 leading-5">
                     <pre className="m-0 whitespace-pre overflow-x-auto leading-[inherit]">{asYamlListItem(row.yaml)}</pre>
                     {row.errorMessage && row.status === "failed" ? (
-                      <p className="mt-0 text-xs leading-4 text-red-600">{row.errorMessage}</p>
+                      <p className="mt-0 text-xs leading-4 text-red-600 dark:text-red-400">{row.errorMessage}</p>
                     ) : null}
                   </div>
                 </li>
@@ -575,7 +575,7 @@ function HardwareButton({ name, label, hideForPlatform, platform, children }: {
         sendInput({ kind: "button", action: "Down", name });
         window.setTimeout(() => sendInput({ kind: "button", action: "Up", name }), 80);
       }}
-      className="grid h-10 w-10 place-items-center rounded-md border border-white/40 bg-white/40 text-neutral-700 shadow-sm backdrop-blur transition hover:border-white/70 hover:bg-white/85 hover:text-neutral-900 active:scale-95 active:bg-white/95 active:shadow-inner"
+      className="grid h-10 w-10 place-items-center rounded-md border border-white/40 bg-white/40 text-neutral-700 shadow-sm backdrop-blur transition hover:border-white/70 hover:bg-white/85 hover:text-neutral-900 active:scale-95 active:bg-white/95 active:shadow-inner dark:border-white/25 dark:bg-white/10 dark:text-neutral-50 dark:hover:border-white/40 dark:hover:bg-white/25 dark:hover:text-white dark:active:bg-white/40"
     >
       {children}
     </button>
@@ -585,7 +585,7 @@ function HardwareButton({ name, label, hideForPlatform, platform, children }: {
 function HardwareRail({ platform }: { platform?: string }) {
   if (platform !== "android" && platform !== "ios") return null;
   return (
-    <div className="flex shrink-0 flex-col gap-1.5 self-start rounded-lg border border-white/40 bg-white/30 p-1.5 shadow-sm backdrop-blur-md">
+    <div className="flex shrink-0 flex-col gap-1.5 self-start rounded-lg border border-white/40 bg-white/30 p-1.5 shadow-sm backdrop-blur-md dark:border-white/20 dark:bg-white/10">
       <HardwareButton name="power" label="Power">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
           <path d="M12 3v9" /><path d="M7 7a7 7 0 1 0 10 0" />
@@ -601,7 +601,7 @@ function HardwareRail({ platform }: { platform?: string }) {
           <path d="M5 12h14" />
         </svg>
       </HardwareButton>
-      <div className="my-1 h-px bg-white/50" />
+      <div className="my-1 h-px bg-white/50 dark:bg-white/15" />
       <HardwareButton name="back" label="Back" hideForPlatform="ios" platform={platform}>
         <svg viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4"><path d="M15 5 L7 12 L15 19 Z" /></svg>
       </HardwareButton>
@@ -654,15 +654,15 @@ function DevicePanel({
     <div
       className={
         "flex min-w-0 flex-1 items-start gap-4 p-4 transition-colors duration-500 " +
-        (showRunning ? "bg-sky-100" : "bg-neutral-100")
+        (showRunning ? "bg-sky-100 dark:bg-sky-950/40" : "bg-neutral-100 dark:bg-neutral-950")
       }
     >
       {device ? (
         <>
           <div
             className={
-              "relative shrink-0 overflow-hidden rounded-[2rem] bg-neutral-900 shadow-xl shadow-neutral-300/60 ring-4 transition-shadow duration-500 " +
-              (showRunning ? "ring-sky-700" : "ring-transparent")
+              "relative shrink-0 overflow-hidden rounded-[2rem] bg-neutral-900 shadow-xl shadow-neutral-300/60 ring-4 transition-shadow duration-500 dark:shadow-black/40 " +
+              (showRunning ? "ring-sky-700 dark:ring-sky-400" : "ring-transparent")
             }
           >
             {device}
@@ -670,11 +670,11 @@ function DevicePanel({
           <HardwareRail platform={platform} />
         </>
       ) : (
-        <div className="grid h-[70vh] w-full max-w-sm shrink-0 place-items-center rounded-[2rem] border border-neutral-200 bg-white text-xs text-neutral-500 shadow-xl shadow-neutral-300/60">
+        <div className="grid h-[70vh] w-full max-w-sm shrink-0 place-items-center rounded-[2rem] border border-neutral-200 bg-white text-xs text-neutral-500 shadow-xl shadow-neutral-300/60 dark:border-neutral-800 dark:bg-neutral-900 dark:text-neutral-400 dark:shadow-black/40">
           <div className="text-center">
             <div>no device stream</div>
             {placeholderMessage && (
-              <div className="mt-2 max-w-xs whitespace-pre-wrap text-neutral-400">{placeholderMessage}</div>
+              <div className="mt-2 max-w-xs whitespace-pre-wrap text-neutral-400 dark:text-neutral-500">{placeholderMessage}</div>
             )}
           </div>
         </div>
@@ -719,7 +719,7 @@ export function VisualizerLayout({
   ) : undefined;
 
   return (
-    <main className="flex h-screen items-stretch overflow-hidden bg-neutral-100 font-mono text-neutral-700">
+    <main className="flex h-screen items-stretch overflow-hidden bg-neutral-100 font-mono text-neutral-700 dark:text-neutral-200 dark:bg-neutral-950 dark:text-neutral-200">
       <CommandsPanel rows={rows} collapsed={collapsed} onToggle={onToggle} onClear={onClear} />
       <DevicePanel
         rows={rows}

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -285,7 +285,7 @@ function CommandsPanel({
   }
 
   return (
-    <aside className="relative m-2 w-80 shrink-0 overflow-hidden rounded-xl border border-neutral-200/70 bg-neutral-50/70 shadow-lg shadow-neutral-300/50 backdrop-blur-md dark:border-neutral-800/70 dark:bg-neutral-900/60 dark:shadow-black/40">
+    <aside className="relative m-2 min-w-80 flex-1 overflow-hidden rounded-xl border border-neutral-200/70 bg-neutral-50/70 shadow-lg shadow-neutral-300/50 backdrop-blur-md dark:border-neutral-800/70 dark:bg-neutral-900/60 dark:shadow-black/40">
      <div className="absolute inset-0 flex flex-col">
       <header className="flex h-8 shrink-0 items-center justify-between border-b border-neutral-200 dark:border-neutral-800 px-2">
         <h2 className="flex items-center gap-0.5 text-xs font-semibold text-neutral-700 dark:text-neutral-200">
@@ -812,7 +812,7 @@ export function VisualizerLayout({
 
   return (
     <main className="flex h-screen items-center justify-center overflow-hidden bg-neutral-100 text-neutral-700 dark:bg-neutral-950 dark:text-neutral-200">
-      <div className="flex items-stretch">
+      <div className={`flex max-w-5xl items-stretch ${collapsed ? "" : "w-full"}`}>
         <CommandsPanel rows={rows} collapsed={collapsed} onToggle={onToggle} onClear={onClear} />
         <DevicePanel
           rows={rows}

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -172,7 +172,7 @@ function HighlightedYamlListItem({ yaml }: { yaml: string }) {
     <>
       {yaml.split("\n").map((line, i) => (
         <React.Fragment key={i}>
-          {i === 0 ? <span className="text-neutral-400 dark:text-neutral-500">- </span> : "\n  "}
+          {i === 0 ? <span className="text-neutral-400 dark:text-white">- </span> : "\n  "}
           {tokenizeYamlLine(line)}
         </React.Fragment>
       ))}
@@ -219,16 +219,16 @@ function tokenizeYamlValue(rest: string): React.ReactNode {
 }
 
 function YamlKey({ children }: { children: React.ReactNode }) {
-  return <span className="text-indigo-700 dark:text-indigo-300">{children}</span>;
+  return <span className="font-semibold text-indigo-700 dark:text-indigo-300">{children}</span>;
 }
 function YamlString({ children }: { children: React.ReactNode }) {
-  return <span className="text-emerald-700 dark:text-emerald-400">{children}</span>;
+  return <span className="font-light text-emerald-700 dark:text-emerald-400">{children}</span>;
 }
 function YamlNumber({ children }: { children: React.ReactNode }) {
-  return <span className="text-violet-700 dark:text-violet-400">{children}</span>;
+  return <span className="font-light text-violet-700 dark:text-violet-400">{children}</span>;
 }
 function YamlPunct({ children }: { children: React.ReactNode }) {
-  return <span className="text-neutral-400 dark:text-neutral-500">{children}</span>;
+  return <span className="font-light text-neutral-400 dark:text-neutral-500">{children}</span>;
 }
 
 function CommandsPanel({
@@ -336,7 +336,7 @@ function CommandsPanel({
                     // transition-colors animates bg from sky-900 back to transparent.
                     "flex gap-2 rounded-xl py-0.5 pl-1.5 pr-2 leading-5 transition-colors duration-300 " +
                     (running
-                      ? "bg-sky-200 text-sky-950 ring-2 ring-inset ring-sky-500/70 shadow-md shadow-sky-500/40 dark:bg-sky-900 dark:text-sky-50 dark:ring-sky-400/70 dark:shadow-sky-500/40"
+                      ? "bg-sky-200 text-sky-950 ring-2 ring-inset ring-sky-500/70 shadow-sm shadow-sky-500/15 dark:bg-sky-900 dark:text-sky-50 dark:ring-sky-400/70 dark:shadow-md dark:shadow-sky-500/40"
                       : row.status === "failed"
                         ? "text-neutral-900 dark:text-neutral-100"
                         : "")
@@ -670,7 +670,7 @@ function HardwareButton({ name, label, hideForPlatform, platform, children }: {
         sendInput({ kind: "button", action: "Down", name });
         window.setTimeout(() => sendInput({ kind: "button", action: "Up", name }), 80);
       }}
-      className="grid h-10 w-10 place-items-center rounded-md border border-white/40 bg-white/40 text-neutral-700 shadow-sm backdrop-blur transition hover:border-white/70 hover:bg-white/85 hover:text-neutral-900 active:scale-95 active:bg-white/95 active:shadow-inner dark:border-white/25 dark:bg-white/10 dark:text-neutral-50 dark:hover:border-white/40 dark:hover:bg-white/25 dark:hover:text-white dark:active:bg-white/40"
+      className="grid h-8 w-8 place-items-center rounded-md border border-white/40 bg-white/40 text-neutral-700 shadow-sm backdrop-blur transition hover:border-white/70 hover:bg-white/85 hover:text-neutral-900 active:scale-95 active:bg-white/95 active:shadow-inner dark:border-white/25 dark:bg-white/10 dark:text-neutral-50 dark:hover:border-white/40 dark:hover:bg-white/25 dark:hover:text-white dark:active:bg-white/40"
     >
       {children}
     </button>
@@ -752,7 +752,7 @@ function DevicePanel({
           <div
             className={
               "relative shrink-0 overflow-hidden rounded-[2rem] bg-neutral-900 shadow-xl shadow-neutral-300/60 ring-4 transition-shadow duration-500 dark:shadow-black/40 " +
-              (showRunning ? "ring-sky-700 dark:ring-sky-400" : "ring-transparent")
+              (showRunning ? "ring-sky-500 dark:ring-sky-400" : "ring-transparent")
             }
           >
             {device}

--- a/maestro-cli/mcp-visualizer/src/main.tsx
+++ b/maestro-cli/mcp-visualizer/src/main.tsx
@@ -285,7 +285,7 @@ function CommandsPanel({
   }
 
   return (
-    <aside className="relative m-2 min-w-80 flex-1 overflow-hidden rounded-xl border border-neutral-200/70 bg-neutral-50/70 shadow-lg shadow-neutral-300/50 backdrop-blur-md dark:border-neutral-800/70 dark:bg-neutral-900/60 dark:shadow-black/40">
+    <aside className="relative m-2 ml-6 min-w-80 flex-1 overflow-hidden rounded-xl border border-neutral-200/70 bg-neutral-50/70 shadow-lg shadow-neutral-300/50 backdrop-blur-md dark:border-neutral-800/70 dark:bg-neutral-900/60 dark:shadow-black/40">
      <div className="absolute inset-0 flex flex-col">
       <header className="flex h-8 shrink-0 items-center justify-between border-b border-neutral-200 dark:border-neutral-800 px-2">
         <h2 className="flex items-center gap-0.5 text-xs font-semibold text-neutral-700 dark:text-neutral-200">

--- a/maestro-cli/mcp-visualizer/src/styles.css
+++ b/maestro-cli/mcp-visualizer/src/styles.css
@@ -5,3 +5,34 @@ html, body, #root {
   margin: 0;
   overflow: hidden;
 }
+
+/* Low-profile scrollbar that doesn't change on hover. Browsers normally swap
+   the thumb to a more prominent color on hover/active — we pin every state to
+   the same translucent neutral. */
+.scrollbar-quiet {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(115 115 115 / 0.15) transparent;
+}
+.scrollbar-quiet::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+.scrollbar-quiet::-webkit-scrollbar-track {
+  background: transparent;
+}
+.scrollbar-quiet::-webkit-scrollbar-thumb,
+.scrollbar-quiet::-webkit-scrollbar-thumb:hover,
+.scrollbar-quiet::-webkit-scrollbar-thumb:active {
+  background-color: rgb(115 115 115 / 0.15);
+  border-radius: 3px;
+}
+@media (prefers-color-scheme: dark) {
+  .scrollbar-quiet {
+    scrollbar-color: rgb(212 212 212 / 0.10) transparent;
+  }
+  .scrollbar-quiet::-webkit-scrollbar-thumb,
+  .scrollbar-quiet::-webkit-scrollbar-thumb:hover,
+  .scrollbar-quiet::-webkit-scrollbar-thumb:active {
+    background-color: rgb(212 212 212 / 0.10);
+  }
+}

--- a/maestro-cli/mcp-visualizer/src/styles.css
+++ b/maestro-cli/mcp-visualizer/src/styles.css
@@ -36,3 +36,4 @@ html, body, #root {
     background-color: rgb(212 212 212 / 0.10);
   }
 }
+

--- a/maestro-cli/mcp-visualizer/src/styles.css
+++ b/maestro-cli/mcp-visualizer/src/styles.css
@@ -1,4 +1,13 @@
+@import "@fontsource-variable/inter";
+@import "@fontsource-variable/jetbrains-mono";
 @import "tailwindcss";
+
+@theme {
+  --default-font-family: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
+  --default-mono-font-family: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-sans: "Inter Variable", ui-sans-serif, system-ui, sans-serif;
+  --font-mono: "JetBrains Mono Variable", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
 
 html, body, #root {
   height: 100%;

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunTool.kt
@@ -5,11 +5,8 @@ import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.*
 import maestro.cli.mcp.McpMaestroSessionManager
-import maestro.cli.mcp.visualizer.CommandStatus
-import maestro.cli.mcp.visualizer.McpVisualizerEvents
-import maestro.cli.mcp.visualizer.VisualizerEvent
+import maestro.cli.mcp.visualizer.McpVisualizerOrchestra
 import maestro.cli.util.WorkingDirectory
-import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withEnv
@@ -22,7 +19,6 @@ import maestro.orchestra.yaml.YamlCommandReader
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.UUID
 
 object RunTool {
 
@@ -87,7 +83,7 @@ object RunTool {
             val result = sessionManager.withSession(
                 deviceId = args.deviceId,
             ) { session ->
-                val orchestra = visualizedOrchestra(session.maestro)
+                val orchestra = McpVisualizerOrchestra.create(session.maestro)
                 when (executable) {
                     is Executable.Inline -> runInline(args.deviceId, orchestra, executable.yaml, args.env)
                     is Executable.Plan -> runPlan(args.deviceId, orchestra, executable.plan, args.env)
@@ -101,62 +97,6 @@ object RunTool {
         } catch (e: Exception) {
             errorResult("Failed to run flow: ${e.message}")
         }
-    }
-
-    private fun visualizedOrchestra(maestro: maestro.Maestro): Orchestra {
-        var flowId = UUID.randomUUID().toString()
-        // Orchestra fires onCommandStart/Complete for nested subflow commands too,
-        // each with a sub-index that restarts at 0. If we publish those, their
-        // callIds (`flowId:index`) collide with outer-flow rows and the visualizer's
-        // upsert reuses the wrong row, making old commands appear "running" again.
-        // Track depth via a stack — push on Start, pop on terminal — and publish only
-        // for the outer-most level. The outer command's yaml already inlines its
-        // nested commands, so users still see what's running.
-        val depth = ArrayDeque<Boolean>() // top-of-stack = isOuter for the most recently started command
-
-        fun publishCommand(status: CommandStatus, index: Int, command: MaestroCommand, error: Throwable? = null) {
-            McpVisualizerEvents.publish(
-                VisualizerEvent.Command(
-                    status = status,
-                    callId = "$flowId:$index",
-                    yaml = command.sourceInfo?.let { it.source.substring(it.startOffset, it.endOffset) },
-                    errorMessage = error?.message,
-                )
-            )
-        }
-
-        return Orchestra(
-            maestro = maestro,
-            onFlowStart = {
-                flowId = UUID.randomUUID().toString()
-                depth.clear()
-            },
-            onCommandStart = { index, command ->
-                val isOuter = depth.isEmpty()
-                depth.addLast(isOuter)
-                if (isOuter) publishCommand(CommandStatus.STARTED, index, command)
-            },
-            onCommandComplete = { index, command ->
-                val wasOuter = depth.removeLast()
-                if (wasOuter) publishCommand(CommandStatus.COMPLETED, index, command)
-            },
-            onCommandWarned = { index, command ->
-                val wasOuter = depth.removeLast()
-                if (wasOuter) publishCommand(CommandStatus.WARNED, index, command)
-            },
-            onCommandSkipped = { index, command ->
-                // onCommandSkipped fires after onCommandStart inside subflows; outside
-                // subflows it can fire without a Start (when a top-level command is
-                // pre-skipped via `when:`). Pop only if our stack has a frame for it.
-                val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) publishCommand(CommandStatus.SKIPPED, index, command)
-            },
-            onCommandFailed = { index, command, error ->
-                val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) publishCommand(CommandStatus.FAILED, index, command, error)
-                throw error
-            },
-        )
     }
 
     private fun resolveExecutable(input: RunInput): Executable = when (input) {

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerEvents.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerEvents.kt
@@ -32,6 +32,9 @@ internal sealed interface VisualizerEvent {
     data class CommandEntry(
         val commandId: String,
         val yaml: String,
+        // 0 = top-level; >0 = nested inside a composite command (runFlow, repeat, retry).
+        // The frontend decides how to render nested commands; today it ignores them.
+        val depth: Int,
         val status: CommandStatus,
         val errorMessage: String? = null,
     )

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerEvents.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerEvents.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicReference
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(
     JsonSubTypes.Type(value = VisualizerEvent.MaestroConnected::class, name = "maestro.connected"),
-    JsonSubTypes.Type(value = VisualizerEvent.Command::class, name = "maestro.command"),
+    JsonSubTypes.Type(value = VisualizerEvent.FlowState::class, name = "maestro.flow_state"),
     JsonSubTypes.Type(value = VisualizerEvent.Tap::class, name = "driver.tap"),
     JsonSubTypes.Type(value = VisualizerEvent.Swipe::class, name = "driver.swipe"),
     JsonSubTypes.Type(value = VisualizerEvent.InputText::class, name = "driver.input_text"),
@@ -22,12 +22,19 @@ internal sealed interface VisualizerEvent {
         val deviceId: String,
     ) : VisualizerEvent
 
-    data class Command(
-        val status: CommandStatus,
-        val callId: String,
-        val yaml: String?,
-        val errorMessage: String? = null,
+    // Full snapshot of the in-flight flow's top-level commands. Published whenever
+    // anything changes — the frontend is a pure projection of the latest snapshot,
+    // merging by commandId so prior runs' rows accumulate alongside the current one.
+    data class FlowState(
+        val commands: List<CommandEntry>,
     ) : VisualizerEvent
+
+    data class CommandEntry(
+        val commandId: String,
+        val yaml: String,
+        val status: CommandStatus,
+        val errorMessage: String? = null,
+    )
 
     data class Tap(
         val status: DriverStatus,
@@ -48,6 +55,7 @@ internal sealed interface VisualizerEvent {
 }
 
 internal enum class CommandStatus(@JsonValue val wire: String) {
+    PENDING("pending"),
     STARTED("started"),
     COMPLETED("completed"),
     FAILED("failed"),

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
@@ -1,6 +1,7 @@
 package maestro.cli.mcp.visualizer
 
 import maestro.Maestro
+import maestro.orchestra.CompositeCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
 import java.util.IdentityHashMap
@@ -22,17 +23,12 @@ internal object McpVisualizerOrchestra {
         fun MaestroCommand.id(): String =
             commandIds.computeIfAbsent(this) { nextCommandId.incrementAndGet() }.toString()
 
-        // Insertion-ordered snapshot of the current flow. Cleared on each onFlowStart so
-        // multi-flow runs (test plans, directories) each get a fresh scope. The frontend
-        // accumulates rows across snapshots because commandIds are globally unique.
+        // Insertion-ordered snapshot of every command in the current flow — top-level
+        // and nested. The frontend chooses what to render (today: depth 0 only). The
+        // map is cleared on each onFlowStart so multi-flow runs each get a fresh scope;
+        // the frontend accumulates rows across snapshots because commandIds are
+        // globally unique.
         val commands = LinkedHashMap<String, VisualizerEvent.CommandEntry>()
-
-        // Orchestra fires onCommandStart/Complete for nested subflow commands too. We
-        // suppress those because the outer `runFlow:` command's yaml already inlines its
-        // nested commands — surfacing each sub-step would clutter the log without adding
-        // information. Track depth via a stack: top frame = isOuter for the most recently
-        // started command; only outer-most frames touch `commands`.
-        val depth = ArrayDeque<Boolean>()
 
         fun publishSnapshot() {
             McpVisualizerEvents.publish(VisualizerEvent.FlowState(commands.values.toList()))
@@ -44,55 +40,46 @@ internal object McpVisualizerOrchestra {
             publishSnapshot()
         }
 
+        // Walk the full tree at flow start so every command — top-level and nested —
+        // gets a PENDING row up front. Runtime callbacks just flip statuses on the
+        // entries seeded here.
+        fun seed(command: MaestroCommand, depth: Int) {
+            val info = command.sourceInfo
+            if (info != null) {
+                val id = command.id()
+                commands[id] = VisualizerEvent.CommandEntry(
+                    commandId = id,
+                    yaml = info.source.substring(info.startOffset, info.endOffset),
+                    depth = depth,
+                    status = CommandStatus.PENDING,
+                )
+            }
+            (command.asCommand() as? CompositeCommand)?.subCommands()?.forEach { child ->
+                seed(child, depth + 1)
+            }
+        }
+
         return Orchestra(
             maestro = maestro,
             onFlowStart = { flowCommands ->
-                depth.clear()
                 commands.clear()
-                flowCommands.forEach { command ->
-                    val yaml = command.sourceInfo?.let { it.source.substring(it.startOffset, it.endOffset) }
-                        ?: return@forEach
-                    val id = command.id()
-                    commands[id] = VisualizerEvent.CommandEntry(
-                        commandId = id,
-                        yaml = yaml,
-                        status = CommandStatus.PENDING,
-                    )
-                }
+                flowCommands.forEach { seed(it, depth = 0) }
                 publishSnapshot()
             },
-            onCommandStart = { _, command ->
-                val isOuter = depth.isEmpty()
-                depth.addLast(isOuter)
-                if (isOuter) updateStatus(command, CommandStatus.STARTED)
-            },
-            onCommandComplete = { _, command ->
-                val wasOuter = depth.removeLast()
-                if (wasOuter) updateStatus(command, CommandStatus.COMPLETED)
-            },
-            onCommandWarned = { _, command ->
-                val wasOuter = depth.removeLast()
-                if (wasOuter) updateStatus(command, CommandStatus.WARNED)
-            },
-            onCommandSkipped = { _, command ->
-                // onCommandSkipped fires after onCommandStart inside subflows; outside
-                // subflows it can fire without a Start (when a top-level command is
-                // pre-skipped via `when:`). Pop only if our stack has a frame for it.
-                val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) updateStatus(command, CommandStatus.SKIPPED)
-            },
+            onCommandStart = { _, command -> updateStatus(command, CommandStatus.STARTED) },
+            onCommandComplete = { _, command -> updateStatus(command, CommandStatus.COMPLETED) },
+            onCommandWarned = { _, command -> updateStatus(command, CommandStatus.WARNED) },
+            onCommandSkipped = { _, command -> updateStatus(command, CommandStatus.SKIPPED) },
             onCommandFailed = { _, command, error ->
-                val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) {
-                    updateStatus(command, CommandStatus.FAILED, error.message)
-                    // Sweep trailing PENDING rows so they don't sit unresolved after the
-                    // flow aborts. Status updates resolve through commands[id()].
-                    commands.replaceAll { _, entry ->
-                        if (entry.status == CommandStatus.PENDING) entry.copy(status = CommandStatus.SKIPPED)
-                        else entry
-                    }
-                    publishSnapshot()
+                updateStatus(command, CommandStatus.FAILED, error.message)
+                // Sweep trailing PENDING rows so they don't sit unresolved after the
+                // flow aborts. Idempotent — repeated failures up the ancestor chain
+                // each call this but only the first sweep does work.
+                commands.replaceAll { _, entry ->
+                    if (entry.status == CommandStatus.PENDING) entry.copy(status = CommandStatus.SKIPPED)
+                    else entry
                 }
+                publishSnapshot()
                 throw error
             },
         )

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
@@ -3,26 +3,36 @@ package maestro.cli.mcp.visualizer
 import maestro.Maestro
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
-import java.util.UUID
+import java.util.IdentityHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 internal object McpVisualizerOrchestra {
 
-    fun create(maestro: Maestro): Orchestra {
-        var flowId = UUID.randomUUID().toString()
-        // Orchestra fires onCommandStart/Complete for nested subflow commands too,
-        // each with a sub-index that restarts at 0. If we publish those, their
-        // callIds (`flowId:index`) collide with outer-flow rows and the visualizer's
-        // upsert reuses the wrong row, making old commands appear "running" again.
-        // Track depth via a stack — push on Start, pop on terminal — and publish only
-        // for the outer-most level. The outer command's yaml already inlines its
-        // nested commands, so users still see what's running.
-        val depth = ArrayDeque<Boolean>() // top-of-stack = isOuter for the most recently started command
+    // Process-scoped so callIds stay unique as the frontend appends commands across runs;
+    // an AtomicInteger retains nothing so this isn't a leak.
+    private val nextCommandId = AtomicInteger()
 
-        fun publishCommand(status: CommandStatus, index: Int, command: MaestroCommand, error: Throwable? = null) {
+    fun create(maestro: Maestro): Orchestra {
+        // Identity-keyed: the same MaestroCommand instance flows from runFlow's input list
+        // through to onCommandStart/Complete, so pending-then-runtime events upsert into
+        // the same visualizer row. Scoped to one create() call so command instances (and
+        // their retained YAML sources) can be GC'd once the flow finishes.
+        val commandIds = IdentityHashMap<MaestroCommand, Int>()
+        fun MaestroCommand.id(): String =
+            commandIds.computeIfAbsent(this) { nextCommandId.incrementAndGet() }.toString()
+
+        // Orchestra fires onCommandStart/Complete for nested subflow commands too. We
+        // suppress those because the outer `runFlow:` command's yaml already inlines its
+        // nested commands — surfacing each sub-step would clutter the log without adding
+        // information. Track depth via a stack: top frame = isOuter for the most recently
+        // started command; only outer-most frames publish events.
+        val depth = ArrayDeque<Boolean>()
+
+        fun publishCommand(status: CommandStatus, command: MaestroCommand, error: Throwable? = null) {
             McpVisualizerEvents.publish(
                 VisualizerEvent.Command(
                     status = status,
-                    callId = "$flowId:$index",
+                    callId = command.id(),
                     yaml = command.sourceInfo?.let { it.source.substring(it.startOffset, it.endOffset) },
                     errorMessage = error?.message,
                 )
@@ -32,32 +42,31 @@ internal object McpVisualizerOrchestra {
         return Orchestra(
             maestro = maestro,
             onFlowStart = {
-                flowId = UUID.randomUUID().toString()
                 depth.clear()
             },
-            onCommandStart = { index, command ->
+            onCommandStart = { _, command ->
                 val isOuter = depth.isEmpty()
                 depth.addLast(isOuter)
-                if (isOuter) publishCommand(CommandStatus.STARTED, index, command)
+                if (isOuter) publishCommand(CommandStatus.STARTED, command)
             },
-            onCommandComplete = { index, command ->
+            onCommandComplete = { _, command ->
                 val wasOuter = depth.removeLast()
-                if (wasOuter) publishCommand(CommandStatus.COMPLETED, index, command)
+                if (wasOuter) publishCommand(CommandStatus.COMPLETED, command)
             },
-            onCommandWarned = { index, command ->
+            onCommandWarned = { _, command ->
                 val wasOuter = depth.removeLast()
-                if (wasOuter) publishCommand(CommandStatus.WARNED, index, command)
+                if (wasOuter) publishCommand(CommandStatus.WARNED, command)
             },
-            onCommandSkipped = { index, command ->
+            onCommandSkipped = { _, command ->
                 // onCommandSkipped fires after onCommandStart inside subflows; outside
                 // subflows it can fire without a Start (when a top-level command is
                 // pre-skipped via `when:`). Pop only if our stack has a frame for it.
                 val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) publishCommand(CommandStatus.SKIPPED, index, command)
+                if (wasOuter) publishCommand(CommandStatus.SKIPPED, command)
             },
-            onCommandFailed = { index, command, error ->
+            onCommandFailed = { _, command, error ->
                 val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) publishCommand(CommandStatus.FAILED, index, command, error)
+                if (wasOuter) publishCommand(CommandStatus.FAILED, command, error)
                 throw error
             },
         )

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
@@ -1,0 +1,65 @@
+package maestro.cli.mcp.visualizer
+
+import maestro.Maestro
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.Orchestra
+import java.util.UUID
+
+internal object McpVisualizerOrchestra {
+
+    fun create(maestro: Maestro): Orchestra {
+        var flowId = UUID.randomUUID().toString()
+        // Orchestra fires onCommandStart/Complete for nested subflow commands too,
+        // each with a sub-index that restarts at 0. If we publish those, their
+        // callIds (`flowId:index`) collide with outer-flow rows and the visualizer's
+        // upsert reuses the wrong row, making old commands appear "running" again.
+        // Track depth via a stack — push on Start, pop on terminal — and publish only
+        // for the outer-most level. The outer command's yaml already inlines its
+        // nested commands, so users still see what's running.
+        val depth = ArrayDeque<Boolean>() // top-of-stack = isOuter for the most recently started command
+
+        fun publishCommand(status: CommandStatus, index: Int, command: MaestroCommand, error: Throwable? = null) {
+            McpVisualizerEvents.publish(
+                VisualizerEvent.Command(
+                    status = status,
+                    callId = "$flowId:$index",
+                    yaml = command.sourceInfo?.let { it.source.substring(it.startOffset, it.endOffset) },
+                    errorMessage = error?.message,
+                )
+            )
+        }
+
+        return Orchestra(
+            maestro = maestro,
+            onFlowStart = {
+                flowId = UUID.randomUUID().toString()
+                depth.clear()
+            },
+            onCommandStart = { index, command ->
+                val isOuter = depth.isEmpty()
+                depth.addLast(isOuter)
+                if (isOuter) publishCommand(CommandStatus.STARTED, index, command)
+            },
+            onCommandComplete = { index, command ->
+                val wasOuter = depth.removeLast()
+                if (wasOuter) publishCommand(CommandStatus.COMPLETED, index, command)
+            },
+            onCommandWarned = { index, command ->
+                val wasOuter = depth.removeLast()
+                if (wasOuter) publishCommand(CommandStatus.WARNED, index, command)
+            },
+            onCommandSkipped = { index, command ->
+                // onCommandSkipped fires after onCommandStart inside subflows; outside
+                // subflows it can fire without a Start (when a top-level command is
+                // pre-skipped via `when:`). Pop only if our stack has a frame for it.
+                val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
+                if (wasOuter) publishCommand(CommandStatus.SKIPPED, index, command)
+            },
+            onCommandFailed = { index, command, error ->
+                val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
+                if (wasOuter) publishCommand(CommandStatus.FAILED, index, command, error)
+                throw error
+            },
+        )
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
@@ -8,65 +8,91 @@ import java.util.concurrent.atomic.AtomicInteger
 
 internal object McpVisualizerOrchestra {
 
-    // Process-scoped so callIds stay unique as the frontend appends commands across runs;
-    // an AtomicInteger retains nothing so this isn't a leak.
+    // Process-scoped so commandIds stay monotonic across runs; the frontend sorts by id
+    // and the new run's commands land after older ones. An AtomicInteger retains nothing.
     private val nextCommandId = AtomicInteger()
 
     fun create(maestro: Maestro): Orchestra {
-        // Identity-keyed: the same MaestroCommand instance flows from runFlow's input list
-        // through to onCommandStart/Complete, so pending-then-runtime events upsert into
-        // the same visualizer row. Scoped to one create() call so command instances (and
-        // their retained YAML sources) can be GC'd once the flow finishes.
+        // Identity-keyed: the same MaestroCommand reference flows from runFlow's input
+        // list through to onCommandStart/Complete, so onFlowStart's seeding and runtime
+        // status updates resolve to the same commandId. Scoped to one create() call so
+        // command instances (and their retained YAML sources) can be GC'd once the
+        // orchestra is done.
         val commandIds = IdentityHashMap<MaestroCommand, Int>()
         fun MaestroCommand.id(): String =
             commandIds.computeIfAbsent(this) { nextCommandId.incrementAndGet() }.toString()
+
+        // Insertion-ordered snapshot of the current flow. Cleared on each onFlowStart so
+        // multi-flow runs (test plans, directories) each get a fresh scope. The frontend
+        // accumulates rows across snapshots because commandIds are globally unique.
+        val commands = LinkedHashMap<String, VisualizerEvent.CommandEntry>()
 
         // Orchestra fires onCommandStart/Complete for nested subflow commands too. We
         // suppress those because the outer `runFlow:` command's yaml already inlines its
         // nested commands — surfacing each sub-step would clutter the log without adding
         // information. Track depth via a stack: top frame = isOuter for the most recently
-        // started command; only outer-most frames publish events.
+        // started command; only outer-most frames touch `commands`.
         val depth = ArrayDeque<Boolean>()
 
-        fun publishCommand(status: CommandStatus, command: MaestroCommand, error: Throwable? = null) {
-            McpVisualizerEvents.publish(
-                VisualizerEvent.Command(
-                    status = status,
-                    callId = command.id(),
-                    yaml = command.sourceInfo?.let { it.source.substring(it.startOffset, it.endOffset) },
-                    errorMessage = error?.message,
-                )
-            )
+        fun publishSnapshot() {
+            McpVisualizerEvents.publish(VisualizerEvent.FlowState(commands.values.toList()))
+        }
+
+        fun updateStatus(command: MaestroCommand, status: CommandStatus, errorMessage: String? = null) {
+            val existing = commands[command.id()] ?: return
+            commands[command.id()] = existing.copy(status = status, errorMessage = errorMessage)
+            publishSnapshot()
         }
 
         return Orchestra(
             maestro = maestro,
-            onFlowStart = {
+            onFlowStart = { flowCommands ->
                 depth.clear()
+                commands.clear()
+                flowCommands.forEach { command ->
+                    val yaml = command.sourceInfo?.let { it.source.substring(it.startOffset, it.endOffset) }
+                        ?: return@forEach
+                    val id = command.id()
+                    commands[id] = VisualizerEvent.CommandEntry(
+                        commandId = id,
+                        yaml = yaml,
+                        status = CommandStatus.PENDING,
+                    )
+                }
+                publishSnapshot()
             },
             onCommandStart = { _, command ->
                 val isOuter = depth.isEmpty()
                 depth.addLast(isOuter)
-                if (isOuter) publishCommand(CommandStatus.STARTED, command)
+                if (isOuter) updateStatus(command, CommandStatus.STARTED)
             },
             onCommandComplete = { _, command ->
                 val wasOuter = depth.removeLast()
-                if (wasOuter) publishCommand(CommandStatus.COMPLETED, command)
+                if (wasOuter) updateStatus(command, CommandStatus.COMPLETED)
             },
             onCommandWarned = { _, command ->
                 val wasOuter = depth.removeLast()
-                if (wasOuter) publishCommand(CommandStatus.WARNED, command)
+                if (wasOuter) updateStatus(command, CommandStatus.WARNED)
             },
             onCommandSkipped = { _, command ->
                 // onCommandSkipped fires after onCommandStart inside subflows; outside
                 // subflows it can fire without a Start (when a top-level command is
                 // pre-skipped via `when:`). Pop only if our stack has a frame for it.
                 val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) publishCommand(CommandStatus.SKIPPED, command)
+                if (wasOuter) updateStatus(command, CommandStatus.SKIPPED)
             },
             onCommandFailed = { _, command, error ->
                 val wasOuter = if (depth.isNotEmpty()) depth.removeLast() else true
-                if (wasOuter) publishCommand(CommandStatus.FAILED, command, error)
+                if (wasOuter) {
+                    updateStatus(command, CommandStatus.FAILED, error.message)
+                    // Sweep trailing PENDING rows so they don't sit unresolved after the
+                    // flow aborts. Status updates resolve through commands[id()].
+                    commands.replaceAll { _, entry ->
+                        if (entry.status == CommandStatus.PENDING) entry.copy(status = CommandStatus.SKIPPED)
+                        else entry
+                    }
+                    publishSnapshot()
+                }
                 throw error
             },
         )

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerOrchestra.kt
@@ -68,7 +68,10 @@ internal object McpVisualizerOrchestra {
             },
             onCommandStart = { _, command -> updateStatus(command, CommandStatus.STARTED) },
             onCommandComplete = { _, command -> updateStatus(command, CommandStatus.COMPLETED) },
-            onCommandWarned = { _, command -> updateStatus(command, CommandStatus.WARNED) },
+            // Optional commands whose target wasn't found surface as a "warning" in
+            // Orchestra, but from the user's perspective they're just expected misses —
+            // render them the same as explicitly skipped commands rather than amber !s.
+            onCommandWarned = { _, command -> updateStatus(command, CommandStatus.SKIPPED) },
             onCommandSkipped = { _, command -> updateStatus(command, CommandStatus.SKIPPED) },
             onCommandFailed = { _, command, error ->
                 updateStatus(command, CommandStatus.FAILED, error.message)

--- a/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/visualizer/McpVisualizerServer.kt
@@ -109,6 +109,14 @@ internal class McpVisualizerServer private constructor(
             val resolvedPort = port ?: getFreePort(host = "127.0.0.1")
             val mapper = jacksonObjectMapper()
             val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            // Single-threaded dispatcher for publishing SSE events so snapshots reach
+            // the browser in the order they were produced. Without this, rapid status
+            // updates (PENDING -> STARTED -> COMPLETED) can be reordered across IO
+            // threads and the frontend's snapshot merge applies the older state last,
+            // producing visible flicker. Long-running side effects (deviceStream.start)
+            // launch on the unconstrained scope so they don't head-of-line block events.
+            @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+            val eventDispatcher = Dispatchers.IO.limitedParallelism(1)
             val events = SseBroadcaster(mapper)
             val deviceStates = SseBroadcaster(mapper)
             val deviceStream = DeviceStream(onStateChange = { deviceStates.publish(it) })
@@ -131,9 +139,11 @@ internal class McpVisualizerServer private constructor(
                 }
 
             val eventRegistration = McpVisualizerEvents.register { event ->
-                scope.launch {
+                scope.launch(eventDispatcher) {
                     events.publish(event)
-                    if (event is VisualizerEvent.MaestroConnected && event.deviceType != null) {
+                }
+                if (event is VisualizerEvent.MaestroConnected && event.deviceType != null) {
+                    scope.launch {
                         deviceStream.start(event.platform, event.deviceType, event.deviceId)
                     }
                 }


### PR DESCRIPTION
## Summary
- Seed the full flow as PENDING up front so users see *what's coming*, not just what already ran (`maestro.flow_state` snapshots now drive a pure projection on the client).
- Redesign the command panel: floating translucent card sized to the device, status-tinted connector lines between icons, circle status icons with glyphs, syntax-highlighted YAML rows, quiet scrollbar.
- Make the running row unmistakable (saturated opaque sky background, ring + halo, no animation since state turns over too fast for an animation to read).
- Auto-scroll to the currently-running command instead of the list bottom (with pending rows queued past it, the bottom is no longer the right target).
- Fix an out-of-order snapshot delivery bug: publishing through `scope.launch` on `Dispatchers.IO` could reorder events across threads and the frontend's blind-overwrite merge would regress statuses. Funneled events through `Dispatchers.IO.limitedParallelism(1)` so writes are FIFO; pushed `deviceStream.start()`'s 30s side effect to its own launch.
- Add dark mode


https://github.com/user-attachments/assets/774bcfb1-9f4d-4ff2-a62e-c3eccb71836d



## Test plan
- [x] `maestro mcp` → connect a device → run a flow → all rows seed as pending, then transition started → completed in order without flicker.
- [x] Run a flow with a failing command midway → failing row goes red, trailing rows become skipped, nothing stays stuck in pending.
- [x] Watch the panel during a fast flow — running row remains visible (auto-scrolled), highlight is readable, no animation jitter.
- [x] Toggle system dark mode — panel, highlight, connector, scrollbar all read correctly in both.
- [x] Collapse + expand the panel via the chevron.
- [x] Disconnect the device → panel switches to "No device connected" placeholder card with phone-aspect dashed outline; reconnect and stream resumes.
- [x] `/?demo` sandbox: toggle "running" and "device connected" — all states render.