### PR TITLE
test(e2e): add iOS repro for issue #1409 (accessibilityLabel hides text)

### DIFF
--- a/e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
+++ b/e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
@@ -1,0 +1,28 @@
+## Reproduces https://github.com/mobile-dev-inc/Maestro/issues/1409
+##
+## On iOS, a touchable with accessibilityLabel is exposed as a single
+## accessibility element. Its `label` carries the label string, but iOS does
+## not expose the inner Text child as a separate accessibility element. So
+## the visible text ("Click me!") is unreachable: no element's `text`,
+## `label`, or `accessibilityText` contains it.
+##
+## `Filters.textMatches` (maestro-client/.../Filters.kt:58) already falls back
+## to `accessibilityText`, which is why `tapOn: "easy-button"` (the label)
+## works today. The bug as filed in #1409 is the opposite case: `tapOn` by
+## the visible inner text, which iOS has genuinely hidden.
+##
+## Expected to fail on iOS. PR #3165's one-line fallback to `element.label`
+## would NOT make this pass (the string "Click me!" exists in no element);
+## this flow is a regression guard for the deeper #1409 symptom.
+
+appId: com.example.example
+name: Issue 1409 (inner text hidden by accessibilityLabel on iOS)
+tags:
+    - failing
+    - ios
+---
+- launchApp:
+    clearState: true
+- tapOn: issue 1409 repro
+- tapOn: "Click me!"
+- assertVisible: tapped!

--- a/e2e/demo_app/lib/issue_1409_repro.dart
+++ b/e2e/demo_app/lib/issue_1409_repro.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+/// Reproduces https://github.com/mobile-dev-inc/Maestro/issues/1409.
+///
+/// On iOS, a touchable with `accessibilityLabel` is exposed as a single
+/// accessibility element whose `label` carries the label string. iOS does NOT
+/// expose the inner `Text` child as a separate accessibility element, so the
+/// visible text ("Click me!") is unreachable through the accessibility tree.
+///
+/// This mirrors React Native's
+/// `<Pressable accessibilityLabel="easy-button"><Text>Click me!</Text></Pressable>`
+/// using Flutter's `Semantics(container, button, label, excludeSemantics)` over
+/// a `GestureDetector`. With label != visible text, `tapOn: "Click me!"` has
+/// nothing to match against in any element's `text`/`label`/`accessibilityText`
+/// — that's the #1409 failure.
+///
+/// The touchable is intentionally positioned in the top-left (not centered)
+/// inside a larger column so a parent-bounds tap (a possible fallback in some
+/// matchers) cannot accidentally land on the touchable region.
+class Issue1409Repro extends StatefulWidget {
+  const Issue1409Repro({super.key});
+
+  @override
+  State<Issue1409Repro> createState() => _Issue1409ReproState();
+}
+
+class _Issue1409ReproState extends State<Issue1409Repro> {
+  bool _tapped = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('issue 1409 repro'),
+      ),
+      body: SizedBox.expand(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 24),
+            Padding(
+              padding: const EdgeInsets.only(left: 16),
+              child: Semantics(
+                container: true,
+                button: true,
+                label: 'easy-button',
+                excludeSemantics: true,
+                child: GestureDetector(
+                  onTap: () => setState(() => _tapped = true),
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: Colors.blueGrey.shade100,
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: const Text('Click me!'),
+                  ),
+                ),
+              ),
+            ),
+            const Spacer(),
+            if (_tapped)
+              const Padding(
+                padding: EdgeInsets.only(left: 16, bottom: 16),
+                child: Text('tapped!'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/e2e/demo_app/lib/main.dart
+++ b/e2e/demo_app/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:demo_app/defects_screen.dart';
 import 'package:demo_app/notifications_permission_screen.dart';
 import 'package:demo_app/form_screen.dart';
 import 'package:demo_app/input_screen.dart';
+import 'package:demo_app/issue_1409_repro.dart';
 import 'package:demo_app/issue_1619_repro.dart';
 import 'package:demo_app/issue_1677_repro.dart';
 import 'package:demo_app/location_screen.dart';
@@ -217,6 +218,14 @@ class _MyHomePageState extends State<MyHomePage> {
                     );
                   },
                   child: const Text('issue 1619 repro'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(builder: (_) => const Issue1409Repro()),
+                    );
+                  },
+                  child: const Text('issue 1409 repro'),
                 ),
                 ElevatedButton(
                   onPressed: () {


### PR DESCRIPTION
## What this adds

A Flutter screen + Maestro flow that reproduces [#1409](https://github.com/mobile-dev-inc/Maestro/issues/1409).

## Why it fails

When `accessibilityLabel` is set on a touchable, iOS replaces its children with that label. So:

```jsx
<Pressable accessibilityLabel="easy-button">
  <Text>Click me!</Text>
</Pressable>
```

…looks like this to iOS (and to Maestro): **a button labeled `"easy-button"`**. The string `"Click me!"` only exists as pixels on screen — it's gone from any tree Maestro can read. So `tapOn: "Click me!"` fails.

<img width="1132" height="594" alt="Screenshot 2026-05-21 at 1 26 45 PM" src="https://github.com/user-attachments/assets/0f7511de-30a1-4d5e-9510-7f63b3bbd820" />

The flow mirrors this in Flutter and is tagged `failing, ios` so the regression suite asserts the failure.

## Note on PR #3165

The case PR #3165 targets (label == visible text) already works on `main` — `Filters.textMatches` falls back to `accessibilityText`, which is populated from `element.label`. The literal #1409 case (label ≠ visible text) is harder and can't be fixed by any label-fallback. Only OCR can recover text iOS has truly hidden.

## How to verify

iOS `demo_app` is skipped in CI (documented OOM on GHA), so verify locally:

```sh
cd e2e/demo_app && flutter pub get && flutter build ios --simulator
# install Runner.app on a booted iOS sim, then:
maestro --platform ios test e2e/demo_app/.maestro/fail_issue1409_accessibility_label.yaml
```

Expected: fails at `Tap on "Click me!"` with `Element not found: Text matching regex: Click me!`. Verified locally on iPhone 16, iOS 18.2.
