### PR TITLE
feat(cli): per-flow artifact folders + single-flow manifest

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import maestro.ai.cloud.Defect
-import maestro.orchestra.ArtifactFiles
-import maestro.orchestra.ArtifactManifest
 import maestro.orchestra.debug.FlowDebugOutput
 import maestro.orchestra.debug.TestOutputWriter
 import maestro.cli.util.CiUtils
@@ -103,66 +101,43 @@ object TestDebugReporter {
     }
 
     /**
-     * Renames the canonical flow-debug bundle (produced by Maestro's
-     * `ArtifactsGenerator` under [sourceDir]) into [destDir] using CLI's
-     * historic flat naming scheme:
+     * Places a flow's canonical artifact bundle (produced by ArtifactsGenerator
+     * under [sourceDir]) into its own folder under [destDir], preserving the
+     * bundle's clean filenames and `manifest.json` verbatim — the manifest's
+     * relativePaths are already correct relative to the folder.
      *
-     *   sourceDir/commands.json
-     *     -> destDir/commands-[shard-N-]?(flow_name).json
-     *   sourceDir/screenshot-<emoji>-<ts>.png
-     *     -> destDir/screenshot-[shard-N-]?<emoji>-<ts>-(flow_name).png
-     *
-     * `maestro.log` produced by the scoped capture stays inside [sourceDir]
-     * — CLI users already get a session-level log from
-     * `TestDebugReporter.install` → `LogConfig.configure`, so we do not
-     * surface a per-flow log file in the session dir.
-     *
-     * Used by [TestSuiteInteractor.runFlow] which produces its bundle via
-     * Orchestra's `artifactsDir` param.
+     * Folder = sanitized flow name, with a `-shard-N` suffix when sharded and a
+     * `-N` suffix on exact-name collision. Returns the folder, or null if
+     * [sourceDir] does not exist.
      */
