### PR TITLE
fix(web): resolve id: selectors against Flutter's flt-semantics-identifier

### DIFF
--- a/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
+++ b/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
@@ -1,0 +1,15 @@
+# Flutter web id selector regression. The data: URL carries a
+# flt-semantics-identifier attribute (what Flutter web emits for a
+# Semantics identifier); with the fix, id: resolves it, taps it, and the
+# onclick flips the status text.
+url: data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Chtml%3E%3Chead%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3Eid%20test%3C/title%3E%3C/head%3E%3Cbody%3E%3Cdiv%20flt-semantics-identifier%3D%22login_button%22%20role%3D%22button%22%20onclick%3D%22document.getElementById%28%27status%27%29.textContent%3D%27Tapped%27%22%3ELog%20in%3C/div%3E%3Cdiv%20id%3D%22status%22%3ENot%20tapped%3C/div%3E%3C/body%3E%3C/html%3E
+tags:
+  - passing
+  - web
+---
+- launchApp
+- assertVisible:
+    id: "login_button"
+- tapOn:
+    id: "login_button"
+- assertVisible: "Tapped"

--- a/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
+++ b/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
@@ -1,8 +1,9 @@
-# Flutter web id selector regression. The data: URL carries a
-# flt-semantics-identifier attribute (what Flutter web emits for a
-# Semantics identifier); with the fix, id: resolves it, taps it, and the
-# onclick flips the status text.
-url: data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Chtml%3E%3Chead%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3Eid%20test%3C/title%3E%3C/head%3E%3Cbody%3E%3Cdiv%20flt-semantics-identifier%3D%22login_button%22%20role%3D%22button%22%20onclick%3D%22document.getElementById%28%27status%27%29.textContent%3D%27Tapped%27%22%3ELog%20in%3C/div%3E%3Cdiv%20id%3D%22status%22%3ENot%20tapped%3C/div%3E%3C/body%3E%3C/html%3E
+# Flutter web id selector regression. The data: URL builds an element that
+# carries an unstable flt-semantic-node-N DOM id and an aria-label that would
+# otherwise win, plus the developer-set flt-semantics-identifier. With the fix
+# id: resolves to the identifier (proving precedence), taps it, and the onclick
+# flips the status text.
+url: data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Chtml%3E%3Chead%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3Eid%20test%3C/title%3E%3C/head%3E%3Cbody%3E%3Cdiv%20id%3D%22flt-semantic-node-7%22%20aria-label%3D%22Log%20in%22%20flt-semantics-identifier%3D%22login_button%22%20role%3D%22button%22%20onclick%3D%22document.getElementById%28%27status%27%29.textContent%3D%27Tapped%27%22%3ELog%20in%3C/div%3E%3Cdiv%20id%3D%22status%22%3ENot%20tapped%3C/div%3E%3C/body%3E%3C/html%3E
 tags:
   - passing
   - web

--- a/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
+++ b/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
@@ -3,6 +3,27 @@
 # otherwise win, plus the developer-set flt-semantics-identifier. With the fix
 # id: resolves to the identifier (proving precedence), taps it, and the onclick
 # flips the status text.
+# Page source, decoded and unminified: 
+# <!doctype html>
+# <html>
+#   <head>
+#     <meta charset="utf-8" />
+#     <title>id test</title>
+#   </head>
+#   <body>
+#     <div
+#       id="flt-semantic-node-7"
+#       aria-label="Log in"
+#       flt-semantics-identifier="login_button"
+#       role="button"
+#       onclick="document.getElementById('status').textContent = 'Tapped'"
+#     >
+#       Log in
+#     </div>
+#     <div id="status">Not tapped</div>
+#   </body>
+# </html>
+
 url: data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Chtml%3E%3Chead%3E%3Cmeta%20charset%3Dutf-8%3E%3Ctitle%3Eid%20test%3C/title%3E%3C/head%3E%3Cbody%3E%3Cdiv%20id%3D%22flt-semantic-node-7%22%20aria-label%3D%22Log%20in%22%20flt-semantics-identifier%3D%22login_button%22%20role%3D%22button%22%20onclick%3D%22document.getElementById%28%27status%27%29.textContent%3D%27Tapped%27%22%3ELog%20in%3C/div%3E%3Cdiv%20id%3D%22status%22%3ENot%20tapped%3C/div%3E%3C/body%3E%3C/html%3E
 tags:
   - passing

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -127,8 +127,8 @@
 
       if (!!node.attributes['flt-semantics-identifier'] || !!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
         const title = typeof node.title === 'string' ? node.title : null
-        // Flutter web exposes Semantics(identifier:) as flt-semantics-identifier
-        // (node.id is an internal flt-semantic-node-N), so prefer it for id:.
+        // Prefer flt-semantics-identifier: on Flutter web node.id is an
+        // unstable internal handle, not the developer-set identifier.
         attributes['resource-id'] = node.attributes['flt-semantics-identifier']?.value || node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
       }
 

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -125,9 +125,11 @@
         return null;
       }
 
