### PR TITLE
[Sharding] Fix Android session reuse with dynamic driver ports

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -38,6 +38,7 @@ import maestro.cli.command.PrintHierarchyCommand
 import maestro.cli.command.QueryCommand
 import maestro.cli.command.RecordCommand
 import maestro.cli.command.StartDeviceCommand
+import maestro.cli.command.StartSessionCommand
 import maestro.cli.command.StudioCommand
 import maestro.cli.command.TestCommand
 import maestro.cli.insights.TestAnalysisManager
@@ -68,6 +69,7 @@ import kotlin.system.exitProcess
         BugReportCommand::class,
         StudioCommand::class,
         StartDeviceCommand::class,
+        StartSessionCommand::class,
         ListDevicesCommand::class,
         ListCloudDevicesCommand::class,
         GenerateCompletion::class,

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -131,7 +131,7 @@ class StartDeviceCommand : Callable<Int> {
         // Start Device
         DeviceService.startDevice(
             device = device,
-            driverHostPort = parent?.port
+            driverHostPort = parent?.driverHostPort
         )
 
         return 0

--- a/maestro-cli/src/main/java/maestro/cli/command/StartSessionCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartSessionCommand.kt
@@ -1,0 +1,64 @@
+package maestro.cli.command
+
+import maestro.cli.App
+import maestro.cli.CliError
+import maestro.cli.DisableAnsiMixin
+import maestro.cli.ShowHelpMixin
+import maestro.cli.report.TestDebugReporter
+import maestro.cli.session.MaestroSessionManager
+import maestro.device.Platform
+import picocli.CommandLine
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+    name = "start-session",
+    description = [
+        "Setup a Maestro Android session once so later commands can reuse the running driver.",
+    ],
+    hidden = true
+)
+class StartSessionCommand : Callable<Int> {
+
+    @CommandLine.Mixin
+    var disableANSIMixin: DisableAnsiMixin? = null
+
+    @CommandLine.Mixin
+    var showHelpMixin: ShowHelpMixin? = null
+
+    @CommandLine.ParentCommand
+    private val parent: App? = null
+
+    override fun call(): Int {
+        TestDebugReporter.install(null, printToConsole = parent?.verbose == true)
+
+        parent?.platform
+            ?.takeIf { it.isNotBlank() }
+            ?.let {
+                if (Platform.fromString(it) != Platform.ANDROID) {
+                    throw CliError("This command is only supported for Android devices.")
+                }
+            }
+
+        MaestroSessionManager.newSession(
+            host = parent?.host,
+            port = parent?.port,
+            driverHostPort = parent?.driverHostPort,
+            deviceId = parent?.deviceId,
+            platform = parent?.platform,
+        ) { session ->
+            val platform = session.device?.platform ?: session.maestro.cachedDeviceInfo.platform
+            if (platform != Platform.ANDROID) {
+                throw CliError("This command is only supported for Android devices.")
+            }
+
+            println("Maestro session started. Keep this running in the background.")
+            println("Run your tests with `maestro test <flow.yaml>` in another terminal.")
+
+            while (!Thread.currentThread().isInterrupted) {
+                Thread.sleep(1000)
+            }
+        }
+
+        return 0
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -93,10 +93,25 @@ object MaestroSessionManager {
             ?: selectedDevice.deviceId
             ?: sessionId // fallback: use session UUID as unique device key when no device ID is available
 
+        val sessionBinding = SessionStore.default
+            .takeUnless { isStudio }
+            ?.activeSessionForDevice(
+                sessionId,
+                selectedDevice.platform,
+                effectiveDeviceId
+            )
+            ?.let { SessionBinding(connectToExistingSession = true, driverHostPort = it.driverHostPort) }
+            ?: SessionBinding(connectToExistingSession = false, driverHostPort = driverHostPort)
+
         val heartbeatFuture = executor.scheduleAtFixedRate(
             {
                 try {
-                    SessionStore.default.heartbeat(sessionId, selectedDevice.platform, effectiveDeviceId)
+                    SessionStore.default.heartbeat(
+                        sessionId,
+                        selectedDevice.platform,
+                        effectiveDeviceId,
+                        sessionBinding.driverHostPort,
+                    )
                 } catch (e: Exception) {
                     logger.error("Failed to record heartbeat", e)
                 }
@@ -108,19 +123,11 @@ object MaestroSessionManager {
 
         val session = createMaestro(
             selectedDevice = selectedDevice,
-            connectToExistingSession = if (isStudio) {
-                false
-            } else {
-                SessionStore.default.hasActiveSessionForDevice(
-                    sessionId,
-                    selectedDevice.platform,
-                    effectiveDeviceId
-                )
-            },
+            connectToExistingSession = sessionBinding.connectToExistingSession,
             isStudio = isStudio,
             isHeadless = isHeadless,
             screenSize = screenSize,
-            driverHostPort = driverHostPort,
+            driverHostPort = sessionBinding.driverHostPort,
             reinstallDriver = reinstallDriver,
             platformConfiguration = executionPlan?.workspaceConfig?.platform
         )
@@ -135,6 +142,11 @@ object MaestroSessionManager {
 
         return block(session)
     }
+
+    private data class SessionBinding(
+        val connectToExistingSession: Boolean,
+        val driverHostPort: Int?,
+    )
 
     private fun selectDevice(
         host: String?,

--- a/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
@@ -7,22 +7,25 @@ import java.util.concurrent.TimeUnit
 
 class SessionStore(private val keyValueStore: KeyValueStore) {
 
-    fun heartbeat(sessionId: String, platform: Platform, deviceId: String) {
+    fun heartbeat(sessionId: String, platform: Platform, deviceId: String, driverHostPort: Int? = null) {
         synchronized(keyValueStore) {
             keyValueStore.set(
                 key = key(sessionId, platform, deviceId),
-                value = System.currentTimeMillis().toString(),
+                value = SessionValue(
+                    lastHeartbeat = System.currentTimeMillis(),
+                    driverHostPort = driverHostPort,
+                ).encode(),
             )
 
             pruneInactiveSessions()
         }
     }
 
-    private fun pruneInactiveSessions() {
+    private fun pruneInactiveSessions(now: Long = System.currentTimeMillis()) {
         keyValueStore.keys()
             .forEach { key ->
-                val lastHeartbeat = keyValueStore.get(key)?.toLongOrNull()
-                if (lastHeartbeat != null && System.currentTimeMillis() - lastHeartbeat >= TimeUnit.SECONDS.toMillis(21)) {
+                val session = keyValueStore.get(key)?.let(SessionValue::parse)
+                if (session?.isActive(now) != true) {
                     keyValueStore.delete(key)
                 }
             }
@@ -38,23 +41,32 @@ class SessionStore(private val keyValueStore: KeyValueStore) {
 
     fun activeSessions(): List<String> {
         synchronized(keyValueStore) {
-            return keyValueStore
-                .keys()
-                .filter { key ->
-                    val lastHeartbeat = keyValueStore.get(key)?.toLongOrNull()
-                    lastHeartbeat != null && System.currentTimeMillis() - lastHeartbeat < TimeUnit.SECONDS.toMillis(21)
-                }
+            return activeSessionRecords().map { it.key }
         }
     }
 
     fun shouldCloseSession(platform: Platform, deviceId: String): Boolean {
-        return activeSessionsForDevice(platform, deviceId).isEmpty()
+        synchronized(keyValueStore) {
+            return activeSessionRecordsForDevice(platform, deviceId).isEmpty()
+        }
     }
 
     fun activeSessionsForDevice(platform: Platform, deviceId: String): List<String> {
-        val devicePrefix = "${platform}_${deviceId}_"
         synchronized(keyValueStore) {
-            return activeSessions().filter { it.startsWith(devicePrefix) }
+            return activeSessionRecordsForDevice(platform, deviceId).map { it.key }
+        }
+    }
+
+    fun activeSessionForDevice(
+        sessionId: String,
+        platform: Platform,
+        deviceId: String,
+    ): ActiveSession? {
+        val currentKey = key(sessionId, platform, deviceId)
+        synchronized(keyValueStore) {
+            return activeSessionRecordsForDevice(platform, deviceId)
+                .firstOrNull { it.key != currentKey }
+                ?.let { ActiveSession(driverHostPort = it.value.driverHostPort) }
         }
     }
 
@@ -63,19 +75,74 @@ class SessionStore(private val keyValueStore: KeyValueStore) {
         platform: Platform,
         deviceId: String
     ): Boolean {
-        val currentKey = key(sessionId, platform, deviceId)
-        val devicePrefix = "${platform}_${deviceId}_"
-        synchronized(keyValueStore) {
-            return activeSessions()
-                .any { it.startsWith(devicePrefix) && it != currentKey }
-        }
+        return activeSessionForDevice(sessionId, platform, deviceId) != null
     }
 
     private fun key(sessionId: String, platform: Platform, deviceId: String): String {
         return "${platform}_${deviceId}_$sessionId"
     }
 
+    private fun devicePrefix(platform: Platform, deviceId: String): String {
+        return "${platform}_${deviceId}_"
+    }
+
+    private fun activeSessionRecordsForDevice(platform: Platform, deviceId: String): List<SessionRecord> {
+        val devicePrefix = devicePrefix(platform, deviceId)
+        return activeSessionRecords().filter { it.key.startsWith(devicePrefix) }
+    }
+
+    private fun activeSessionRecords(now: Long = System.currentTimeMillis()): List<SessionRecord> {
+        return keyValueStore.keys()
+            .mapNotNull { key ->
+                val session = keyValueStore.get(key)?.let(SessionValue::parse) ?: return@mapNotNull null
+                if (session.isActive(now)) {
+                    SessionRecord(key, session)
+                } else {
+                    null
+                }
+            }
+    }
+
+    data class ActiveSession(
+        val driverHostPort: Int?,
+    )
+
+    private data class SessionRecord(
+        val key: String,
+        val value: SessionValue,
+    )
+
+    private data class SessionValue(
+        val lastHeartbeat: Long,
+        val driverHostPort: Int?,
+    ) {
+        fun isActive(now: Long): Boolean {
+            return now - lastHeartbeat < ACTIVE_SESSION_TIMEOUT_MS
+        }
+
+        fun encode(): String {
+            return listOfNotNull(
+                lastHeartbeat.toString(),
+                driverHostPort?.let { "driverHostPort:$it" },
+            ).joinToString("|")
+        }
+
+        companion object {
+            fun parse(value: String): SessionValue? {
+                val parts = value.split("|")
+                val lastHeartbeat = parts.firstOrNull()?.toLongOrNull() ?: return null
+                val driverHostPort = parts
+                    .firstOrNull { it.startsWith("driverHostPort:") }
+                    ?.substringAfter(":")
+                    ?.toIntOrNull()
+                return SessionValue(lastHeartbeat, driverHostPort)
+            }
+        }
+    }
+
     companion object {
+        private val ACTIVE_SESSION_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(21)
+
         val default by lazy {
             SessionStore(
                 KeyValueStore(

--- a/maestro-cli/src/test/kotlin/maestro/cli/session/SessionStoreTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/session/SessionStoreTest.kt
@@ -82,6 +82,31 @@ class SessionStoreTest {
     }
 
     @Test
+    fun `activeSessionForDevice returns driver host port for another session on same device`() {
+        sessionStore.heartbeat("session-1", Platform.ANDROID, "emulator-5554", driverHostPort = 53245)
+
+        val activeSession = sessionStore.activeSessionForDevice(
+            "session-2", Platform.ANDROID, "emulator-5554"
+        )
+
+        assertThat(activeSession?.driverHostPort).isEqualTo(53245)
+    }
+
+    @Test
+    fun `activeSessionForDevice supports old timestamp-only session values`() {
+        val kvStore = KeyValueStore(tempDir.resolve("sessions-old-value").toFile())
+        kvStore.set("ANDROID_emulator-5554_session-1", System.currentTimeMillis().toString())
+        val store = SessionStore(kvStore)
+
+        val activeSession = store.activeSessionForDevice(
+            "session-2", Platform.ANDROID, "emulator-5554"
+        )
+
+        assertThat(activeSession).isNotNull()
+        assertThat(activeSession?.driverHostPort).isNull()
+    }
+
+    @Test
     fun `hasActiveSessionForDevice ignores sessions on different devices`() {
         sessionStore.heartbeat("session-1", Platform.IOS, "device-A")
         sessionStore.heartbeat("session-2", Platform.IOS, "device-B")

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -215,9 +215,6 @@ class AndroidDriver(
         launchArguments: Map<String, Any>,
     ) {
         metrics.measured("operation", mapOf("command" to "launchApp", "appId" to appId)) {
-            if(!open) // pick device flow, no open() invocation
-                open()
-
             if (!isPackageInstalled(appId)) {
                 throw IllegalArgumentException("Package $appId is not installed")
             }


### PR DESCRIPTION
## Summary

Fix Android persistent-session reuse when a later process reconnects to an existing driver session whose Android driver port was chosen dynamically.

This is a follow-through on the Android sharding/session thread, not a new sharding model.

---

## Changes

- Persist the active session's `driverHostPort` in `SessionStore`.
- Reuse that stored port when `MaestroSessionManager` reconnects to an active session for the same device.
- Stop Android `launchApp()` from lazily calling `open()` when the current process is intentionally reusing an existing driver session.
- Add hidden `maestro start-session` support so the persistent-session path from #1902 is reachable and testable.
- Pass `--driver-host-port` correctly through `start-device`.

---

## Context

- #1732 added sharding / parallel execution and dynamic Android driver ports.
- #1853 reported the Android sharded `Connection refused` symptom.
- #1867 added a sleep workaround for the Android shard race. Later work showed the underlying issue was session/port identity.
- #1902 proposed `start-session` and correctly identified that Android `launchApp()` could defeat session reuse by calling `open()`.
- #2339 and #2821 explored the custom-port / multi-process direction.
- #3138 landed the important per-device session tracking/file locking work and removed the sleep workaround.
- #3139 is the broader startup-performance thread. This PR keeps the scope to Android session correctness.

A few historical details matter here.

Before #3138, session identity was too broad for sharded Android runs. A shard could observe another shard's Android heartbeat and incorrectly decide it did not need to open its own driver.

The old `launchApp()` lazy-open fallback could sometimes mask that false reuse, but only if `launchApp()` was the first driver call. Calls like `deviceInfo()` could still fail before `launchApp()` had any chance to reopen the driver, which matches the failure shape in #1853.

#3138 fixed the larger session identity problem by moving session tracking to `{platform, deviceId}` and adding cross-process file locking. The remaining Android gap was port ownership: for sharded runs, the driver host port can be dynamic, so "there is an active session for this device" is still not enough. The reconnecting process also needs the driver port owned by that active session.

---

## Android `launchApp()`

The `launchApp()` change follows directly from #1902: `AndroidDriver.open` is local to the current driver object, not proof that no driver session exists.

In a reused persistent session, `open == false` can simply mean this process did not start instrumentation itself. Calling `open()` from `launchApp()` in that state restarts instrumentation and defeats `start-session`.

This PR removes that fallback and leaves the open/reuse decision in `MaestroSessionManager`.

---

## Session Store

The heartbeat still records session liveness, but it now also carries the optional Android driver port:

```text
<lastHeartbeat>|driverHostPort:<port>
```

Old timestamp-only heartbeat values remain supported. They parse as active sessions with no stored driver port.

This keeps existing session liveness behavior while making the reuse decision complete: a later process can skip startup and connect its gRPC channel to the same endpoint as the already-running Android driver.

---

## Validation

- `git diff --check`
- `./gradlew :maestro-client:compileKotlin :maestro-cli:test --tests maestro.cli.session.SessionStoreTest :maestro-cli:installDist`
- Live Android check on `emulator-5554`:
  - started `start-session` with `--driver-host-port 61234`
  - verified `~/.maestro/sessions` recorded `driverHostPort:61234`
  - ran a separate `maestro test` process that selected another free port (`51911`)
  - verified the test reused the stored active session port and passed
  - verified session cleanup after stopping `start-session`
- Local stress check: 10 visible API 30 Android emulators completed the intensive sharded flow successfully. Benchmark scaffolding and timing logs are intentionally not included.
