### PR TITLE
fix(cli): point project-creation hint to app.maestro.dev

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -268,7 +268,7 @@ class CloudInteractor(
         }
 
         if (projects.isEmpty()) {
-            throw CliError("No projects found. Please create a project first at https://console.mobile.dev")
+            throw CliError("No projects found. Please create a project first at https://app.maestro.dev")
         }
 
         return when (projects.size) {

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/RunOnCloudTool.kt
@@ -142,7 +142,7 @@ object RunOnCloudTool {
                     }
                     when (projects.size) {
                         0 -> return@RegisteredTool errorResult(
-                            "No Maestro Cloud projects found for this account. Create one at https://console.mobile.dev."
+                            "No Maestro Cloud projects found for this account. Create one at https://app.maestro.dev."
                         )
                         1 -> projects[0].id
                         else -> return@RegisteredTool errorResult(


### PR DESCRIPTION
## What

The "create a project" hints in the CLI pointed users to `https://console.mobile.dev`, which no longer resolves (the domain was decommissioned in the move to the `maestro.dev` brand). Updated both occurrences to `https://app.maestro.dev`.

- `CloudInteractor.kt:271` — "No projects found. Please create a project first at …"
- `RunOnCloudTool.kt:145` — run_on_cloud MCP tool's "No Maestro Cloud projects found … Create one at …"

## Why

`app.maestro.dev` is the live cloud console and is already the URL the rest of the CLI points at (`CloudCommand.kt:46`, `TestSuiteStatusView.kt:130`, `RunOnCloudTool.kt:239`). These two strings were the only stragglers still on the old host, so users hitting the empty-projects path were sent to a dead domain.

## Scope

Verified no other `console.mobile.dev` references remain in the repo. Other `*.mobile.dev` hosts (`get.maestro.mobile.dev` installer, `maestro.mobile.dev` docs, `api.copilot.mobile.dev` cloud API) are live and intentionally left unchanged.