### PR TITLE
fix(web): handle stale iframe in fetchCrossOriginIframeContent

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -706,9 +706,11 @@ class CdpWebDriver(
         val iframeW = (params["viewportWidth"]  as? Number)?.toDouble() ?: 0.0
         val iframeH = (params["viewportHeight"] as? Number)?.toDouble() ?: 0.0
 
-        // ChromeDriver can execute scripts inside cross-origin iframes via switchTo().frame()
-        driver.switchTo().frame(iframeElement)
         return try {
+            // ChromeDriver can execute scripts inside cross-origin iframes via switchTo().frame().
+            // This can race with page mutation (iframe removed/replaced between findElement and
+            // switchTo), producing a StaleElementReferenceException — treat as a graceful skip.
+            driver.switchTo().frame(iframeElement)
             val resultJson = jsExecutor.executeScript("""
                 $maestroWebScript
                 window.maestro.viewportX = $iframeX;

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -693,9 +693,11 @@ class WebDriver(
         val iframeW = (params["viewportWidth"]  as? Number)?.toDouble() ?: 0.0
         val iframeH = (params["viewportHeight"] as? Number)?.toDouble() ?: 0.0
 
-        // ChromeDriver can execute scripts inside cross-origin iframes via switchTo().frame()
-        driver.switchTo().frame(iframeElement)
         return try {
+            // ChromeDriver can execute scripts inside cross-origin iframes via switchTo().frame().
+            // This can race with page mutation (iframe removed/replaced between findElement and
+            // switchTo), producing a StaleElementReferenceException — treat as a graceful skip.
+            driver.switchTo().frame(iframeElement)
             val resultJson = jsExecutor.executeScript("""
                 $maestroWebScript
                 window.maestro.viewportX = $iframeX;

--- a/maestro-client/src/test/java/maestro/drivers/WebDriverTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/WebDriverTest.kt
@@ -1,10 +1,15 @@
 package maestro.drivers
 
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import maestro.web.selenium.SeleniumFactory
 import org.junit.jupiter.api.Test
+import org.openqa.selenium.JavascriptExecutor
+import org.openqa.selenium.StaleElementReferenceException
+import org.openqa.selenium.WebElement
 import org.openqa.selenium.devtools.HasDevTools
+import java.lang.reflect.InvocationTargetException
 import java.util.ServiceConfigurationError
 import org.openqa.selenium.WebDriver as SeleniumWebDriver
 
@@ -34,5 +39,53 @@ class WebDriverTest {
         )
 
         driver.open()
+    }
+
+    @Test
+    fun `fetchCrossOriginIframeContent returns null when switchTo frame throws StaleElementReferenceException`() {
+        val seleniumDriver = mockk<SeleniumWebDriver>(
+            relaxed = true,
+            moreInterfaces = arrayOf(JavascriptExecutor::class, HasDevTools::class),
+        )
+        val iframeElement = mockk<WebElement>(relaxed = true)
+        val targetLocator = mockk<SeleniumWebDriver.TargetLocator>(relaxed = true)
+
+        val iframeSrc = "https://example.com/iframe"
+        val executor = seleniumDriver as JavascriptExecutor
+
+        every {
+            executor.executeScript(match<String> { it.contains("querySelectorAll('iframe')") }, iframeSrc)
+        } returns iframeElement
+
+        every {
+            executor.executeScript(match<String> { it.contains("getIframeViewportParams") }, iframeSrc)
+        } returns """{"viewportX":0,"viewportY":0,"viewportWidth":100,"viewportHeight":100}"""
+
+        every { seleniumDriver.switchTo() } returns targetLocator
+        every { targetLocator.frame(iframeElement) } throws
+            StaleElementReferenceException("stale element not found")
+
+        val factory = object : SeleniumFactory {
+            override fun create(): SeleniumWebDriver = seleniumDriver
+        }
+        val driver = WebDriver(
+            isStudio = false,
+            isHeadless = true,
+            screenSize = null,
+            seleniumFactory = factory,
+        )
+        driver.open()
+
+        val method = WebDriver::class.java
+            .getDeclaredMethod("fetchCrossOriginIframeContent", String::class.java)
+            .apply { isAccessible = true }
+
+        val result = try {
+            method.invoke(driver, iframeSrc)
+        } catch (e: InvocationTargetException) {
+            throw e.targetException
+        }
+
+        assertThat(result).isNull()
     }
 }


### PR DESCRIPTION
`switchTo().frame()` sat outside the try/catch in `fetchCrossOriginIframeContent`, so a `StaleElementReferenceException` (iframe removed/replaced between `findElement` and `switchTo` on dynamic pages) escaped the method instead of degrading to the same `null` return every other failure already produces. Caller already handles `null` by emitting an empty-children placeholder, so the hierarchy renders without the cross-origin iframe and the test continues.

Mirrors the same fix into `CdpWebDriver`.