### PR TITLE
feat(mcp): add describe_cloud_run tool

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -798,6 +798,32 @@ class ApiClient(
         }
     }
 
+    fun describeRun(
+        authToken: String,
+        runId: String,
+    ): RunDetails {
+        val url = "$baseUrl/v2/runs/$runId"
+
+        val request = Request.Builder()
+            .header("Authorization", "Bearer $authToken")
+            .url(url)
+            .get()
+            .build()
+
+        val response = try {
+            client.newCall(request).execute()
+        } catch (e: IOException) {
+            throw ApiException(statusCode = null)
+        }
+
+        response.use {
+            if (!response.isSuccessful) {
+                throw ApiException(statusCode = response.code)
+            }
+            return JSON.readValue(response.body?.bytes(), RunDetails::class.java)
+        }
+    }
+
     data class ApiException(
         val statusCode: Int?,
     ) : Exception("Request failed. Status code: $statusCode")
@@ -884,6 +910,40 @@ data class UploadStatus(
         RUN_EXPIRED,
     }
 }
+
+/**
+ * Mirrors the backend `RunResponse` from `GET /v2/runs/{runId}`. Fields that are enums on the
+ * backend (`status`, `failureReason`, artifact `type`/`format`) are modelled as `String` here so a
+ * new backend value never breaks an older CLI — the tool just passes them through.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class RunDetails(
+    val id: String,
+    val createdAt: String,
+    val startedAt: String?,
+    val finishedAt: String?,
+    val status: String,
+    val failureReason: String?,
+    val resultMessage: String?,
+    val deviceSpec: RunDeviceSpec,
+    val totalTimeMs: Long?,
+    val artifacts: List<RunArtifact>,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class RunDeviceSpec(
+    val platform: String,
+    val model: String,
+    val osVersion: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class RunArtifact(
+    val type: String,
+    val format: String,
+    val url: String,
+    val sizeBytes: Long?,
+)
 
 data class RenderResponse(
     val id: String,

--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpServer.kt
@@ -18,6 +18,7 @@ import maestro.cli.mcp.tools.InspectScreenTool
 import maestro.cli.mcp.tools.CheatSheetTool
 import maestro.cli.mcp.tools.RunOnCloudTool
 import maestro.cli.mcp.tools.GetCloudRunStatusTool
+import maestro.cli.mcp.tools.DescribeCloudRunTool
 import maestro.cli.mcp.tools.ListCloudDevicesTool
 import maestro.cli.mcp.tools.OpenMaestroViewerTool
 import maestro.cli.mcp.viewer.withViewerHint
@@ -29,7 +30,7 @@ internal val INSTRUCTIONS = """
 
     Every local tool (`take_screenshot`, `inspect_screen`, `run`) needs a `device_id` from `list_devices` first.
 
-    Docs: https://docs.maestro.dev/llms.txt. Call `cheat_sheet` before authoring unfamiliar commands, required args, nested properties, conditionals, or multi-screen flows.
+    Docs: https://docs.maestro.dev/llms.txt. Call `cheat_sheet` before authoring unfamiliar commands, args, conditionals, or multi-screen flows.
 
     ## Local workflow
 
@@ -45,7 +46,7 @@ internal val INSTRUCTIONS = """
 
     `list_cloud_devices` -> `run_on_cloud` -> `get_cloud_run_status` (poll).
 
-    `list_cloud_devices` returns valid `{device_model, device_os}` pairs. Pass them verbatim; never lowercase, reformat, or infer. `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 60s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). Tags only apply with a folder. No tool lists past runs; ask for the `upload_id` or URL for previous runs.
+    `list_cloud_devices` returns valid `{device_model, device_os}` pairs. Pass them verbatim; never reformat. `run_on_cloud` submits a flow or folder, returns `upload_id`, `project_id`, and a dashboard URL (async). Poll `get_cloud_run_status` every 60s until `status` is terminal (SUCCESS, ERROR, CANCELED, WARNING). Tags only apply with a folder. `describe_cloud_run` takes a `run_id` (one flow's run, not the `upload_id`) and returns its metadata plus signed artifact URLs. No tool lists past runs.
 
     Auth: `maestro login` (or `MAESTRO_CLOUD_API_KEY` for non-interactive). Never echo the API key.
 """.trimIndent()
@@ -97,6 +98,7 @@ fun runMaestroMcpServer(viewerUrl: String? = null) {
         ListCloudDevicesTool.create(),
         RunOnCloudTool.create(),
         GetCloudRunStatusTool.create(),
+        DescribeCloudRunTool.create(),
     ))
 
     val transport = StdioServerTransport(

--- a/maestro-cli/src/main/java/maestro/cli/mcp/tools/DescribeCloudRunTool.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/tools/DescribeCloudRunTool.kt
@@ -1,0 +1,105 @@
+package maestro.cli.mcp.tools
+
+import io.modelcontextprotocol.kotlin.sdk.types.*
+import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
+import kotlinx.serialization.json.*
+import maestro.auth.ApiKey
+import maestro.cli.api.ApiClient
+
+object DescribeCloudRunTool {
+    fun create(): RegisteredTool {
+        return RegisteredTool(
+            Tool(
+                name = "describe_cloud_run",
+                description = "Fetch full metadata and downloadable artifacts for a single Maestro Cloud run by its run_id. " +
+                    "Artifacts may include the screen recording, simulator/xctest/emulator logs, the view hierarchy, " +
+                    "a screenshots archive, and an artifacts archive — each as a short-lived signed URL. " +
+                    "A run_id identifies one flow's run (not the upload_id from run_on_cloud); get a run_id from a " +
+                    "dashboard run URL. Only runs created under the run-scoped storage layout expose artifacts; older " +
+                    "runs return an empty artifacts list. " +
+                    "Requires Maestro Cloud authentication: run `maestro login` (recommended), or set MAESTRO_CLOUD_API_KEY for non-interactive use.",
+                inputSchema = ToolSchema(
+                    properties = buildJsonObject {
+                        putJsonObject("run_id") {
+                            put("type", "string")
+                            put("description", "The run_id of the run to describe (the public run id, e.g. from a dashboard run URL).")
+                        }
+                    },
+                    required = listOf("run_id")
+                )
+            )
+        ) { request ->
+            val originalOut = System.out
+            System.setOut(System.err)
+            try {
+                val runId = request.arguments?.get("run_id")?.jsonPrimitive?.content
+                if (runId.isNullOrBlank()) {
+                    return@RegisteredTool errorResult("run_id is required")
+                }
+
+                val apiKey = ApiKey.getToken()
+                if (apiKey.isNullOrBlank()) {
+                    return@RegisteredTool errorResult(
+                        "Not authenticated with Maestro Cloud. Run `maestro login` in your terminal to authenticate " +
+                            "via your browser, then retry this request. For non-interactive setups, set MAESTRO_CLOUD_API_KEY."
+                    )
+                }
+
+                val apiUrl = System.getenv("MAESTRO_CLOUD_API_URL")
+                    ?: System.getenv("MAESTRO_API_URL")
+                    ?: "https://api.copilot.mobile.dev"
+                val client = ApiClient(apiUrl)
+
+                val run = try {
+                    client.describeRun(apiKey, runId)
+                } catch (e: ApiClient.ApiException) {
+                    return@RegisteredTool if (e.statusCode == 404) {
+                        errorResult("No run found with run_id=$runId for this account.")
+                    } else {
+                        errorResult("Failed to fetch cloud run (HTTP ${e.statusCode}) for run_id=$runId")
+                    }
+                }
+
+                val result = buildJsonObject {
+                    put("success", true)
+                    put("run_id", run.id)
+                    put("status", run.status)
+                    run.failureReason?.let { put("failure_reason", it) }
+                    run.resultMessage?.let { put("result_message", it) }
+                    put("created_at", run.createdAt)
+                    run.startedAt?.let { put("started_at", it) }
+                    run.finishedAt?.let { put("finished_at", it) }
+                    run.totalTimeMs?.let { put("total_time_ms", it) }
+                    putJsonObject("device") {
+                        put("platform", run.deviceSpec.platform)
+                        put("model", run.deviceSpec.model)
+                        put("os_version", run.deviceSpec.osVersion)
+                    }
+                    putJsonArray("artifacts") {
+                        run.artifacts.forEach { artifact ->
+                            addJsonObject {
+                                put("type", artifact.type)
+                                put("format", artifact.format)
+                                put("url", artifact.url)
+                                artifact.sizeBytes?.let { put("size_bytes", it) }
+                            }
+                        }
+                    }
+                }.toString()
+
+                CallToolResult(content = listOf(TextContent(result)))
+            } catch (e: Exception) {
+                CallToolResult(
+                    content = listOf(TextContent("Failed to describe cloud run: ${e.message ?: e.javaClass.simpleName}")),
+                    isError = true
+                )
+            } finally {
+                System.setOut(originalOut)
+            }
+        }
+    }
+
+    private fun errorResult(message: String): CallToolResult {
+        return CallToolResult(content = listOf(TextContent(message)), isError = true)
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/McpServerTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/McpServerTest.kt
@@ -21,6 +21,7 @@ class McpServerTest {
             "list_cloud_devices",
             "run_on_cloud",
             "get_cloud_run_status",
+            "describe_cloud_run",
         )
         registeredTools.forEach { tool ->
             assertThat(INSTRUCTIONS).contains(tool)

--- a/maestro-cli/src/test/mcp/tool-tests-without-device.yaml
+++ b/maestro-cli/src/test/mcp/tool-tests-without-device.yaml
@@ -10,6 +10,7 @@ tools:
     - list_cloud_devices
     - run_on_cloud
     - get_cloud_run_status
+    - describe_cloud_run
 
   tests:
     - name: "List available devices"
@@ -59,6 +60,15 @@ tools:
       params:
         upload_id: "deadbeef"
         project_id: "deadbeef"
+      expect:
+        success: false
+        error:
+          contains: "MAESTRO_CLOUD_API_KEY"
+
+    - name: "Describe cloud run (expect API key required)"
+      tool: "describe_cloud_run"
+      params:
+        run_id: "deadbeef"
       expect:
         success: false
         error:


### PR DESCRIPTION
Adds an MCP tool that fetches a Maestro Cloud run's metadata and signed artifact URLs by `run_id` (via `GET /v2/runs/{runId}`). Covered by `McpServerTest` and the no-device tool eval.