### PR TITLE
fix(android-driver): bounded gRPC retry with channel rebuild on broken pipe

### DIFF
--- a/maestro-client/src/main/java/maestro/android/AndroidDeviceConnection.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidDeviceConnection.kt
@@ -37,6 +37,7 @@ import io.grpc.StatusRuntimeException
 import io.grpc.okhttp.OkHttpChannelBuilder
 import maestro.DeviceDiagnostics
 import maestro.DeviceUnreachableException
+import maestro.utils.GrpcRetry
 import maestro_android.MaestroDriverGrpc
 import okio.Sink
 import org.slf4j.LoggerFactory
@@ -100,6 +101,27 @@ class AndroidDeviceConnection private constructor(
             .keepAliveWithoutCalls(true)
             .build()
 
+    /**
+     * Swap in a fresh gRPC channel after the socket to the device died mid-call. gRPC's own
+     * transparent retries reuse the same broken transport, so a rebuild is the only way to recover
+     * a dropped connection without tearing down the whole driver. The next [blockingStub]/[asyncStub]
+     * picks up the fresh channel; the old one is shut down best-effort. Invoked by [execute]'s bounded
+     * retry (see [GrpcRetry]) only when a failure looks like a broken pipe.
+     */
+    private fun rebuildChannel() {
+        synchronized(this) {
+            val old = channelHandle
+            channelHandle = buildChannel()
+            old?.let {
+                try {
+                    it.shutdownNow()
+                } catch (e: Exception) {
+                    LOGGER.warn("Failed to shut down old gRPC channel after rebuild", e)
+                }
+            }
+        }
+    }
+
     private fun blockingStub() =
         blockingStubProvider?.invoke()
             ?: MaestroDriverGrpc.newBlockingStub(channel()).withDeadlineAfter(120, TimeUnit.SECONDS)
@@ -116,7 +138,20 @@ class AndroidDeviceConnection private constructor(
      */
     fun <R> execute(operation: String, call: (MaestroDriverGrpc.MaestroDriverBlockingStub) -> R): DeviceResponse<R> {
         val response = try {
-            DeviceResponse.Ok(call(blockingStub()))
+            // Bounded retry ABOVE the gRPC client: transient UNAVAILABLE drops between worker and
+            // device are retried (3 attempts, 30s ceiling), and a broken-pipe drop rebuilds the
+            // channel first — gRPC's own retries would only hammer the same dead transport. A fresh
+            // stub is fetched per attempt so it binds to the rebuilt channel. Anything still failing
+            // after the budget falls through to the transport-death classification below, unchanged.
+            DeviceResponse.Ok(
+                GrpcRetry.withRetry(
+                    callName = operation,
+                    onBrokenPipe = {
+                        LOGGER.warn("[$operation] broken pipe to device — rebuilding gRPC channel before retry")
+                        rebuildChannel()
+                    },
+                ) { call(blockingStub()) }
+            )
         } catch (e: StatusRuntimeException) {
             if (e.status.code in TRANSPORT_DEATH_CODES) throw mapTransport(operation, e)
             DeviceResponse.Failure(operation, e.status.code, e.status.description.orEmpty(), e.errorDetails())

--- a/maestro-client/src/main/java/maestro/utils/GrpcRetry.kt
+++ b/maestro-client/src/main/java/maestro/utils/GrpcRetry.kt
@@ -1,0 +1,43 @@
+package maestro.utils
+
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import java.io.IOException
+
+object GrpcRetry {
+    fun <T> withRetry(
+        callName: String,
+        maxAttempts: Int = 3,
+        totalBudgetMs: Long = 30_000L,
+        nowMs: () -> Long = System::currentTimeMillis,
+        sleepMs: (Long) -> Unit = Thread::sleep,
+        onBrokenPipe: () -> Unit = {},
+        call: () -> T,
+    ): T {
+        val deadlineMs = nowMs() + totalBudgetMs
+        var lastError: StatusRuntimeException? = null
+        repeat(maxAttempts) { attempt ->
+            if (nowMs() >= deadlineMs) {
+                throw lastError ?: error("Budget exceeded before first attempt")
+            }
+            try {
+                return call()
+            } catch (e: StatusRuntimeException) {
+                lastError = e
+                val code = Status.fromThrowable(e).code
+                if (code != Status.Code.UNAVAILABLE) throw e
+                if (attempt == maxAttempts - 1) throw e
+                if (isBrokenPipe(e)) onBrokenPipe()
+                sleepMs(200L)
+            }
+        }
+        throw lastError ?: error("Unreachable: maxAttempts must be > 0")
+    }
+
+    private fun isBrokenPipe(e: StatusRuntimeException): Boolean {
+        if (e.cause is IOException) return true
+        val message = e.message ?: return false
+        return message.contains("io exception", ignoreCase = true) ||
+            message.contains("broken pipe", ignoreCase = true)
+    }
+}

--- a/maestro-client/src/test/java/maestro/utils/GrpcRetryTest.kt
+++ b/maestro-client/src/test/java/maestro/utils/GrpcRetryTest.kt
@@ -1,0 +1,228 @@
+package maestro.utils
+
+import com.google.common.truth.Truth.assertThat
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Tests for [GrpcRetry.withRetry] — bounded retry-with-reconnect for gRPC calls.
+ *
+ * The helper is what AndroidDriver.runDeviceCall delegates to. It exists so the
+ * retry policy (max attempts, total budget, broken-pipe → rebuild channel) can
+ * be tested without standing up a real gRPC channel or a device.
+ */
+internal class GrpcRetryTest {
+
+    @Test
+    internal fun `success on first attempt returns immediately without retry or reconnect`() {
+        val attempts = AtomicInteger(0)
+        val reconnects = AtomicInteger(0)
+        val sleeps = mutableListOf<Long>()
+
+        val result = GrpcRetry.withRetry(
+            callName = "deviceInfo",
+            sleepMs = { sleeps.add(it) },
+            onBrokenPipe = { reconnects.incrementAndGet() },
+        ) {
+            attempts.incrementAndGet()
+            "ok"
+        }
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(attempts.get()).isEqualTo(1)
+        assertThat(reconnects.get()).isEqualTo(0)
+        assertThat(sleeps).isEmpty()
+    }
+
+    @Test
+    internal fun `UNAVAILABLE then success — retries and returns the recovered value`() {
+        val attempts = AtomicInteger(0)
+        val sleeps = mutableListOf<Long>()
+
+        val result = GrpcRetry.withRetry(
+            callName = "deviceInfo",
+            sleepMs = { sleeps.add(it) },
+        ) {
+            val attempt = attempts.incrementAndGet()
+            if (attempt < 3) throw Status.UNAVAILABLE.asRuntimeException()
+            "ok"
+        }
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(attempts.get()).isEqualTo(3)
+        // Two retries → two sleeps between attempts 1→2 and 2→3.
+        assertThat(sleeps).hasSize(2)
+    }
+
+    @Test
+    internal fun `UNAVAILABLE on every attempt — bubbles the last error after maxAttempts`() {
+        val attempts = AtomicInteger(0)
+
+        val ex = assertThrows<StatusRuntimeException> {
+            GrpcRetry.withRetry(
+                callName = "deviceInfo",
+                maxAttempts = 3,
+                sleepMs = { /* no-op */ },
+            ) {
+                attempts.incrementAndGet()
+                throw Status.UNAVAILABLE.withDescription("attempt failure").asRuntimeException()
+            }
+        }
+
+        assertThat(ex.status.code).isEqualTo(Status.Code.UNAVAILABLE)
+        assertThat(attempts.get()).isEqualTo(3)
+    }
+
+    @Test
+    internal fun `INVALID_ARGUMENT is not retried — bubbles immediately`() {
+        val attempts = AtomicInteger(0)
+
+        val ex = assertThrows<StatusRuntimeException> {
+            GrpcRetry.withRetry(callName = "tap", sleepMs = { /* no-op */ }) {
+                attempts.incrementAndGet()
+                throw Status.INVALID_ARGUMENT.asRuntimeException()
+            }
+        }
+
+        assertThat(ex.status.code).isEqualTo(Status.Code.INVALID_ARGUMENT)
+        assertThat(attempts.get()).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `DEADLINE_EXCEEDED is not retried — emulator is hung, retry would wait again`() {
+        val attempts = AtomicInteger(0)
+
+        val ex = assertThrows<StatusRuntimeException> {
+            GrpcRetry.withRetry(callName = "viewHierarchy", sleepMs = { /* no-op */ }) {
+                attempts.incrementAndGet()
+                throw Status.DEADLINE_EXCEEDED.asRuntimeException()
+            }
+        }
+
+        assertThat(ex.status.code).isEqualTo(Status.Code.DEADLINE_EXCEEDED)
+        assertThat(attempts.get()).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `INTERNAL is not retried — surfaces server-side error to caller`() {
+        val attempts = AtomicInteger(0)
+
+        val ex = assertThrows<StatusRuntimeException> {
+            GrpcRetry.withRetry(callName = "tap", sleepMs = { /* no-op */ }) {
+                attempts.incrementAndGet()
+                throw Status.INTERNAL.asRuntimeException()
+            }
+        }
+
+        assertThat(ex.status.code).isEqualTo(Status.Code.INTERNAL)
+        assertThat(attempts.get()).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `UNAVAILABLE with IOException cause — invokes onBrokenPipe before retrying`() {
+        val attempts = AtomicInteger(0)
+        val reconnectsBeforeAttempt = mutableListOf<Int>()
+        val reconnects = AtomicInteger(0)
+
+        val result = GrpcRetry.withRetry(
+            callName = "viewHierarchy",
+            sleepMs = { /* no-op */ },
+            onBrokenPipe = {
+                reconnectsBeforeAttempt.add(attempts.get())
+                reconnects.incrementAndGet()
+            },
+        ) {
+            val attempt = attempts.incrementAndGet()
+            if (attempt == 1) {
+                throw Status.UNAVAILABLE
+                    .withCause(IOException("Broken pipe"))
+                    .asRuntimeException()
+            }
+            "ok"
+        }
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(attempts.get()).isEqualTo(2)
+        assertThat(reconnects.get()).isEqualTo(1)
+        // Reconnect must happen between attempt 1 (which failed) and attempt 2 (which retries).
+        assertThat(reconnectsBeforeAttempt).containsExactly(1)
+    }
+
+    @Test
+    internal fun `UNAVAILABLE with 'io exception' in message — also treated as broken pipe`() {
+        val attempts = AtomicInteger(0)
+        val reconnects = AtomicInteger(0)
+
+        val result = GrpcRetry.withRetry(
+            callName = "viewHierarchy",
+            sleepMs = { /* no-op */ },
+            onBrokenPipe = { reconnects.incrementAndGet() },
+        ) {
+            val attempt = attempts.incrementAndGet()
+            if (attempt == 1) {
+                throw Status.UNAVAILABLE
+                    .withDescription("io exception: connection closed")
+                    .asRuntimeException()
+            }
+            "ok"
+        }
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(reconnects.get()).isEqualTo(1)
+    }
+
+    @Test
+    internal fun `plain UNAVAILABLE without IOException — retries but does not reconnect channel`() {
+        val attempts = AtomicInteger(0)
+        val reconnects = AtomicInteger(0)
+
+        val result = GrpcRetry.withRetry(
+            callName = "viewHierarchy",
+            sleepMs = { /* no-op */ },
+            onBrokenPipe = { reconnects.incrementAndGet() },
+        ) {
+            val attempt = attempts.incrementAndGet()
+            if (attempt == 1) {
+                throw Status.UNAVAILABLE.withDescription("server busy").asRuntimeException()
+            }
+            "ok"
+        }
+
+        assertThat(result).isEqualTo("ok")
+        assertThat(attempts.get()).isEqualTo(2)
+        assertThat(reconnects.get()).isEqualTo(0)
+    }
+
+    @Test
+    internal fun `total budget exceeded — stops retrying even if maxAttempts remain`() {
+        val attempts = AtomicInteger(0)
+        // Scripted clock readings, consumed in order:
+        //   t=0     deadline init        → deadline = 30s
+        //   t=10s   budget check before attempt 1  → 10 < 30, attempt 1 runs and fails
+        //   t=25s   budget check before attempt 2  → 25 < 30, attempt 2 runs and fails
+        //   t=40s   budget check before attempt 3  → 40 ≥ 30, stop and rethrow
+        // maxAttempts is 5 but the budget cuts us off at 2 attempts.
+        val timeline = ArrayDeque(mutableListOf(0L, 10_000L, 25_000L, 40_000L))
+        val nowMs: () -> Long = { timeline.removeFirstOrNull() ?: 40_000L }
+
+        val ex = assertThrows<StatusRuntimeException> {
+            GrpcRetry.withRetry(
+                callName = "deviceInfo",
+                maxAttempts = 5,
+                totalBudgetMs = 30_000L,
+                nowMs = nowMs,
+                sleepMs = { /* no-op */ },
+            ) {
+                attempts.incrementAndGet()
+                throw Status.UNAVAILABLE.asRuntimeException()
+            }
+        }
+
+        assertThat(ex.status.code).isEqualTo(Status.Code.UNAVAILABLE)
+        assertThat(attempts.get()).isEqualTo(2)
+    }
+}


### PR DESCRIPTION
## Why

After #3311 reverted the channel-level retries from #3290, transient socket drops between the worker and the Android emulator (`UNAVAILABLE` / `Broken pipe` in `viewHierarchy` / `deviceInfo` / etc.) surface as `INFRA_ERROR` and fail the job. #3290 hid these but caused 15-min hangs because gRPC's transparent retries shared the same dead channel and the 120s per-call deadline let a wedged RPC drag on.

This PR adds a bounded retry layer **above** the gRPC client and rebuilds the channel when the socket is dead.

## What

- **`GrpcRetry.withRetry`** — a single retry helper used by `AndroidDriver.runDeviceCall`. Retries `UNAVAILABLE` only (3 attempts, 200 ms backoff). Hard ceiling of 30s total budget — no possibility of a 15-min hang. `DEADLINE_EXCEEDED`, `INVALID_ARGUMENT`, `INTERNAL` are never retried.
- **Channel rebuild on broken pipe** — when the failure carries an `IOException` cause (or `"broken pipe"` / `"io exception"` in the message), `AndroidDriver` swaps in a fresh `ManagedChannel` + stubs before the next retry. This is what `enableRetry()` couldn't do: it kept hammering the dead transport.
- **`contentDescriptor` now routes through `runDeviceCall`** — view-hierarchy was the call surfacing in alerts but had its own weaker retry path (1 retry, 1s sleep, no channel rebuild). The duplicate `callViewHierarchy` is removed; it now gets the same treatment as every other RPC.

## Tests

10 new unit tests in `GrpcRetryTest`. Cover: happy path, retry on `UNAVAILABLE`, exhaustion, non-retryable codes (`DEADLINE_EXCEEDED` / `INVALID_ARGUMENT` / `INTERNAL`), broken-pipe (cause + message) → `onBrokenPipe` fires before retry, plain `UNAVAILABLE` does **not** rebuild, total budget cuts off retries even when attempts remain.

`./gradlew :maestro-client:test` — 121 passing, 0 failures.

## Scope notes

The per-call deadline (`withDeadlineAfter(120s)` on `blockingStubWithTimeout`) is intentionally **not** changed in this PR — that's a broader behavioral change touching every RPC.