### PR TITLE
refactor(orchestra): record artifacts via ArtifactCollector instead of scanning

### DIFF
--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
@@ -1,0 +1,125 @@
+package maestro.orchestra.debug
+
+import maestro.orchestra.ArtifactEntry
+import maestro.orchestra.ArtifactFiles
+import maestro.orchestra.ArtifactFormat
+import maestro.orchestra.ArtifactKind
+import maestro.orchestra.ArtifactManifest
+import maestro.orchestra.MaestroCommand
+import java.io.File
+import java.nio.file.Path
+
+/**
+ * Single owner of the run-root bundle. Allocates every path core writes and
+ * records every artifact as it is produced; the manifest is its records and the
+ * per-command list is the same records grouped by owning command. Nothing
+ * reaches the bundle unrecorded, and there is no end-of-flow disk scan.
+ *
+ * Layout knowledge — which kinds are folder collections — lives here, the one
+ * place the bundle shape is encoded, resolving paths against [ArtifactFiles].
+ *
+ * Not thread-safe: assumes Orchestra's single-threaded, synchronous per-flow
+ * dispatch (the same invariant the listener relies on).
+ */
+internal class ArtifactCollector(private val runRoot: Path) {
+
+    /** A kind the manifest reports as one folder entry with a member count. */
+    private data class Collection(val dir: String, val format: ArtifactFormat)
+
+    private val collectionKinds: Map<ArtifactKind, Collection> = mapOf(
+        ArtifactKind.TAKE_SCREENSHOT to Collection(ArtifactFiles.TAKE_SCREENSHOT_DIR, ArtifactFormat.PNG),
+        ArtifactKind.START_SCREEN_RECORDING to Collection(ArtifactFiles.START_RECORDING_DIR, ArtifactFormat.MP4),
+        ArtifactKind.SCREENSHOT to Collection(ArtifactFiles.STEP_SCREENSHOTS_DIR, ArtifactFormat.PNG),
+        ArtifactKind.SCREEN_HIERARCHY to Collection(ArtifactFiles.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),
+    )
+
+    private data class Record(
+        val kind: ArtifactKind,
+        val format: ArtifactFormat?,
+        val relativePath: String,
+        val metadata: Map<String, String>,
+        val command: MaestroCommand?,
+    )
+
+    private val records = mutableListOf<Record>()
+
+    /**
+     * Reserve [relativePath] for a file core is about to write — creating parent
+     * dirs and recording it — and return the file to write into. A record whose
+     * file never lands (capture failed or was deduped) is dropped at read time,
+     * preserving best-effort capture without extra bookkeeping at the call site.
+     */
+    fun allocate(
+        kind: ArtifactKind,
+        format: ArtifactFormat?,
+        relativePath: String,
+        metadata: Map<String, String> = emptyMap(),
+        command: MaestroCommand? = null,
+    ): File {
+        val file = runRoot.resolve(relativePath).toFile()
+        file.parentFile?.mkdirs()
+        records += Record(kind, format, relativePath, metadata, command)
+        return file
+    }
+
+    /** Record a file written outside the generator's own path (device logs, crash/ANR, command output) that already lives under the run root. */
+    fun adopt(
+        kind: ArtifactKind,
+        relativePath: String,
+        format: ArtifactFormat?,
+        metadata: Map<String, String> = emptyMap(),
+        command: MaestroCommand? = null,
+    ) {
+        records += Record(kind, format, relativePath, metadata, command)
+    }
+
+    /**
+     * Individual files owned by [command], in allocation order, that landed on
+     * disk. Deduped by path: a command re-run in a repeat/retry loop overwrites
+     * the same file, which is one artifact, not one per iteration.
+     */
+    fun artifactsFor(command: MaestroCommand): List<CommandArtifact> =
+        records.filter { it.command === command && it.fileExists() }
+            .distinctBy { it.relativePath }
+            .map { CommandArtifact(it.kind, it.relativePath) }
+
+    /** Collection kinds folded to one folder entry with a member count; everything else 1:1. */
+    fun manifest(): ArtifactManifest {
+        val entries = buildList {
+            // Dedup by path: a file overwritten across loop iterations is one artifact.
+            records.filter { it.fileExists() }
+                .distinctBy { it.relativePath }
+                .groupBy { it.kind }
+                .forEach { (kind, kindRecords) ->
+                    val collection = collectionKinds[kind]
+                    if (collection != null) {
+                        add(
+                            ArtifactEntry(
+                                kind = kind,
+                                format = collection.format,
+                                relativePath = collection.dir,
+                                count = kindRecords.size,
+                            )
+                        )
+                    } else {
+                        kindRecords.forEach { record ->
+                            add(
+                                ArtifactEntry(
+                                    kind = record.kind,
+                                    format = record.format,
+                                    relativePath = record.relativePath,
+                                    sizeBytes = record.file().length(),
+                                    metadata = record.metadata,
+                                )
+                            )
+                        }
+                    }
+                }
+        }
+        return ArtifactManifest(entries = entries)
+    }
+
+    private fun Record.file(): File = runRoot.resolve(relativePath).toFile()
+
+    private fun Record.fileExists(): Boolean = file().exists()
+}

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -5,7 +5,6 @@ import maestro.Maestro
 import maestro.MaestroException
 import maestro.ScreenRecording
 import maestro.debuglog.ScopedLogCapture
