### PR TITLE
feat(orchestra): point manifest $schema at the in-repo schema on main

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactFiles.kt
@@ -49,12 +49,20 @@ object ArtifactFiles {
     const val SCREEN_RECORDING = "screen-recording.mp4"
 
     /**
-     * The hand-written JSON Schema describing [ArtifactManifest], bundled next to
-     * [MANIFEST_JSON] in each run dir so an agent reading the manifest can resolve
-     * its own `$schema` offline.
+     * Stable identity written as each manifest's `$schema`: the hand-written
+     * schema served straight from this repo's `main` branch via GitHub raw.
+     * Using a fixed branch keeps the URL constant while its content tracks the
+     * latest schema — safe here because the model tolerates unknown fields and a
+     * test blocks undocumented artifact kinds. The manifest therefore stays
+     * self-describing even after it is moved away from its run folder, with no
+     * extra hosting infrastructure. Keep this in sync with [MANIFEST_SCHEMA_RESOURCE].
      */
-    const val MANIFEST_SCHEMA_JSON = "manifest.schema.json"
+    const val MANIFEST_SCHEMA_URL = "https://raw.githubusercontent.com/mobile-dev-inc/Maestro/main/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json"
 
-    /** Classpath location of the bundled schema, copied to [MANIFEST_SCHEMA_JSON] at write time. */
+    /**
+     * Classpath location of the hand-written schema, and the same file [MANIFEST_SCHEMA_URL]
+     * serves from `main`. Kept in the repo as the source of truth and for the
+     * schema-coverage test; no longer copied into each run dir.
+     */
     const val MANIFEST_SCHEMA_RESOURCE = "/maestro/orchestra/manifest.schema.json"
 }

--- a/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json
+++ b/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://maestro.mobile.dev/schemas/artifact-manifest.schema.json",
+  "$id": "https://raw.githubusercontent.com/mobile-dev-inc/Maestro/main/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json",
   "title": "ArtifactManifest",
   "description": "The set of artifacts produced for a single Maestro flow run. Owned and emitted by Orchestra; written as manifest.json in the run's artifact root and consumed verbatim by the CLI and the cloud worker.",
   "type": "object",
