### PR TITLE
test(e2e): add iOS repro for issue(accessibilityLabel hides text)

### DIFF
--- a/e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
+++ b/e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
@@ -1,16 +1,22 @@
 ## Reproduces https://github.com/mobile-dev-inc/Maestro/issues/1409
 ##
-## On iOS, when a touchable parent has an accessibilityLabel, iOS exposes only
-## the parent (with `label` populated, `title`/`value` empty). Maestro maps
-## `text` from `title`/`value` only (IOSDriver.kt:197), so `tapOn: "<label>"`
-## fails to find the element even though the same string is visible on screen.
+## On iOS, a touchable with accessibilityLabel is exposed as a single
+## accessibility element. Its `label` carries the label string, but iOS does
+## not expose the inner Text child as a separate accessibility element. So
+## the visible text ("Click me!") is unreachable: no element's `text`,
+## `label`, or `accessibilityText` contains it.
 ##
-## Expected to fail on iOS today. PR #3165 makes `text` fall back to `label`,
-## which would let this flow pass. When that fix lands, change the tag to
-## `passing` and rename to `pass_issue1409_accessibility_label.yaml`.
+## `Filters.textMatches` (maestro-client/.../Filters.kt:58) already falls back
+## to `accessibilityText`, which is why `tapOn: "easy-button"` (the label)
+## works today. The bug as filed in #1409 is the opposite case: `tapOn` by
+## the visible inner text, which iOS has genuinely hidden.
+##
+## Expected to fail on iOS. PR #3165's one-line fallback to `element.label`
+## would NOT make this pass (the string "Click me!" exists in no element);
+## this flow is a regression guard for the deeper #1409 symptom.
 
 appId: com.example.example
-name: Issue 1409 (accessibility label hides text on iOS)
+name: Issue 1409 (inner text hidden by accessibilityLabel on iOS)
 tags:
     - failing
     - ios
@@ -18,5 +24,5 @@ tags:
 - launchApp:
     clearState: true
 - tapOn: issue 1409 repro
-- tapOn: Continue with Google
+- tapOn: "Click me!"
 - assertVisible: tapped!

--- a/e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
+++ b/e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
@@ -1,0 +1,22 @@
+## Reproduces https://github.com/mobile-dev-inc/Maestro/issues/1409
+##
+## On iOS, when a touchable parent has an accessibilityLabel, iOS exposes only
+## the parent (with `label` populated, `title`/`value` empty). Maestro maps
+## `text` from `title`/`value` only (IOSDriver.kt:197), so `tapOn: "<label>"`
+## fails to find the element even though the same string is visible on screen.
+##
+## Expected to fail on iOS today. PR #3165 makes `text` fall back to `label`,
+## which would let this flow pass. When that fix lands, change the tag to
+## `passing` and rename to `pass_issue1409_accessibility_label.yaml`.
+
+appId: com.example.example
+name: Issue 1409 (accessibility label hides text on iOS)
+tags:
+    - failing
+    - ios
+---
+- launchApp:
+    clearState: true
+- tapOn: issue 1409 repro
+- tapOn: Continue with Google
+- assertVisible: tapped!

