### PR TITLE
feat(web): translate Selenium exceptions at the Driver boundary

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpMaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpMaestroSessionManager.kt
@@ -16,6 +16,7 @@ import maestro.device.Platform
 import maestro.drivers.AndroidDriver
 import maestro.drivers.CdpWebDriver
 import maestro.drivers.IOSDriver
+import maestro.drivers.SeleniumExceptionTranslator
 import maestro.utils.CliInsights
 import maestro.utils.TempFileHandler
 import util.IOSDeviceType
@@ -100,7 +101,12 @@ internal class McpMaestroSessionManager : AutoCloseable {
     }
 
     private fun createWebSession(): McpMaestroSession {
-        val driver = McpViewerDriver(CdpWebDriver(isStudio = false, isHeadless = false, screenSize = null), "web")
+        val driver = McpViewerDriver(
+            SeleniumExceptionTranslator.wrap(
+                CdpWebDriver(isStudio = false, isHeadless = false, screenSize = null)
+            ),
+            "web",
+        )
         driver.open()
         return McpMaestroSession(
             maestro = Maestro(driver),

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -23,6 +23,7 @@ import com.github.romankh3.image.comparison.ImageComparison
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.device.DeviceOrientation
 import maestro.drivers.CdpWebDriver
+import maestro.drivers.SeleniumExceptionTranslator
 import maestro.utils.MaestroTimer
 import maestro.utils.ScreenshotUtils
 import maestro.utils.SocketUtils
@@ -708,10 +709,12 @@ class Maestro(
                 }
             }
 
-            val driver = CdpWebDriver(
-                isStudio = isStudio,
-                isHeadless = isHeadless,
-                screenSize = screenSize,
+            val driver = SeleniumExceptionTranslator.wrap(
+                CdpWebDriver(
+                    isStudio = isStudio,
+                    isHeadless = isHeadless,
+                    screenSize = screenSize,
+                )
             )
             driver.open()
             return Maestro(driver)

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -7,6 +7,7 @@ import maestro.device.util.AvdDevice
 import maestro.device.util.PrintUtils
 import maestro.drivers.AndroidDriver
 import maestro.drivers.CdpWebDriver
+import maestro.drivers.SeleniumExceptionTranslator
 import maestro.utils.MaestroTimer
 import maestro.utils.TempFileHandler
 import okio.buffer
@@ -121,7 +122,9 @@ object DeviceService {
 
             Platform.WEB -> {
                 PrintUtils.message("Launching Web...")
-                CdpWebDriver(isStudio = false, isHeadless = false, screenSize = null).open()
+                SeleniumExceptionTranslator.wrap(
+                    CdpWebDriver(isStudio = false, isHeadless = false, screenSize = null)
+                ).open()
 
                 return Device.Connected(
                     instanceId = "chromium",

--- a/maestro-client/src/main/java/maestro/drivers/SeleniumExceptionTranslator.kt
+++ b/maestro-client/src/main/java/maestro/drivers/SeleniumExceptionTranslator.kt
@@ -1,0 +1,57 @@
+package maestro.drivers
+
+import maestro.DeviceUnreachableException
+import maestro.Driver
+import maestro.MaestroException
+import maestro.TreeNode
+import org.openqa.selenium.NoSuchSessionException
+import org.openqa.selenium.SessionNotCreatedException
+import org.openqa.selenium.WebDriverException
+import java.lang.reflect.InvocationTargetException
+import java.lang.reflect.Proxy
+
+/**
+ * Wraps a [Driver] so Selenium exceptions thrown by the underlying web driver are translated
+ * into maestro-level exceptions at the [Driver] interface boundary. Callers (Orchestra, worker)
+ * see only [MaestroException] (test failure) or [DeviceUnreachableException] (infra failure),
+ * never `org.openqa.selenium.*` — driver-specific knowledge stays inside this package.
+ *
+ * Infra-shaped Selenium failures (session gone, browser unreachable, network errors) map to
+ * [DeviceUnreachableException]. Everything else is page-state and maps to
+ * [MaestroException.AssertionFailure].
+ */
+object SeleniumExceptionTranslator {
+
+    fun wrap(delegate: Driver): Driver =
+        Proxy.newProxyInstance(
+            Driver::class.java.classLoader,
+            arrayOf(Driver::class.java),
+        ) { _, method, args ->
+            try {
+                method.invoke(delegate, *(args ?: emptyArray()))
+            } catch (e: InvocationTargetException) {
+                throw translate(e.targetException, method.name)
+            }
+        } as Driver
+
+    private fun translate(throwable: Throwable, callName: String): Throwable {
+        if (throwable !is WebDriverException) return throwable
+
+        val message = throwable.message.orEmpty()
+        val isInfra = throwable is SessionNotCreatedException ||
+            throwable is NoSuchSessionException ||
+            message.contains("chrome not reachable") ||
+            message.contains("net::ERR_")
+
+        return if (isInfra) {
+            DeviceUnreachableException(callName = callName, cause = throwable)
+        } else {
+            MaestroException.AssertionFailure(
+                message = "Web automation failed: ${throwable.message ?: throwable::class.simpleName}",
+                hierarchyRoot = TreeNode(),
+                debugMessage = throwable.message ?: throwable::class.simpleName.orEmpty(),
+                cause = throwable,
+            )
+        }
+    }
+}

--- a/maestro-client/src/test/java/maestro/drivers/SeleniumExceptionTranslatorTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/SeleniumExceptionTranslatorTest.kt
@@ -1,0 +1,89 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import maestro.DeviceUnreachableException
+import maestro.Driver
+import maestro.MaestroException
+import maestro.Point
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.openqa.selenium.NoSuchElementException
+import org.openqa.selenium.NoSuchSessionException
+import org.openqa.selenium.SessionNotCreatedException
+import org.openqa.selenium.StaleElementReferenceException
+import org.openqa.selenium.WebDriverException
+
+class SeleniumExceptionTranslatorTest {
+
+    private val delegate: Driver = mockk(relaxed = true)
+    private val wrapped: Driver = SeleniumExceptionTranslator.wrap(delegate)
+
+    @Test
+    fun `StaleElementReferenceException is translated to MaestroException`() {
+        every { delegate.tap(any()) } throws StaleElementReferenceException("stale")
+
+        assertThrows<MaestroException> { wrapped.tap(Point(0, 0)) }
+    }
+
+    @Test
+    fun `NoSuchElementException is translated to MaestroException`() {
+        every { delegate.tap(any()) } throws NoSuchElementException("no such")
+
+        assertThrows<MaestroException> { wrapped.tap(Point(0, 0)) }
+    }
+
+    @Test
+    fun `SessionNotCreatedException is translated to DeviceUnreachableException`() {
+        every { delegate.tap(any()) } throws SessionNotCreatedException("chrome not started")
+
+        assertThrows<DeviceUnreachableException> { wrapped.tap(Point(0, 0)) }
+    }
+
+    @Test
+    fun `NoSuchSessionException is translated to DeviceUnreachableException`() {
+        every { delegate.tap(any()) } throws NoSuchSessionException("session lost")
+
+        assertThrows<DeviceUnreachableException> { wrapped.tap(Point(0, 0)) }
+    }
+
+    @Test
+    fun `WebDriverException with chrome-not-reachable message is translated to DeviceUnreachableException`() {
+        every { delegate.tap(any()) } throws WebDriverException("chrome not reachable")
+
+        assertThrows<DeviceUnreachableException> { wrapped.tap(Point(0, 0)) }
+    }
+
+    @Test
+    fun `WebDriverException with network error message is translated to DeviceUnreachableException`() {
+        every { delegate.tap(any()) } throws WebDriverException("net::ERR_CONNECTION_REFUSED")
+
+        assertThrows<DeviceUnreachableException> { wrapped.tap(Point(0, 0)) }
+    }
+
+    @Test
+    fun `non-Selenium exception is propagated unchanged`() {
+        val original = IllegalStateException("something else")
+        every { delegate.tap(any()) } throws original
+
+        val thrown = assertThrows<IllegalStateException> { wrapped.tap(Point(0, 0)) }
+        assertThat(thrown).isSameInstanceAs(original)
+    }
+
+    @Test
+    fun `MaestroException from delegate is propagated unchanged`() {
+        val original = MaestroException.UnableToClearState("clear failed")
+        every { delegate.tap(any()) } throws original
+
+        val thrown = assertThrows<MaestroException.UnableToClearState> { wrapped.tap(Point(0, 0)) }
+        assertThat(thrown).isSameInstanceAs(original)
+    }
+
+    @Test
+    fun `successful call returns the delegate's result`() {
+        every { delegate.isKeyboardVisible() } returns true
+
+        assertThat(wrapped.isKeyboardVisible()).isTrue()
+    }
+}


### PR DESCRIPTION
Selenium exceptions thrown by the underlying ChromeDriver currently leak through the `Driver` interface to callers (Orchestra, the cloud worker), forcing them to know about `org.openqa.selenium.*` to classify infra vs. test failures. This concentrates the translation in one place at the driver boundary.

`SeleniumExceptionTranslator.wrap(...)` is a dynamic-proxy `Driver` decorator: it forwards every call to the real driver and catches `WebDriverException` once. Infra-shaped failures (`SessionNotCreatedException`, `NoSuchSessionException`, "chrome not reachable", `net::ERR_*`) become `DeviceUnreachableException`; everything else is treated as page-state and becomes `MaestroException.AssertionFailure`. Callers see only maestro-level types.

Applied at every `CdpWebDriver` construction site (`Maestro.web`, `McpMaestroSessionManager`, `DeviceService`). `CdpWebDriver` / `WebDriver` themselves are unchanged.

## Changes
- `SeleniumExceptionTranslator.kt` — the wrapper (40 lines)
- `SeleniumExceptionTranslatorTest.kt` — 9 cases covering both directions and the propagate-unchanged paths
- 3 construction sites updated