@@ -9,7 +9,7 @@
   "properties": {
     "$schema": {
       "type": "string",
-      "description": "Relative path to this schema file, bundled alongside manifest.json in the same run dir so the manifest is self-documenting and resolvable offline."
+      "description": "Stable URL identifying this schema (served from the repo's main branch), so the manifest stays self-describing wherever it is moved, copied, or uploaded."
     },
     "schemaVersion": {
       "type": "integer",

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -155,14 +155,9 @@ internal class ArtifactsGenerator(
         if (artifactsDir != null) {
             artifactManifest = buildManifest(artifactsDir)
             try {
-                TestOutputWriter.saveManifest(artifactsDir, artifactManifest, ArtifactFiles.MANIFEST_SCHEMA_JSON)
+                TestOutputWriter.saveManifest(artifactsDir, artifactManifest)
             } catch (e: Exception) {
                 logger.warn("Failed to write manifest.json under $artifactsDir", e)
-            }
-            try {
-                TestOutputWriter.saveManifestSchema(artifactsDir)
-            } catch (e: Exception) {
-                logger.warn("Failed to write manifest.schema.json under $artifactsDir", e)
             }
         }
     }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/TestOutputWriter.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/TestOutputWriter.kt
@@ -71,27 +71,16 @@ object TestOutputWriter {
 
     /**
      * Writes [manifest] to [path]/manifest.json with a leading `$schema` pointing
-     * at [schemaRef] (a sibling filename written by [saveManifestSchema]), so an
-     * agent reading the manifest can resolve the bundled schema offline.
+     * at the stable [ArtifactFiles.MANIFEST_SCHEMA_URL], so the manifest stays
+     * self-describing wherever it ends up.
      */
-    fun saveManifest(path: Path, manifest: ArtifactManifest, schemaRef: String) {
+    fun saveManifest(path: Path, manifest: ArtifactManifest) {
         val tree = bundleMapper.valueToTree<ObjectNode>(manifest)
         val withSchema = bundleMapper.createObjectNode()
-            .put("\$schema", schemaRef)
+            .put("\$schema", ArtifactFiles.MANIFEST_SCHEMA_URL)
             .setAll<ObjectNode>(tree)
         File(path.absolutePathString(), ArtifactFiles.MANIFEST_JSON)
             .writeText(bundleWriter.writeValueAsString(withSchema))
-    }
-
-    /**
-     * Copies the hand-written JSON Schema bundled on the classpath into
-     * [path]/manifest.schema.json, so it travels next to the manifest it documents.
-     */
-    fun saveManifestSchema(path: Path) {
-        val bytes = TestOutputWriter::class.java.getResourceAsStream(ArtifactFiles.MANIFEST_SCHEMA_RESOURCE)
-            ?.use { it.readBytes() }
-            ?: error("Bundled schema not found at ${ArtifactFiles.MANIFEST_SCHEMA_RESOURCE}")
-        File(path.absolutePathString(), ArtifactFiles.MANIFEST_SCHEMA_JSON).writeBytes(bytes)
     }
 
     /**

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -382,7 +382,7 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `bundles the schema next to manifest_json and points manifest at it`() {
+    fun `points manifest at the stable schema URL and bundles no schema file`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -391,14 +391,13 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(cmd, CommandOutcome.Completed, startedAt = 100L, finishedAt = 150L)
         gen.onFlowEnd()
 
-        // The schema travels with the manifest so an agent can resolve it offline.
-        val schemaFile = tempDir.resolve("manifest.schema.json").toFile()
-        assertThat(schemaFile.exists()).isTrue()
-        val schema = jacksonObjectMapper().readTree(schemaFile)
-        assertThat(schema["title"].asText()).isEqualTo("ArtifactManifest")
-
-        // manifest.json references the bundled schema by its relative filename.
+        // The manifest's identity is a stable, versioned URL — so it stays
+        // self-describing even after it's moved away from its run folder.
         val manifest = jacksonObjectMapper().readTree(tempDir.resolve("manifest.json").toFile())
-        assertThat(manifest["\$schema"].asText()).isEqualTo("manifest.schema.json")
+        assertThat(manifest["\$schema"].asText())
+            .isEqualTo("https://raw.githubusercontent.com/mobile-dev-inc/Maestro/main/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json")
+
+        // No per-run schema file is bundled any more.
+        assertThat(tempDir.resolve("manifest.schema.json").toFile().exists()).isFalse()
     }
 }


### PR DESCRIPTION
## What

PR-B of the artifact-manifest follow-ups (covers feedback item #1). Targets `feat/orchestra-artifact-manifest`.

Gives the manifest a **stable identity** instead of a per-run sibling file, so it stays self-describing even after it's moved/copied/uploaded away from its run folder — with **no hosting infrastructure** to stand up.

`manifest.json` `$schema` now points at the hand-written schema served straight from this repo's `main` branch via GitHub raw:

```
https://raw.githubusercontent.com/mobile-dev-inc/Maestro/main/maestro-orchestra-models/src/main/resources/maestro/orchestra/manifest.schema.json
```

- Drop the per-run bundled `manifest.schema.json` (`saveManifestSchema` removed); `saveManifest` writes the URL directly.
- Set the schema's own `$id` to the same URL.
- Keep the in-repo schema resource as the source of truth — it's the exact file the URL serves, and the schema-coverage test (`ArtifactManifestSchemaTest`) keeps it honest.

### Why `main` (not a versioned path / pinned tag)
A fixed branch keeps the URL constant while its content tracks the latest schema. That's safe here: the manifest model tolerates unknown fields and a test blocks undocumented artifact kinds, so "latest" never breaks older readers. No web infra, no CDN, no sync workflow.

### Notes
- **Offline resolution is intentionally dropped** (agreed): air-gapped agents no longer get a local schema copy.
- If we ever move the schema file in the repo, this URL must be updated in lockstep (`MANIFEST_SCHEMA_URL` + `$id`).

## Test
- `:maestro-orchestra:test`, `:maestro-orchestra-models:test` green. The bundling test writes a real `manifest.json` and asserts `$schema` is the raw URL and that no `manifest.schema.json` is written.
