### PR TITLE
Use XDG state home for session store

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/SessionStore.kt
@@ -1,8 +1,8 @@
 package maestro.cli.session
 
 import maestro.cli.db.KeyValueStore
+import maestro.cli.util.EnvUtils
 import maestro.device.Platform
-import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
 class SessionStore(private val keyValueStore: KeyValueStore) {
@@ -79,12 +79,15 @@ class SessionStore(private val keyValueStore: KeyValueStore) {
         val default by lazy {
             SessionStore(
                 KeyValueStore(
-                    dbFile = Paths
-                        .get(System.getProperty("user.home"), ".maestro", "sessions")
-                        .toFile()
-                        .also { it.parentFile.mkdirs() }
+                    dbFile = defaultDbFile()
                 )
             )
         }
+
+        internal fun defaultDbFile() =
+            EnvUtils.xdgStateHome()
+                .resolve("sessions")
+                .toFile()
+                .also { it.parentFile.mkdirs() }
     }
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/session/SessionStoreTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/session/SessionStoreTest.kt
@@ -5,10 +5,18 @@ import maestro.cli.db.KeyValueStore
 import maestro.device.Platform
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.io.TempDir
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
+import uk.org.webcompere.systemstubs.jupiter.SystemStub
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension
 import java.nio.file.Path
 
+@ExtendWith(SystemStubsExtension::class)
 class SessionStoreTest {
+
+    @SystemStub
+    private val environmentVariables = EnvironmentVariables()
 
     @TempDir
     lateinit var tempDir: Path
@@ -36,6 +44,16 @@ class SessionStoreTest {
         sessionStore.delete("session-1", Platform.IOS, "device-A")
 
         assertThat(sessionStore.activeSessions()).isEmpty()
+    }
+
+    @Test
+    fun `default session store uses xdgStateHome`() {
+        val xdgStateHome = tempDir.resolve("xdg-state")
+        environmentVariables.set("XDG_STATE_HOME", xdgStateHome.toString())
+
+        val dbFile = SessionStore.defaultDbFile()
+
+        assertThat(dbFile.toPath()).isEqualTo(xdgStateHome.resolve("maestro").resolve("sessions"))
     }
 
     // --- Task #16: Session key format migration ---


### PR DESCRIPTION
## Summary
- store the default session DB under the existing EnvUtils.xdgStateHome() location
- keep the existing ~/.maestro fallback when XDG_STATE_HOME is unset
- add a unit test that pins XDG_STATE_HOME/maestro/sessions for the default session DB path

Part of #1798.

## Test plan
- ./gradlew :maestro-cli:test --tests maestro.cli.session.SessionStoreTest
- git diff --check