### PR TITLE
feat(orchestra): nest bundle under artifacts/, flag-gated step screenshots + full recording

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -151,7 +151,7 @@ class TestCommand : Callable<Int> {
 
     @Option(
         names = ["--test-output-dir"],
-        description = ["Directory for this run's artifacts — screenshots, recordings, logs, commands.json, and manifest.json (overrides the default output location)"],
+        description = ["Directory for this run's artifacts — manifest.json plus an artifacts/ folder with logs, commands.json, takeScreenshot/, and startRecording/ (overrides the default output location)"],
     )
     private var testOutputDir: String? = null
 

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -66,9 +66,9 @@ object TestRunner {
         aiOutput = aiOutput.copy(flowName = flowName)
         logger.info("Running flow ${flowFile.name}...")
 
-        // ArtifactsGenerator writes the canonical bundle (commands.json, maestro.log,
-        // manifest.json, screenshots/, recordings/, failure screenshot) straight into
-        // this per-flow folder.
+        // ArtifactsGenerator writes the canonical bundle (manifest.json plus the
+        // artifacts/ folder holding commands.json, logs/maestro.log, takeScreenshot/,
+        // startRecording/, and the failure screenshot) straight into this per-flow folder.
         val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName)
 
         val result = runCatching(resultView, maestro) {

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -176,8 +176,9 @@ class TestSuiteInteractor(
         logger.info("$shardPrefix Running flow $flowName")
 
         // Per-flow output folder. ArtifactsGenerator writes the canonical bundle
-        // (commands.json, maestro.log, manifest.json, screenshots/, recordings/,
-        // screenshot-❌-*.png) straight into it.
+        // (manifest.json plus the artifacts/ folder holding commands.json,
+        // logs/maestro.log, takeScreenshot/, startRecording/, and the failure
+        // screenshot) straight into it.
         val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName, shardIndex)
 
         var debugOutput = FlowDebugOutput()

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
@@ -1,19 +1,52 @@
 package maestro.orchestra
 
 /**
- * Canonical relative filenames for the artifacts a flow run produces. Single
- * source of truth so the writer and the manifest-builder (and the CLI's flat
- * copier) never drift on a filename. These are relative to the artifact root.
+ * Canonical relative paths for the artifacts a flow run produces, all relative
+ * to the run root (the dir that holds [MANIFEST_JSON]). Single source of truth
+ * so the writer, the manifest-builder, and the CLI's copier never drift.
+ *
+ * Layout under the run root:
+ * ```
+ * <run-root>/
+ *   manifest.json
+ *   artifacts/                ← everything core makes, zipped as one unit
+ *     commands.json
+ *     logs/maestro.log
+ *     takeScreenshot/         ← takeScreenshot command output
+ *     startRecording/         ← startRecording command output
+ *     screenshot-❌-*.png      ← failure screenshot
+ *   screenshots/              ← per-step screenshots (flag-gated), its own zip
+ *   screen-recording.mp4      ← full-run recording (flag-gated)
+ * ```
  */
 object ArtifactFiles {
-    const val COMMANDS_JSON = "commands.json"
-    const val MAESTRO_LOG = "maestro.log"
+    /** Self-describing manifest, at the run root so its relative paths resolve against the root. */
     const val MANIFEST_JSON = "manifest.json"
+
+    /** The folder holding everything core writes; zipped/served as the "artifacts" bundle. */
+    const val ARTIFACTS_DIR = "artifacts"
+
+    const val COMMANDS_JSON = "$ARTIFACTS_DIR/commands.json"
+
+    /** Holds maestro.log plus (worker/cloud) device logs and crash/ANR reports. */
+    const val LOGS_DIR = "$ARTIFACTS_DIR/logs"
+    const val MAESTRO_LOG = "$LOGS_DIR/maestro.log"
+
+    /** takeScreenshot command output; folder name matches the command. */
+    const val TAKE_SCREENSHOT_DIR = "$ARTIFACTS_DIR/takeScreenshot"
+
+    /** startRecording command output; folder name matches the command. */
+    const val START_RECORDING_DIR = "$ARTIFACTS_DIR/startRecording"
+
+    /** Failure screenshot filename prefix; the file lives at the root of [ARTIFACTS_DIR]. */
     const val FAILURE_SCREENSHOT_PREFIX = "screenshot-❌-"
     const val SCREENSHOT_EXTENSION = ".png"
 
-    const val SCREENSHOTS_DIR = "screenshots"
-    const val RECORDINGS_DIR = "recordings"
+    /** Per-step screenshots, a run-root sibling of [ARTIFACTS_DIR] so it zips on its own. */
+    const val STEP_SCREENSHOTS_DIR = "screenshots"
+
+    /** Full-run recording, a single file at the run root. */
+    const val SCREEN_RECORDING = "screen-recording.mp4"
 
     /**
      * The hand-written JSON Schema describing [ArtifactManifest], bundled next to

--- a/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json
+++ b/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json
@@ -38,7 +38,7 @@
         },
         "relativePath": {
           "type": "string",
-          "description": "Path under the artifact root (the artifacts dir locally, run/{runId}/ in cloud). A directory when count is set, otherwise a single file."
+          "description": "Path relative to the run root (the dir holding manifest.json). Most of core's output lives under artifacts/ (e.g. artifacts/commands.json, artifacts/logs/maestro.log, artifacts/takeScreenshot, artifacts/startRecording, the failure screenshot); the per-step screenshots/ folder and screen-recording.mp4 sit at the run root. A directory when count is set, otherwise a single file."
         },
         "count": {
           "type": "integer",
@@ -50,7 +50,7 @@
         },
         "metadata": {
           "type": "object",
-          "description": "Free-form string key/value pairs qualifying the artifact, e.g. DEVICE_LOG carries metadata.source = simulator | xctest | emulator. Omitted when empty.",
+          "description": "Free-form string key/value pairs qualifying the artifact. metadata.source disambiguates entries that share a kind: SCREENSHOT is failure | take_screenshot | step; SCREEN_RECORDING is start_recording | full_run; DEVICE_LOG is simulator | xctest | emulator. Omitted when empty.",
           "additionalProperties": { "type": "string" }
         }
       }
@@ -61,7 +61,7 @@
       "oneOf": [
         {
           "const": "SCREENSHOT",
-          "description": "A PNG screenshot of the device: the failure screenshot auto-captured when a command fails (core), the output of a takeScreenshot command, or a per-step collection (worker)."
+          "description": "A PNG screenshot of the device. metadata.source tells them apart: failure (auto-captured when a command fails, under artifacts/), take_screenshot (takeScreenshot command output, under artifacts/takeScreenshot/), or step (per-step capture in the run-root screenshots/ folder)."
         },
         {
           "const": "COMMAND_METADATA",
@@ -73,7 +73,7 @@
         },
         {
           "const": "SCREEN_RECORDING",
-          "description": "A video recording of the device screen across the run."
+          "description": "A video recording of the device screen. metadata.source is start_recording (startRecording command output, under artifacts/startRecording/) or full_run (the whole-run recording at the run-root screen-recording.mp4)."
         },
         {
           "const": "DEVICE_LOG",

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -129,6 +129,12 @@ class Orchestra(
     private val maestro: Maestro,
     // TODO(bartekpacia): Orchestra shouldn't interact with files directly.
     private val artifactsDir: Path? = null,
+    /**
+     * When true (worker, not the local CLI), the artifacts bundle also gets a
+     * per-step screenshot after each non-failed command and a full-run recording.
+     */
+    private val captureStepScreenshots: Boolean = false,
+    private val captureScreenRecording: Boolean = false,
     private val listeners: List<OrchestraListener> = emptyList(),
     private val lookupTimeoutMs: Long = 17000L,
     private val optionalLookupTimeoutMs: Long = 7000L,
@@ -175,7 +181,8 @@ class Orchestra(
      * it only populates [debugOutput] in memory. Consumer-supplied
      * [listeners] follow.
      */
-    private val artifactsGenerator: ArtifactsGenerator = ArtifactsGenerator(artifactsDir, maestro)
+    private val artifactsGenerator: ArtifactsGenerator =
+        ArtifactsGenerator(artifactsDir, maestro, captureStepScreenshots, captureScreenRecording)
     private val effectiveListeners: List<OrchestraListener> = listOf(artifactsGenerator) + listeners
 
     /** Global per-flow sequence counter shared with listeners. */
@@ -595,8 +602,8 @@ class Orchestra(
 
         val candidates = buildList {
             command.flowPath?.let { add(it.resolve(path).toFile()) }
-            // the screenshots/ folder takeScreenshot writes to
-            artifactsDir?.let { add(it.resolve(ArtifactFiles.SCREENSHOTS_DIR).resolve(path).toFile()) }
+            // the takeScreenshot/ folder takeScreenshot writes to
+            artifactsDir?.let { add(it.resolve(ArtifactFiles.TAKE_SCREENSHOT_DIR).resolve(path).toFile()) }
             add(File(path))
         }.distinctBy { it.canonicalPath }
 
@@ -1161,7 +1168,7 @@ class Orchestra(
 
     private suspend fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
         val pathStr = if (artifactsDir != null) {
-            "${ArtifactFiles.SCREENSHOTS_DIR}/${command.path}.png"
+            "${ArtifactFiles.TAKE_SCREENSHOT_DIR}/${command.path}.png"
         } else {
             "${command.path}.png"
         }
@@ -1187,7 +1194,7 @@ class Orchestra(
 
     private suspend fun startRecordingCommand(command: StartRecordingCommand): Boolean {
         val pathStr = if (artifactsDir != null) {
-            "${ArtifactFiles.RECORDINGS_DIR}/${command.path}.mp4"
+            "${ArtifactFiles.START_RECORDING_DIR}/${command.path}.mp4"
         } else {
             "${command.path}.mp4"
         }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -3,6 +3,7 @@ package maestro.orchestra.debug
 import kotlinx.coroutines.runBlocking
 import maestro.Maestro
 import maestro.MaestroException
+import maestro.ScreenRecording
 import maestro.debuglog.ScopedLogCapture
 import maestro.orchestra.ArtifactEntry
 import maestro.orchestra.ArtifactFormat
@@ -11,6 +12,7 @@ import maestro.orchestra.ArtifactFiles
 import maestro.orchestra.ArtifactManifest
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
+import okio.sink
 import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Path
@@ -22,13 +24,20 @@ import java.nio.file.Path
  *     error, sequenceNumber, evaluatedCommand). Always on — cheap, no I/O,
  *     consumers read it via `Orchestra.debugOutput`.
  *
- *   - When `artifactsDir` is non-null: produces the on-disk flow-debug
- *     bundle:
- *       `artifactsDir/maestro.log` — scoped capture of `maestro.*` loggers
- *       `artifactsDir/commands.json` — per-command metadata, with hierarchy
- *         inline on the failing command
- *       `artifactsDir/screenshot-❌-<unix-millis>.png` — auto-capture at the
- *         moment of a command failure
+ *   - When `artifactsDir` is non-null: produces the on-disk flow-debug bundle
+ *     under `artifactsDir` (the run root):
+ *       `manifest.json` — self-describing index of everything below
+ *       `artifacts/commands.json` — per-command metadata, hierarchy inline on
+ *         the failing command
+ *       `artifacts/logs/maestro.log` — scoped capture of `maestro.*` loggers
+ *       `artifacts/screenshot-❌-<unix-millis>.png` — auto-capture at the moment
+ *         of a command failure
+ *
+ *   - When the corresponding flag is on (worker, not the CLI):
+ *       `screenshots/step-<sequenceNumber>.png` — a screenshot after each
+ *         non-failed command ([captureStepScreenshots])
+ *       `screen-recording.mp4` — a recording of the whole run
+ *         ([captureScreenRecording])
  *
  * On a failed command (with `artifactsDir != null`), hierarchy capture and
  * screenshot capture run in independent `try/catch` blocks — either failing
@@ -46,6 +55,8 @@ import java.nio.file.Path
 internal class ArtifactsGenerator(
     private val artifactsDir: Path?,
     private val maestro: Maestro,
+    private val captureStepScreenshots: Boolean = false,
+    private val captureScreenRecording: Boolean = false,
 ) : OrchestraListener {
 
     val debugOutput = FlowDebugOutput()
@@ -54,15 +65,18 @@ internal class ArtifactsGenerator(
     var artifactManifest: ArtifactManifest = ArtifactManifest()
         private set
     private var logCapture: ScopedLogCapture? = null
+    private var fullRunRecording: ScreenRecording? = null
 
     override fun onFlowStart() {
         if (artifactsDir == null) return
         try {
-            artifactsDir.toFile().mkdirs()
+            // Creates the run root, the artifacts/ bundle dir, and artifacts/logs/.
+            artifactsDir.resolve(ArtifactFiles.LOGS_DIR).toFile().mkdirs()
             logCapture = ScopedLogCapture.start(artifactsDir.resolve(ArtifactFiles.MAESTRO_LOG).toFile())
         } catch (e: Exception) {
             logger.warn("Failed to set up artifacts directory at $artifactsDir", e)
         }
+        if (captureScreenRecording) startFullRunRecording()
     }
 
     override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int) {
@@ -97,6 +111,13 @@ internal class ArtifactsGenerator(
                 captureHierarchy(metadata)
                 captureFailureScreenshot()
             }
+        } else if (artifactsDir != null && captureStepScreenshots &&
+            (outcome is CommandOutcome.Completed || outcome is CommandOutcome.Warned)
+        ) {
+            // The failure screenshot already covers failed commands, and skipped
+            // commands never ran, so only commands that actually executed get a
+            // per-step screenshot.
+            captureStepScreenshot(metadata.sequenceNumber)
         }
     }
 
@@ -111,6 +132,7 @@ internal class ArtifactsGenerator(
     }
 
     override fun onFlowEnd() {
+        stopFullRunRecording()
         if (artifactsDir != null) {
             try {
                 TestOutputWriter.saveCommands(
@@ -153,12 +175,30 @@ internal class ArtifactsGenerator(
             dir.resolve(ArtifactFiles.MAESTRO_LOG).toFile().takeIf { it.exists() }?.let {
                 add(ArtifactEntry(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, ArtifactFiles.MAESTRO_LOG, sizeBytes = it.length()))
             }
-            dir.toFile()
+            dir.resolve(ArtifactFiles.ARTIFACTS_DIR).toFile()
                 .listFiles { _, name -> name.startsWith(ArtifactFiles.FAILURE_SCREENSHOT_PREFIX) && name.endsWith(ArtifactFiles.SCREENSHOT_EXTENSION) }
                 ?.sortedBy { it.name }
-                ?.forEach { add(ArtifactEntry(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, it.name, sizeBytes = it.length())) }
-            addFolderEntry(dir, ArtifactFiles.SCREENSHOTS_DIR, ArtifactKind.SCREENSHOT, ArtifactFormat.PNG)
-            addFolderEntry(dir, ArtifactFiles.RECORDINGS_DIR, ArtifactKind.SCREEN_RECORDING, ArtifactFormat.MP4)
+                ?.forEach {
+                    add(ArtifactEntry(
+                        ArtifactKind.SCREENSHOT,
+                        ArtifactFormat.PNG,
+                        "${ArtifactFiles.ARTIFACTS_DIR}/${it.name}",
+                        sizeBytes = it.length(),
+                        metadata = mapOf("source" to "failure"),
+                    ))
+                }
+            addFolderEntry(dir, ArtifactFiles.TAKE_SCREENSHOT_DIR, ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, source = "take_screenshot")
+            addFolderEntry(dir, ArtifactFiles.START_RECORDING_DIR, ArtifactKind.SCREEN_RECORDING, ArtifactFormat.MP4, source = "start_recording")
+            addFolderEntry(dir, ArtifactFiles.STEP_SCREENSHOTS_DIR, ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, source = "step")
+            dir.resolve(ArtifactFiles.SCREEN_RECORDING).toFile().takeIf { it.isFile }?.let {
+                add(ArtifactEntry(
+                    ArtifactKind.SCREEN_RECORDING,
+                    ArtifactFormat.MP4,
+                    ArtifactFiles.SCREEN_RECORDING,
+                    sizeBytes = it.length(),
+                    metadata = mapOf("source" to "full_run"),
+                ))
+            }
         }
         return ArtifactManifest(entries = entries)
     }
@@ -168,10 +208,11 @@ internal class ArtifactsGenerator(
         subdir: String,
         kind: ArtifactKind,
         format: ArtifactFormat,
+        source: String,
     ) {
         val folder = dir.resolve(subdir).toFile().takeIf { it.isDirectory } ?: return
         val count = folder.walkTopDown().count { it.isFile }
-        if (count > 0) add(ArtifactEntry(kind, format, subdir, count = count))
+        if (count > 0) add(ArtifactEntry(kind, format, subdir, count = count, metadata = mapOf("source" to source)))
     }
 
     private fun captureHierarchy(metadata: CommandDebugMetadata) {
@@ -187,7 +228,7 @@ internal class ArtifactsGenerator(
         if (artifactsDir == null) return
         try {
             val destFile = File(
-                artifactsDir.toFile(),
+                artifactsDir.resolve(ArtifactFiles.ARTIFACTS_DIR).toFile(),
                 "${ArtifactFiles.FAILURE_SCREENSHOT_PREFIX}${System.currentTimeMillis()}${ArtifactFiles.SCREENSHOT_EXTENSION}",
             )
             ScreenshotUtils.takeDebugScreenshot(
@@ -198,6 +239,39 @@ internal class ArtifactsGenerator(
             )
         } catch (e: Exception) {
             logger.warn("Failed to capture failure screenshot", e)
+        }
+    }
+
+    private fun captureStepScreenshot(sequenceNumber: Int) {
+        if (artifactsDir == null) return
+        try {
+            val dir = artifactsDir.resolve(ArtifactFiles.STEP_SCREENSHOTS_DIR).toFile()
+            dir.mkdirs()
+            val destFile = File(dir, "step-$sequenceNumber${ArtifactFiles.SCREENSHOT_EXTENSION}")
+            runBlocking { maestro.takeScreenshot(destFile.sink(), false) }
+        } catch (e: Exception) {
+            logger.warn("Failed to capture per-step screenshot", e)
+        }
+    }
+
+    private fun startFullRunRecording() {
+        if (artifactsDir == null) return
+        try {
+            val destFile = artifactsDir.resolve(ArtifactFiles.SCREEN_RECORDING).toFile()
+            destFile.parentFile?.mkdirs()
+            fullRunRecording = runBlocking { maestro.startScreenRecording(destFile.sink()) }
+        } catch (e: Exception) {
+            logger.warn("Failed to start full-run screen recording", e)
+        }
+    }
+
+    private fun stopFullRunRecording() {
+        try {
+            fullRunRecording?.close()
+        } catch (e: Exception) {
+            logger.warn("Failed to stop full-run screen recording", e)
+        } finally {
+            fullRunRecording = null
         }
     }
 

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -59,7 +60,7 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `writes commands_json to artifactsDir at onFlowEnd`() {
+    fun `writes commands_json under artifacts subdir at onFlowEnd`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -68,9 +69,23 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(cmd, CommandOutcome.Completed, startedAt = 100L, finishedAt = 150L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("commands.json").exists()).isTrue()
-        val content = Files.readString(tempDir.resolve("commands.json"))
+        val commandsFile = tempDir.resolve("artifacts/commands.json")
+        assertThat(commandsFile.exists()).isTrue()
+        val content = Files.readString(commandsFile)
         assertThat(content).contains("\"status\" : \"COMPLETED\"")
+    }
+
+    @Test
+    fun `writes maestro_log under artifacts logs subdir`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, startedAt = 100L, finishedAt = 150L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("artifacts/logs/maestro.log").exists()).isTrue()
     }
 
     @Test
@@ -106,8 +121,8 @@ class ArtifactsGeneratorTest {
         assertThat(metadata.error).isEqualTo(error)
         assertThat(metadata.hierarchy).isNotNull()
 
-        // Failure screenshot written as a separate file in the artifacts dir.
-        val screenshots = tempDir.toFile().listFiles { _, n -> n.startsWith("screenshot-❌-") }
+        // Failure screenshot written as a separate file inside the artifacts subdir.
+        val screenshots = tempDir.resolve("artifacts").toFile().listFiles { _, n -> n.startsWith("screenshot-❌-") }
         assertThat(screenshots).isNotNull()
         assertThat(screenshots!!.size).isEqualTo(1)
         assertThat(gen.debugOutput.screenshots).hasSize(1)
@@ -134,7 +149,7 @@ class ArtifactsGeneratorTest {
         val metadata = gen.debugOutput.commands[cmd]!!
         assertThat(metadata.hierarchy).isNotNull()
         // No screenshot file landed (capture threw)
-        val screenshots = tempDir.toFile().listFiles { _, n -> n.startsWith("screenshot-❌-") } ?: emptyArray()
+        val screenshots = tempDir.resolve("artifacts").toFile().listFiles { _, n -> n.startsWith("screenshot-❌-") } ?: emptyArray()
         assertThat(screenshots).isEmpty()
     }
 
@@ -160,7 +175,7 @@ class ArtifactsGeneratorTest {
 
         val metadata = gen.debugOutput.commands[cmd]!!
         assertThat(metadata.hierarchy).isNull()
-        val screenshots = tempDir.toFile().listFiles { _, n -> n.startsWith("screenshot-❌-") }
+        val screenshots = tempDir.resolve("artifacts").toFile().listFiles { _, n -> n.startsWith("screenshot-❌-") }
         assertThat(screenshots).isNotNull()
         assertThat(screenshots!!.size).isEqualTo(1)
     }
@@ -190,7 +205,7 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `manifest exposes command metadata and maestro log entries`() {
+    fun `manifest exposes command metadata and maestro log entries under artifacts`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -204,13 +219,16 @@ class ArtifactsGeneratorTest {
         assertThat(byKind.keys).contains(ArtifactKind.MAESTRO_LOG)
 
         val cmdEntry = byKind[ArtifactKind.COMMAND_METADATA]!!
-        assertThat(cmdEntry.relativePath).isEqualTo("commands.json")
+        assertThat(cmdEntry.relativePath).isEqualTo("artifacts/commands.json")
         assertThat(cmdEntry.format).isEqualTo(ArtifactFormat.JSON)
         assertThat(cmdEntry.sizeBytes).isGreaterThan(0L)
+
+        val logEntry = byKind[ArtifactKind.MAESTRO_LOG]!!
+        assertThat(logEntry.relativePath).isEqualTo("artifacts/logs/maestro.log")
     }
 
     @Test
-    fun `manifest includes a failure screenshot entry`() {
+    fun `manifest includes a failure screenshot entry under artifacts with source failure`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -222,11 +240,12 @@ class ArtifactsGeneratorTest {
         val shots = gen.artifactManifest.entries.filter { it.kind == ArtifactKind.SCREENSHOT }
         assertThat(shots).hasSize(1)
         assertThat(shots[0].format).isEqualTo(ArtifactFormat.PNG)
-        assertThat(shots[0].relativePath).startsWith("screenshot-❌-")
+        assertThat(shots[0].relativePath).startsWith("artifacts/screenshot-❌-")
+        assertThat(shots[0].metadata["source"]).isEqualTo("failure")
     }
 
     @Test
-    fun `writes manifest_json to artifactsDir at onFlowEnd`() {
+    fun `writes manifest_json to artifactsDir root at onFlowEnd`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -246,41 +265,120 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `registers screenshots and recordings folders as collections`() {
-        Files.createDirectories(tempDir.resolve("screenshots/login"))
-        Files.write(tempDir.resolve("screenshots/login/home.png"), byteArrayOf(1))
-        Files.write(tempDir.resolve("screenshots/splash.png"), byteArrayOf(1))
-        Files.createDirectories(tempDir.resolve("recordings"))
-        Files.write(tempDir.resolve("recordings/clip.mp4"), byteArrayOf(1))
+    fun `registers takeScreenshot and startRecording folders as collections with source`() {
+        Files.createDirectories(tempDir.resolve("artifacts/takeScreenshot/login"))
+        Files.write(tempDir.resolve("artifacts/takeScreenshot/login/home.png"), byteArrayOf(1))
+        Files.write(tempDir.resolve("artifacts/takeScreenshot/splash.png"), byteArrayOf(1))
+        Files.createDirectories(tempDir.resolve("artifacts/startRecording"))
+        Files.write(tempDir.resolve("artifacts/startRecording/clip.mp4"), byteArrayOf(1))
 
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         gen.onFlowStart()
         gen.onFlowEnd()
 
-        val screenshots = gen.artifactManifest.entries
-            .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
-        assertThat(screenshots.format).isEqualTo(ArtifactFormat.PNG)
-        assertThat(screenshots.count).isEqualTo(2)
-        assertThat(screenshots.sizeBytes).isNull()
+        val takeScreenshot = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "artifacts/takeScreenshot" }
+        assertThat(takeScreenshot.format).isEqualTo(ArtifactFormat.PNG)
+        assertThat(takeScreenshot.count).isEqualTo(2)
+        assertThat(takeScreenshot.sizeBytes).isNull()
+        assertThat(takeScreenshot.metadata["source"]).isEqualTo("take_screenshot")
 
-        val recordings = gen.artifactManifest.entries
-            .single { it.kind == ArtifactKind.SCREEN_RECORDING }
-        assertThat(recordings.relativePath).isEqualTo("recordings")
-        assertThat(recordings.format).isEqualTo(ArtifactFormat.MP4)
-        assertThat(recordings.count).isEqualTo(1)
-        assertThat(recordings.sizeBytes).isNull()
+        val startRecording = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREEN_RECORDING && it.relativePath == "artifacts/startRecording" }
+        assertThat(startRecording.format).isEqualTo(ArtifactFormat.MP4)
+        assertThat(startRecording.count).isEqualTo(1)
+        assertThat(startRecording.sizeBytes).isNull()
+        assertThat(startRecording.metadata["source"]).isEqualTo("start_recording")
     }
 
     @Test
-    fun `omits screenshots and recordings entries when folders are absent or empty`() {
-        Files.createDirectories(tempDir.resolve("recordings")) // present but empty
+    fun `omits takeScreenshot and startRecording entries when folders are absent or empty`() {
+        Files.createDirectories(tempDir.resolve("artifacts/startRecording")) // present but empty
 
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         gen.onFlowStart()
         gen.onFlowEnd()
 
-        assertThat(gen.artifactManifest.entries.none { it.kind == ArtifactKind.SCREEN_RECORDING }).isTrue()
+        assertThat(gen.artifactManifest.entries.none { it.relativePath == "artifacts/startRecording" }).isTrue()
+        assertThat(gen.artifactManifest.entries.none { it.relativePath == "artifacts/takeScreenshot" }).isTrue()
+    }
+
+    @Test
+    fun `captures per-step screenshots into screenshots folder when the flag is on`() {
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureStepScreenshots = true,
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 3)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("screenshots/step-3.png").exists()).isTrue()
+
+        val steps = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
+        assertThat(steps.count).isEqualTo(1)
+        assertThat(steps.metadata["source"]).isEqualTo("step")
+    }
+
+    @Test
+    fun `does not capture per-step screenshots by default`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("screenshots").exists()).isFalse()
         assertThat(gen.artifactManifest.entries.none { it.relativePath == "screenshots" }).isTrue()
+    }
+
+    @Test
+    fun `starts and stops a full-run recording when the flag is on`() {
+        val maestro = mockMaestro()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = maestro,
+            captureScreenRecording = true,
+        )
+
+        gen.onFlowStart()
+        gen.onFlowEnd()
+
+        coVerify { maestro.startScreenRecording(any()) }
+    }
+
+    @Test
+    fun `does not start a full-run recording by default`() {
+        val maestro = mockMaestro()
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
+
+        gen.onFlowStart()
+        gen.onFlowEnd()
+
+        coVerify(exactly = 0) { maestro.startScreenRecording(any()) }
+    }
+
+    @Test
+    fun `registers the full-run recording at the run root with source full_run`() {
+        Files.write(tempDir.resolve("screen-recording.mp4"), byteArrayOf(1, 2, 3))
+
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        gen.onFlowStart()
+        gen.onFlowEnd()
+
+        val recording = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREEN_RECORDING && it.relativePath == "screen-recording.mp4" }
+        assertThat(recording.format).isEqualTo(ArtifactFormat.MP4)
+        assertThat(recording.count).isNull()
+        assertThat(recording.sizeBytes).isGreaterThan(0L)
+        assertThat(recording.metadata["source"]).isEqualTo("full_run")
     }
 
     @Test


### PR DESCRIPTION
## What

PR-A of the artifact-manifest follow-ups (covers feedback items #2 and #3). Targets `feat/orchestra-artifact-manifest`.

Restructures the per-run artifact bundle and adds flag-gated capture in core.

### Layout
```
<run-root>/
  manifest.json
  artifacts/                  ← ZIP "artifacts" = everything core makes
    commands.json
    logs/maestro.log
    takeScreenshot/           ← takeScreenshot command output (was screenshots/)
    startRecording/           ← startRecording command output (was recordings/)
    screenshot-❌-*.png        ← failure screenshot
  screenshots/                ← ZIP "screenshots" = per-step screenshots (flag-gated)
  screen-recording.mp4        ← full-run recording (flag-gated)
```

### Changes
- Folders renamed to match the command that writes them; everything core makes nested under `artifacts/`, with `maestro.log` under `logs/`.
- New `Orchestra` flags `captureStepScreenshots` / `captureScreenRecording`, **default off** so the local `maestro test` bundle is unchanged. The worker turns them on.
  - When on, `ArtifactsGenerator` writes `screenshots/step-<seq>.png` after each non-failed command and records the whole run to `screen-recording.mp4`.
- Manifest entries use the new relative paths and carry `metadata.source` to disambiguate same-kind entries (`failure`/`take_screenshot`/`step`, `start_recording`/`full_run`).
- `assertScreenshot` reference lookup and the schema prose updated.

### Out of scope (follow-up in `copilot/maestro-worker`)
Turning the flags on in the worker and reconciling its own per-step capture.

### Risk to validate
`captureScreenRecording` and the `startRecording` command both go through `maestro.startScreenRecording`; a flow using `startRecording` while the full-run flag is on may conflict on some drivers.

## Test
- `:maestro-orchestra:test`, `:maestro-orchestra-models:test` green (updated + new `ArtifactsGeneratorTest` cases for the new layout, capture flags, and manifest sources).
- `:maestro-cli` `TestDebugReporterTest` green; takeScreenshot/recording integration cases (041/098/099/134/135) green.