-    fun copyToFlatLayout(
+    fun copyBundleToFlowDir(
         sourceDir: Path,
         destDir: Path,
         flowName: String,
-        manifest: ArtifactManifest,
         shardIndex: Int? = null,
-    ) {
-        val shardPrefix = shardIndex?.let { "shard-${it + 1}-" }.orEmpty()
-        val cleanFlow = flowName.replace("/", "_")
+    ): Path? {
         val src = sourceDir.toFile()
-        val dst = destDir.toFile().also { it.mkdirs() }
-        if (!src.exists() || !src.isDirectory) return
+        if (!src.exists() || !src.isDirectory) return null
 
-        // Old bundle filename -> new flat filename, for files we surface in destDir.
-        val renamed = mutableMapOf<String, String>()
-
-        src.resolve(ArtifactFiles.COMMANDS_JSON).takeIf { it.exists() }?.let { file ->
-            val flat = "commands-$shardPrefix($cleanFlow).json"
-            file.copyTo(File(dst, flat), overwrite = true)
-            renamed[ArtifactFiles.COMMANDS_JSON] = flat
-        }
-
-        src.listFiles { _, name -> name.startsWith("screenshot-") && name.endsWith(".png") }
-            ?.forEach { shot ->
-                val match = SCREENSHOT_NAME.matchEntire(shot.name) ?: return@forEach
-                val (emoji, ts) = match.destructured
-                val flat = "screenshot-$shardPrefix$emoji-$ts-($cleanFlow).png"
-                shot.copyTo(File(dst, flat), overwrite = true)
-                renamed[shot.name] = flat
-            }
-
-        // Rewrite the manifest to the flat layout: keep only entries whose file we
-        // surfaced, repointing relativePath at the flat name. maestro.log is not
-        // surfaced per-flow, so its entry drops out.
-        val flatEntries = manifest.entries.mapNotNull { entry ->
-            renamed[entry.relativePath]?.let { entry.copy(relativePath = it) }
-        }
-        File(dst, ArtifactFiles.MANIFEST_JSON).writeText(
-            mapper.writeValueAsString(manifest.copy(entries = flatEntries)),
-        )
+        destDir.toFile().mkdirs()
+        val flowDir = resolveFlowDir(destDir, flowName, shardIndex)
+        Files.createDirectories(flowDir)
+        src.copyRecursively(flowDir.toFile(), overwrite = true)
+        return flowDir
     }
 
-    private val SCREENSHOT_NAME = Regex("screenshot-(.+)-(\\d+)\\.png")
+    private fun resolveFlowDir(destDir: Path, flowName: String, shardIndex: Int?): Path {
+        val cleanFlow = flowName.replace("/", "_")
+        val shardSuffix = shardIndex?.let { "-shard-${it + 1}" }.orEmpty()
+        val base = "$cleanFlow$shardSuffix"
+        var candidate = destDir.resolve(base)
+        var n = 2
+        while (Files.exists(candidate)) {
+            candidate = destDir.resolve("$base-$n")
+            n++
+        }
+        return candidate
+    }
 
     fun deleteOldFiles(days: Long = 14) {
         try {

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -119,7 +119,7 @@ object TestDebugReporter {
         val src = sourceDir.toFile()
         if (!src.exists() || !src.isDirectory) return null
 
-        destDir.toFile().mkdirs()
+        Files.createDirectories(destDir)
         val flowDir = resolveFlowDir(destDir, flowName, shardIndex)
         Files.createDirectories(flowDir)
         src.copyRecursively(flowDir.toFile(), overwrite = true)

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -72,32 +72,19 @@ object TestDebugReporter {
     }
 
     /**
-     * Save debug information about a single flow, after it has finished.
-     * Delegates to [maestro.orchestra.debug.TestOutputWriter] so CLI and cloud
-     * share the same on-disk output format. Used by [TestRunner.runSingle]
-     * (one-shot and continuous modes) which has not been migrated to the
-     * listener-based artifact production yet.
+     * Persists in-memory debug screenshots (analyze per-command + warned shots,
+     * which ArtifactsGenerator does not capture) into [flowDir] with clean names.
+     * FAILED shots are owned by the bundle, so they don't appear here (the
+     * runner no longer captures FAILED into debugOutput).
      */
-    fun saveFlow(flowName: String, debugOutput: FlowDebugOutput, path: Path, shardIndex: Int? = null) {
-        val shardPrefix = shardIndex?.let { "shard-${it + 1}-" }.orEmpty()
-        val logPrefix = shardIndex?.let { "[shard ${it + 1}] " }.orEmpty()
-        val cleanFlow = flowName.replace("/", "_")
-
-        TestOutputWriter.saveCommands(
-            path = path,
-            debugOutput = debugOutput,
-            commandsFilename = "commands-$shardPrefix($cleanFlow).json",
-            logPrefix = logPrefix,
-        )
-
-        val named = debugOutput.screenshots.map { shot ->
+    fun persistDebugScreenshots(debugOutput: FlowDebugOutput, flowDir: Path) {
+        debugOutput.screenshots.forEach { shot ->
             val emoji = TestOutputWriter.emojiFor(shot.status)
-            TestOutputWriter.NamedScreenshot(
-                source = shot.screenshot,
-                filename = "screenshot-$shardPrefix$emoji-${shot.timestamp}-($cleanFlow).png",
+            shot.screenshot.copyTo(
+                File(flowDir.absolutePathString(), "screenshot-$emoji-${shot.timestamp}.png"),
+                overwrite = true,
             )
         }
-        TestOutputWriter.saveScreenshots(path, named)
     }
 
     /**

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -63,8 +63,9 @@ object MaestroCommandRunner {
         aiOutput: FlowAIOutput,
         apiKey: String? = null,
         analyze: Boolean = false,
-        testOutputDir: Path?
-    ): Boolean {
+        testOutputDir: Path?,
+        artifactsDir: Path? = null
+    ): Orchestra.FlowResult {
         val config = YamlCommandReader.getConfig(commands)
         val onFlowComplete = config?.onFlowComplete
         val onFlowStart = config?.onFlowStart
@@ -107,6 +108,7 @@ object MaestroCommandRunner {
         val orchestra = Orchestra(
             maestro = maestro,
             screenshotsDir = testOutputDir?.resolve("screenshots"),
+            artifactsDir = artifactsDir,
             insights = CliInsights,
             onCommandStart = { _, command ->
                 logger.info("${command.description()} RUNNING")
@@ -138,8 +140,6 @@ object MaestroCommandRunner {
                     calculateDuration()
                     error = e
                 }
-
-                ScreenshotUtils.takeDebugScreenshot(maestro, debugOutput, CommandStatus.FAILED)
 
                 if (e !is MaestroException) {
                     throw e
@@ -199,7 +199,7 @@ object MaestroCommandRunner {
             apiKey = apiKey,    
         )
 
-        return orchestra.runFlow(commands).success
+        return orchestra.runFlow(commands)
     }
 
     private fun toCommandStates(

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -23,6 +23,7 @@ import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import maestro.orchestra.yaml.YamlCommandReader
+import maestro.utils.TempFileHandler
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Path
@@ -53,66 +54,62 @@ object TestRunner {
         deviceId: String?,
     ): Int {
         val debugOutput = FlowDebugOutput()
-        var aiOutput = FlowAIOutput(
-            flowName = flowFile.nameWithoutExtension,
-            flowFile = flowFile,
-        )
+        var aiOutput = FlowAIOutput(flowName = flowFile.nameWithoutExtension, flowFile = flowFile)
 
-        val updatedEnv = env
-            .withInjectedShellEnvVars()
-            .withDefaultEnvVars(flowFile, deviceId)
+        val updatedEnv = env.withInjectedShellEnvVars().withDefaultEnvVars(flowFile, deviceId)
 
-        val result = runCatching(resultView, maestro) {
-            val commands = YamlCommandReader.readCommands(flowFile.toPath())
-                .withEnv(updatedEnv)
+        val tempFileHandler = TempFileHandler()
+        val flowBundleDir = tempFileHandler
+            .createTempDirectory("maestro-cli-${flowFile.nameWithoutExtension.replace("/", "_")}-")
+            .toPath()
 
+        try {
+            val commands = YamlCommandReader.readCommands(flowFile.toPath()).withEnv(updatedEnv)
             val flowName = YamlCommandReader.getConfig(commands)?.name ?: flowFile.nameWithoutExtension
             aiOutput = aiOutput.copy(flowName = flowName)
-
             logger.info("Running flow ${flowFile.name}...")
 
-            runBlocking {
-                MaestroCommandRunner.runCommands(
-                    flowName = flowName,
-                    maestro = maestro,
-                    device = device,
-                    view = resultView,
-                    commands = commands,
-                    debugOutput = debugOutput,
-                    aiOutput = aiOutput,
-                    analyze = analyze,
-                    apiKey = apiKey,
-                    testOutputDir = testOutputDir,
-                )
-            }
-        }
-
-        TestDebugReporter.saveFlow(
-            flowName = flowFile.name,
-            debugOutput = debugOutput,
-            path = debugOutputPath,
-        )
-        TestDebugReporter.saveSuggestions(
-            outputs = listOf(aiOutput),
-            path = debugOutputPath,
-        )
-
-        val exception = debugOutput.exception
-        if (exception != null) {
-            PrintUtils.err(exception.message)
-            if (exception is MaestroException.AssertionFailure) {
-                PrintUtils.err(exception.debugMessage)
-            } else if (exception is MaestroException.HideKeyboardFailure) {
-                PrintUtils.err(exception.debugMessage)
-            } else {
-                val debugMessage = (exception as? MaestroException.DriverTimeout)?.debugMessage
-                if (exception is MaestroException.DriverTimeout && debugMessage != null) {
-                    PrintUtils.err(debugMessage)
+            val result = runCatching(resultView, maestro) {
+                runBlocking {
+                    MaestroCommandRunner.runCommands(
+                        flowName = flowName,
+                        maestro = maestro,
+                        device = device,
+                        view = resultView,
+                        commands = commands,
+                        debugOutput = debugOutput,
+                        aiOutput = aiOutput,
+                        analyze = analyze,
+                        apiKey = apiKey,
+                        testOutputDir = testOutputDir,
+                        artifactsDir = flowBundleDir,
+                    )
                 }
             }
-        }
 
-        return if (result.get() == true) 0 else 1
+            val flowDir = TestDebugReporter.copyBundleToFlowDir(flowBundleDir, debugOutputPath, flowName)
+            if (flowDir != null) TestDebugReporter.persistDebugScreenshots(debugOutput, flowDir)
+            TestDebugReporter.saveSuggestions(outputs = listOf(aiOutput), path = debugOutputPath)
+
+            val exception = debugOutput.exception
+            if (exception != null) {
+                PrintUtils.err(exception.message)
+                if (exception is MaestroException.AssertionFailure) {
+                    PrintUtils.err(exception.debugMessage)
+                } else if (exception is MaestroException.HideKeyboardFailure) {
+                    PrintUtils.err(exception.debugMessage)
+                } else {
+                    val debugMessage = (exception as? MaestroException.DriverTimeout)?.debugMessage
+                    if (exception is MaestroException.DriverTimeout && debugMessage != null) {
+                        PrintUtils.err(debugMessage)
+                    }
+                }
+            }
+
+            return if (result.get()?.success == true) 0 else 1
+        } finally {
+            tempFileHandler.close()
+        }
     }
 
     /**

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -179,10 +179,10 @@ class TestSuiteInteractor(
         logger.info("$shardPrefix Running flow $flowName")
 
         // Per-flow staging directory. ArtifactsGenerator writes the canonical
-        // bundle here (commands.json, maestro.log, screenshot-❌-*.png); then
-        // copyToFlatLayout renames the files out into the session dir using
-        // CLI's historic flat naming. TempFileHandler.close() in finally
-        // recursively deletes it (and any other temp files this flow created).
+        // bundle here (commands.json, maestro.log, manifest.json, screenshot-❌-*.png);
+        // then copyBundleToFlowDir copies the whole bundle into its own folder
+        // under the session dir. TempFileHandler.close() in finally recursively
+        // deletes the staging dir.
         val tempFileHandler = TempFileHandler()
         val flowBundleDir = tempFileHandler
             .createTempDirectory("maestro-cli-${flowName.replace("/", "_")}-")

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -15,7 +15,6 @@ import maestro.cli.util.TimeUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
-import maestro.orchestra.ArtifactManifest
 import maestro.orchestra.Orchestra
 import maestro.orchestra.debug.FlowDebugOutput
 import maestro.orchestra.util.Env.withEnv
@@ -190,7 +189,6 @@ class TestSuiteInteractor(
             .toPath()
 
         var debugOutput = FlowDebugOutput()
-        var artifactManifest = ArtifactManifest()
         val flowTimeMillis = measureTimeMillis {
             try {
                 val orchestra = Orchestra(
@@ -214,7 +212,6 @@ class TestSuiteInteractor(
                 val result = orchestra.runFlow(commands)
                 flowStatus = if (result.success) FlowStatus.SUCCESS else FlowStatus.ERROR
                 debugOutput = result.debugOutput
-                artifactManifest = result.artifactManifest
             } catch (e: Exception) {
                 logger.error("${shardPrefix}Failed to complete flow", e)
                 flowStatus = FlowStatus.ERROR
@@ -223,11 +220,10 @@ class TestSuiteInteractor(
         }
         val flowDuration = TimeUtils.durationInSeconds(flowTimeMillis)
         try {
-            TestDebugReporter.copyToFlatLayout(
+            TestDebugReporter.copyBundleToFlowDir(
                 sourceDir = flowBundleDir,
                 destDir = debugOutputPath,
                 flowName = flowName,
-                manifest = artifactManifest,
                 shardIndex = shardIndex,
             )
         } finally {

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
@@ -5,7 +5,6 @@ import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import maestro.cli.util.EnvUtils
-import maestro.orchestra.debug.CommandDebugMetadata
 import maestro.orchestra.debug.CommandStatus
 import maestro.orchestra.debug.FlowDebugOutput
 import org.junit.jupiter.api.BeforeEach
@@ -147,33 +146,16 @@ class TestDebugReporterTest {
     }
 
     @Test
-    fun `saveFlow with shardIndex 2 produces shard-3 prefixed filenames via facade`() {
-        val outputDir = Files.createDirectories(tempDir.resolve("out"))
-        val shot = Files.createFile(tempDir.resolve("raw.png")).toFile()
-        val cmd = maestro.orchestra.MaestroCommand(tapOnElement = null)
-        val debug = FlowDebugOutput().apply {
-            commands[cmd] = CommandDebugMetadata(status = CommandStatus.COMPLETED, timestamp = 1L)
-            screenshots.add(FlowDebugOutput.Screenshot(shot, 555L, CommandStatus.COMPLETED))
+    fun `persistDebugScreenshots writes in-memory shots into the flow folder`() {
+        val flowDir = Files.createDirectories(tempDir.resolve("session/login"))
+        val shot = Files.createTempFile(tempDir, "shot-", ".png").toFile().apply { writeBytes(byteArrayOf(1)) }
+        val debugOutput = FlowDebugOutput().apply {
+            screenshots.add(FlowDebugOutput.Screenshot(screenshot = shot, timestamp = 777L, status = CommandStatus.WARNED))
         }
 
-        TestDebugReporter.saveFlow("my_flow", debug, outputDir, shardIndex = 2)
+        TestDebugReporter.persistDebugScreenshots(debugOutput, flowDir)
 
-        val names = outputDir.toFile().listFiles()!!.map { it.name }
-        assertThat(names).contains("commands-shard-3-(my_flow).json")
-        assertThat(names).contains("screenshot-shard-3-✅-555-(my_flow).png")
-    }
-
-    @Test
-    fun `saveFlow replaces slashes in flow name with underscores in commands filename via facade`() {
-        val outputDir = Files.createDirectories(tempDir.resolve("out"))
-        val cmd = maestro.orchestra.MaestroCommand(tapOnElement = null)
-        val debug = FlowDebugOutput().apply {
-            commands[cmd] = CommandDebugMetadata(status = CommandStatus.COMPLETED)
-        }
-
-        TestDebugReporter.saveFlow("feature/login", debug, outputDir)
-
-        assertThat(outputDir.resolve("commands-(feature_login).json").toFile().exists()).isTrue()
+        assertThat(flowDir.resolve("screenshot-⚠️-777.png").toFile().exists()).isTrue()
     }
 
     @Test

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
@@ -1,16 +1,10 @@
 package maestro.cli.report
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import maestro.cli.util.EnvUtils
-import maestro.orchestra.ArtifactEntry
-import maestro.orchestra.ArtifactFormat
-import maestro.orchestra.ArtifactKind
-import maestro.orchestra.ArtifactManifest
 import maestro.orchestra.debug.CommandDebugMetadata
 import maestro.orchestra.debug.CommandStatus
 import maestro.orchestra.debug.FlowDebugOutput
@@ -183,128 +177,74 @@ class TestDebugReporterTest {
     }
 
     @Test
-    fun `copyToFlatLayout with shardIndex 2 renames canonical files using shard-3 prefix`() {
-        val sourceDir = Files.createDirectories(tempDir.resolve("source"))
-        Files.writeString(sourceDir.resolve("commands.json"), "[]")
-        val rawShot = Files.createFile(sourceDir.resolve("screenshot-✅-555.png")).toFile()
-        rawShot.writeBytes(byteArrayOf(1, 2, 3))
-        val destDir = Files.createDirectories(tempDir.resolve("dest"))
-
-        TestDebugReporter.copyToFlatLayout(
-            sourceDir = sourceDir,
-            destDir = destDir,
-            flowName = "my_flow",
-            manifest = ArtifactManifest(),
-            shardIndex = 2,
-        )
-
-        val names = destDir.toFile().listFiles()!!.map { it.name }
-        assertThat(names).contains("commands-shard-3-(my_flow).json")
-        assertThat(names).contains("screenshot-shard-3-✅-555-(my_flow).png")
-        // Source is untouched (renamer copies, doesn't move).
-        assertThat(sourceDir.resolve("commands.json").toFile().exists()).isTrue()
-        assertThat(sourceDir.resolve("screenshot-✅-555.png").toFile().exists()).isTrue()
-    }
-
-    @Test
-    fun `copyToFlatLayout manifest carries shard-prefixed flat paths`() {
-        val sourceDir = Files.createDirectories(tempDir.resolve("source"))
-        Files.writeString(sourceDir.resolve("commands.json"), "[]")
-        Files.createFile(sourceDir.resolve("screenshot-❌-555.png")).toFile()
-            .writeBytes(byteArrayOf(1, 2, 3))
-        val destDir = Files.createDirectories(tempDir.resolve("dest"))
-
-        val manifest = ArtifactManifest(
-            entries = listOf(
-                ArtifactEntry(ArtifactKind.COMMAND_METADATA, ArtifactFormat.JSON, "commands.json", sizeBytes = 2),
-                ArtifactEntry(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshot-❌-555.png", sizeBytes = 3),
-            ),
-        )
-
-        TestDebugReporter.copyToFlatLayout(
-            sourceDir = sourceDir,
-            destDir = destDir,
-            flowName = "my_flow",
-            manifest = manifest,
-            shardIndex = 2,
-        )
-
-        val decoded = jacksonObjectMapper().readValue<ArtifactManifest>(
-            destDir.resolve("manifest.json").toFile().readText(),
-        )
-        val byKind = decoded.entries.associateBy { it.kind }
-        assertThat(byKind[ArtifactKind.COMMAND_METADATA]!!.relativePath)
-            .isEqualTo("commands-shard-3-(my_flow).json")
-        assertThat(byKind[ArtifactKind.SCREENSHOT]!!.relativePath)
-            .isEqualTo("screenshot-shard-3-❌-555-(my_flow).png")
-    }
-
-    @Test
-    fun `copyToFlatLayout replaces slashes in flow name with underscores`() {
-        val sourceDir = Files.createDirectories(tempDir.resolve("source"))
-        Files.writeString(sourceDir.resolve("commands.json"), "[]")
-        val destDir = Files.createDirectories(tempDir.resolve("dest"))
-
-        TestDebugReporter.copyToFlatLayout(
-            sourceDir = sourceDir,
-            destDir = destDir,
-            flowName = "feature/login",
-            manifest = ArtifactManifest(),
-        )
-
-        assertThat(destDir.resolve("commands-(feature_login).json").toFile().exists()).isTrue()
-    }
-
-    @Test
-    fun `copyToFlatLayout is a no-op when sourceDir does not exist`() {
-        val missingSource = tempDir.resolve("does-not-exist")
-        val destDir = Files.createDirectories(tempDir.resolve("dest"))
-
-        // Must not throw.
-        TestDebugReporter.copyToFlatLayout(
-            sourceDir = missingSource,
-            destDir = destDir,
-            flowName = "my_flow",
-            manifest = ArtifactManifest(),
-        )
-
-        // Early return fires before any copy or manifest.json write, so destDir stays empty.
-        assertThat(destDir.toFile().listFiles()?.toList().orEmpty()).isEmpty()
-    }
-
-    @Test
-    fun `copyToFlatLayout writes a manifest with flat-renamed paths and drops unsurfaced entries`() {
-        val sourceDir = Files.createDirectories(tempDir.resolve("source"))
+    fun `copyBundleToFlowDir places the bundle in a per-flow folder with clean names`() {
+        val sourceDir = Files.createDirectories(tempDir.resolve("bundle"))
         Files.writeString(sourceDir.resolve("commands.json"), "[]")
         Files.writeString(sourceDir.resolve("maestro.log"), "log")
-        Files.createFile(sourceDir.resolve("screenshot-❌-555.png")).toFile()
-            .writeBytes(byteArrayOf(1, 2, 3))
-        val destDir = Files.createDirectories(tempDir.resolve("dest"))
+        Files.writeString(sourceDir.resolve("manifest.json"), """{"schemaVersion":1,"entries":[]}""")
+        Files.createFile(sourceDir.resolve("screenshot-❌-555.png")).toFile().writeBytes(byteArrayOf(1, 2, 3))
+        val destDir = Files.createDirectories(tempDir.resolve("session"))
 
-        val manifest = ArtifactManifest(
-            entries = listOf(
-                ArtifactEntry(ArtifactKind.COMMAND_METADATA, ArtifactFormat.JSON, "commands.json", sizeBytes = 2),
-                ArtifactEntry(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, "maestro.log", sizeBytes = 3),
-                ArtifactEntry(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshot-❌-555.png", sizeBytes = 3),
-            ),
-        )
+        val flowDir = TestDebugReporter.copyBundleToFlowDir(sourceDir, destDir, flowName = "login")
 
-        TestDebugReporter.copyToFlatLayout(
-            sourceDir = sourceDir,
-            destDir = destDir,
-            flowName = "my_flow",
-            manifest = manifest,
-        )
+        assertThat(flowDir).isEqualTo(destDir.resolve("login"))
+        val names = flowDir!!.toFile().listFiles()!!.map { it.name }.toSet()
+        assertThat(names).containsExactly("commands.json", "maestro.log", "manifest.json", "screenshot-❌-555.png")
+    }
 
-        val manifestFile = destDir.resolve("manifest.json").toFile()
-        assertThat(manifestFile.exists()).isTrue()
+    @Test
+    fun `copyBundleToFlowDir keeps each flow in its own folder - no clobber`() {
+        fun bundle(name: String): Path {
+            val d = Files.createDirectories(tempDir.resolve("bundle-$name"))
+            Files.writeString(d.resolve("commands.json"), "[\"$name\"]")
+            Files.writeString(d.resolve("manifest.json"), """{"schemaVersion":1,"entries":[]}""")
+            return d
+        }
+        val destDir = Files.createDirectories(tempDir.resolve("session"))
 
-        val decoded = jacksonObjectMapper().readValue<ArtifactManifest>(manifestFile.readText())
-        val byKind = decoded.entries.associateBy { it.kind }
-        // maestro.log is not surfaced per-flow, so it drops out of the flat manifest.
-        assertThat(byKind.keys).containsExactly(ArtifactKind.COMMAND_METADATA, ArtifactKind.SCREENSHOT)
-        assertThat(byKind[ArtifactKind.COMMAND_METADATA]!!.relativePath).isEqualTo("commands-(my_flow).json")
-        assertThat(byKind[ArtifactKind.SCREENSHOT]!!.relativePath).isEqualTo("screenshot-❌-555-(my_flow).png")
+        TestDebugReporter.copyBundleToFlowDir(bundle("a"), destDir, flowName = "a")
+        TestDebugReporter.copyBundleToFlowDir(bundle("b"), destDir, flowName = "b")
+
+        assertThat(Files.readString(destDir.resolve("a/commands.json"))).isEqualTo("[\"a\"]")
+        assertThat(Files.readString(destDir.resolve("b/commands.json"))).isEqualTo("[\"b\"]")
+    }
+
+    @Test
+    fun `copyBundleToFlowDir sanitizes slashes and applies shard suffix`() {
+        val sourceDir = Files.createDirectories(tempDir.resolve("bundle"))
+        Files.writeString(sourceDir.resolve("commands.json"), "[]")
+        val destDir = Files.createDirectories(tempDir.resolve("session"))
+
+        val flowDir = TestDebugReporter.copyBundleToFlowDir(sourceDir, destDir, flowName = "feature/login", shardIndex = 2)
+
+        assertThat(flowDir).isEqualTo(destDir.resolve("feature_login-shard-3"))
+        assertThat(flowDir!!.resolve("commands.json").toFile().exists()).isTrue()
+    }
+
+    @Test
+    fun `copyBundleToFlowDir disambiguates same-name flows with a numeric suffix`() {
+        fun bundle(): Path {
+            val d = Files.createTempDirectory(tempDir, "bundle-")
+            Files.writeString(d.resolve("commands.json"), "[]")
+            return d
+        }
+        val destDir = Files.createDirectories(tempDir.resolve("session"))
+
+        val first = TestDebugReporter.copyBundleToFlowDir(bundle(), destDir, flowName = "dup")
+        val second = TestDebugReporter.copyBundleToFlowDir(bundle(), destDir, flowName = "dup")
+
+        assertThat(first).isEqualTo(destDir.resolve("dup"))
+        assertThat(second).isEqualTo(destDir.resolve("dup-2"))
+    }
+
+    @Test
+    fun `copyBundleToFlowDir returns null and writes nothing when sourceDir is absent`() {
+        val destDir = Files.createDirectories(tempDir.resolve("session"))
+
+        val flowDir = TestDebugReporter.copyBundleToFlowDir(tempDir.resolve("missing"), destDir, flowName = "x")
+
+        assertThat(flowDir).isNull()
+        assertThat(destDir.toFile().listFiles()?.toList().orEmpty()).isEmpty()
     }
 
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
@@ -190,6 +190,8 @@ class TestDebugReporterTest {
         assertThat(flowDir).isEqualTo(destDir.resolve("login"))
         val names = flowDir!!.toFile().listFiles()!!.map { it.name }.toSet()
         assertThat(names).containsExactly("commands.json", "maestro.log", "manifest.json", "screenshot-❌-555.png")
+        assertThat(Files.readString(flowDir!!.resolve("manifest.json")))
+            .isEqualTo("""{"schemaVersion":1,"entries":[]}""")
     }
 
     @Test


### PR DESCRIPTION
> **Note (folded into #3343):** This PR was not merged to `main` independently. Its branch `feat/cli-per-flow-artifact-folders` was fast-forward merged into its base branch `feat/orchestra-artifact-manifest` (#3343), so #3343 now carries this per-flow-folder + single-flow-manifest work together with the typed-manifest change. GitHub auto-closed this PR as "merged" because its commits now live in its base. Review and land this work as part of **#3343**. The follow-up device-log work branches off #3343.

---

Stacked on the artifact-manifest PR. Restructures the CLI's debug output from a flat session dir into **per-flow folders**, and migrates the single-flow run path so it produces a manifest too.

## Why
Today the CLI flattens every flow's artifacts into one `~/.maestro/tests/<ts>/` dir with flow-suffixed names (`commands-(login).json`), so a large multi-flow upload is an unreadable pile, the per-flow `manifest.json` clobbers (only the last flow survives), and a single-flow `maestro test x.yaml` produces no manifest at all (it ran through the un-migrated `runSingle`/`saveFlow` path).

## What
- **Per-flow folders.** Each flow's canonical bundle is copied wholesale into `~/.maestro/tests/<ts>/<flow>/` with clean names. New `TestDebugReporter.copyBundleToFlowDir` (recursive copy; folder = sanitized flow name, `-shard-N` when sharded, `-N` on collision) replaces `copyToFlatLayout` (deleted, along with its rename + manifest-rewrite machinery). The manifest's relative paths are already correct, so it's copied verbatim — no rewriting.
- **Single-flow migration.** `MaestroCommandRunner.runCommands` gains `artifactsDir` and returns `Orchestra.FlowResult`; `runSingle` now produces a bundle and writes a per-flow folder + manifest, just like the suite path. `saveFlow` is removed (its only caller). `runContinuous` is unchanged (`artifactsDir = null`).
- **Screenshot ownership.** `ArtifactsGenerator` owns the failure screenshot (into the bundle); `MaestroCommandRunner` drops only its `onCommandFailed` capture but keeps WARNED + analyze per-command captures, which `runSingle` persists into the flow folder via `persistDebugScreenshots` — so no duplicate failure shot, and analyze/warned coverage is preserved.

## Result (verified on a real iOS sim)
- `maestro test single.yaml` → `<ts>/single/{commands.json, maestro.log, manifest.json, screenshot-❌-*.png}` — manifest now present (COMMAND_METADATA, MAESTRO_LOG, SCREENSHOT).
- `maestro test <workspace>` → `<ts>/flow_a/` and `<ts>/flow_b/`, each with its own `manifest.json` — no clobber.

## Notes / for reviewer 
- This **changes the `~/.maestro/tests/` layout** (flat → nested) and does the **`runSingle` → listener/`artifactsDir` migration that #3282 deferred** — both squarely in your area, flagging for awareness.
- Layout consumers are unaffected: `TestAnalysisManager.processDebugFiles` uses a recursive `Files.walk` and matches by filename; the MCP `logsDir` and `CloudInteractor` use the session root.
- `--flatten-debug-output` (root-location) semantics unchanged.
- Device/session logs (root `maestro.log` from `LogConfig`, the driver's `xctest_runner.log`) remain session-level and are not in the per-flow manifest — they're produced below Orchestra; unifying those is a separate device-artifact-seam follow-up.

## Tests
- `:maestro-cli:test` green (new `copyBundleToFlowDir` + `persistDebugScreenshots` tests; old `copyToFlatLayout`/`saveFlow` tests removed).
- Manual: single + suite runs verified on `iphone_11_ios_17`.
