### PR TITLE
ci: notify release-comms on published releases

### DIFF
--- a/.github/workflows/notify-release-comms.yml
+++ b/.github/workflows/notify-release-comms.yml
@@ -1,0 +1,28 @@
+# Copy this file to .github/workflows/notify-release-comms.yml in each source
+# repo (mobile-dev-inc/Maestro and mobile-dev-inc/copilot).
+#
+# Requires the source repo to have a secret RELEASE_COMMS_DISPATCH_TOKEN set
+# to a fine-grained PAT with `actions: write` scope on mobile-dev-inc/release-comms.
+
+name: Notify release-comms
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to release-comms
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASE_COMMS_DISPATCH_TOKEN }}
+          repository: mobile-dev-inc/release-comms
+          event-type: new-release
+          client-payload: |
+            {
+              "source_repo": "${{ github.repository }}",
+              "release_tag": "${{ github.event.release.tag_name }}",
+              "release_url": "${{ github.event.release.html_url }}"
+            }

--- a/.github/workflows/notify-release-comms.yml
+++ b/.github/workflows/notify-release-comms.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   dispatch:
+    # Skip pre-releases (betas, dev builds, etc) — comms only fires on stable releases.
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - name: Send repository_dispatch to release-comms

--- a/.github/workflows/notify-release-comms.yml
+++ b/.github/workflows/notify-release-comms.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send repository_dispatch to release-comms
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.RELEASE_COMMS_DISPATCH_TOKEN }}
           repository: mobile-dev-inc/release-comms


### PR DESCRIPTION
## Summary

Adds `.github/workflows/notify-release-comms.yml` so that every time a release is published in this repo, a `repository_dispatch` event is sent to [`mobile-dev-inc/release-comms`](https://github.com/mobile-dev-inc/release-comms). That repo then runs the release-comms pipeline: generates a release-context doc in Notion, sizes the comms tier, opens a Linear project, drafts assets, and pings me on Slack for approval.

## What this does

- Triggers on `release: published` only — no effect on PRs, pushes, or any other event.
- Posts an HTTP request to GitHub Actions on the `release-comms` repo with `release_tag`, `release_url`, and `source_repo`.
- Doesn't modify any source, build artifacts, or release outputs.
- Failure is non-fatal to the release — if the dispatch fails, the release itself is untouched.

## Requirements

- Repo secret `RELEASE_COMMS_DISPATCH_TOKEN` already set (fine-grained PAT scoped to `actions: write` on `release-comms` only).

## Test plan

- [ ] Workflow file is valid YAML — GitHub linter passes
- [ ] After merge, publishing a release in this repo triggers a run in [release-comms actions](https://github.com/mobile-dev-inc/release-comms/actions)

Owner: @manuarp