-      if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
+      if (!!node.attributes['flt-semantics-identifier'] || !!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
         const title = typeof node.title === 'string' ? node.title : null
-        attributes['resource-id'] = node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
+        // Flutter web exposes Semantics(identifier:) as flt-semantics-identifier
+        // (node.id is an internal flt-semantic-node-N), so prefer it for id:.
+        attributes['resource-id'] = node.attributes['flt-semantics-identifier']?.value || node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
       }
 
       if (node.tagName.toLowerCase() === 'body') {

--- a/maestro-client/src/test/java/maestro/drivers/FlutterWebSemanticsIdentifierTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/FlutterWebSemanticsIdentifierTest.kt
@@ -1,0 +1,173 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import org.graalvm.polyglot.Context
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the bundled maestro-web.js directly in a JS engine so the
+ * resource-id derivation is pinned without standing up a browser.
+ *
+ * Flutter web puts a developer's Semantics(identifier:) on the DOM attribute
+ * flt-semantics-identifier, while node.id is an internal handle of the form
+ * flt-semantic-node-N that is reassigned between frames. resource-id must
+ * therefore prefer the stable identifier, and must leave every existing
+ * (non-Flutter) resolution path untouched.
+ */
+class FlutterWebSemanticsIdentifierTest {
+
+    @Test
+    fun `resource-id is taken from flt-semantics-identifier when present`() {
+        val resourceId = resolveResourceId(
+            attributes = mapOf("flt-semantics-identifier" to "login_button"),
+        )
+        assertThat(resourceId).isEqualTo("login_button")
+    }
+
+    @Test
+    fun `flt-semantics-identifier wins over the unstable node id and aria-label`() {
+        val resourceId = resolveResourceId(
+            id = "flt-semantic-node-7",
+            ariaLabel = "Log in",
+            attributes = mapOf("flt-semantics-identifier" to "login_button"),
+        )
+        assertThat(resourceId).isEqualTo("login_button")
+    }
+
+    @Test
+    fun `node id is still used when there is no flt-semantics-identifier`() {
+        val resourceId = resolveResourceId(id = "native-dom-id")
+        assertThat(resourceId).isEqualTo("native-dom-id")
+    }
+
+    @Test
+    fun `data-testid is still used when present and no flt identifier exists`() {
+        val resourceId = resolveResourceId(
+            attributes = mapOf("data-testid" to "submit"),
+        )
+        assertThat(resourceId).isEqualTo("submit")
+    }
+
+    @Test
+    fun `an empty flt-semantics-identifier falls through to the next candidate`() {
+        val resourceId = resolveResourceId(
+            id = "native-dom-id",
+            attributes = mapOf("flt-semantics-identifier" to ""),
+        )
+        assertThat(resourceId).isEqualTo("native-dom-id")
+    }
+
+    @Test
+    fun `an empty data-testid still yields an empty resource-id (unchanged)`() {
+        val resourceId = resolveResourceId(
+            attributes = mapOf("data-testid" to ""),
+        )
+        assertThat(resourceId).isEqualTo("")
+    }
+
+    @Test
+    fun `a node with no identifying attributes gets no resource-id`() {
+        val resourceId = resolveResourceId()
+        assertThat(resourceId).isNull()
+    }
+
+    // --- harness -------------------------------------------------------------
+
+    private val webScript: String by lazy {
+        requireNotNull(javaClass.classLoader.getResource("maestro-web.js")) {
+            "maestro-web.js was not found on the test classpath"
+        }.readText()
+    }
+
+    /**
+     * Builds a single element under <body>, runs maestro-web.js over it, and
+     * returns the resolved resource-id (null when the key is absent, "" when
+     * it is present but empty).
+     */
+    private fun resolveResourceId(
+        tagName: String = "flt-semantics",
+        id: String? = null,
+        ariaLabel: String? = null,
+        name: String? = null,
+        title: String? = null,
+        htmlFor: String? = null,
+        attributes: Map<String, String> = emptyMap(),
+    ): String? {
+        Context.newBuilder("js").build().use { context ->
+            context.eval("js", domScript(tagName, id, ariaLabel, name, title, htmlFor, attributes))
+            context.eval("js", webScript)
+
+            val value = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id'] ?? null",
+            )
+            return if (value.isNull) null else value.asString()
+        }
+    }
+
+    private fun domScript(
+        tagName: String,
+        id: String?,
+        ariaLabel: String?,
+        name: String?,
+        title: String?,
+        htmlFor: String?,
+        attributes: Map<String, String>,
+    ): String {
+        val directProps = buildList {
+            add("tagName: '$tagName'")
+            add("id: '${id.orEmpty()}'")
+            ariaLabel?.let { add("ariaLabel: '$it'") }
+            name?.let { add("name: '$it'") }
+            title?.let { add("title: '$it'") }
+            htmlFor?.let { add("htmlFor: '$it'") }
+        }.joinToString(",\n          ")
+
+        val attrEntries = attributes.entries.joinToString(",\n            ") { (key, v) ->
+            "'$key': { value: '$v' }"
+        }
+
+        return """
+            globalThis.Node = { TEXT_NODE: 3 };
+            globalThis.window = globalThis;
+            globalThis.innerWidth = 1024;
+            globalThis.innerHeight = 768;
+
+            const element = {
+              $directProps,
+              attributes: {
+                $attrEntries
+              },
+              childNodes: [{ nodeType: Node.TEXT_NODE, textContent: 'label' }],
+              children: [],
+              selected: false,
+              parentElement: null,
+              getBoundingClientRect() {
+                return { x: 0, y: 0, width: 100, height: 20 };
+              },
+            };
+
+            const body = {
+              tagName: 'body',
+              id: '',
+              attributes: {},
+              childNodes: [],
+              children: [element],
+              selected: false,
+              parentElement: null,
+              getBoundingClientRect() {
+                return { x: 0, y: 0, width: 1024, height: 768 };
+              },
+            };
+            element.parentElement = body;
+
+            globalThis.document = {
+              body: body,
+              readyState: 'complete',
+              querySelectorAll() { return []; },
+            };
+
+            globalThis.maestro = {};
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Proposed changes

I hit this while writing Maestro flows against a Flutter web app: `id:` selectors just never match anything. The reason turned out to be a bit sneaky. When you set `Semantics(identifier: 'login_button')` in Flutter, the web engine puts that on a `flt-semantics-identifier` DOM attribute, but Maestro builds a node's `resource-id` (what `id:` actually looks at) from `node.id`, and on Flutter `node.id` is an internal handle like `flt-semantic-node-7` that gets reassigned between frames. So there's nothing stable to target, and `tapOn: { id: ... }` just times out.

The change makes `maestro-web.js` read `flt-semantics-identifier` first when it's present:

## Why

Flutter web is the one place `id:` is basically unusable. The identifier you set in code doesn't land in the DOM `id`, it goes into a separate attribute Maestro wasn't looking at. Once it reads that attribute, `Semantics(identifier:)` behaves the way you'd already expect `id:` to. That matters more on Flutter than elsewhere, since most text is painted on canvas and labels drift, so a stable `id:` is really the only reliable selector.

## Design notes

I tried to keep this as small and boring as possible:

- The existing `node.id || ariaLabel || …` chain is untouched. The new attribute is just tried first, and on any page that doesn't have it the expression falls through to exactly the old behaviour.
- `flt-semantics-identifier` only ever shows up on Flutter web, so nothing changes for any other web app.
- Both web drivers read `resource-id` out of this script, so they both pick it up from the one change.

Worth flagging: Flutter web only emits its semantics tree once accessibility is enabled, so the attribute isn't in the DOM until then. The demo screen turns it on with `ensureSemantics()` (web only).

## Testing

I added a screen and a flow to the demo app so this is easy to run yourself. `lib/semantics_identifier_screen.dart` wraps a button in `Semantics(identifier: 'login_button')`, and `.maestro/web_flows/flutter_semantics_identifier.yaml` matches and taps it purely by `id:`, then checks the tap actually fired. With the patch it passes. On `main` it fails at the `id: login_button` assertion.

I also checked a plain non-Flutter page still resolves `id:` (via `node.id`) and `data-testid` exactly as before, and `:maestro-client:test` / `:maestro-web:test` are green.

## Issues fixed

Nothing filed on my end, and I didn't find any in the issues tab that talk about this problem.