### PR TITLE
MCP take_screenshot: downscale screenshots to 2000px

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/TakeScreenshotTool.kt
@@ -9,9 +9,18 @@ import okio.Buffer
 import java.util.Base64
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.awt.RenderingHints
+import java.awt.image.BufferedImage
+import javax.imageio.IIOImage
 import javax.imageio.ImageIO
+import javax.imageio.ImageWriteParam
 
 object TakeScreenshotTool {
+    // Vision models (e.g. Claude) reject images whose longest side exceeds 2000px,
+    // so screenshots are downscaled to this limit before being returned. See issue #2952.
+    private const val MAX_IMAGE_DIMENSION = 2000
+    private const val JPEG_QUALITY = 0.9f
+
     internal fun create(sessionManager: McpMaestroSessionManager): RegisteredTool {
         return RegisteredTool(
             Tool(
@@ -30,40 +39,68 @@ object TakeScreenshotTool {
         ) { request ->
             try {
                 val deviceId = request.arguments?.get("device_id")?.jsonPrimitive?.content
-                
+
                 if (deviceId == null) {
                     return@RegisteredTool CallToolResult(
                         content = listOf(TextContent("device_id is required")),
                         isError = true
                     )
                 }
-                
+
                 val result = sessionManager.withSession(
                     deviceId = deviceId,
                 ) { session ->
                     val buffer = Buffer()
                     runBlocking { session.maestro.takeScreenshot(buffer, true) }
                     val pngBytes = buffer.readByteArray()
-                    
-                    // Convert PNG to JPEG
+
+                    // Convert PNG to JPEG, downscaling so the longest side stays within
+                    // MAX_IMAGE_DIMENSION. Drawing onto an RGB canvas applies the scale and
+                    // flattens any alpha channel, which JPEG cannot represent.
                     val pngImage = ImageIO.read(ByteArrayInputStream(pngBytes))
+                        ?: error("Failed to decode screenshot image")
+
+                    val longestSide = maxOf(pngImage.width, pngImage.height)
+                    val scale = if (longestSide > MAX_IMAGE_DIMENSION) {
+                        MAX_IMAGE_DIMENSION.toDouble() / longestSide
+                    } else {
+                        1.0
+                    }
+                    val targetWidth = (pngImage.width * scale).toInt().coerceAtLeast(1)
+                    val targetHeight = (pngImage.height * scale).toInt().coerceAtLeast(1)
+
+                    val jpegImage = BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_RGB)
+                    val graphics = jpegImage.createGraphics()
+                    graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC)
+                    graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+                    graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON)
+                    graphics.drawImage(pngImage, 0, 0, targetWidth, targetHeight, null)
+                    graphics.dispose()
+
                     val jpegOutput = ByteArrayOutputStream()
-                    ImageIO.write(pngImage, "JPEG", jpegOutput)
-                    val jpegBytes = jpegOutput.toByteArray()
-                    
-                    val base64 = Base64.getEncoder().encodeToString(jpegBytes)
-                    base64
+                    val writer = ImageIO.getImageWritersByFormatName("JPEG").next()
+                    val params = writer.defaultWriteParam.apply {
+                        compressionMode = ImageWriteParam.MODE_EXPLICIT
+                        compressionQuality = JPEG_QUALITY
+                    }
+                    ImageIO.createImageOutputStream(jpegOutput).use { imageOutputStream ->
+                        writer.output = imageOutputStream
+                        writer.write(null, IIOImage(jpegImage, null, null), params)
+                    }
+                    writer.dispose()
+
+                    Base64.getEncoder().encodeToString(jpegOutput.toByteArray())
                 }
-                
+
                 val imageContent = ImageContent(
                     data = result,
                     mimeType = "image/jpeg"
                 )
-                
+
                 CallToolResult(content = listOf(imageContent))
             } catch (e: Exception) {
                 CallToolResult(
-                    content = listOf(TextContent("Failed to take screenshot: ${e.message}")),
+                    content = listOf(TextContent("Failed to take screenshot: ${e::class.simpleName}: ${e.message}")),
                     isError = true
                 )
             }


### PR DESCRIPTION
## Background

The MCP `take_screenshot` tool returns an image of the device screen on every call. That image was captured at the device's full resolution and re-encoded straight to JPEG with no explicit quality setting — as large as the physical screen, every time.

For this tool's main consumer, an AI vision model, that's a problem twice over:

1. Phone screenshots routinely exceed 2000px on the long edge — the hard limit several vision models enforce. When that happens the call is rejected and the MCP session is left unusable (#2952).
2. Even under that limit, a full-resolution frame at the default JPEG quality is bigger than needed and softer than it should be.

## Change

The PNG→JPEG conversion is reworked so the screenshot is prepared for how it is actually consumed:

- Screenshots whose longest side exceeds 2000px are resampled down to fit, with a bicubic `Graphics2D` pass so the smaller image stays sharp.
- JPEG is encoded at an explicit 0.9 quality (`ImageWriteParam`) rather than the platform default.
- The frame is always drawn onto an RGB surface first, which also drops any alpha channel — JPEG can't represent one.
- A decode failure (`ImageIO.read` returning null) is caught up front instead of surfacing later as a confusing error, and messages now include the exception type.

The outcome is a smaller payload and a sharper image — and screenshots that no longer get rejected mid-session.

## On the 2000px limit

#3035 exposed this as a `maxDimensions` argument on the tool. Here it's an internal constant instead: current vision models all sit around the same 2000px sweet spot, and the agent calling the tool has nothing to base a per-call override on — so exposing it would only widen the tool's contract for no real benefit.

Supersedes #3035
Fixes #2952
