### PR TITLE
fix(web): map Flutter Web semantics identifiers to resource IDs

### DIFF
--- a/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
+++ b/e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml
@@ -1,0 +1,9 @@
+url: data:text/html;charset=utf-8,%3C!doctype%20html%3E%3Chtml%3E%3Cbody%3E%3Cflt-semantics%20id%3D%22flt-semantic-node-372%22%20aria-label%3D%22Email%22%20flt-semantics-identifier%3D%22admin-login-email-input%22%3EEmail%3C%2Fflt-semantics%3E%3C%2Fbody%3E%3C%2Fhtml%3E
+name: Flutter Web semantics identifiers should be selectable by id
+tags:
+  - passing
+  - web
+---
+- launchApp
+- assertVisible:
+    id: admin-login-email-input

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -125,9 +125,12 @@
         return null;
       }
 
-      if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
+      const flutterSemanticsIdentifier = node.attributes['flt-semantics-identifier']?.value
+      const dataTestIdAttribute = node.attributes['data-testid']
+      const dataTestId = dataTestIdAttribute?.value
+      if (!!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!dataTestIdAttribute || !!flutterSemanticsIdentifier) {
         const title = typeof node.title === 'string' ? node.title : null
-        attributes['resource-id'] = node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
+        attributes['resource-id'] = flutterSemanticsIdentifier || node.id || node.ariaLabel || node.name || title || node.htmlFor || dataTestId
       }
 
       if (node.tagName.toLowerCase() === 'body') {

--- a/maestro-client/src/test/java/maestro/drivers/MaestroWebScriptTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/MaestroWebScriptTest.kt
@@ -1,0 +1,161 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import org.graalvm.polyglot.Context
+import org.junit.jupiter.api.Test
+
+class MaestroWebScriptTest {
+
+    @Test
+    fun `maps Flutter Web semantics identifier to resource id`() {
+        Context.newBuilder("js").build().use { context ->
+            context.eval("js", domStubScript())
+            context.eval("js", maestroWebScript())
+
+            val resourceId = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id']",
+            ).asString()
+
+            assertThat(resourceId).isEqualTo("admin-login-email-input")
+        }
+    }
+
+    @Test
+    fun `keeps native DOM id behavior without Flutter Web semantics identifier`() {
+        Context.newBuilder("js").build().use { context ->
+            context.eval(
+                "js",
+                domStubScript(
+                    nodeProperties = "id: 'native-dom-id',",
+                    semanticsAttributes = "",
+                ),
+            )
+            context.eval("js", maestroWebScript())
+
+            val resourceId = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id']",
+            ).asString()
+
+            assertThat(resourceId).isEqualTo("native-dom-id")
+        }
+    }
+
+    @Test
+    fun `prefers Flutter Web semantics identifier over generated semantic DOM id and aria label`() {
+        Context.newBuilder("js").build().use { context ->
+            context.eval(
+                "js",
+                domStubScript(
+                    nodeProperties = "id: 'flt-semantic-node-372', ariaLabel: 'Email',",
+                ),
+            )
+            context.eval("js", maestroWebScript())
+
+            val resourceId = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id']",
+            ).asString()
+
+            assertThat(resourceId).isEqualTo("admin-login-email-input")
+        }
+    }
+
+    @Test
+    fun `keeps empty data-testid resource id behavior without Flutter Web semantics identifier`() {
+        Context.newBuilder("js").build().use { context ->
+            context.eval(
+                "js",
+                domStubScript(
+                    semanticsAttributes = "'data-testid': { value: '' },",
+                ),
+            )
+            context.eval("js", maestroWebScript())
+
+            val hasResourceId = context.eval(
+                "js",
+                "Object.prototype.hasOwnProperty.call(maestro.getContentDescription().children[0].attributes, 'resource-id')",
+            ).asBoolean()
+            val resourceId = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id']",
+            ).asString()
+
+            assertThat(hasResourceId).isTrue()
+            assertThat(resourceId).isEqualTo("")
+        }
+    }
+
+    private fun maestroWebScript(): String {
+        return requireNotNull(javaClass.classLoader.getResource("maestro-web.js")) {
+            "maestro-web.js resource was not found"
+        }.readText()
+    }
+
+    private fun domStubScript(
+        nodeProperties: String = "",
+        semanticsAttributes: String = "'flt-semantics-identifier': { value: 'admin-login-email-input' },",
+    ): String {
+        return """
+            globalThis.Node = { TEXT_NODE: 3 };
+            globalThis.window = globalThis;
+            globalThis.innerWidth = 800;
+            globalThis.innerHeight = 600;
+
+            function createTextNode(text) {
+              return {
+                nodeType: Node.TEXT_NODE,
+                textContent: text,
+              };
+            }
+
+            function createElement(tagName, properties = {}) {
+              const children = properties.children || [];
+              const node = {
+                tagName,
+                id: '',
+                attributes: {},
+                childNodes: [],
+                children,
+                selected: false,
+                parentElement: null,
+                getBoundingClientRect() {
+                  return {
+                    x: 0,
+                    y: 0,
+                    width: 100,
+                    height: 20,
+                  };
+                },
+                ...properties,
+              };
+
+              children.forEach(child => child.parentElement = node);
+              return node;
+            }
+
+            const semanticsNode = createElement('flt-semantics', {
+              $nodeProperties
+              attributes: {
+                $semanticsAttributes
+              },
+              childNodes: [createTextNode('Email')],
+            });
+
+            const bodyNode = createElement('body', {
+              children: [semanticsNode],
+            });
+
+            globalThis.document = {
+              body: bodyNode,
+              readyState: 'complete',
+              querySelectorAll() {
+                return [];
+              },
+            };
+
+            globalThis.maestro = {};
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
## Proposed changes

Maps Flutter Web `flt-semantics-identifier` attributes into Maestro Web `resource-id` values so selectors can target Flutter `Semantics(identifier:)` values.

The mapping gives Flutter's developer-provided semantics identifier precedence over Flutter Web's generated semantic DOM ids such as `flt-semantic-node-*`, while preserving existing DOM id/data-testid behavior when no Flutter semantics identifier is present.

Also adds JVM coverage for `maestro-web.js` hierarchy extraction and a Web e2e regression flow that matches a Flutter-shaped semantics element by `id:`.

## Testing

- `git diff --check origin/main..HEAD`
- `./gradlew :maestro-client:test --tests 'maestro.drivers.MaestroWebScriptTest' --console=plain`
- `./maestro --platform web test --headless e2e/demo_app/.maestro/web_flows/flutter_semantics_identifier.yaml`

Note: `./gradlew test` currently fails locally in upstream-existing `maestro-test IntegrationTest Case 112`; reproduced on clean `origin/main`, unrelated to this patch.

## Issues fixed

No linked issue.