### PR TITLE
feat(orchestra): takeScreenshot/startRecording artifact folders + manifest entries

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -158,7 +158,6 @@ class RecordCommand : Callable<Int> {
                             env,
                             resultView,
                             path,
-                            testOutputDir = null,
                             deviceId = parent?.deviceId,
                         )
                     }

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -294,7 +294,7 @@ class TestCommand : Callable<Int> {
         val deviceCount = getDeviceCount(executionPlan)
 
         val result = try {
-            handleSessions(debugOutputPath, executionPlan, resolvedTestOutputDir)
+            handleSessions(debugOutputPath, executionPlan)
         } catch (e: Exception) {
             // Track workspace failure for runtime errors
             if (flowCount > 1) {
@@ -355,7 +355,7 @@ class TestCommand : Callable<Int> {
         return null
     }
 
-    private fun handleSessions(debugOutputPath: Path, plan: ExecutionPlan, testOutputDir: Path?): Int = runBlocking(Dispatchers.IO) {
+    private fun handleSessions(debugOutputPath: Path, plan: ExecutionPlan): Int = runBlocking(Dispatchers.IO) {
         val requestedShards = shardSplit ?: shardAll ?: 1
         if (requestedShards > 1 && plan.sequence.flows.isNotEmpty()) {
             error("Cannot run sharded tests with sequential execution")
@@ -441,7 +441,6 @@ class TestCommand : Callable<Int> {
                     shardIndex = shardIndex,
                     chunkPlans = chunkPlans,
                     debugOutputPath = debugOutputPath,
-                    testOutputDir = testOutputDir,
                 )
             }
         }.awaitAll()
@@ -468,7 +467,6 @@ class TestCommand : Callable<Int> {
         shardIndex: Int,
         chunkPlans: List<ExecutionPlan>,
         debugOutputPath: Path,
-        testOutputDir: Path?,
     ): Triple<Int?, Int?, TestExecutionSummary?> {
         val driverHostPort = selectPort(effectiveShards)
         val deviceId = deviceIds[shardIndex]
@@ -508,7 +506,6 @@ class TestCommand : Callable<Int> {
                         chunkPlans,
                         shardIndex,
                         debugOutputPath,
-                        testOutputDir,
                         deviceId,
                     )
                 }
@@ -525,11 +522,10 @@ class TestCommand : Callable<Int> {
                         env,
                         analyze,
                         authToken,
-                        testOutputDir,
                         deviceId,
                     )
                 } else {
-                    runSingleFlow(maestro, device, flowFile, debugOutputPath, testOutputDir, deviceId)
+                    runSingleFlow(maestro, device, flowFile, debugOutputPath, deviceId)
                 }
             }
         }
@@ -553,7 +549,6 @@ class TestCommand : Callable<Int> {
         device: Device?,
         flowFile: File,
         debugOutputPath: Path,
-        testOutputDir: Path?,
         deviceId: String?,
     ): Triple<Int, Int, Nothing?> {
         val resultView =
@@ -577,7 +572,6 @@ class TestCommand : Callable<Int> {
             debugOutputPath = debugOutputPath,
             analyze = analyze,
             apiKey = authToken,
-            testOutputDir = testOutputDir,
             deviceId = deviceId,
         )
         val duration = System.currentTimeMillis() - startTime
@@ -609,7 +603,6 @@ class TestCommand : Callable<Int> {
         chunkPlans: List<ExecutionPlan>,
         shardIndex: Int,
         debugOutputPath: Path,
-        testOutputDir: Path?,
         deviceId: String?,
     ): Triple<Int?, Int?, TestExecutionSummary> {
         val startTime = System.currentTimeMillis()
@@ -631,7 +624,6 @@ class TestCommand : Callable<Int> {
             env = env,
             reportOut = null,
             debugOutputPath = debugOutputPath,
-            testOutputDir = testOutputDir,
             deviceId = deviceId,
         )
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -151,7 +151,7 @@ class TestCommand : Callable<Int> {
 
     @Option(
         names = ["--test-output-dir"],
-        description = ["Configures the test output directory for screenshots and other test artifacts (note: this does NOT include debug output)"],
+        description = ["Directory for this run's artifacts — screenshots, recordings, logs, commands.json, and manifest.json (overrides the default output location)"],
     )
     private var testOutputDir: String? = null
 

--- a/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/TestDebugReporter.kt
@@ -88,28 +88,16 @@ object TestDebugReporter {
     }
 
     /**
-     * Places a flow's canonical artifact bundle (produced by ArtifactsGenerator
-     * under [sourceDir]) into its own folder under [destDir], preserving the
-     * bundle's clean filenames and `manifest.json` verbatim — the manifest's
-     * relativePaths are already correct relative to the folder.
+     * Resolves and creates a flow's own output folder under [destDir], which
+     * Orchestra then writes its artifact bundle into directly.
      *
      * Folder = sanitized flow name, with a `-shard-N` suffix when sharded and a
-     * `-N` suffix on exact-name collision. Returns the folder, or null if
-     * [sourceDir] does not exist.
+     * `-N` suffix on exact-name collision.
      */
-    fun copyBundleToFlowDir(
-        sourceDir: Path,
-        destDir: Path,
-        flowName: String,
-        shardIndex: Int? = null,
-    ): Path? {
-        val src = sourceDir.toFile()
-        if (!src.exists() || !src.isDirectory) return null
-
+    fun createFlowDir(destDir: Path, flowName: String, shardIndex: Int? = null): Path {
         Files.createDirectories(destDir)
         val flowDir = resolveFlowDir(destDir, flowName, shardIndex)
         Files.createDirectories(flowDir)
-        src.copyRecursively(flowDir.toFile(), overwrite = true)
         return flowDir
     }
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -107,7 +107,10 @@ object MaestroCommandRunner {
 
         val orchestra = Orchestra(
             maestro = maestro,
-            screenshotsDir = testOutputDir?.resolve("screenshots"),
+            // When artifactsDir is set (single-run), both fields share the same root so takeScreenshot/
+            // startRecording output lands alongside the artifact bundle. When null (continuous mode),
+            // screenshotsDir falls back to testOutputDir and artifactsDir stays null (ArtifactsGenerator inactive).
+            screenshotsDir = artifactsDir ?: testOutputDir,
             artifactsDir = artifactsDir,
             insights = CliInsights,
             onCommandStart = { _, command ->

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -107,11 +107,9 @@ object MaestroCommandRunner {
 
         val orchestra = Orchestra(
             maestro = maestro,
-            // When artifactsDir is set (single-run), both fields share the same root so takeScreenshot/
-            // startRecording output lands alongside the artifact bundle. When null (continuous mode),
-            // screenshotsDir falls back to testOutputDir and artifactsDir stays null (ArtifactsGenerator inactive).
-            screenshotsDir = artifactsDir ?: testOutputDir,
             artifactsDir = artifactsDir,
+            // Single-run uses artifactsDir as the media root; continuous mode has no bundle, so persist media under testOutputDir.
+            screenshotsDir = if (artifactsDir == null) testOutputDir else null,
             insights = CliInsights,
             onCommandStart = { _, command ->
                 logger.info("${command.description()} RUNNING")

--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -63,7 +63,6 @@ object MaestroCommandRunner {
         aiOutput: FlowAIOutput,
         apiKey: String? = null,
         analyze: Boolean = false,
-        testOutputDir: Path?,
         artifactsDir: Path? = null
     ): Orchestra.FlowResult {
         val config = YamlCommandReader.getConfig(commands)
@@ -108,8 +107,6 @@ object MaestroCommandRunner {
         val orchestra = Orchestra(
             maestro = maestro,
             artifactsDir = artifactsDir,
-            // Single-run uses artifactsDir as the media root; continuous mode has no bundle, so persist media under testOutputDir.
-            screenshotsDir = if (artifactsDir == null) testOutputDir else null,
             insights = CliInsights,
             onCommandStart = { _, command ->
                 logger.info("${command.description()} RUNNING")

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -23,7 +23,6 @@ import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import maestro.orchestra.yaml.YamlCommandReader
-import maestro.utils.TempFileHandler
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Path
@@ -50,7 +49,6 @@ object TestRunner {
         debugOutputPath: Path,
         analyze: Boolean = false,
         apiKey: String? = null,
-        testOutputDir: Path?,
         deviceId: String?,
     ): Int {
         val debugOutput = FlowDebugOutput()
@@ -63,49 +61,39 @@ object TestRunner {
             .withInjectedShellEnvVars()
             .withDefaultEnvVars(flowFile, deviceId)
 
+        val commands = YamlCommandReader.readCommands(flowFile.toPath()).withEnv(updatedEnv)
+        val flowName = YamlCommandReader.getConfig(commands)?.name ?: flowFile.nameWithoutExtension
+        aiOutput = aiOutput.copy(flowName = flowName)
+        logger.info("Running flow ${flowFile.name}...")
+
         // ArtifactsGenerator writes the canonical bundle (commands.json, maestro.log,
-        // manifest.json, failure screenshot) here; copyBundleToFlowDir then places it
-        // in a per-flow folder under debugOutputPath. Closed in finally so the staging
-        // dir never leaks.
-        val tempFileHandler = TempFileHandler()
-        val flowBundleDir = tempFileHandler
-            .createTempDirectory("maestro-cli-${flowFile.nameWithoutExtension.replace("/", "_")}-")
-            .toPath()
+        // manifest.json, screenshots/, recordings/, failure screenshot) straight into
+        // this per-flow folder.
+        val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName)
 
-        try {
-            val commands = YamlCommandReader.readCommands(flowFile.toPath()).withEnv(updatedEnv)
-            val flowName = YamlCommandReader.getConfig(commands)?.name ?: flowFile.nameWithoutExtension
-            aiOutput = aiOutput.copy(flowName = flowName)
-            logger.info("Running flow ${flowFile.name}...")
-
-            val result = runCatching(resultView, maestro) {
-                runBlocking {
-                    MaestroCommandRunner.runCommands(
-                        flowName = flowName,
-                        maestro = maestro,
-                        device = device,
-                        view = resultView,
-                        commands = commands,
-                        debugOutput = debugOutput,
-                        aiOutput = aiOutput,
-                        analyze = analyze,
-                        apiKey = apiKey,
-                        testOutputDir = testOutputDir,
-                        artifactsDir = flowBundleDir,
-                    )
-                }
+        val result = runCatching(resultView, maestro) {
+            runBlocking {
+                MaestroCommandRunner.runCommands(
+                    flowName = flowName,
+                    maestro = maestro,
+                    device = device,
+                    view = resultView,
+                    commands = commands,
+                    debugOutput = debugOutput,
+                    aiOutput = aiOutput,
+                    analyze = analyze,
+                    apiKey = apiKey,
+                    artifactsDir = flowDir,
+                )
             }
-
-            val flowDir = TestDebugReporter.copyBundleToFlowDir(flowBundleDir, debugOutputPath, flowName)
-            if (flowDir != null) TestDebugReporter.persistDebugScreenshots(debugOutput, flowDir)
-            TestDebugReporter.saveSuggestions(outputs = listOf(aiOutput), path = debugOutputPath)
-
-            debugOutput.exception?.let { printFlowError(it) }
-
-            return if (result.get()?.success == true) 0 else 1
-        } finally {
-            tempFileHandler.close()
         }
+
+        TestDebugReporter.persistDebugScreenshots(debugOutput, flowDir)
+        TestDebugReporter.saveSuggestions(outputs = listOf(aiOutput), path = debugOutputPath)
+
+        debugOutput.exception?.let { printFlowError(it) }
+
+        return if (result.get()?.success == true) 0 else 1
     }
 
     /**
@@ -133,7 +121,6 @@ object TestRunner {
         env: Map<String, String>,
         analyze: Boolean = false,
         apiKey: String? = null,
-        testOutputDir: Path?,
         deviceId: String?,
     ): Nothing {
         val resultView = AnsiResultView("> Press [ENTER] to restart the Flow\n\n")
@@ -181,7 +168,6 @@ object TestRunner {
                                     ),
                                     analyze = analyze,
                                     apiKey = apiKey,
-                                    testOutputDir = testOutputDir
                                 )
                             }
                         }.get()

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -29,7 +29,6 @@ import kotlin.time.Duration.Companion.seconds
 import maestro.cli.util.ScreenshotUtils
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
-import maestro.utils.TempFileHandler
 
 /**
  * Similar to [TestRunner], but:
@@ -54,7 +53,6 @@ class TestSuiteInteractor(
         reportOut: Sink?,
         env: Map<String, String>,
         debugOutputPath: Path,
-        testOutputDir: Path? = null,
         deviceId: String? = null,
     ): TestExecutionSummary {
         if (executionPlan.flowsToRun.isEmpty() && executionPlan.sequence.flows.isEmpty()) {
@@ -75,7 +73,7 @@ class TestSuiteInteractor(
             val updatedEnv = env
                 .withInjectedShellEnvVars()
                 .withDefaultEnvVars(flowFile, deviceId, shardIndex)
-            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir)
+            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath)
             flowResults.add(result)
             aiOutputs.add(aiOutput)
 
@@ -95,7 +93,7 @@ class TestSuiteInteractor(
             val updatedEnv = env
                 .withInjectedShellEnvVars()
                 .withDefaultEnvVars(flowFile, deviceId, shardIndex)
-            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath, testOutputDir)
+            val (result, aiOutput) = runFlow(flowFile, updatedEnv, maestro, debugOutputPath)
             aiOutputs.add(aiOutput)
 
             if (result.status == FlowStatus.ERROR) {
@@ -156,7 +154,6 @@ class TestSuiteInteractor(
         env: Map<String, String>,
         maestro: Maestro,
         debugOutputPath: Path,
-        testOutputDir: Path? = null
     ): Pair<TestExecutionSummary.FlowResult, FlowAIOutput> {
         // TODO(bartekpacia): merge TestExecutionSummary with AI suggestions
         //  (i.e. consider them also part of the test output)
@@ -178,22 +175,17 @@ class TestSuiteInteractor(
 
         logger.info("$shardPrefix Running flow $flowName")
 
-        // Per-flow staging directory. ArtifactsGenerator writes the canonical
-        // bundle here (commands.json, maestro.log, manifest.json, screenshot-❌-*.png);
-        // then copyBundleToFlowDir copies the whole bundle into its own folder
-        // under the session dir. TempFileHandler.close() in finally recursively
-        // deletes the staging dir.
-        val tempFileHandler = TempFileHandler()
-        val flowBundleDir = tempFileHandler
-            .createTempDirectory("maestro-cli-${flowName.replace("/", "_")}-")
-            .toPath()
+        // Per-flow output folder. ArtifactsGenerator writes the canonical bundle
+        // (commands.json, maestro.log, manifest.json, screenshots/, recordings/,
+        // screenshot-❌-*.png) straight into it.
+        val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName, shardIndex)
 
         var debugOutput = FlowDebugOutput()
         val flowTimeMillis = measureTimeMillis {
             try {
                 val orchestra = Orchestra(
                     maestro = maestro,
-                    artifactsDir = flowBundleDir,
+                    artifactsDir = flowDir,
                     listeners = listOf(CliConsoleListener(shardPrefix)),
                     onCommandFailed = { _, _, _ -> Orchestra.ErrorResolution.FAIL },
                     onCommandGeneratedOutput = { command, defects, screenshot ->
@@ -218,16 +210,6 @@ class TestSuiteInteractor(
             }
         }
         val flowDuration = TimeUtils.durationInSeconds(flowTimeMillis)
-        try {
-            TestDebugReporter.copyBundleToFlowDir(
-                sourceDir = flowBundleDir,
-                destDir = debugOutputPath,
-                flowName = flowName,
-                shardIndex = shardIndex,
-            )
-        } finally {
-            tempFileHandler.close()
-        }
         // FIXME(bartekpacia): Save AI output as well
 
         TestSuiteStatusView.showFlowCompletion(

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -193,7 +193,6 @@ class TestSuiteInteractor(
             try {
                 val orchestra = Orchestra(
                     maestro = maestro,
-                    screenshotsDir = flowBundleDir,
                     artifactsDir = flowBundleDir,
                     listeners = listOf(CliConsoleListener(shardPrefix)),
                     onCommandFailed = { _, _, _ -> Orchestra.ErrorResolution.FAIL },

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -193,7 +193,7 @@ class TestSuiteInteractor(
             try {
                 val orchestra = Orchestra(
                     maestro = maestro,
-                    screenshotsDir = testOutputDir?.resolve("screenshots"),
+                    screenshotsDir = flowBundleDir,
                     artifactsDir = flowBundleDir,
                     listeners = listOf(CliConsoleListener(shardPrefix)),
                     onCommandFailed = { _, _, _ -> Orchestra.ErrorResolution.FAIL },

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/TestDebugReporterTest.kt
@@ -159,59 +159,34 @@ class TestDebugReporterTest {
     }
 
     @Test
-    fun `copyBundleToFlowDir places the bundle in a per-flow folder with clean names`() {
-        val sourceDir = Files.createDirectories(tempDir.resolve("bundle"))
-        Files.writeString(sourceDir.resolve("commands.json"), "[]")
-        Files.writeString(sourceDir.resolve("maestro.log"), "log")
-        Files.writeString(sourceDir.resolve("manifest.json"), """{"schemaVersion":1,"entries":[]}""")
-        Files.createFile(sourceDir.resolve("screenshot-❌-555.png")).toFile().writeBytes(byteArrayOf(1, 2, 3))
+    fun `createFlowDir creates a per-flow folder with a clean name`() {
         val destDir = Files.createDirectories(tempDir.resolve("session"))
 
-        val flowDir = TestDebugReporter.copyBundleToFlowDir(sourceDir, destDir, flowName = "login")
+        val flowDir = TestDebugReporter.createFlowDir(destDir, flowName = "login")
 
         assertThat(flowDir).isEqualTo(destDir.resolve("login"))
-        val names = flowDir!!.toFile().listFiles()!!.map { it.name }.toSet()
-        assertThat(names).containsExactly("commands.json", "maestro.log", "manifest.json", "screenshot-❌-555.png")
-        assertThat(Files.readString(flowDir!!.resolve("manifest.json")))
-            .isEqualTo("""{"schemaVersion":1,"entries":[]}""")
+        assertThat(flowDir.toFile().isDirectory).isTrue()
     }
 
     @Test
-    fun `copyBundleToFlowDir sanitizes slashes and applies shard suffix`() {
-        val sourceDir = Files.createDirectories(tempDir.resolve("bundle"))
-        Files.writeString(sourceDir.resolve("commands.json"), "[]")
+    fun `createFlowDir sanitizes slashes and applies shard suffix`() {
         val destDir = Files.createDirectories(tempDir.resolve("session"))
 
-        val flowDir = TestDebugReporter.copyBundleToFlowDir(sourceDir, destDir, flowName = "feature/login", shardIndex = 2)
+        val flowDir = TestDebugReporter.createFlowDir(destDir, flowName = "feature/login", shardIndex = 2)
 
         assertThat(flowDir).isEqualTo(destDir.resolve("feature_login-shard-3"))
-        assertThat(flowDir!!.resolve("commands.json").toFile().exists()).isTrue()
+        assertThat(flowDir.toFile().isDirectory).isTrue()
     }
 
     @Test
-    fun `copyBundleToFlowDir disambiguates same-name flows with a numeric suffix`() {
-        fun bundle(): Path {
-            val d = Files.createTempDirectory(tempDir, "bundle-")
-            Files.writeString(d.resolve("commands.json"), "[]")
-            return d
-        }
+    fun `createFlowDir disambiguates same-name flows with a numeric suffix`() {
         val destDir = Files.createDirectories(tempDir.resolve("session"))
 
-        val first = TestDebugReporter.copyBundleToFlowDir(bundle(), destDir, flowName = "dup")
-        val second = TestDebugReporter.copyBundleToFlowDir(bundle(), destDir, flowName = "dup")
+        val first = TestDebugReporter.createFlowDir(destDir, flowName = "dup")
+        val second = TestDebugReporter.createFlowDir(destDir, flowName = "dup")
 
         assertThat(first).isEqualTo(destDir.resolve("dup"))
         assertThat(second).isEqualTo(destDir.resolve("dup-2"))
-    }
-
-    @Test
-    fun `copyBundleToFlowDir returns null and writes nothing when sourceDir is absent`() {
-        val destDir = Files.createDirectories(tempDir.resolve("session"))
-
-        val flowDir = TestDebugReporter.copyBundleToFlowDir(tempDir.resolve("missing"), destDir, flowName = "x")
-
-        assertThat(flowDir).isNull()
-        assertThat(destDir.toFile().listFiles()?.toList().orEmpty()).isEmpty()
     }
 
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
@@ -12,6 +12,12 @@ object ArtifactFiles {
     const val FAILURE_SCREENSHOT_PREFIX = "screenshot-❌-"
     const val SCREENSHOT_EXTENSION = ".png"
 
+    /** Subdirectory under the artifact root holding `takeScreenshot` command output. */
+    const val SCREENSHOTS_DIR = "screenshots"
+
+    /** Subdirectory under the artifact root holding `startRecording` command output. */
+    const val RECORDINGS_DIR = "recordings"
+
     /**
      * The hand-written JSON Schema describing [ArtifactManifest], bundled next to
      * [MANIFEST_JSON] in each run dir so an agent reading the manifest can resolve

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
@@ -12,10 +12,7 @@ object ArtifactFiles {
     const val FAILURE_SCREENSHOT_PREFIX = "screenshot-❌-"
     const val SCREENSHOT_EXTENSION = ".png"
 
-    /** Subdirectory under the artifact root holding `takeScreenshot` command output. */
     const val SCREENSHOTS_DIR = "screenshots"
-
-    /** Subdirectory under the artifact root holding `startRecording` command output. */
     const val RECORDINGS_DIR = "recordings"
 
     /**

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
@@ -7,14 +7,14 @@ package maestro.orchestra
  * model usable from any consumer's mapper.
  */
 enum class ArtifactKind {
-    SCREENSHOT,         // failure screenshot (core) or a per-step collection (worker)
+    SCREENSHOT,         // failure screenshot (core), takeScreenshot output, or a per-step collection (worker)
     COMMAND_METADATA,   // commands.json — view hierarchy inline on the failing command
     MAESTRO_LOG,        // maestro.log
     SCREEN_RECORDING,
     DEVICE_LOG,         // metadata["source"] = simulator | xctest | emulator
     CRASH_REPORT,
     ANR_REPORT,
-    USER_FILE,          // customer takeScreenshot / pushed files — a collection
+    USER_FILE,          // other files the flow produced or pushed, excluding screenshots — a collection
     AI_ANALYSIS,        // reserved; not emitted yet
 }
 

--- a/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json
+++ b/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json
@@ -61,7 +61,7 @@
       "oneOf": [
         {
           "const": "SCREENSHOT",
-          "description": "A PNG screenshot of the device. The failure screenshot auto-captured at the moment a command fails (core), or a per-step collection of screenshots (worker)."
+          "description": "A PNG screenshot of the device: the failure screenshot auto-captured when a command fails (core), the output of a takeScreenshot command, or a per-step collection (worker)."
         },
         {
           "const": "COMMAND_METADATA",
@@ -89,7 +89,7 @@
         },
         {
           "const": "USER_FILE",
-          "description": "Files the flow itself produced: customer takeScreenshot output or pushed files. A collection."
+          "description": "Other files the flow produced or pushed to the run output, excluding screenshots. A collection."
         },
         {
           "const": "AI_ANALYSIS",

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -595,7 +595,8 @@ class Orchestra(
 
         val candidates = buildList {
             command.flowPath?.let { add(it.resolve(path).toFile()) }
-            // takeScreenshot writes under <screenshotsDir>/screenshots/; check there first, then the legacy flat location.
+            // Reference lookup order: flow YAML dir (references shipped with the flow), then the
+            // screenshots/ subdir takeScreenshot writes into, then the legacy flat screenshotsDir, then an absolute path.
             screenshotsDir?.let { add(it.resolve(ArtifactFiles.SCREENSHOTS_DIR).resolve(path).toFile()) }
             screenshotsDir?.let { add(it.resolve(path).toFile()) }
             add(File(path))

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -166,6 +166,9 @@ class Orchestra(
 
     private var screenRecording: ScreenRecording? = null
 
+    /** Root for takeScreenshot/startRecording output (screenshots/ and recordings/ live here); defaults to [artifactsDir]. */
+    private val mediaRoot: Path? = screenshotsDir ?: artifactsDir
+
     private val rawCommandToMetadata = mutableMapOf<MaestroCommand, CommandMetadata>()
 
     /**
@@ -595,10 +598,8 @@ class Orchestra(
 
         val candidates = buildList {
             command.flowPath?.let { add(it.resolve(path).toFile()) }
-            // Reference lookup order: flow YAML dir (references shipped with the flow), then the
-            // screenshots/ subdir takeScreenshot writes into, then the legacy flat screenshotsDir, then an absolute path.
-            screenshotsDir?.let { add(it.resolve(ArtifactFiles.SCREENSHOTS_DIR).resolve(path).toFile()) }
-            screenshotsDir?.let { add(it.resolve(path).toFile()) }
+            // the screenshots/ folder takeScreenshot writes to
+            mediaRoot?.let { add(it.resolve(ArtifactFiles.SCREENSHOTS_DIR).resolve(path).toFile()) }
             add(File(path))
         }.distinctBy { it.canonicalPath }
 
@@ -1162,12 +1163,12 @@ class Orchestra(
     }
 
     private suspend fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
-        val pathStr = if (screenshotsDir != null) {
+        val pathStr = if (mediaRoot != null) {
             "${ArtifactFiles.SCREENSHOTS_DIR}/${command.path}.png"
         } else {
             "${command.path}.png"
         }
-        val fileSink = getFileSink(screenshotsDir, pathStr)
+        val fileSink = getFileSink(mediaRoot, pathStr)
 
         val cropOn = command.cropOn
         if (cropOn == null) {
@@ -1188,12 +1189,12 @@ class Orchestra(
     }
 
     private suspend fun startRecordingCommand(command: StartRecordingCommand): Boolean {
-        val pathStr = if (screenshotsDir != null) {
+        val pathStr = if (mediaRoot != null) {
             "${ArtifactFiles.RECORDINGS_DIR}/${command.path}.mp4"
         } else {
             "${command.path}.mp4"
         }
-        val fileSink = getFileSink(screenshotsDir, pathStr)
+        val fileSink = getFileSink(mediaRoot, pathStr)
         screenRecording = maestro.startScreenRecording(fileSink)
         return false
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -127,7 +127,7 @@ class DefaultFlowController : FlowController {
  */
 class Orchestra(
     private val maestro: Maestro,
-    private val screenshotsDir: Path? = null, // TODO(bartekpacia): Orchestra shouldn't interact with files directly.
+    // TODO(bartekpacia): Orchestra shouldn't interact with files directly.
     private val artifactsDir: Path? = null,
     private val listeners: List<OrchestraListener> = emptyList(),
     private val lookupTimeoutMs: Long = 17000L,
@@ -165,9 +165,6 @@ class Orchestra(
     private var timeMsOfLastInteraction = System.currentTimeMillis()
 
     private var screenRecording: ScreenRecording? = null
-
-    /** Root for takeScreenshot/startRecording output (screenshots/ and recordings/ live here); defaults to [artifactsDir]. */
-    private val mediaRoot: Path? = screenshotsDir ?: artifactsDir
 
     private val rawCommandToMetadata = mutableMapOf<MaestroCommand, CommandMetadata>()
 
@@ -599,7 +596,7 @@ class Orchestra(
         val candidates = buildList {
             command.flowPath?.let { add(it.resolve(path).toFile()) }
             // the screenshots/ folder takeScreenshot writes to
-            mediaRoot?.let { add(it.resolve(ArtifactFiles.SCREENSHOTS_DIR).resolve(path).toFile()) }
+            artifactsDir?.let { add(it.resolve(ArtifactFiles.SCREENSHOTS_DIR).resolve(path).toFile()) }
             add(File(path))
         }.distinctBy { it.canonicalPath }
 
@@ -1163,12 +1160,12 @@ class Orchestra(
     }
 
     private suspend fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
-        val pathStr = if (mediaRoot != null) {
+        val pathStr = if (artifactsDir != null) {
             "${ArtifactFiles.SCREENSHOTS_DIR}/${command.path}.png"
         } else {
             "${command.path}.png"
         }
-        val fileSink = getFileSink(mediaRoot, pathStr)
+        val fileSink = getFileSink(artifactsDir, pathStr)
 
         val cropOn = command.cropOn
         if (cropOn == null) {
@@ -1189,12 +1186,12 @@ class Orchestra(
     }
 
     private suspend fun startRecordingCommand(command: StartRecordingCommand): Boolean {
-        val pathStr = if (mediaRoot != null) {
+        val pathStr = if (artifactsDir != null) {
             "${ArtifactFiles.RECORDINGS_DIR}/${command.path}.mp4"
         } else {
             "${command.path}.mp4"
         }
-        val fileSink = getFileSink(mediaRoot, pathStr)
+        val fileSink = getFileSink(artifactsDir, pathStr)
         screenRecording = maestro.startScreenRecording(fileSink)
         return false
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -595,6 +595,8 @@ class Orchestra(
 
         val candidates = buildList {
             command.flowPath?.let { add(it.resolve(path).toFile()) }
+            // takeScreenshot writes under <screenshotsDir>/screenshots/; check there first, then the legacy flat location.
+            screenshotsDir?.let { add(it.resolve(ArtifactFiles.SCREENSHOTS_DIR).resolve(path).toFile()) }
             screenshotsDir?.let { add(it.resolve(path).toFile()) }
             add(File(path))
         }.distinctBy { it.canonicalPath }
@@ -1159,7 +1161,11 @@ class Orchestra(
     }
 
     private suspend fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
-        val pathStr = command.path + ".png"
+        val pathStr = if (screenshotsDir != null) {
+            "${ArtifactFiles.SCREENSHOTS_DIR}/${command.path}.png"
+        } else {
+            "${command.path}.png"
+        }
         val fileSink = getFileSink(screenshotsDir, pathStr)
 
         val cropOn = command.cropOn
@@ -1181,7 +1187,11 @@ class Orchestra(
     }
 
     private suspend fun startRecordingCommand(command: StartRecordingCommand): Boolean {
-        val pathStr = command.path + ".mp4"
+        val pathStr = if (screenshotsDir != null) {
+            "${ArtifactFiles.RECORDINGS_DIR}/${command.path}.mp4"
+        } else {
+            "${command.path}.mp4"
+        }
         val fileSink = getFileSink(screenshotsDir, pathStr)
         screenRecording = maestro.startScreenRecording(fileSink)
         return false

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -157,8 +157,21 @@ internal class ArtifactsGenerator(
                 .listFiles { _, name -> name.startsWith(ArtifactFiles.FAILURE_SCREENSHOT_PREFIX) && name.endsWith(ArtifactFiles.SCREENSHOT_EXTENSION) }
                 ?.sortedBy { it.name }
                 ?.forEach { add(ArtifactEntry(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, it.name, sizeBytes = it.length())) }
+            addFolderEntry(dir, ArtifactFiles.SCREENSHOTS_DIR, ArtifactKind.SCREENSHOT, ArtifactFormat.PNG)
+            addFolderEntry(dir, ArtifactFiles.RECORDINGS_DIR, ArtifactKind.SCREEN_RECORDING, ArtifactFormat.MP4)
         }
         return ArtifactManifest(entries = entries)
+    }
+
+    private fun MutableList<ArtifactEntry>.addFolderEntry(
+        dir: Path,
+        subdir: String,
+        kind: ArtifactKind,
+        format: ArtifactFormat,
+    ) {
+        val folder = dir.resolve(subdir).toFile().takeIf { it.isDirectory } ?: return
+        val count = folder.walkTopDown().count { it.isFile }
+        if (count > 0) add(ArtifactEntry(kind, format, subdir, count = count))
     }
 
     private fun captureHierarchy(metadata: CommandDebugMetadata) {

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -246,6 +246,44 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
+    fun `registers screenshots and recordings folders as collections`() {
+        Files.createDirectories(tempDir.resolve("screenshots/login"))
+        Files.write(tempDir.resolve("screenshots/login/home.png"), byteArrayOf(1))
+        Files.write(tempDir.resolve("screenshots/splash.png"), byteArrayOf(1))
+        Files.createDirectories(tempDir.resolve("recordings"))
+        Files.write(tempDir.resolve("recordings/clip.mp4"), byteArrayOf(1))
+
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        gen.onFlowStart()
+        gen.onFlowEnd()
+
+        val screenshots = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
+        assertThat(screenshots.format).isEqualTo(ArtifactFormat.PNG)
+        assertThat(screenshots.count).isEqualTo(2)
+        assertThat(screenshots.sizeBytes).isNull()
+
+        val recordings = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREEN_RECORDING }
+        assertThat(recordings.relativePath).isEqualTo("recordings")
+        assertThat(recordings.format).isEqualTo(ArtifactFormat.MP4)
+        assertThat(recordings.count).isEqualTo(1)
+        assertThat(recordings.sizeBytes).isNull()
+    }
+
+    @Test
+    fun `omits screenshots and recordings entries when folders are absent or empty`() {
+        Files.createDirectories(tempDir.resolve("recordings")) // present but empty
+
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        gen.onFlowStart()
+        gen.onFlowEnd()
+
+        assertThat(gen.artifactManifest.entries.none { it.kind == ArtifactKind.SCREEN_RECORDING }).isTrue()
+        assertThat(gen.artifactManifest.entries.none { it.relativePath == "screenshots" }).isTrue()
+    }
+
+    @Test
     fun `bundles the schema next to manifest_json and points manifest at it`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)


### PR DESCRIPTION
**Stacked on #3343.** Review → merge into #3343 before #3343 goes out.

Brings `takeScreenshot` / `startRecording` output into the run's artifact bundle and manifest, so local and cloud emit the same shape.

## What changed
- **Core** writes `takeScreenshot` → `screenshots/` and `startRecording` → `recordings/` under the run's artifact dir, and registers each folder as one manifest entry (`SCREENSHOT` / `SCREEN_RECORDING`, with a file `count`). No artifact dir (e.g. continuous mode) → writes relative to CWD, as before.
- **One artifact dir.** Each flow's output folder is resolved upfront and passed to Orchestra as the single `artifactsDir`; Orchestra writes the bundle + `screenshots/` + `recordings/` + `manifest.json` straight into it. This drops the temp-staging dir, `copyBundleToFlowDir`, the separate `screenshotsDir`, and the vestigial `testOutputDir` plumbing (net −84 lines).

## `--test-output-dir`
When set, it *is* that artifact dir, so a run's whole bundle lands there as one tree:
```
<--test-output-dir or default>/<ts>/<flow>/
  commands.json  maestro.log  manifest.json  manifest.schema.json
  screenshots/…  recordings/…
```
**Why:** one folder = one run's artifacts, one-to-one with the manifest and the cloud's `run/{runId}/` layout. Behavior change to flag for @bartekpacia: `--test-output-dir` now holds the full bundle (incl. `manifest.json`), not just screenshots — help text updated to match.

## Verified
- `:maestro-orchestra:test`, `:maestro-orchestra-models:test` (incl. schema drift guard), `:maestro-cli:test`, `:maestro-test:test` `IntegrationTest` (156, incl. cases 134/135) — all green.
- Real iOS sim, three scenarios: single flow (`~/.maestro/.../<flow>/`), `--test-output-dir` (`<dir>/<ts>/<flow>/`), and a 2-flow suite (separate `<flow>/` folders, no clobber) — layout + manifest counts confirmed.
