### PR TITLE
feat(device): support API 37 in DeviceSpec

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -14,6 +14,7 @@ on:
           - 'android-34'
           - 'android-35'
           - 'android-36'
+          - 'android-37'
       app:
         description: 'App workspace to test (e.g. demo_app, simple_web_view). Empty = all apps.'
         type: string
@@ -252,7 +253,6 @@ jobs:
       ANDROID_HOME: /home/runner/androidsdk
       ANDROID_SDK_ROOT: /home/runner/androidsdk
       ANDROID_AVD_HOME: /home/runner/.config/.android/avd/
-      ANDROID_OS_IMAGE: system-images;${{ inputs.android_version || 'android-32' }};google_apis;x86_64
       MAESTRO_APP: ${{ inputs.app }}
       MAESTRO_FLOW_PATH: ${{ needs.validate-inputs.outputs.flow_path }}
 
@@ -283,6 +283,19 @@ jobs:
           # v13 - see https://stackoverflow.com/a/78890086/7009800
           install_android_sdk https://dl.google.com/android/repository/commandlinetools-linux-12266719_latest.zip
           echo "$ANDROID_HOME/cmdline-tools/latest/bin:$PATH" >> $GITHUB_PATH
+
+      - name: Compute Android OS image path
+        run: |
+          version="${{ inputs.android_version || 'android-32' }}"
+          suffix="${version#android-}"
+          if [ "$suffix" -ge 37 ]; then
+            platform="${version}.0"
+            dir="google_apis_ps16k"
+          else
+            platform="$version"
+            dir="google_apis"
+          fi
+          echo "ANDROID_OS_IMAGE=system-images;${platform};${dir};x86_64" >> "$GITHUB_ENV"
 
       - name: Set up Android SDK components
         run: |

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
@@ -133,8 +133,6 @@ object DeviceCreateUtil {
                 deviceName = deviceSpec.deviceName,
                 device = deviceSpec.model,
                 systemImage = systemImage,
-                tag = deviceSpec.tag,
-                abi = deviceSpec.cpuArchitecture.value,
                 force = forceCreate,
             )
         } catch (e: IllegalStateException) {

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -494,20 +494,21 @@ object DeviceService {
     }
 
     /**
-     * Creates an Android emulator
+     * Creates an Android emulator.
+     *
+     * Only the fully-qualified [systemImage] package is passed via `--package`; avdmanager
+     * auto-selects the tag and ABI from it, since the package path already pins both. Passing
+     * `--tag`/`--abi` is redundant in this flow and, for multi-tag images such as API 37's
+     * `google_apis_ps16k`, actively breaks — the package-path segment is not a valid `--tag`.
      *
      * @param deviceName Any device name
      * @param device Device type as specified by the Android SDK i.e. "pixel_6"
      * @param systemImage Full system package i.e "system-images;android-28;google_apis;x86_64"
-     * @param tag google apis or playstore tag i.e. google_apis or google_apis_playstore
-     * @param abi x86_64, x86, arm64 etc..
      */
     fun createAndroidDevice(
         deviceName: String,
         device: String,
         systemImage: String,
-        tag: String,
-        abi: String,
         force: Boolean = false,
     ): String {
         val avd = requireAvdManagerBinary()
@@ -517,8 +518,6 @@ object DeviceService {
             "create", "avd",
             "--name", name,
             "--package", systemImage,
-            "--tag", tag,
-            "--abi", abi,
             "--device", device,
         )
 

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -59,19 +59,23 @@ sealed class DeviceSpec {
         override val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
         override val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
 
-        // API 37+ system images differ from the ≤36 form on two axes. (1) The platform id
-        // carries a minor version ("android-37.0", not "android-37") — Google's permanent
-        // minor-SDK scheme since Android 16 QPR2. (2) Only the 16 KB page-size image is
-        // published, whose package-path segment is "google_apis_ps16k" rather than the plain
-        // "google_apis". Both are encoded in this fully-qualified sdkmanager package path;
-        // avdmanager derives the tag and ABI from the package itself, so neither is passed
-        // separately when creating the AVD (the path segment "google_apis_ps16k" is NOT a
-        // valid avdmanager --tag — the image's tag id is plain "google_apis").
+        // emulatorImage is an sdkmanager "SDK-style path": system-images;<platform>;<dir>;<abi>.
+        // The 3rd segment is the on-disk directory under system-images/<platform>/, NOT a "tag"
+        // (the image's SystemImage.TagId). They coincided for single-tag images (≤36), but API 37's
+        // multi-tag 16 KB image has dir "google_apis_ps16k" while its tag id is plain "google_apis",
+        // so the dir name is rejected as an avdmanager --tag.
+        //
+        // CRITICAL: a fully-qualified --package makes avdmanager derive the tag and ABI from it, so
+        // createAndroidDevice passes ONLY --package — never --tag/--abi. This path is the sole source
+        // of truth; keep it that way.
+        //
+        // API 37+: platform carries a minor version ("android-37.0", not "android-37"; Google's
+        // permanent minor-SDK scheme since Android 16 QPR2) and only the 16 KB ("…_ps16k") dir ships.
         // https://android-developers.googleblog.com/2025/12/android-16-qpr2-is-released.html
         // https://developer.android.com/guide/practices/page-sizes
         private val imagePlatform: String get() = if (osVersion >= 37) "$os.0" else os
-        private val imagePackageTag: String get() = if (osVersion >= 37) "google_apis_ps16k" else "google_apis"
-        val emulatorImage: String get() = "system-images;$imagePlatform;$imagePackageTag;${cpuArchitecture.value}"
+        private val imageDir: String get() = if (osVersion >= 37) "google_apis_ps16k" else "google_apis"
+        val emulatorImage: String get() = "system-images;$imagePlatform;$imageDir;${cpuArchitecture.value}"
 
         companion object {
             val DEFAULT: Android = Android(model = "pixel_6", os = "android-33")

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -58,8 +58,20 @@ sealed class DeviceSpec {
         override val platform = Platform.ANDROID
         override val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
         override val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
-        val tag: String get() = "google_apis"
-        val emulatorImage: String get() = "system-images;$os;$tag;${cpuArchitecture.value}"
+
+        // API 37+ system images differ from the ≤36 form on two axes. (1) The platform id
+        // carries a minor version ("android-37.0", not "android-37") — Google's permanent
+        // minor-SDK scheme since Android 16 QPR2. (2) Only the 16 KB page-size image is
+        // published, whose package-path segment is "google_apis_ps16k" rather than the plain
+        // "google_apis". Both are encoded in this fully-qualified sdkmanager package path;
+        // avdmanager derives the tag and ABI from the package itself, so neither is passed
+        // separately when creating the AVD (the path segment "google_apis_ps16k" is NOT a
+        // valid avdmanager --tag — the image's tag id is plain "google_apis").
+        // https://android-developers.googleblog.com/2025/12/android-16-qpr2-is-released.html
+        // https://developer.android.com/guide/practices/page-sizes
+        private val imagePlatform: String get() = if (osVersion >= 37) "$os.0" else os
+        private val imagePackageTag: String get() = if (osVersion >= 37) "google_apis_ps16k" else "google_apis"
+        val emulatorImage: String get() = "system-images;$imagePlatform;$imagePackageTag;${cpuArchitecture.value}"
 
         companion object {
             val DEFAULT: Android = Android(model = "pixel_6", os = "android-33")

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -64,6 +64,18 @@ internal class DeviceSpecTest {
     }
 
     @Test
+    fun `Android API 37+ emulatorImage uses minor-versioned ps16k package`() {
+        // API 37 ships only as "android-37.0" / "google_apis_ps16k" (see DeviceSpec comment).
+        // avdmanager derives the tag and ABI from this fully-qualified package path, so the
+        // creation flow passes nothing else; the "google_apis_ps16k" segment is a package
+        // path component, not an avdmanager --tag value.
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-37")
+
+        assertThat(spec.osVersion).isEqualTo(37)
+        assertThat(spec.emulatorImage).isEqualTo("system-images;android-37.0;google_apis_ps16k;arm64-v8a")
+    }
+
+    @Test
     fun `Android computed osVersion is parsed from os string`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
         assertThat(spec.osVersion).isEqualTo(34)


### PR DESCRIPTION
## Why

API 37 (Android 17) publishes its system images differently from API ≤36, and `maestro start-device --platform android --device-os android-37` failed because of it. Two things changed upstream:

1. **Minor-versioned platform** — the image is `android-37.0`, not `android-37` (Google's permanent minor-SDK scheme since Android 16 QPR2).
2. **16 KB page-size variant only** — its on-disk directory is `google_apis_ps16k`, not plain `google_apis`. This is also the first **multi-tag** image: its `SystemImage.TagId` is `google_apis,page_size_16kb,ai_glasses_compatible`.

## What

**1. Build the correct package path** (`DeviceSpec.Android.emulatorImage`)
Derive the platform (`android-37.0`) and directory (`google_apis_ps16k`) from `osVersion` for API ≥37; ≤36 is unchanged.

**2. Stop passing `--tag`/`--abi` to `avdmanager`** (`DeviceService.createAndroidDevice`, `DeviceCreateUtil`)
The old code passed `deviceSpec.tag` as `avdmanager --tag`. That worked for ≤36 only because the package-path directory happened to equal the tag id (both `google_apis`). For API 37 they diverge: the directory is `google_apis_ps16k` but the tag id is still `google_apis`, so `--tag google_apis_ps16k` is rejected:

```
Error: Invalid --tag google_apis_ps16k for the selected package. Valid tags are: google_apis
```

A fully-qualified `--package` already pins the tag and ABI, and `avdmanager` auto-derives both from it — so `--tag`/`--abi` are redundant in this flow and can only match-or-fail. We now pass **only `--package`** (matching how the `maestro-device` worker already creates AVDs) and delete the now-dead `DeviceSpec.Android.tag` property.

## Testing

- `DeviceSpecTest` asserts the API 37 package path resolves to `system-images;android-37.0;google_apis_ps16k;arm64-v8a`.
- Ran `maestro start-device --platform android --device-os android-37` end-to-end: AVD created with the correct `tag.id=google_apis` / `abi=arm64-v8a` (avdmanager-derived), emulator booted to Android 17 / 16 KB page size.

> **Note for local repro:** these 16 KB images require the emulator's **Vulkan** rendering path. If a local boot hangs at the Google spinner with `Assertion failed: !rcEnc->featureInfo()->hasReadColorBufferDma`, check `~/.android/advancedFeatures.ini` for a stale `Vulkan = off`. This is an environment setting, not affected by this PR.
