### PR TITLE
feat(orchestra): add custom commands with typed arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for declaring custom commands in YAML flows. A flow file can declare itself as a reusable command via `command:` + `arguments:` in its config block; callers invoke it as if it were a built-in command (e.g. `- takeScreenshotWithContext: { label: "login" }`) instead of `runFlow:` with `env:`. Files placed under a sibling `subflows/` folder are auto-discovered in single-file runs; in workspace runs, any file with a `command:` header is registered regardless of folder.
+
 ## 2.6.0
 
 - Add Maestro Viewer - a desktop visualizer for live hierarchy and commands

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -61,6 +61,7 @@ import maestro.cli.auth.Auth
 import maestro.cli.model.FlowStatus
 import maestro.cli.view.cyan
 import maestro.cli.promotion.PromotionStateManager
+import maestro.orchestra.CustomCommandDef
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner.ExecutionPlan
@@ -556,7 +557,7 @@ class TestCommand : Callable<Int> {
         debugOutputPath: Path,
         testOutputDir: Path?,
         deviceId: String?,
-        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
     ): Triple<Int, Int, Nothing?> {
         val resultView =
             if (DisableAnsiMixin.ansiEnabled) {

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -527,9 +527,10 @@ class TestCommand : Callable<Int> {
                         authToken,
                         testOutputDir,
                         deviceId,
+                        executionPlan.customCommands,
                     )
                 } else {
-                    runSingleFlow(maestro, device, flowFile, debugOutputPath, testOutputDir, deviceId)
+                    runSingleFlow(maestro, device, flowFile, debugOutputPath, testOutputDir, deviceId, executionPlan.customCommands)
                 }
             }
         }