-import maestro.orchestra.ArtifactEntry
 import maestro.orchestra.ArtifactFormat
 import maestro.orchestra.ArtifactKind
 import maestro.orchestra.ArtifactFiles
@@ -14,7 +13,6 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
 import okio.sink
 import org.slf4j.LoggerFactory
-import java.io.File
 import java.nio.file.Path
 
 /**
@@ -25,6 +23,10 @@ import java.nio.file.Path
  * [artifactsDir] (Studio's interactive runner) only the in-memory population
  * happens. Per-step screenshots and the full-run recording are flag-gated
  * ([captureStepScreenshots], [captureScreenRecording] — worker, not the CLI).
+ *
+ * Every file is routed through an [ArtifactCollector]: the manifest is the
+ * collector's records and each command's artifact list is the same records
+ * grouped by command, so the two can never disagree.
  */
 internal class ArtifactsGenerator(
     private val artifactsDir: Path?,
@@ -38,6 +40,7 @@ internal class ArtifactsGenerator(
     /** The run's artifact manifest; populated at [onFlowEnd], empty when [artifactsDir] is null. */
     var artifactManifest: ArtifactManifest = ArtifactManifest()
         private set
+    private var collector: ArtifactCollector? = null
     private var logCapture: ScopedLogCapture? = null
     private var fullRunRecording: ScreenRecording? = null
     /**
@@ -49,8 +52,9 @@ internal class ArtifactsGenerator(
     override fun onFlowStart() {
         if (artifactsDir == null) return
         try {
-            artifactsDir.resolve(ArtifactFiles.LOGS_DIR).toFile().mkdirs()
-            logCapture = ScopedLogCapture.start(artifactsDir.resolve(ArtifactFiles.MAESTRO_LOG).toFile())
+            val collector = ArtifactCollector(artifactsDir).also { this.collector = it }
+            val logFile = collector.allocate(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, ArtifactFiles.MAESTRO_LOG)
+            logCapture = ScopedLogCapture.start(logFile)
         } catch (e: Exception) {
             logger.warn("Failed to set up artifacts directory at $artifactsDir", e)
         }
@@ -62,12 +66,18 @@ internal class ArtifactsGenerator(
             timestamp = System.currentTimeMillis(),
             status = CommandStatus.RUNNING,
             sequenceNumber = sequenceNumber,
+            command = cmd,
         ).also { currentCommandMetadata = it }
     }
 
     override fun onCommandArtifact(kind: ArtifactKind, relativePath: String) {
-        if (artifactsDir == null) return
-        currentCommandMetadata?.artifacts?.add(CommandArtifact(kind, relativePath))
+        val collector = collector ?: return
+        val format = when (kind) {
+            ArtifactKind.TAKE_SCREENSHOT -> ArtifactFormat.PNG
+            ArtifactKind.START_SCREEN_RECORDING -> ArtifactFormat.MP4
+            else -> null
+        }
+        collector.adopt(kind, relativePath, format, command = currentCommandMetadata?.command)
     }
 
     override fun onCommandFinished(
@@ -110,13 +120,23 @@ internal class ArtifactsGenerator(
 
     override fun onFlowEnd() {
         stopFullRunRecording()
-        if (artifactsDir != null) {
+        val collector = collector
+        if (artifactsDir != null && collector != null) {
+            // Each command's artifact list is its collector records — the same
+            // source the manifest reads from, so commands.json can't drift.
+            debugOutput.commands.values.forEach { meta ->
+                meta.command?.let { cmd ->
+                    meta.artifacts.clear()
+                    meta.artifacts.addAll(collector.artifactsFor(cmd))
+                }
+            }
             try {
                 TestOutputWriter.saveCommands(
                     path = artifactsDir,
                     debugOutput = debugOutput,
                     commandsFilename = ArtifactFiles.COMMANDS_JSON,
                 )
+                collector.adopt(ArtifactKind.COMMAND_METADATA, ArtifactFiles.COMMANDS_JSON, ArtifactFormat.JSON)
             } catch (e: Exception) {
                 logger.warn("Failed to write commands.json under $artifactsDir", e)
             }
@@ -129,8 +149,8 @@ internal class ArtifactsGenerator(
             logCapture = null
         }
 
-        if (artifactsDir != null) {
-            artifactManifest = buildManifest(artifactsDir)
+        if (artifactsDir != null && collector != null) {
+            artifactManifest = collector.manifest()
             try {
                 TestOutputWriter.saveManifest(artifactsDir, artifactManifest)
             } catch (e: Exception) {
@@ -139,99 +159,64 @@ internal class ArtifactsGenerator(
         }
     }
 
-    private fun buildManifest(dir: Path): ArtifactManifest {
-        val entries = buildList {
-            dir.resolve(ArtifactFiles.COMMANDS_JSON).toFile().takeIf { it.exists() }?.let {
-                add(ArtifactEntry(ArtifactKind.COMMAND_METADATA, ArtifactFormat.JSON, ArtifactFiles.COMMANDS_JSON, sizeBytes = it.length()))
-            }
-            dir.resolve(ArtifactFiles.MAESTRO_LOG).toFile().takeIf { it.exists() }?.let {
-                add(ArtifactEntry(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, ArtifactFiles.MAESTRO_LOG, sizeBytes = it.length()))
-            }
-            addFolderEntry(dir, ArtifactFiles.TAKE_SCREENSHOT_DIR, ArtifactKind.TAKE_SCREENSHOT, ArtifactFormat.PNG)
-            addFolderEntry(dir, ArtifactFiles.START_RECORDING_DIR, ArtifactKind.START_SCREEN_RECORDING, ArtifactFormat.MP4)
-            addFolderEntry(dir, ArtifactFiles.STEP_SCREENSHOTS_DIR, ArtifactKind.SCREENSHOT, ArtifactFormat.PNG)
-            addFolderEntry(dir, ArtifactFiles.SCREEN_HIERARCHY_DIR, ArtifactKind.SCREEN_HIERARCHY, ArtifactFormat.JSON)
-            dir.resolve(ArtifactFiles.SCREEN_RECORDING).toFile().takeIf { it.isFile }?.let {
-                add(ArtifactEntry(
-                    ArtifactKind.SCREEN_RECORDING,
-                    ArtifactFormat.MP4,
-                    ArtifactFiles.SCREEN_RECORDING,
-                    sizeBytes = it.length(),
-                ))
-            }
-        }
-        return ArtifactManifest(entries = entries)
-    }
-
-    private fun MutableList<ArtifactEntry>.addFolderEntry(
-        dir: Path,
-        subdir: String,
-        kind: ArtifactKind,
-        format: ArtifactFormat,
-    ) {
-        val folder = dir.resolve(subdir).toFile().takeIf { it.isDirectory } ?: return
-        val count = folder.walkTopDown().count { it.isFile }
-        if (count > 0) add(ArtifactEntry(kind, format, subdir, count = count))
-    }
-
     private fun captureStepHierarchy(metadata: CommandDebugMetadata) {
-        if (artifactsDir == null) return
+        val collector = collector ?: return
         try {
             val tree = runBlocking { maestro.viewHierarchy() }.root
-            val dir = artifactsDir.resolve(ArtifactFiles.SCREEN_HIERARCHY_DIR).toFile()
-            dir.mkdirs()
-            val destFile = File(dir, "step-${metadata.sequenceNumber}.json")
-            TestOutputWriter.bundleWriter.writeValue(destFile, tree)
-            metadata.artifacts.add(
-                CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "${ArtifactFiles.SCREEN_HIERARCHY_DIR}/${destFile.name}")
+            val destFile = collector.allocate(
+                ArtifactKind.SCREEN_HIERARCHY,
+                ArtifactFormat.JSON,
+                "${ArtifactFiles.SCREEN_HIERARCHY_DIR}/step-${metadata.sequenceNumber}.json",
+                command = metadata.command,
             )
+            TestOutputWriter.bundleWriter.writeValue(destFile, tree)
         } catch (e: Exception) {
             logger.warn("Failed to capture step hierarchy", e)
         }
     }
 
     private fun captureFailureScreenshot(metadata: CommandDebugMetadata) {
-        if (artifactsDir == null) return
+        val collector = collector ?: return
         try {
-            val dir = artifactsDir.resolve(ArtifactFiles.STEP_SCREENSHOTS_DIR).toFile()
-            dir.mkdirs()
-            val destFile = File(dir, "step-${metadata.sequenceNumber}${ArtifactFiles.SCREENSHOT_EXTENSION}")
-            val written = ScreenshotUtils.takeDebugScreenshot(
+            val destFile = collector.allocate(
+                ArtifactKind.SCREENSHOT,
+                ArtifactFormat.PNG,
+                "${ArtifactFiles.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${ArtifactFiles.SCREENSHOT_EXTENSION}",
+                command = metadata.command,
+            )
+            // Null when capture failed or was deduped (parent composite after a
+            // failed leaf). The file then never lands, so the collector drops the
+            // record — attribution stays on the leaf, no extra bookkeeping here.
+            ScreenshotUtils.takeDebugScreenshot(
                 maestro = maestro,
                 debugOutput = debugOutput,
                 status = CommandStatus.FAILED,
                 destFile = destFile,
             )
-            // Null when capture failed or was deduped (parent composite after a
-            // failed leaf) — attribution then stays on the leaf command.
-            if (written != null) {
-                metadata.artifacts.add(
-                    CommandArtifact(ArtifactKind.SCREENSHOT, "${ArtifactFiles.STEP_SCREENSHOTS_DIR}/${destFile.name}")
-                )
-            }
         } catch (e: Exception) {
             logger.warn("Failed to capture failure screenshot", e)
         }
     }
 
     private fun captureStepScreenshot(metadata: CommandDebugMetadata) {
-        if (artifactsDir == null) return
+        val collector = collector ?: return
         try {
-            val dir = artifactsDir.resolve(ArtifactFiles.STEP_SCREENSHOTS_DIR).toFile()
-            dir.mkdirs()
-            val destFile = File(dir, "step-${metadata.sequenceNumber}${ArtifactFiles.SCREENSHOT_EXTENSION}")
+            val destFile = collector.allocate(
+                ArtifactKind.SCREENSHOT,
+                ArtifactFormat.PNG,
+                "${ArtifactFiles.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${ArtifactFiles.SCREENSHOT_EXTENSION}",
+                command = metadata.command,
+            )
             runBlocking { maestro.takeScreenshot(destFile.sink(), false) }
-            metadata.artifacts.add(CommandArtifact(ArtifactKind.SCREENSHOT, "${ArtifactFiles.STEP_SCREENSHOTS_DIR}/${destFile.name}"))
         } catch (e: Exception) {
             logger.warn("Failed to capture per-step screenshot", e)
         }
     }
 
     private fun startFullRunRecording() {
-        if (artifactsDir == null) return
+        val collector = collector ?: return
         try {
-            val destFile = artifactsDir.resolve(ArtifactFiles.SCREEN_RECORDING).toFile()
-            destFile.parentFile?.mkdirs()
+            val destFile = collector.allocate(ArtifactKind.SCREEN_RECORDING, ArtifactFormat.MP4, ArtifactFiles.SCREEN_RECORDING)
             fullRunRecording = runBlocking { maestro.startScreenRecording(destFile.sink()) }
         } catch (e: Exception) {
             logger.warn("Failed to start full-run screen recording", e)

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/FlowDebugOutput.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/FlowDebugOutput.kt
@@ -1,5 +1,6 @@
 package maestro.orchestra.debug
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import maestro.MaestroException
 import maestro.orchestra.ArtifactKind
 import maestro.orchestra.MaestroCommand
@@ -17,6 +18,8 @@ data class CommandDebugMetadata(
     var sequenceNumber: Int = 0,
     var evaluatedCommand: MaestroCommand? = null,
     val artifacts: MutableList<CommandArtifact> = mutableListOf(),
+    /** Back-reference used to attribute collector records; excluded from commands.json (it keys this map). */
+    @field:JsonIgnore var command: MaestroCommand? = null,
 ) {
     fun calculateDuration() {
         if (timestamp != null) {

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactCollectorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactCollectorTest.kt
@@ -1,0 +1,125 @@
+package maestro.orchestra.debug
+
+import com.google.common.truth.Truth.assertThat
+import maestro.orchestra.ArtifactFormat
+import maestro.orchestra.ArtifactKind
+import maestro.orchestra.MaestroCommand
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class ArtifactCollectorTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `allocate creates parent dirs and returns a file under the run root`() {
+        val collector = ArtifactCollector(tempDir)
+
+        val file = collector.allocate(
+            ArtifactKind.SCREEN_HIERARCHY,
+            ArtifactFormat.JSON,
+            "screen-hierarchy/step-0.json",
+        )
+        file.writeText("{}")
+
+        assertThat(file.exists()).isTrue()
+        assertThat(file.toPath().startsWith(tempDir)).isTrue()
+    }
+
+    @Test
+    fun `manifest folds a collection kind into one folder entry with a count`() {
+        val collector = ArtifactCollector(tempDir)
+
+        collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-0.png").writeText("a")
+        collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-1.png").writeText("b")
+
+        val entry = collector.manifest().entries.single { it.kind == ArtifactKind.SCREENSHOT }
+        assertThat(entry.relativePath).isEqualTo("screenshots")
+        assertThat(entry.count).isEqualTo(2)
+        assertThat(entry.sizeBytes).isNull()
+    }
+
+    @Test
+    fun `manifest emits a single-file entry with sizeBytes for non-collection kinds`() {
+        val collector = ArtifactCollector(tempDir)
+
+        collector.allocate(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, "logs/maestro.log").writeText("hello")
+
+        val entry = collector.manifest().entries.single { it.kind == ArtifactKind.MAESTRO_LOG }
+        assertThat(entry.relativePath).isEqualTo("logs/maestro.log")
+        assertThat(entry.count).isNull()
+        assertThat(entry.sizeBytes).isEqualTo(5L)
+    }
+
+    @Test
+    fun `records whose file was never written are dropped from manifest and per-command list`() {
+        val collector = ArtifactCollector(tempDir)
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        // Allocated but never written (e.g. a deduped failure screenshot).
+        collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-0.png", command = cmd)
+
+        assertThat(collector.manifest().entries.none { it.kind == ArtifactKind.SCREENSHOT }).isTrue()
+        assertThat(collector.artifactsFor(cmd)).isEmpty()
+    }
+
+    @Test
+    fun `adopt records an externally-produced file with its metadata`() {
+        val collector = ArtifactCollector(tempDir)
+        tempDir.resolve("logs").toFile().mkdirs()
+        tempDir.resolve("logs/device-logcat.txt").toFile().writeText("logcat")
+
+        collector.adopt(
+            ArtifactKind.DEVICE_LOG,
+            "logs/device-logcat.txt",
+            ArtifactFormat.TXT,
+            metadata = mapOf("source" to "emulator"),
+        )
+
+        val entry = collector.manifest().entries.single { it.kind == ArtifactKind.DEVICE_LOG }
+        assertThat(entry.relativePath).isEqualTo("logs/device-logcat.txt")
+        assertThat(entry.metadata["source"]).isEqualTo("emulator")
+        assertThat(entry.format).isEqualTo(ArtifactFormat.TXT)
+    }
+
+    @Test
+    fun `artifactsFor returns this command's individual files in allocation order`() {
+        val collector = ArtifactCollector(tempDir)
+        val first = MaestroCommand(tapOnElement = null)
+        val second = MaestroCommand(tapOnElement = null)
+
+        tempDir.resolve("takeScreenshot").toFile().mkdirs()
+        tempDir.resolve("takeScreenshot/a.png").toFile().writeText("x")
+        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/a.png", ArtifactFormat.PNG, command = second)
+        collector.allocate(ArtifactKind.SCREEN_HIERARCHY, ArtifactFormat.JSON, "screen-hierarchy/step-0.json", command = first).writeText("{}")
+        collector.allocate(ArtifactKind.SCREEN_HIERARCHY, ArtifactFormat.JSON, "screen-hierarchy/step-1.json", command = second).writeText("{}")
+
+        assertThat(collector.artifactsFor(first))
+            .containsExactly(CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-0.json"))
+        assertThat(collector.artifactsFor(second))
+            .containsExactly(
+                CommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/a.png"),
+                CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-1.json"),
+            ).inOrder()
+    }
+
+    @Test
+    fun `a path overwritten across loop iterations counts once, not per record`() {
+        val collector = ArtifactCollector(tempDir)
+        val cmd = MaestroCommand(tapOnElement = null)
+        tempDir.resolve("takeScreenshot").toFile().mkdirs()
+        tempDir.resolve("takeScreenshot/shot.png").toFile().writeText("x")
+
+        // Same command path re-run twice (repeat loop) overwrites the one file.
+        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png", ArtifactFormat.PNG, command = cmd)
+        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png", ArtifactFormat.PNG, command = cmd)
+
+        val entry = collector.manifest().entries.single { it.kind == ArtifactKind.TAKE_SCREENSHOT }
+        assertThat(entry.count).isEqualTo(1)
+        assertThat(collector.artifactsFor(cmd))
+            .containsExactly(CommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png"))
+    }
+
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -261,6 +261,8 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `registers takeScreenshot and startRecording folders as collections`() {
+        // The command-output files are written by Orchestra and reported via
+        // onCommandArtifact; the collector folds same-kind files into one entry.
         Files.createDirectories(tempDir.resolve("takeScreenshot/login"))
         Files.write(tempDir.resolve("takeScreenshot/login/home.png"), byteArrayOf(1))
         Files.write(tempDir.resolve("takeScreenshot/splash.png"), byteArrayOf(1))
@@ -268,7 +270,12 @@ class ArtifactsGeneratorTest {
         Files.write(tempDir.resolve("startRecording/clip.mp4"), byteArrayOf(1))
 
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val cmd = MaestroCommand(tapOnElement = null)
         gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/login/home.png")
+        gen.onCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/splash.png")
+        gen.onCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "startRecording/clip.mp4")
         gen.onFlowEnd()
 
         val takeScreenshot = gen.artifactManifest.entries
@@ -383,9 +390,18 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `registers the full-run recording at the run root`() {
-        Files.write(tempDir.resolve("screen-recording.mp4"), byteArrayOf(1, 2, 3))
+        // The recording is allocated through the collector when the flag is on;
+        // the driver streams bytes into the allocated sink.
+        val maestro = mockMaestro()
+        coEvery { maestro.startScreenRecording(any()) } answers {
+            val sink = firstArg<Sink>()
+            val buffer = Buffer().write(byteArrayOf(1, 2, 3))
+            sink.write(buffer, buffer.size)
+            sink.flush()
+            mockk(relaxed = true)
+        }
 
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureScreenRecording = true)
         gen.onFlowStart()
         gen.onFlowEnd()
 
@@ -404,6 +420,9 @@ class ArtifactsGeneratorTest {
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
+        // Orchestra writes the file before dispatching onCommandArtifact.
+        Files.createDirectories(tempDir.resolve("takeScreenshot"))
+        Files.write(tempDir.resolve("takeScreenshot/checkout.png"), byteArrayOf(1))
         gen.onCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/checkout.png")
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
@@ -442,6 +461,9 @@ class ArtifactsGeneratorTest {
         gen.onCommandStart(first, sequenceNumber = 0)
         gen.onCommandFinished(first, CommandOutcome.Completed, 100L, 150L)
         gen.onCommandStart(second, sequenceNumber = 1)
+        // Orchestra writes the file before dispatching onCommandArtifact.
+        Files.createDirectories(tempDir.resolve("takeScreenshot"))
+        Files.write(tempDir.resolve("takeScreenshot/checkout.png"), byteArrayOf(1))
         gen.onCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/checkout.png")
         gen.onCommandFinished(second, CommandOutcome.Completed, 150L, 200L)
         gen.onFlowEnd()


### PR DESCRIPTION
**Addresses review on #3343** ("Artifact manifest: record, don't scan"). Builds on `feat/orchestra-artifact-manifest`.

## The problem 
The manifest was *derived* by scanning the run-root folders at flow end (`ArtifactsGenerator.buildManifest` → `walkTopDown()`/`File.exists()`), while the per-command `artifacts` list in `commands.json` was built separately from listener events + direct appends. Two independent derivations of the same truth → they can disagree, the scan only sees hardcoded kinds, and there was no single "register an artifact" operation.

## The change: record, don't scan
A single `ArtifactCollector` owns path allocation and the artifact record:
- **`allocate(kind, format, relativePath, …) → File`** — for files core writes. Records the artifact atomically; nothing reaches the bundle unrecorded.
- **`adopt(kind, relativePath, format, …)`** — for files collected from outside (device logs, crash/ANR on the worker; takeScreenshot/startRecording command output).

The **manifest is `collector.manifest()`** and each **command's artifact list is `collector.artifactsFor(cmd)`** — two views of one record set, so they can no longer drift. The disk scan (`buildManifest`/`addFolderEntry`) and the four direct `metadata.artifacts.add(...)` sites are deleted.

`producer` (`CORE`/`WORKER`) is added to `ArtifactEntry` so worker- vs core-produced is *data*, not a second code path — and `adopt` generalizes to non-core producers (e.g. a future `USER_FILE`) without re-implementing capture in core.

## Deliberate scoping
- **Capture gating stays two booleans.** They're worker-set and orthogonal; collapsing to one policy needs worker-side verification and is out of scope here.
- **`ArtifactFiles` stays in `-models`.** It's a real shared contract (CLI copier + schema); the drift surface is removed by routing all writes through the collector, not by relocating constants.
- **No device-log code here** — this PR is on the pre-device base. The stacked device branch (#3346) will route its capture through `adopt(...)` when it rebases.

## Testing
- New `ArtifactCollectorTest` (8 tests) covering allocate/adopt, collection folding, dedup-by-path, the drop-if-unwritten rule, and per-command attribution.
- The existing `ArtifactsGeneratorTest` is the regression harness and stays green; four tests that exercised the *scan* were rewritten to drive the real *record* path.
- `:maestro-orchestra:test`, `:maestro-orchestra-models:test`, and the CLI `TestDebugReporter` tests pass locally.
- An adversarial self-review caught a count regression (a `takeScreenshot` reused across a `repeat`/`retry` loop overwrites one file but produced N records) — fixed with dedup-by-path and a test.
