### PR TITLE
Allow configuring Android driver port

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -62,8 +62,6 @@ import kotlin.io.use
 
 private val logger = LoggerFactory.getLogger(Maestro::class.java)
 
-private const val DefaultDriverHostPort = 7001
-
 class AndroidDriver(
     private val dadb: Dadb,
     hostPort: Int? = null,
@@ -72,7 +70,7 @@ class AndroidDriver(
     private val metricsProvider: Metrics = MetricsProvider.getInstance(),
     ) : Driver {
     private var open = false
-    private val hostPort: Int = hostPort ?: DefaultDriverHostPort
+    private val hostPort: Int = hostPort ?: resolveDriverPort()
 
     private val metrics = metricsProvider.withPrefix("maestro.driver").withTags(mapOf("platform" to "android", "emulatorName" to emulatorName))
 
@@ -1309,6 +1307,13 @@ class AndroidDriver(
         private const val SERVER_LAUNCH_TIMEOUT_MS = 15000L
         private const val MAESTRO_DRIVER_STARTUP_TIMEOUT = "MAESTRO_DRIVER_STARTUP_TIMEOUT"
         private const val WINDOW_UPDATE_TIMEOUT_MS = 750
+
+        private const val DEFAULT_DRIVER_HOST_PORT = 7001
+        private const val ENV_DRIVER_PORT = "ANDROID_DRIVER_PORT"
+
+        private fun resolveDriverPort(): Int {
+            return System.getenv(ENV_DRIVER_PORT)?.toIntOrNull() ?: DEFAULT_DRIVER_HOST_PORT
+        }
 
         private val REGEX_OPTIONS = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE)
 


### PR DESCRIPTION
## Proposed changes
Added support for configuring the Android driver host port via the ANDROID_DRIVER_PORT environment variable.
Preserved the existing default behavior by continuing to use port 7001 when the environment variable is not set or contains an invalid value.
This allows users to avoid port conflicts and run multiple Maestro processes with custom port assignments.
Testing


## Testing

Verified that Maestro continues to use port 7001 when ANDROID_DRIVER_PORT is not set.
Verified that setting ANDROID_DRIVER_PORT causes the Android driver to bind to the specified port.

## Issues fixed
https://github.com/mobile-dev-inc/Maestro/issues/3335