@@ -555,6 +556,7 @@ class TestCommand : Callable<Int> {
         debugOutputPath: Path,
         testOutputDir: Path?,
         deviceId: String?,
+        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
     ): Triple<Int, Int, Nothing?> {
         val resultView =
             if (DisableAnsiMixin.ansiEnabled) {
@@ -579,6 +581,7 @@ class TestCommand : Callable<Int> {
             apiKey = authToken,
             testOutputDir = testOutputDir,
             deviceId = deviceId,
+            customCommands = customCommands,
         )
         val duration = System.currentTimeMillis() - startTime
 
@@ -665,7 +668,7 @@ class TestCommand : Callable<Int> {
             .groupBy { it.index % effectiveShards }
             .map { (_, files) ->
                 val flowsToRun = files.map { it.value }
-                ExecutionPlan(flowsToRun, plan.sequence, plan.workspaceConfig)
+                ExecutionPlan(flowsToRun, plan.sequence, plan.workspaceConfig, plan.customCommands)
             }
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -51,6 +51,7 @@ object TestRunner {
         apiKey: String? = null,
         testOutputDir: Path?,
         deviceId: String?,
+        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
     ): Int {
         val debugOutput = FlowDebugOutput()
         var aiOutput = FlowAIOutput(
@@ -63,7 +64,7 @@ object TestRunner {
             .withDefaultEnvVars(flowFile, deviceId)
 
         val result = runCatching(resultView, maestro) {
-            val commands = YamlCommandReader.readCommands(flowFile.toPath())
+            val commands = YamlCommandReader.readCommands(flowFile.toPath(), customCommands)
                 .withEnv(updatedEnv)
 
             val flowName = YamlCommandReader.getConfig(commands)?.name ?: flowFile.nameWithoutExtension
@@ -127,6 +128,7 @@ object TestRunner {
         apiKey: String? = null,
         testOutputDir: Path?,
         deviceId: String?,
+        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
     ): Nothing {
         val resultView = AnsiResultView("> Press [ENTER] to restart the Flow\n\n")
 
@@ -147,7 +149,7 @@ object TestRunner {
                     .withDefaultEnvVars(flowFile, deviceId)
 
                 val commands = YamlCommandReader
-                    .readCommands(flowFile.toPath())
+                    .readCommands(flowFile.toPath(), customCommands)
                     .withEnv(updatedEnv)
 
                 val flowName = YamlCommandReader.getConfig(commands)?.name

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -17,6 +17,7 @@ import maestro.cli.runner.resultview.ResultView
 import maestro.cli.runner.resultview.UiState
 import maestro.cli.util.PrintUtils
 import maestro.cli.view.ErrorViewUtils
+import maestro.orchestra.CustomCommandDef
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.debug.FlowDebugOutput
 import maestro.orchestra.util.Env.withEnv
@@ -51,7 +52,7 @@ object TestRunner {
         apiKey: String? = null,
         testOutputDir: Path?,
         deviceId: String?,
-        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
     ): Int {
         val debugOutput = FlowDebugOutput()
         var aiOutput = FlowAIOutput(
@@ -128,7 +129,7 @@ object TestRunner {
         apiKey: String? = null,
         testOutputDir: Path?,
         deviceId: String?,
-        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
     ): Nothing {
         val resultView = AnsiResultView("> Press [ENTER] to restart the Flow\n\n")
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -16,6 +16,7 @@ import maestro.cli.util.TimeUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
+import maestro.orchestra.CustomCommandDef
 import maestro.orchestra.Orchestra
 import maestro.orchestra.debug.CommandDebugMetadata
 import maestro.orchestra.debug.CommandStatus
@@ -159,7 +160,7 @@ class TestSuiteInteractor(
         maestro: Maestro,
         debugOutputPath: Path,
         testOutputDir: Path? = null,
-        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
     ): Pair<TestExecutionSummary.FlowResult, FlowAIOutput> {
         // TODO(bartekpacia): merge TestExecutionSummary with AI suggestions
         //  (i.e. consider them also part of the test output)

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -77,7 +77,7 @@ class TestSuiteInteractor(
             val updatedEnv = env
                 .withInjectedShellEnvVars()
                 .withDefaultEnvVars(flowFile, deviceId, shardIndex)
-            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir)
+            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir, executionPlan.customCommands)
             flowResults.add(result)
             aiOutputs.add(aiOutput)
 
@@ -97,7 +97,7 @@ class TestSuiteInteractor(
             val updatedEnv = env
                 .withInjectedShellEnvVars()
                 .withDefaultEnvVars(flowFile, deviceId, shardIndex)
-            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir)
+            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir, executionPlan.customCommands)
             aiOutputs.add(aiOutput)
 
             if (result.status == FlowStatus.ERROR) {
@@ -158,7 +158,8 @@ class TestSuiteInteractor(
         env: Map<String, String>,
         maestro: Maestro,
         debugOutputPath: Path,
-        testOutputDir: Path? = null
+        testOutputDir: Path? = null,
+        customCommands: Map<String, maestro.orchestra.CustomCommandDef> = emptyMap(),
     ): Pair<TestExecutionSummary.FlowResult, FlowAIOutput> {
         // TODO(bartekpacia): merge TestExecutionSummary with AI suggestions
         //  (i.e. consider them also part of the test output)
@@ -173,7 +174,7 @@ class TestSuiteInteractor(
             flowFile = flowFile,
         )
         val commands = YamlCommandReader
-            .readCommands(flowFile.toPath())
+            .readCommands(flowFile.toPath(), customCommands)
             .withEnv(env)
 
         val maestroConfig = YamlCommandReader.getConfig(commands)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -812,6 +812,8 @@ data class RunFlowCommand(
     val config: MaestroConfig?,
     override val label: String? = null,
     override val optional: Boolean = false,
+    /** Non-null only when this RunFlowCommand was produced by expanding a custom-command call. */
+    val customCommandName: String? = null,
 ) : CompositeCommand {
 
     override fun subCommands(): List<MaestroCommand> {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/CustomCommandDef.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/CustomCommandDef.kt
@@ -1,0 +1,19 @@
+package maestro.orchestra
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import java.nio.file.Path
+
+enum class ArgumentType { STRING, NUMBER, BOOLEAN }
+
+data class CustomCommandArgument(
+    val name: String,
+    val type: ArgumentType = ArgumentType.STRING,
+    val required: Boolean = false,
+    val default: String? = null,
+)
+
+data class CustomCommandDef(
+    val name: String,
+    @field:JsonIgnore val sourceFile: Path,
+    val arguments: List<CustomCommandArgument>,
+)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -13,6 +13,8 @@ data class MaestroConfig(
     val onFlowStart: MaestroOnFlowStart? = null,
     val onFlowComplete: MaestroOnFlowComplete? = null,
     val properties: Map<String, String> = emptyMap(),
+    val command: String? = null,
+    val arguments: List<CustomCommandArgument>? = null,
 ) {
 
     fun evaluateScripts(jsEngine: JsEngine): MaestroConfig {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -202,8 +202,12 @@ object WorkspaceExecutionPlanner {
             if (!seenFiles.add(canonical)) continue
             val config = try {
                 YamlCommandReader.readConfig(file)
-            } catch (_: Throwable) {
-                // Skip files that fail to parse here; they'll surface real errors later.
+            } catch (e: Exception) {
+                // Skip files that fail to parse during the pre-pass. If the file is a
+                // runnable flow, the real parse error will surface during validation;
+                // if it was meant as a command-definition file, callers see "Invalid
+                // Command" — log a hint so the cause is recoverable from DEBUG output.
+                logger.debug("Skipping {} during custom-command discovery: {}", file, e.message)
                 continue
             }
             val name = config.command ?: continue
@@ -233,7 +237,8 @@ object WorkspaceExecutionPlanner {
         for (def in registry.values) {
             val body = try {
                 YamlCommandReader.readCommands(def.sourceFile, registry)
-            } catch (_: Throwable) {
+            } catch (e: Exception) {
+                logger.debug("Skipping nesting check for {}: {}", def.sourceFile, e.message)
                 continue
             }
             val nested = body.firstNotNullOfOrNull { mc ->

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -183,7 +183,9 @@ object WorkspaceExecutionPlanner {
         val parent = flowFile.absolute().parent ?: return emptyMap()
         val cmdDir = parent.resolve("subflows")
         if (!cmdDir.isDirectory()) return emptyMap()
-        val files = Files.walk(cmdDir).filter { it.isRegularFile() && isYamlFile(it) }.toList()
+        val files = Files.walk(cmdDir).use { stream ->
+            stream.filter { it.isRegularFile() && isYamlFile(it) }.toList()
+        }
         return discoverCustomCommands(files)
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -1,9 +1,12 @@
 package maestro.orchestra.workspace
 
+import maestro.orchestra.CustomCommandDef
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.WorkspaceConfig
+import maestro.orchestra.error.SyntaxError
 import maestro.orchestra.error.ValidationError
 import maestro.orchestra.workspace.ExecutionOrderPlanner.getFlowsToRunInSequence
+import maestro.orchestra.yaml.MaestroFlowParser
 import maestro.orchestra.yaml.YamlCommandReader
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
@@ -29,7 +32,9 @@ object WorkspaceExecutionPlanner {
         }
 
         if (input.isRegularFile) {
-            validateFlowFile(input.first())
+            val flow = input.first()
+            val singleFileCustomCommands = discoverCustomCommandsFromSubflowsDir(flow)
+            validateFlowFile(flow, singleFileCustomCommands)
             val workspaceConfig = if (config != null) {
                 YamlCommandReader.readWorkspaceConfig(config.absolute())
             } else {
@@ -38,7 +43,8 @@ object WorkspaceExecutionPlanner {
             return ExecutionPlan(
                 flowsToRun = input.toList(),
                 sequence = FlowSequence(emptyList()),
-                workspaceConfig = workspaceConfig
+                workspaceConfig = workspaceConfig,
+                customCommands = singleFileCustomCommands,
             )
         }
 
@@ -62,6 +68,11 @@ object WorkspaceExecutionPlanner {
             """.trimIndent())
         }
 
+        val customCommands = discoverCustomCommands(flowFiles + flowFilesInDirs)
+
+        // Command-definition files (any file declaring `command:`) are not runnable flows.
+        val customCommandFiles = customCommands.values.map { it.sourceFile }.toSet()
+
         // Filter flows based on flows config
 
         val workspaceConfig =
@@ -74,9 +85,9 @@ object WorkspaceExecutionPlanner {
             directories.map { it.fileSystem.getPathMatcher(escapeSlashesForWindows("glob:${it.pathString}${it.fileSystem.separator}$glob")) }
         }
 
-        val unsortedFlowFiles = flowFiles + flowFilesInDirs.filter { path ->
+        val unsortedFlowFiles = (flowFiles + flowFilesInDirs.filter { path ->
             matchers.any { matcher -> matcher.matches(path) }
-        }.toList()
+        }).filter { it.absolute() !in customCommandFiles }
 
         if (unsortedFlowFiles.isEmpty()) {
             if ("*" == globs.singleOrNull()) {
@@ -99,7 +110,7 @@ object WorkspaceExecutionPlanner {
         // Filter flows based on tags
 
         val configPerFlowFile = unsortedFlowFiles.associateWith {
-            val commands = validateFlowFile(it)
+            val commands = validateFlowFile(it, customCommands)
             YamlCommandReader.getConfig(commands)
         }
 
@@ -140,7 +151,7 @@ object WorkspaceExecutionPlanner {
         // validation of media files for add media command
         allFlows.forEach {
             val commands = YamlCommandReader
-                .readCommands(it)
+                .readCommands(it, customCommands)
                 .mapNotNull { maestroCommand -> maestroCommand.addMediaCommand }
             val mediaPaths = commands.flatMap { addMediaCommand -> addMediaCommand.mediaPaths }
             YamlCommandsPathValidator.validatePathsExistInWorkspace(input, it, mediaPaths)
@@ -153,6 +164,7 @@ object WorkspaceExecutionPlanner {
                 workspaceConfig.executionOrder?.continueOnFailure
             ),
             workspaceConfig = workspaceConfig,
+            customCommands = customCommands,
         )
 
         logger.info("Created execution plan: $executionPlan")
@@ -160,8 +172,82 @@ object WorkspaceExecutionPlanner {
         return executionPlan
     }
 
-    private fun validateFlowFile(topLevelFlowPath: Path): List<MaestroCommand> {
-        return YamlCommandReader.readCommands(topLevelFlowPath)
+    private fun validateFlowFile(
+        topLevelFlowPath: Path,
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
+    ): List<MaestroCommand> {
+        return YamlCommandReader.readCommands(topLevelFlowPath, customCommands)
+    }
+
+    internal fun discoverCustomCommandsFromSubflowsDir(flowFile: Path): Map<String, CustomCommandDef> {
+        val parent = flowFile.absolute().parent ?: return emptyMap()
+        val cmdDir = parent.resolve("subflows")
+        if (!cmdDir.isDirectory()) return emptyMap()
+        val files = Files.walk(cmdDir).filter { it.isRegularFile() && isYamlFile(it) }.toList()
+        return discoverCustomCommands(files)
+    }
+
+    private fun isYamlFile(path: Path): Boolean {
+        val name = path.fileName.toString().lowercase()
+        return name.endsWith(".yaml") || name.endsWith(".yml")
+    }
+
+    internal fun discoverCustomCommands(files: Iterable<Path>): Map<String, CustomCommandDef> {
+        val registry = mutableMapOf<String, CustomCommandDef>()
+        val seenFiles = mutableSetOf<Path>()
+        for (file in files) {
+            val canonical = file.absolute().normalize()
+            if (!seenFiles.add(canonical)) continue
+            val config = try {
+                YamlCommandReader.readConfig(file)
+            } catch (_: Throwable) {
+                // Skip files that fail to parse here; they'll surface real errors later.
+                continue
+            }
+            val name = config.command ?: continue
+            val arguments = config.toCustomCommandArguments().orEmpty()
+
+            if (MaestroFlowParser.isBuiltInCommand(name)) {
+                throw SyntaxError(
+                    "Custom command name '$name' (declared in ${file.absolutePathString()}) " +
+                        "collides with a built-in Maestro command."
+                )
+            }
+            val existing = registry[name]
+            if (existing != null) {
+                throw SyntaxError(
+                    "Duplicate custom command name '$name': declared in both " +
+                        "${existing.sourceFile.absolutePathString()} and ${file.absolutePathString()}."
+                )
+            }
+            registry[name] = CustomCommandDef(
+                name = name,
+                sourceFile = file.absolute(),
+                arguments = arguments,
+            )
+        }
+
+        // Reject nesting: a custom-command body cannot invoke another custom command.
+        for (def in registry.values) {
+            val body = try {
+                YamlCommandReader.readCommands(def.sourceFile, registry)
+            } catch (_: Throwable) {
+                continue
+            }
+            val nested = body.firstNotNullOfOrNull { mc ->
+                val source = mc.runFlowCommand?.sourceDescription
+                registry.values.firstOrNull { other ->
+                    other.name != def.name && source != null && other.sourceFile.toString() == source
+                }
+            }
+            if (nested != null) {
+                throw SyntaxError(
+                    "Custom command '${nested.name}' invoked inside custom command '${def.name}' " +
+                        "— nesting is not supported."
+                )
+            }
+        }
+        return registry
     }
 
     private fun findConfigFile(input: Path): Path? {
@@ -192,5 +278,6 @@ object WorkspaceExecutionPlanner {
         val flowsToRun: List<Path>,
         val sequence: FlowSequence,
         val workspaceConfig: WorkspaceConfig = WorkspaceConfig(),
+        val customCommands: Map<String, CustomCommandDef> = emptyMap(),
     )
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceExecutionPlanner.kt
@@ -242,10 +242,9 @@ object WorkspaceExecutionPlanner {
                 continue
             }
             val nested = body.firstNotNullOfOrNull { mc ->
-                val source = mc.runFlowCommand?.sourceDescription
-                registry.values.firstOrNull { other ->
-                    other.name != def.name && source != null && other.sourceFile.toString() == source
-                }
+                mc.runFlowCommand?.customCommandName
+                    ?.takeIf { it != def.name }
+                    ?.let(registry::get)
             }
             if (nested != null) {
                 throw SyntaxError(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
@@ -34,6 +34,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.fasterxml.jackson.core.type.TypeReference
+import maestro.orchestra.CustomCommandDef
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.SourceInfo
 import maestro.orchestra.WorkspaceConfig
@@ -54,18 +56,25 @@ import kotlin.reflect.jvm.javaType
 //  - Sanity check: Parsed workspace equality check for 10 users on cloud
 
 private val yamlFluentCommandConstructor = YamlFluentCommand::class.primaryConstructor!!
+private val INTERNAL_FLUENT_COMMAND_FIELDS = setOf("_sourceInfo", "customCommand")
 private val yamlFluentCommandParameters = yamlFluentCommandConstructor.parameters
-private val yamlFluentCommandSourceInfoParameter = yamlFluentCommandParameters.first { it.name == "_sourceInfo" }
-private val objectCommands = yamlFluentCommandConstructor.parameters
-    .filter { it.name != "_sourceInfo" }
-    .map { it.name!! }
+    .filter { it.name !in INTERNAL_FLUENT_COMMAND_FIELDS }
+private val yamlFluentCommandSourceInfoParameter = yamlFluentCommandConstructor.parameters
+    .first { it.name == "_sourceInfo" }
+private val yamlFluentCommandCustomCommandParameter = yamlFluentCommandConstructor.parameters
+    .first { it.name == "customCommand" }
+private val objectCommands = yamlFluentCommandParameters.map { it.name!! }
 
 private const val PARSE_CONTEXT_ATTR = "maestroParseContext"
 
 // Per-parse cache so per-command provenance is O(1) instead of re-tokenizing
 // the full YAML for every command. Offsets reference [source] verbatim — no
 // normalization — so SourceInfo offsets stay aligned with whatever was on disk.
-private class ParseContext(val source: String, val path: String?) {
+internal class ParseContext(
+    val source: String,
+    val path: String?,
+    val customCommands: Map<String, CustomCommandDef> = emptyMap(),
+) {
     val lines: List<String> = source.lines()
     private val lineStarts: IntArray = computeLineStarts(source)
 
@@ -169,7 +178,7 @@ private val stringCommands = mapOf<String, (YamlFluentCommand) -> YamlFluentComm
     "assertNoDefectsWithAI" to { it.copy(assertNoDefectsWithAI = YamlAssertNoDefectsWithAI()) },
 )
 
-private val allCommands = (stringCommands.keys + objectCommands).distinct()
+private val builtInCommands = (stringCommands.keys + objectCommands).distinct()
 
 private const val DOCS_FIRST_FLOW = "https://docs.maestro.dev/getting-started/writing-your-first-flow"
 private const val DOCS_COMMANDS = "https://docs.maestro.dev/api-reference/commands"
@@ -391,7 +400,7 @@ private object YamlCommandDeserializer : JsonDeserializer<YamlFluentCommand>() {
             errorMessage = """
                 |`$commandText` is not a valid command.
                 |
-                |${suggestCommandMessage(commandText)}
+                |${suggestCommandMessage(commandText, ctx)}
             """.trimMargin("|").trim(),
             docs = DOCS_COMMANDS,
         )
@@ -402,13 +411,17 @@ private object YamlCommandDeserializer : JsonDeserializer<YamlFluentCommand>() {
         val commandName = parser.nextFieldName()
         val commandParameter = yamlFluentCommandParameters.firstOrNull { it.name == commandName }
         if (commandParameter == null) {
+            val customDef = ctx.customCommands[commandName]
+            if (customDef != null) {
+                return parseCustomCommandCall(parser, ctx, commandLocation, customDef)
+            }
             throw ParseException(
                 location = parser.currentLocation(),
                 title = "Invalid Command: $commandName",
                 errorMessage = """
                     |`$commandName` is not a valid command.
                     |
-                    |${suggestCommandMessage(commandName)}
+                    |${suggestCommandMessage(commandName, ctx)}
                 """.trimMargin("|").trim(),
             )
         }
@@ -471,7 +484,50 @@ private object YamlCommandDeserializer : JsonDeserializer<YamlFluentCommand>() {
         )
     }
 
-    private fun suggestCommandMessage(invalidCommand: String): String {
+    private fun parseCustomCommandCall(
+        parser: JsonParser,
+        ctx: ParseContext,
+        commandLocation: JsonLocation,
+        def: CustomCommandDef,
+    ): YamlFluentCommand {
+        val next = parser.nextToken()
+        val argsMap: Map<String, Any?> = when (next) {
+            JsonToken.VALUE_NULL -> emptyMap()
+            JsonToken.START_OBJECT -> (parser.codec as ObjectMapper)
+                .readValue(parser, object : TypeReference<Map<String, Any?>>() {})
+            else -> throw ParseException(
+                location = parser.currentLocation(),
+                title = "Invalid Command Format: ${def.name}",
+                errorMessage = """
+                    |Custom command `${def.name}` expects a map of arguments. Example:
+                    |```yaml
+                    |- ${def.name}:
+                    |    argName: value
+                    |```
+                """.trimMargin("|"),
+            )
+        }
+        // Consume the trailing END_OBJECT of the outer command map
+        if (parser.nextToken() != JsonToken.END_OBJECT) {
+            throw ParseException(
+                location = parser.currentLocation(),
+                title = "Invalid Command Format: ${def.name}",
+                errorMessage = "Custom command `${def.name}` must have exactly one entry.",
+            )
+        }
+        val endLocation = parser.currentLocation()
+        return yamlFluentCommandConstructor.callBy(mapOf(
+            yamlFluentCommandSourceInfoParameter to buildSourceInfo(ctx, commandLocation, endLocation),
+            yamlFluentCommandCustomCommandParameter to YamlCustomCommandCall(
+                name = def.name,
+                args = argsMap,
+                def = def,
+            ),
+        ))
+    }
+
+    private fun suggestCommandMessage(invalidCommand: String, ctx: ParseContext): String {
+        val allCommands = (builtInCommands + ctx.customCommands.keys).distinct()
         val prefixCommands = if (invalidCommand.length < 3) emptyList() else allCommands.filter { it.startsWith(invalidCommand) || invalidCommand.startsWith(it) }
         val substringCommands = if (invalidCommand.length < 3) emptyList() else allCommands.filter { it.contains(invalidCommand) || invalidCommand.contains(it) }
         val similarCommands = invalidCommand.findSimilar(allCommands, threshold = 3)
@@ -504,6 +560,11 @@ class FlowParseException(
 
 object MaestroFlowParser {
 
+    val builtInCommandNames: Set<String> = builtInCommands.toSet()
+
+    fun isBuiltInCommand(name: String): Boolean = name in builtInCommandNames
+
+
     private val MAPPER = ObjectMapper(YAMLFactory().apply {
         disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)
     }).apply {
@@ -513,8 +574,12 @@ object MaestroFlowParser {
         })
     }
 
-    fun parseFlow(flowPath: Path, flow: String): List<MaestroCommand> {
-        val ctx = parseContextFor(flow, flowPath)
+    fun parseFlow(
+        flowPath: Path,
+        flow: String,
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
+    ): List<MaestroCommand> {
+        val ctx = parseContextFor(flow, flowPath, customCommands)
         MAPPER.createParser(flow).use { parser ->
             try {
                 val config = parseConfig(parser, ctx)
@@ -529,8 +594,13 @@ object MaestroFlowParser {
         }
     }
 
-    fun parseCommand(flowPath: Path, appId: String, command: String): List<MaestroCommand> {
-        val ctx = parseContextFor(command, flowPath)
+    fun parseCommand(
+        flowPath: Path,
+        appId: String,
+        command: String,
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
+    ): List<MaestroCommand> {
+        val ctx = parseContextFor(command, flowPath, customCommands)
         MAPPER.createParser(command).use { parser ->
             try {
                 val reader = MAPPER.readerFor(YamlFluentCommand::class.java)
@@ -553,8 +623,16 @@ object MaestroFlowParser {
         }
     }
 
-    private fun parseContextFor(source: String, path: Path?): ParseContext =
-        ParseContext(source = source, path = path?.absolute()?.toString())
+    private fun parseContextFor(
+        source: String,
+        path: Path?,
+        customCommands: Map<String, CustomCommandDef> = emptyMap(),
+    ): ParseContext =
+        ParseContext(
+            source = source,
+            path = path?.absolute()?.toString(),
+            customCommands = customCommands,
+        )
 
     fun parseWorkspaceConfig(configPath: Path, workspaceConfig: String): WorkspaceConfig {
         MAPPER.createParser(workspaceConfig).use { parser ->

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/MaestroFlowParser.kt
@@ -560,10 +560,7 @@ class FlowParseException(
 
 object MaestroFlowParser {
 
-    val builtInCommandNames: Set<String> = builtInCommands.toSet()
-
-    fun isBuiltInCommand(name: String): Boolean = name in builtInCommandNames
-
+    fun isBuiltInCommand(name: String): Boolean = name in builtInCommands
 
     private val MAPPER = ObjectMapper(YAMLFactory().apply {
         disable(YAMLGenerator.Feature.WRITE_DOC_START_MARKER)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCommandReader.kt
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonProcessingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import maestro.orchestra.ApplyConfigurationCommand
+import maestro.orchestra.CustomCommandDef
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.WorkspaceConfig
@@ -40,9 +41,14 @@ object YamlCommandReader {
     private val logger = LoggerFactory.getLogger(YamlCommandReader::class.java)
 
     // If it exists, automatically resolves the initFlow file and inlines the commands into the config
-    fun readCommands(flowPath: Path): List<MaestroCommand> = mapParsingErrors(flowPath) {
+    fun readCommands(flowPath: Path): List<MaestroCommand> = readCommands(flowPath, emptyMap())
+
+    fun readCommands(
+        flowPath: Path,
+        customCommands: Map<String, CustomCommandDef>,
+    ): List<MaestroCommand> = mapParsingErrors(flowPath) {
         val flow = flowPath.readText()
-        MaestroFlowParser.parseFlow(flowPath, flow)
+        MaestroFlowParser.parseFlow(flowPath, flow, customCommands)
     }
 
     fun readSingleCommand(flowPath: Path, appId: String, command: String): List<MaestroCommand> = mapParsingErrors(flowPath) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -33,19 +33,28 @@ data class YamlConfig(
     private val ext: MutableMap<String, Any?> = mutableMapOf<String, Any?>()
 ) {
 
-    // Computed appId: uses url for web flows, _appId for mobile apps
-    // Preserving both fields allows detecting web vs app configuration contexts
-    // Custom-command definition files may omit the app target since they are not runnable flows.
+    // Computed appId: uses url for web flows, _appId for mobile apps.
+    // Preserving both fields allows detecting web vs app configuration contexts.
     val appId: String
 
     init {
-        if (url == null && _appId == null && command == null) {
+        val isCommandDefinition = command != null
+        if (!isCommandDefinition && url == null && _appId == null) {
             throw ConfigParseError("missing_app_target")
         }
         if (arguments != null && command == null) {
             throw SyntaxError("`arguments` declared without `command` name")
         }
-        appId = url ?: _appId ?: ""
+        appId = if (isCommandDefinition) {
+            // Command-definition files have no runtime app target. The empty
+            // string is a placeholder that's never consulted: such files are
+            // excluded from flowsToRun, and their RunFlowCommand has config = null.
+            url ?: _appId ?: ""
+        } else {
+            // Same invariant as before custom commands were added: at least one
+            // of url/_appId is guaranteed non-null by the check above.
+            url ?: _appId!!
+        }
     }
 
     @JsonAnySetter

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -68,7 +68,7 @@ data class YamlConfig(
         return MaestroCommand(ApplyConfigurationCommand(config))
     }
 
-    fun toCustomCommandArguments(): List<CustomCommandArgument>? {
+    internal fun toCustomCommandArguments(): List<CustomCommandArgument>? {
         if (arguments == null) return null
         val ownerCommand = command ?: return null
         val seen = mutableSetOf<String>()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlConfig.kt
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonAnySetter
 import com.fasterxml.jackson.core.JsonLocation
 import maestro.orchestra.ApplyConfigurationCommand
+import maestro.orchestra.CustomCommandArgument
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.MaestroOnFlowComplete
 import maestro.orchestra.MaestroOnFlowStart
+import maestro.orchestra.error.SyntaxError
 import java.nio.file.Path
 
 // Exception for config field validation errors
@@ -26,18 +28,24 @@ data class YamlConfig(
     val onFlowStart: YamlOnFlowStart?,
     val onFlowComplete: YamlOnFlowComplete?,
     val properties: Map<String, String> = emptyMap(),
+    val command: String? = null,
+    val arguments: List<YamlFlowArgument>? = null,
     private val ext: MutableMap<String, Any?> = mutableMapOf<String, Any?>()
 ) {
 
     // Computed appId: uses url for web flows, _appId for mobile apps
     // Preserving both fields allows detecting web vs app configuration contexts
+    // Custom-command definition files may omit the app target since they are not runnable flows.
     val appId: String
 
     init {
-        if (url == null && _appId == null) {
+        if (url == null && _appId == null && command == null) {
             throw ConfigParseError("missing_app_target")
         }
-        appId = url ?: _appId!!
+        if (arguments != null && command == null) {
+            throw SyntaxError("`arguments` declared without `command` name")
+        }
+        appId = url ?: _appId ?: ""
     }
 
     @JsonAnySetter
@@ -53,9 +61,23 @@ data class YamlConfig(
             ext = ext.toMap(),
             onFlowStart = onFlowStart(flowPath),
             onFlowComplete = onFlowComplete(flowPath),
-            properties = properties
+            properties = properties,
+            command = command,
+            arguments = toCustomCommandArguments(),
         )
         return MaestroCommand(ApplyConfigurationCommand(config))
+    }
+
+    fun toCustomCommandArguments(): List<CustomCommandArgument>? {
+        if (arguments == null) return null
+        val ownerCommand = command ?: return null
+        val seen = mutableSetOf<String>()
+        return arguments.map { arg ->
+            if (!seen.add(arg.name)) {
+                throw SyntaxError("Duplicate argument '${arg.name}' on command '$ownerCommand'")
+            }
+            arg.toCustomCommandArgument(ownerCommand)
+        }
     }
 
     private fun onFlowComplete(flowPath: Path): MaestroOnFlowComplete? {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCustomCommandCall.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlCustomCommandCall.kt
@@ -1,0 +1,12 @@
+package maestro.orchestra.yaml
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import maestro.orchestra.CustomCommandDef
+
+data class YamlCustomCommandCall(
+    val name: String,
+    val args: Map<String, Any?>,
+    @JsonIgnore val def: CustomCommandDef,
+    val label: String? = null,
+    val optional: Boolean = false,
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFlowArgument.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFlowArgument.kt
@@ -40,11 +40,8 @@ data class YamlFlowArgument(
             ArgumentType.NUMBER -> requireNumeric(value.toString()) {
                 "Default for argument '$name' on command '$ownerCommand' is not a valid number: $value"
             }
-            ArgumentType.BOOLEAN -> when (value.toString().lowercase()) {
-                "true", "false" -> value.toString().lowercase()
-                else -> throw SyntaxError(
-                    "Default for argument '$name' on command '$ownerCommand' is not a valid boolean: $value"
-                )
+            ArgumentType.BOOLEAN -> requireBoolean(value.toString()) {
+                "Default for argument '$name' on command '$ownerCommand' is not a valid boolean: $value"
             }
         }
     }
@@ -58,4 +55,14 @@ data class YamlFlowArgument(
 internal fun requireNumeric(raw: String, errorMessage: () -> String): String {
     raw.toDoubleOrNull() ?: throw SyntaxError(errorMessage())
     return raw
+}
+
+/**
+ * Returns the lowercase form of [raw] if it is "true" or "false"; otherwise
+ * throws a [SyntaxError] built from [errorMessage].
+ */
+internal fun requireBoolean(raw: String, errorMessage: () -> String): String {
+    val normalized = raw.lowercase()
+    if (normalized != "true" && normalized != "false") throw SyntaxError(errorMessage())
+    return normalized
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFlowArgument.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFlowArgument.kt
@@ -37,12 +37,8 @@ data class YamlFlowArgument(
     private fun coerceDefault(value: Any, type: ArgumentType, ownerCommand: String): String {
         return when (type) {
             ArgumentType.STRING -> value.toString()
-            ArgumentType.NUMBER -> {
-                val asString = value.toString()
-                asString.toDoubleOrNull() ?: throw SyntaxError(
-                    "Default for argument '$name' on command '$ownerCommand' is not a valid number: $asString"
-                )
-                asString
+            ArgumentType.NUMBER -> requireNumeric(value.toString()) {
+                "Default for argument '$name' on command '$ownerCommand' is not a valid number: $value"
             }
             ArgumentType.BOOLEAN -> when (value.toString().lowercase()) {
                 "true", "false" -> value.toString().lowercase()
@@ -52,4 +48,14 @@ data class YamlFlowArgument(
             }
         }
     }
+}
+
+/**
+ * Returns [raw] unchanged if it parses as a number; otherwise throws a [SyntaxError]
+ * built from [errorMessage]. Shared between argument-default validation and
+ * call-site argument coercion.
+ */
+internal fun requireNumeric(raw: String, errorMessage: () -> String): String {
+    raw.toDoubleOrNull() ?: throw SyntaxError(errorMessage())
+    return raw
 }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFlowArgument.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFlowArgument.kt
@@ -1,0 +1,55 @@
+package maestro.orchestra.yaml
+
+import maestro.orchestra.ArgumentType
+import maestro.orchestra.CustomCommandArgument
+import maestro.orchestra.error.SyntaxError
+
+data class YamlFlowArgument(
+    val name: String,
+    val type: String = "string",
+    val required: Boolean = false,
+    val default: Any? = null,
+) {
+
+    fun toCustomCommandArgument(ownerCommand: String): CustomCommandArgument {
+        val parsedType = parseType(type, ownerCommand)
+        val coercedDefault = default?.let { coerceDefault(it, parsedType, ownerCommand) }
+        return CustomCommandArgument(
+            name = name,
+            type = parsedType,
+            required = required,
+            default = coercedDefault,
+        )
+    }
+
+    private fun parseType(raw: String, ownerCommand: String): ArgumentType {
+        return when (raw.lowercase()) {
+            "string" -> ArgumentType.STRING
+            "number" -> ArgumentType.NUMBER
+            "boolean", "bool" -> ArgumentType.BOOLEAN
+            else -> throw SyntaxError(
+                "Invalid argument type '$raw' for command '$ownerCommand'. " +
+                    "Allowed: string, number, boolean."
+            )
+        }
+    }
+
+    private fun coerceDefault(value: Any, type: ArgumentType, ownerCommand: String): String {
+        return when (type) {
+            ArgumentType.STRING -> value.toString()
+            ArgumentType.NUMBER -> {
+                val asString = value.toString()
+                asString.toDoubleOrNull() ?: throw SyntaxError(
+                    "Default for argument '$name' on command '$ownerCommand' is not a valid number: $asString"
+                )
+                asString
+            }
+            ArgumentType.BOOLEAN -> when (value.toString().lowercase()) {
+                "true", "false" -> value.toString().lowercase()
+                else -> throw SyntaxError(
+                    "Default for argument '$name' on command '$ownerCommand' is not a valid boolean: $value"
+                )
+            }
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -571,14 +571,8 @@ data class YamlFluentCommand(
             ArgumentType.NUMBER -> requireNumeric(value.toString()) {
                 "Argument '${spec.name}' for command '$commandName' must be a number, got: $value"
             }
-            ArgumentType.BOOLEAN -> {
-                val asString = value.toString().lowercase()
-                if (asString != "true" && asString != "false") {
-                    throw SyntaxError(
-                        "Argument '${spec.name}' for command '$commandName' must be true or false, got: $value"
-                    )
-                }
-                asString
+            ArgumentType.BOOLEAN -> requireBoolean(value.toString()) {
+                "Argument '${spec.name}' for command '$commandName' must be true or false, got: $value"
             }
         }
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -568,12 +568,8 @@ data class YamlFluentCommand(
     private fun coerceArg(commandName: String, spec: CustomCommandArgument, value: Any): String {
         return when (spec.type) {
             ArgumentType.STRING -> value.toString()
-            ArgumentType.NUMBER -> {
-                val asString = value.toString()
-                asString.toDoubleOrNull() ?: throw SyntaxError(
-                    "Argument '${spec.name}' for command '$commandName' must be a number, got: $asString"
-                )
-                asString
+            ArgumentType.NUMBER -> requireNumeric(value.toString()) {
+                "Argument '${spec.name}' for command '$commandName' must be a number, got: $value"
             }
             ArgumentType.BOOLEAN -> {
                 val asString = value.toString().lowercase()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -526,6 +526,7 @@ data class YamlFluentCommand(
                 config = null,
                 label = call.label,
                 optional = call.optional,
+                customCommandName = call.name,
             )
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -25,7 +25,9 @@ import maestro.KeyCode
 import maestro.Point
 import maestro.TapRepeat
 import maestro.orchestra.AddMediaCommand
+import maestro.orchestra.ArgumentType
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.CustomCommandArgument
 import maestro.orchestra.AssertNoDefectsWithAICommand
 import maestro.orchestra.AssertScreenshotCommand
 import maestro.orchestra.AssertWithAICommand
@@ -141,6 +143,7 @@ data class YamlFluentCommand(
     val setAirplaneMode: YamlSetAirplaneMode? = null,
     val toggleAirplaneMode: YamlToggleAirplaneMode? = null,
     val retry: YamlRetryCommand? = null,
+    @JsonIgnore val customCommand: YamlCustomCommandCall? = null,
     @JsonIgnore val _sourceInfo: SourceInfo,
 ) {
 
@@ -483,6 +486,8 @@ data class YamlFluentCommand(
                 )
             )
 
+            customCommand != null -> listOf(buildCustomCommandRunFlow(customCommand))
+
             else -> throw SyntaxError("Invalid command: No mapping provided for $this")
         }
     }
@@ -507,6 +512,79 @@ data class YamlFluentCommand(
         }
         val mediaAbsolutePathStrings = mediaPaths.mapNotNull { it.absolutePathString() }
         return AddMediaCommand(mediaAbsolutePathStrings, addMedia.label, addMedia.optional)
+    }
+
+    private fun buildCustomCommandRunFlow(call: YamlCustomCommandCall): MaestroCommand {
+        val resolvedArgs = validateAndCoerceArgs(call)
+        // Pass an empty registry into the nested read so the subflow body cannot
+        // invoke another custom command — nesting is disallowed.
+        val body = YamlCommandReader.readCommands(call.def.sourceFile, emptyMap())
+        return MaestroCommand(
+            RunFlowCommand(
+                commands = body.withEnv(resolvedArgs),
+                sourceDescription = call.def.sourceFile.toString(),
+                config = null,
+                label = call.label,
+                optional = call.optional,
+            )
+        )
+    }
+
+    private fun validateAndCoerceArgs(call: YamlCustomCommandCall): Map<String, String> {
+        val def = call.def
+        val knownNames = def.arguments.map { it.name }.toSet()
+        val unknown = call.args.keys - knownNames
+        if (unknown.isNotEmpty()) {
+            throw SyntaxError(
+                "Unknown argument(s) ${unknown.joinToString(", ") { "'$it'" }} for command '${call.name}'. " +
+                    "Allowed: ${knownNames.joinToString(", ")}"
+            )
+        }
+        val result = linkedMapOf<String, String>()
+        for (spec in def.arguments) {
+            val provided = call.args.containsKey(spec.name)
+            val rawValue = call.args[spec.name]
+            if (!provided) {
+                if (spec.required) {
+                    throw SyntaxError("Missing required argument '${spec.name}' for command '${call.name}'")
+                }
+                val default = spec.default
+                if (default != null) {
+                    result[spec.name] = default
+                }
+                continue
+            }
+            if (rawValue == null) {
+                if (spec.required) {
+                    throw SyntaxError("Argument '${spec.name}' for command '${call.name}' may not be null")
+                }
+                continue
+            }
+            result[spec.name] = coerceArg(call.name, spec, rawValue)
+        }
+        return result
+    }
+
+    private fun coerceArg(commandName: String, spec: CustomCommandArgument, value: Any): String {
+        return when (spec.type) {
+            ArgumentType.STRING -> value.toString()
+            ArgumentType.NUMBER -> {
+                val asString = value.toString()
+                asString.toDoubleOrNull() ?: throw SyntaxError(
+                    "Argument '${spec.name}' for command '$commandName' must be a number, got: $asString"
+                )
+                asString
+            }
+            ArgumentType.BOOLEAN -> {
+                val asString = value.toString().lowercase()
+                if (asString != "true" && asString != "false") {
+                    throw SyntaxError(
+                        "Argument '${spec.name}' for command '$commandName' must be true or false, got: $value"
+                    )
+                }
+                asString
+            }
+        }
     }
 
     private fun runFlowCommand(

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -533,7 +533,7 @@ data class YamlFluentCommand(
     private fun validateAndCoerceArgs(call: YamlCustomCommandCall): Map<String, String> {
         val def = call.def
         val knownNames = def.arguments.map { it.name }.toSet()
-        val unknown = call.args.keys - knownNames
+        val unknown = call.args.keys.filterNot { it in knownNames }
         if (unknown.isNotEmpty()) {
             throw SyntaxError(
                 "Unknown argument(s) ${unknown.joinToString(", ") { "'$it'" }} for command '${call.name}'. " +

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -425,6 +425,24 @@ internal class WorkspaceExecutionPlannerTest {
     }
 
     @Test
+    internal fun `022 - malformed command-definition file is skipped during discovery`() {
+        // A subflow YAML with broken syntax should NOT crash the planner — the
+        // file is skipped during the custom-command pre-pass and simply not
+        // registered. The runnable `main.yaml` still produces a valid plan.
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/022_malformed_command_file"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        assertThat(plan.customCommands).isEmpty()
+        assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/022_malformed_command_file/main.yaml"),
+        )
+    }
+
+    @Test
     internal fun `021 - single-file mode picks up subflows commands beside the flow`() {
         val plan = WorkspaceExecutionPlanner.plan(
             input = paths("/workspaces/021_subflows_commands/main.yaml"),

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -377,6 +377,65 @@ internal class WorkspaceExecutionPlannerTest {
     }
 
 
+    @Test
+    internal fun `020 - Nested custom commands are rejected`() {
+        val ex = org.junit.jupiter.api.Assertions.assertThrows(maestro.orchestra.error.SyntaxError::class.java) {
+            WorkspaceExecutionPlanner.plan(
+                input = paths("/workspaces/020_nested_custom_commands"),
+                includeTags = listOf(),
+                excludeTags = listOf(),
+                config = null,
+            )
+        }
+        assertThat(ex.message).contains("nesting is not supported")
+    }
+
+    @Test
+    internal fun `019 - Custom commands are discovered`() {
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/019_custom_commands"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        assertThat(plan.customCommands.keys).containsExactly("greet")
+        val def = plan.customCommands.getValue("greet")
+        assertThat(def.arguments.map { it.name }).containsExactly("who")
+        assertThat(def.arguments.single().required).isTrue()
+        // The command-definition file must NOT show up as a runnable flow.
+        assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/019_custom_commands/mainFlow.yaml"),
+        )
+    }
+
+    @Test
+    internal fun `021 - subflows folder is auto-discovered and excluded from runs`() {
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/021_subflows_commands"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        assertThat(plan.customCommands.keys).containsExactly("greet")
+        assertThat(plan.flowsToRun).containsExactly(
+            path("/workspaces/021_subflows_commands/main.yaml"),
+        )
+    }
+
+    @Test
+    internal fun `021 - single-file mode picks up subflows commands beside the flow`() {
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/021_subflows_commands/main.yaml"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        assertThat(plan.customCommands.keys).containsExactly("greet")
+    }
+
     private fun path(path: String): Path? {
         val clazz = WorkspaceExecutionPlannerTest::class.java
         val resource = clazz.getResource(path)?.toURI()

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -10,8 +10,10 @@ import maestro.device.DeviceOrientation
 import maestro.orchestra.AddMediaCommand
 import maestro.orchestra.AirplaneValue
 import maestro.orchestra.ApplyConfigurationCommand
+import maestro.orchestra.ArgumentType
 import maestro.orchestra.AssertConditionCommand
 import maestro.orchestra.BackPressCommand
+import maestro.orchestra.CustomCommandArgument
 import maestro.orchestra.ClearKeychainCommand
 import maestro.orchestra.ClearStateCommand
 import maestro.orchestra.Command
@@ -882,6 +884,131 @@ internal class YamlCommandReaderTest {
     fun `findUnknownWorkspaceConfigKeys returns null for non-map yaml`() {
         val config = "- launchApp"
         assertThat(YamlCommandReader.findUnknownWorkspaceConfigKeys(config)).isNull()
+    }
+
+    @Test
+    fun customCommandHeader(
+        @YamlFile("034_custom_command_header.yaml") commands: List<Command>,
+    ) {
+        val apply = commands.first() as ApplyConfigurationCommand
+        assertThat(apply.config.command).isEqualTo("takeScreenshotWithContext")
+        assertThat(apply.config.arguments).containsExactly(
+            CustomCommandArgument(name = "label", type = ArgumentType.STRING, required = true, default = null),
+            CustomCommandArgument(name = "region", type = ArgumentType.STRING, required = false, default = "body"),
+            CustomCommandArgument(name = "count", type = ArgumentType.NUMBER, required = false, default = "1"),
+        ).inOrder()
+    }
+
+    private fun parseCallerWithRegistry(callerYaml: String, def: maestro.orchestra.CustomCommandDef): List<MaestroCommand> {
+        val tmp = java.nio.file.Files.createTempFile("caller", ".yaml")
+        tmp.toFile().writeText(callerYaml)
+        return try {
+            YamlCommandReader.readCommands(tmp, mapOf(def.name to def))
+        } finally {
+            tmp.toFile().delete()
+        }
+    }
+
+    @Test
+    fun customCommand_suggestionIncludesRegisteredNames() {
+        val bodyPath = Paths.get(javaClass.getResource("/YamlCommandReaderTest/035_custom_command_body.yaml")!!.toURI())
+        val def = maestro.orchestra.CustomCommandDef(
+            name = "screenshotWithContext",
+            sourceFile = bodyPath,
+            arguments = emptyList(),
+        )
+        val caller = "appId: com.example.app\n---\n- screenshotWithContxt: {}\n"
+        val ex = assertThrows(maestro.orchestra.error.SyntaxError::class.java) { parseCallerWithRegistry(caller, def) }
+        assertThat(ex.detail.orEmpty() + " " + ex.message).contains("screenshotWithContext")
+    }
+
+    @Test
+    fun customCommand_missingRequiredArg_throws() {
+        val bodyPath = Paths.get(javaClass.getResource("/YamlCommandReaderTest/035_custom_command_body.yaml")!!.toURI())
+        val def = maestro.orchestra.CustomCommandDef(
+            name = "greet",
+            sourceFile = bodyPath,
+            arguments = listOf(
+                CustomCommandArgument(name = "who", type = ArgumentType.STRING, required = true, default = null),
+            ),
+        )
+        val caller = "appId: com.example.app\n---\n- greet: {}\n"
+        val ex = assertThrows(maestro.orchestra.error.SyntaxError::class.java) { parseCallerWithRegistry(caller, def) }
+        assertThat(ex.detail.orEmpty() + " " + ex.message).contains("Missing required argument 'who'")
+    }
+
+    @Test
+    fun customCommand_unknownArg_throws() {
+        val bodyPath = Paths.get(javaClass.getResource("/YamlCommandReaderTest/035_custom_command_body.yaml")!!.toURI())
+        val def = maestro.orchestra.CustomCommandDef(
+            name = "greet",
+            sourceFile = bodyPath,
+            arguments = listOf(
+                CustomCommandArgument(name = "who", type = ArgumentType.STRING, required = true, default = null),
+            ),
+        )
+        val caller = "appId: com.example.app\n---\n- greet:\n    who: world\n    bogus: 1\n"
+        val ex = assertThrows(maestro.orchestra.error.SyntaxError::class.java) { parseCallerWithRegistry(caller, def) }
+        assertThat(ex.detail.orEmpty() + " " + ex.message).contains("Unknown argument")
+        assertThat(ex.detail.orEmpty() + " " + ex.message).contains("bogus")
+    }
+
+    @Test
+    fun customCommand_numberTypeMismatch_throws() {
+        val bodyPath = Paths.get(javaClass.getResource("/YamlCommandReaderTest/035_custom_command_body.yaml")!!.toURI())
+        val def = maestro.orchestra.CustomCommandDef(
+            name = "greet",
+            sourceFile = bodyPath,
+            arguments = listOf(
+                CustomCommandArgument(name = "count", type = ArgumentType.NUMBER, required = true, default = null),
+            ),
+        )
+        val caller = "appId: com.example.app\n---\n- greet:\n    count: notANumber\n"
+        val ex = assertThrows(maestro.orchestra.error.SyntaxError::class.java) { parseCallerWithRegistry(caller, def) }
+        assertThat(ex.detail.orEmpty() + " " + ex.message).contains("must be a number")
+    }
+
+    @Test
+    fun customCommand_booleanTypeMismatch_throws() {
+        val bodyPath = Paths.get(javaClass.getResource("/YamlCommandReaderTest/035_custom_command_body.yaml")!!.toURI())
+        val def = maestro.orchestra.CustomCommandDef(
+            name = "greet",
+            sourceFile = bodyPath,
+            arguments = listOf(
+                CustomCommandArgument(name = "flag", type = ArgumentType.BOOLEAN, required = true, default = null),
+            ),
+        )
+        val caller = "appId: com.example.app\n---\n- greet:\n    flag: maybe\n"
+        val ex = assertThrows(maestro.orchestra.error.SyntaxError::class.java) { parseCallerWithRegistry(caller, def) }
+        assertThat(ex.detail.orEmpty() + " " + ex.message).contains("must be true or false")
+    }
+
+    @Test
+    fun customCommandCall_expandsToRunFlowWithDefineVariables() {
+        val bodyPath = Paths.get(javaClass.getResource("/YamlCommandReaderTest/035_custom_command_body.yaml")!!.toURI())
+        val callerPath = Paths.get(javaClass.getResource("/YamlCommandReaderTest/035_custom_command_caller.yaml")!!.toURI())
+
+        val def = maestro.orchestra.CustomCommandDef(
+            name = "greet",
+            sourceFile = bodyPath,
+            arguments = listOf(
+                CustomCommandArgument(name = "who", type = ArgumentType.STRING, required = true, default = null),
+            ),
+        )
+
+        val commands = MaestroFlowParser.parseFlow(
+            flowPath = callerPath,
+            flow = callerPath.toFile().readText(),
+            customCommands = mapOf("greet" to def),
+        )
+
+        val maestroCommands = commands.map(MaestroCommand::asCommand)
+        // [ApplyConfigurationCommand, LaunchAppCommand, RunFlowCommand]
+        assertThat(maestroCommands).hasSize(3)
+        val runFlow = maestroCommands[2] as RunFlowCommand
+        assertThat(runFlow.commands).isNotEmpty()
+        val first = runFlow.commands.first().asCommand() as DefineVariablesCommand
+        assertThat(first.env).containsExactly("who", "world")
     }
 
     private fun commands(vararg commands: Command): List<MaestroCommand> =

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/034_custom_command_header.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/034_custom_command_header.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+command: takeScreenshotWithContext
+arguments:
+  - { name: label, type: string, required: true }
+  - { name: region, type: string, default: body }
+  - { name: count, type: number, default: 1 }
+---
+- takeScreenshot: "${label}_${region}"

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/035_custom_command_body.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/035_custom_command_body.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+command: greet
+arguments:
+  - { name: who, required: true }
+---
+- inputText: "Hello ${who}"

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/035_custom_command_caller.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/035_custom_command_caller.yaml
@@ -1,0 +1,5 @@
+appId: com.example.app
+---
+- launchApp
+- greet:
+    who: "world"

--- a/maestro-orchestra/src/test/resources/workspaces/019_custom_commands/greetCommand.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/019_custom_commands/greetCommand.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+command: greet
+arguments:
+  - { name: who, required: true }
+---
+- inputText: "Hello ${who}"

--- a/maestro-orchestra/src/test/resources/workspaces/019_custom_commands/mainFlow.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/019_custom_commands/mainFlow.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/020_nested_custom_commands/innerCmd.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/020_nested_custom_commands/innerCmd.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+command: inner
+arguments:
+  - { name: x, required: true }
+---
+- inputText: "${x}"

--- a/maestro-orchestra/src/test/resources/workspaces/020_nested_custom_commands/main.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/020_nested_custom_commands/main.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/020_nested_custom_commands/outerCmd.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/020_nested_custom_commands/outerCmd.yaml
@@ -1,0 +1,7 @@
+appId: com.example.app
+command: outer
+arguments:
+  - { name: y, required: true }
+---
+- inner:
+    x: "${y}"

--- a/maestro-orchestra/src/test/resources/workspaces/021_subflows_commands/main.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/021_subflows_commands/main.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- greet:
+    who: "world"

--- a/maestro-orchestra/src/test/resources/workspaces/021_subflows_commands/subflows/greet.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/021_subflows_commands/subflows/greet.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+command: greet
+arguments:
+  - { name: who, required: true }
+---
+- inputText: "Hello ${who}"

--- a/maestro-orchestra/src/test/resources/workspaces/022_malformed_command_file/main.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/022_malformed_command_file/main.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp

--- a/maestro-orchestra/src/test/resources/workspaces/022_malformed_command_file/subflows/broken.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/022_malformed_command_file/subflows/broken.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+command: broken
+arguments:
+  - [this is, not, a valid mapping
+---
+- launchApp

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -4933,4 +4933,41 @@ class IntegrationTest {
         return YamlCommandReader.readCommands(flowPath)
             .withEnv(withEnv().withDefaultEnvVars(flowPath.toFile(), deviceId, shardIndex))
     }
+
+    @Test
+    fun `Case 100 - Custom command invocation runs subflow with provided args`() {
+        // Given: a registered custom command "greet" that does inputText: "Hello ${who}".
+        val greetBodyPath = Paths.get(
+            javaClass.classLoader.getResource("100_custom_command_greet.yaml")!!.toURI()
+        )
+        val callerPath = Paths.get(
+            javaClass.classLoader.getResource("100_custom_command_caller.yaml")!!.toURI()
+        )
+        val def = maestro.orchestra.CustomCommandDef(
+            name = "greet",
+            sourceFile = greetBodyPath,
+            arguments = listOf(
+                maestro.orchestra.CustomCommandArgument(
+                    name = "who",
+                    type = maestro.orchestra.ArgumentType.STRING,
+                    required = true,
+                    default = null,
+                ),
+            ),
+        )
+        val commands = YamlCommandReader.readCommands(callerPath, mapOf("greet" to def))
+
+        val driver = driver { }
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        driver.assertHasEvent(Event.InputText("Hello world"))
+        driver.assertCurrentTextInput("Hello world")
+    }
 }

--- a/maestro-test/src/test/resources/100_custom_command_caller.yaml
+++ b/maestro-test/src/test/resources/100_custom_command_caller.yaml
@@ -1,0 +1,4 @@
+appId: com.example.app
+---
+- greet:
+    who: "world"

--- a/maestro-test/src/test/resources/100_custom_command_greet.yaml
+++ b/maestro-test/src/test/resources/100_custom_command_greet.yaml
@@ -1,0 +1,6 @@
+appId: com.example.app
+command: greet
+arguments:
+  - { name: who, required: true }
+---
+- inputText: "Hello ${who}"


### PR DESCRIPTION
## Proposed changes

Adds support for declaring custom commands directly in YAML flows. A flow file can declare itself as a reusable, first-class command via a `command:` + `arguments:` header in its config block; callers invoke it like a built-in instead of going through `runFlow:` + `env:`.

**Example — declare:**
```yaml
# subflows/greet.yaml
appId: com.example
command: greet
arguments:
  - { name: who,   type: string,  required: true }
  - { name: count, type: number,  default: 1 }
---
- inputText: "Hello \${who}"
```

**Example — call:**
```yaml
- greet:
    who: world
```

Highlights:
- Workspace mode auto-registers any flow with a `command:` header.
- Single-file mode (`maestro test foo.yaml`) auto-discovers commands from `<flow parent>/subflows/`.
- Arguments support `string` / `number` / `boolean` with `required` and `default`.
- Parse-time validation: unknown keys, missing required, type mismatch.
- Custom-command bodies cannot invoke other custom commands (no nesting); enforced explicitly during the workspace pre-pass.
- A custom-command call desugars at parse time into a `RunFlowCommand` with a prepended `DefineVariablesCommand` — **zero changes to `Orchestra`'s dispatcher**.

A cross-cutting fix is bundled: `TestCommand.makeChunkPlans` was reconstructing `ExecutionPlan` and silently dropping the discovered registry — even single-file runs go through chunking, so the registry was being lost between `plan()` and the run. This had no prior visible effect (the registry was always empty before this change) but had to be fixed for the feature to function end-to-end.

## Testing

- New unit tests in `YamlCommandReaderTest` (header parsing, call expansion, all four validation error types, suggestion-list inclusion).
- New planner tests in `WorkspaceExecutionPlannerTest` (workspace-mode discovery, single-file `subflows/` discovery, command-definition files excluded from runnable flows, nested-custom-command rejection, malformed-command-file is skipped during discovery).
- New end-to-end test in `maestro-test/IntegrationTest` (`Case 100`) — drives `Orchestra` with a fake driver and asserts the executed sequence.
- All pre-existing tests continue to pass (`./gradlew :maestro-orchestra-models:test :maestro-orchestra:test :maestro-test:test`).
- **Manual end-to-end against an Android emulator** — full reproduction steps + sample fixtures: https://github.com/mobile-dev-inc/Maestro/pull/3339#issuecomment-4627171336
- Self code-review (Kotlin best practices) — findings + resolutions: https://github.com/mobile-dev-inc/Maestro/pull/3339#issuecomment-4626867318

> Does this need e2e tests? — The feature is parser/orchestra-layer and is covered by integration tests under `maestro-test`. No demo-app change needed.

## Issues fixed

N/A