--- a/e2e/demo_app/lib/issue_1409_repro.dart
+++ b/e2e/demo_app/lib/issue_1409_repro.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+
+/// Reproduces https://github.com/mobile-dev-inc/Maestro/issues/1409.
+///
+/// On iOS, when a touchable parent has an accessibility label, iOS treats it as
+/// a single accessibility element and does not expose its child labels. The
+/// React Native pattern `<Pressable accessibilityLabel="X"><Text>X</Text></Pressable>`
+/// hits this: only the parent is in the hierarchy, with `label="X"` but empty
+/// `title`/`value`. Maestro's iOS hierarchy mapping populates the `text`
+/// attribute from `title`/`value` only, so `tapOn: "X"` fails to find anything.
+///
+/// We mirror the RN structure in Flutter with `Semantics(container, label,
+/// excludeSemantics)` over a `GestureDetector`, which produces the same
+/// "label-only, no text" element on iOS.
+class Issue1409Repro extends StatefulWidget {
+  const Issue1409Repro({super.key});
+
+  @override
+  State<Issue1409Repro> createState() => _Issue1409ReproState();
+}
+
+class _Issue1409ReproState extends State<Issue1409Repro> {
+  bool _tapped = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('issue 1409 repro'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Semantics(
+              container: true,
+              button: true,
+              label: 'Continue with Google',
+              excludeSemantics: true,
+              child: GestureDetector(
+                onTap: () => setState(() => _tapped = true),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 24, vertical: 12),
+                  decoration: BoxDecoration(
+                    color: Colors.blueGrey.shade100,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Text('Continue with Google'),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            if (_tapped) const Text('tapped!'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/e2e/demo_app/lib/issue_1409_repro.dart
+++ b/e2e/demo_app/lib/issue_1409_repro.dart
@@ -2,16 +2,21 @@ import 'package:flutter/material.dart';
 
 /// Reproduces https://github.com/mobile-dev-inc/Maestro/issues/1409.
 ///
-/// On iOS, when a touchable parent has an accessibility label, iOS treats it as
-/// a single accessibility element and does not expose its child labels. The
-/// React Native pattern `<Pressable accessibilityLabel="X"><Text>X</Text></Pressable>`
-/// hits this: only the parent is in the hierarchy, with `label="X"` but empty
-/// `title`/`value`. Maestro's iOS hierarchy mapping populates the `text`
-/// attribute from `title`/`value` only, so `tapOn: "X"` fails to find anything.
+/// On iOS, a touchable with `accessibilityLabel` is exposed as a single
+/// accessibility element whose `label` carries the label string. iOS does NOT
+/// expose the inner `Text` child as a separate accessibility element, so the
+/// visible text ("Click me!") is unreachable through the accessibility tree.
 ///
-/// We mirror the RN structure in Flutter with `Semantics(container, label,
-/// excludeSemantics)` over a `GestureDetector`, which produces the same
-/// "label-only, no text" element on iOS.
+/// This mirrors React Native's
+/// `<Pressable accessibilityLabel="easy-button"><Text>Click me!</Text></Pressable>`
+/// using Flutter's `Semantics(container, button, label, excludeSemantics)` over
+/// a `GestureDetector`. With label != visible text, `tapOn: "Click me!"` has
+/// nothing to match against in any element's `text`/`label`/`accessibilityText`
+/// — that's the #1409 failure.
+///
+/// The touchable is intentionally positioned in the top-left (not centered)
+/// inside a larger column so a parent-bounds tap (a possible fallback in some
+/// matchers) cannot accidentally land on the touchable region.
 class Issue1409Repro extends StatefulWidget {
   const Issue1409Repro({super.key});
 
@@ -28,30 +33,38 @@ class _Issue1409ReproState extends State<Issue1409Repro> {
       appBar: AppBar(
         title: const Text('issue 1409 repro'),
       ),
-      body: Center(
+      body: SizedBox.expand(
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Semantics(
-              container: true,
-              button: true,
-              label: 'Continue with Google',
-              excludeSemantics: true,
-              child: GestureDetector(
-                onTap: () => setState(() => _tapped = true),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 24, vertical: 12),
-                  decoration: BoxDecoration(
-                    color: Colors.blueGrey.shade100,
-                    borderRadius: BorderRadius.circular(8),
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.only(left: 16),
+              child: Semantics(
+                container: true,
+                button: true,
+                label: 'easy-button',
+                excludeSemantics: true,
+                child: GestureDetector(
+                  onTap: () => setState(() => _tapped = true),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: Colors.blueGrey.shade100,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: const Text('Click me!'),
                   ),
-                  child: const Text('Continue with Google'),
                 ),
               ),
             ),
-            const SizedBox(height: 24),
-            if (_tapped) const Text('tapped!'),
+            const Spacer(),
+            if (_tapped)
+              const Padding(
+                padding: EdgeInsets.only(left: 16, bottom: 16),
+                child: Text('tapped!'),
+              ),
           ],
         ),
       ),

--- a/e2e/demo_app/lib/main.dart
+++ b/e2e/demo_app/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:demo_app/defects_screen.dart';
 import 'package:demo_app/notifications_permission_screen.dart';
 import 'package:demo_app/form_screen.dart';
 import 'package:demo_app/input_screen.dart';
+import 'package:demo_app/issue_1409_repro.dart';
 import 'package:demo_app/issue_1619_repro.dart';
 import 'package:demo_app/issue_1677_repro.dart';
 import 'package:demo_app/location_screen.dart';
@@ -205,6 +206,14 @@ class _MyHomePageState extends State<MyHomePage> {
                     );
                   },
                   child: const Text('issue 1619 repro'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const Issue1409Repro()),
+                    );
+                  },
+                  child: const Text('issue 1409 repro'),
                 ),
                 ElevatedButton(
                   onPressed: () {


### PR DESCRIPTION
## What this adds

A Flutter screen + Maestro flow that reproduces [#1409](https://github.com/mobile-dev-inc/Maestro/issues/1409) — `tapOn: "<visible text>"` fails on iOS when the touchable's parent has `accessibilityLabel` set.

## What's going on

This is how iOS accessibility works, not a Maestro defect.

When you set `accessibilityLabel` on a `Pressable` (or any touchable), iOS replaces the children with that label. So:

```jsx
<Pressable accessibilityLabel="easy-button">
  <Text>Click me!</Text>
</Pressable>
```

…looks like this to iOS (and therefore to Maestro): **a button labeled `"easy-button"`**.

The string `"Click me!"` is gone. It's only on the screen as pixels, not in any tree Maestro can read. That's why `tapOn: "Click me!"` fails.

## The repro

I mirrored the RN structure in Flutter with `Semantics(container, button, label, excludeSemantics)` over a `GestureDetector`. The flow tries `tapOn: "Click me!"` and is tagged `failing, ios` so the regression suite asserts the failure.

The touchable is intentionally placed top-left (not centered) so a parent-bounds-center fallback tap can't accidentally land on it.

## What I learned while reproducing

The first version of the repro had `accessibilityLabel="Continue with Google"` matching the visible text `"Continue with Google"` (the example in PR #3165). That flow **passed on `main`** without any fix — because `Filters.textMatches` already falls back to `accessibilityText`, and `IOSDriver` already sets `accessibilityText = element.label`. So the common case where label matches visible text already works today.

The literal #1409 example (label ≠ visible text) is the one that still fails, and it can't be fixed by any label-fallback in `IOSDriver.mapViewHierarchy` — the string `"Click me!"` exists in no element. Only an OCR fallback could recover it.

## ⚠️ iOS CI does not exercise this flow

`e2e/run_tests:133,158` skips `demo_app` on iOS in both single-app and full-suite modes (documented OOM on GHA). Android and web jobs pass (they skip via the `ios` tag). iOS verification has to be local:

```sh
cd e2e/demo_app
flutter pub get
flutter build ios --simulator
# boot an iOS sim, install build/ios/iphonesimulator/Runner.app

# from repo root, with a maestro CLI built from main:
maestro --platform ios test e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
```

Expected: flow fails at `Tap on "Click me!"` with `Element not found: Text matching regex: Click me!`. Verified locally on GOLDEN_MAESTRO iPhone 16, iOS 18.2.

## Test plan

- [x] `flutter analyze` clean
- [x] iOS local: flow fails at `tapOn: "Click me!"` as expected
- [ ] Workaround verified: `tapOn: { label: "easy-button" }` succeeds on the same screen
- [ ] Once OCR fallback or equivalent lands: flip tag to `passing` and rename to `pass_*`
