### PR TITLE
fix: preserve hostname in DummyDns so devtools augmentation works

### DIFF
--- a/e2e/demo_app/.maestro/webView_chromeDevTools_idMatching.yaml
+++ b/e2e/demo_app/.maestro/webView_chromeDevTools_idMatching.yaml
@@ -1,0 +1,18 @@
+appId: com.example.example
+androidWebViewHierarchy: devtools
+tags:
+  - passing
+  - android
+---
+# Regression guard for the DummyDns hostname fix (commit e8a87992).
+# The `<div id="devtools-regression-marker">` in `webview_devtools_test_screen.dart`
+# is non-interactive and aria-hidden — it should NOT surface in Android's native
+# a11y tree, so the `id:` match below only succeeds when devtools augmentation is
+# working. A silent devtools failure (the original bug) makes this flow fail.
+- launchApp:
+    clearState: true
+- scrollUntilVisible:
+    element: Webview Devtools Test
+- tapOn: Webview Devtools Test
+- assertVisible:
+    id: "devtools-regression-marker"

--- a/e2e/demo_app/lib/main.dart
+++ b/e2e/demo_app/lib/main.dart
@@ -16,6 +16,7 @@ import 'package:demo_app/gesture_tester_screen.dart';
 import 'package:demo_app/scrollable_list_screen.dart';
 import 'package:demo_app/sensors_screen.dart';
 import 'package:demo_app/webview.dart';
+import 'package:demo_app/webview_devtools_test_screen.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -212,6 +213,15 @@ class _MyHomePageState extends State<MyHomePage> {
                     );
                   },
                   child: const Text('Webview Test'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                          builder: (_) => const WebViewDevtoolsTestScreen()),
+                    );
+                  },
+                  child: const Text('Webview Devtools Test'),
                 ),
                 ElevatedButton(
                   onPressed: () {

--- a/e2e/demo_app/lib/webview_devtools_test_screen.dart
+++ b/e2e/demo_app/lib/webview_devtools_test_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_android/webview_flutter_android.dart';
+
+// `#devtools-regression-marker` is a non-interactive, aria-hidden div: it
+// should not surface in Android's native a11y tree, but devtools augmentation
+// emits it (via `node.id` in maestro-web.js). An `id:` match against it
+// passes iff the devtools path is working — guards the DummyDns hostname fix.
+const _html = '''
+<!DOCTYPE html>
+<html>
+  <head><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+  <body>
+    <h1>WebView Devtools Test</h1>
+    <div id="devtools-regression-marker" aria-hidden="true">marker</div>
+  </body>
+</html>
+''';
+
+class WebViewDevtoolsTestScreen extends StatefulWidget {
+  const WebViewDevtoolsTestScreen({super.key});
+
+  @override
+  State<WebViewDevtoolsTestScreen> createState() =>
+      _WebViewDevtoolsTestScreenState();
+}
+
+class _WebViewDevtoolsTestScreenState extends State<WebViewDevtoolsTestScreen> {
+  late final WebViewController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      AndroidWebViewController.enableDebugging(true);
+    }
+    controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..loadHtmlString(_html);
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(title: const Text('WebView Devtools Test')),
+        body: WebViewWidget(controller: controller),
+      );
+}

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
@@ -70,8 +70,13 @@ private data class DevToolsResponse<T>(
     val result: T,
 )
 
-private class DummyDns : Dns {
-    override fun lookup(hostname: String) = listOf(java.net.InetAddress.getLoopbackAddress())
+// `getByAddress(hostname, bytes)` preserves the hostname through OkHttp's
+// `InetSocketAddress`, so `AdbSocketFactory` opens `localabstract:<webview-socket>`
+// instead of `localabstract:localhost` (which `getLoopbackAddress()` would yield).
+internal class DummyDns : Dns {
+    override fun lookup(hostname: String) = listOf(
+        java.net.InetAddress.getByAddress(hostname, byteArrayOf(127, 0, 0, 1))
+    )
 }
 
 class DadbChromeDevToolsClient(private val dadb: Dadb): Closeable {

--- a/maestro-client/src/test/java/maestro/android/chromedevtools/DadbChromeDevToolsClientTest.kt
+++ b/maestro-client/src/test/java/maestro/android/chromedevtools/DadbChromeDevToolsClientTest.kt
@@ -1,0 +1,22 @@
+package maestro.android.chromedevtools
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.net.InetSocketAddress
+
+class DadbChromeDevToolsClientTest {
+
+    // OkHttp builds `InetSocketAddress(InetAddress, port)` from the Dns result;
+    // `AdbSocket.connect()` then reads `endpoint.hostString` to build
+    // `dadb.open("localabstract:<host>")`, so the webview socket name MUST
+    // survive the round-trip through DummyDns.
+    @Test
+    fun `DummyDns preserves the original hostname through OkHttp's InetSocketAddress`() {
+        val hostname = "webview_devtools_remote_25535"
+
+        val resolved = DummyDns().lookup(hostname).single()
+        val socketAddr = InetSocketAddress(resolved, 9222)
+
+        assertThat(socketAddr.hostString).isEqualTo(hostname)
+    }
+}


### PR DESCRIPTION
## Summary

`androidWebViewHierarchy: devtools` was silently returning empty webview hierarchies, so flows that rely on webview-only elements stopped finding them. Hierarchy discovery via `cat /proc/net/unix` still worked; the actual `/json` fetch and the devtools websocket eval did not.

### Root cause

In `DadbChromeDevToolsClient`, `DummyDns` returns `InetAddress.getLoopbackAddress()`. OkHttp's route selector then builds `InetSocketAddress(InetAddress, port)` — that constructor copies `addr.getHostName()` into the holder, which for the loopback address is `"localhost"`, erasing the original webview socket name (e.g. `webview_devtools_remote_25535`). `AdbSocket.connect()` reads `endpoint.hostString` to build `dadb.open("localabstract:<host>")`, so it ends up calling `dadb.open("localabstract:localhost")` — which fails. The `IOException` is swallowed by the catch blocks in `getWebViewInfos` / `getWebViewTreeNodes`, so the hierarchy is never augmented.

Verified empirically against OkHttp 4.12.0: with the old `DummyDns`, the host captured at `socket.connect()` is `"localhost"`; with the fix it is the original webview socket name.

### Fix

Switch `DummyDns` to `InetAddress.getByAddress(hostname, loopback bytes)` so the original hostname round-trips through to `endpoint.hostString` and `AdbSocketFactory` opens the correct unix abstract socket.

### Regression window

Introduced in #3171 (Apr 14) — the prior `.dadb(dadb)` HTTP client routed `localabstract.<socket>.adb` hosts via its own resolver, which preserved the socket name; the new SocketFactory + DummyDns pair did not.

The existing e2e flow `e2e/demo_app/.maestro/webView_chromeDevTools.yaml` did not catch this because its `assertVisible: Swag Labs` text is also exposed by WebView's accessibility tree, so the flow passes even when the chrome-devtools augmentation contributes nothing.

## Test plan

- [x] Added a unit test that exercises the OkHttp address-constructor path (`InetSocketAddress(InetAddress, port)`) and asserts the host string survives the round-trip. Confirmed it fails on the old code (`expected: webview_devtools_remote_25535, but was: localhost`) and passes on this branch.
- [x] `:maestro-client:test` for `DadbChromeDevToolsClientTest`, `AdbSocketFactoryTest`, and `AndroidWebViewHierarchyClientTest` — all green.
- [ ] Re-run the affected customer flows on Maestro Cloud after the worker bump.