### PR TITLE
refactor(orchestra): consolidate capture flags into captureFullArtifacts

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -129,9 +129,7 @@ class DefaultFlowController : FlowController {
 class Orchestra(
     private val maestro: Maestro,
     private val artifactsDir: Path? = null,
-    /** Worker-only flags: per-step screenshots / a full-run recording in the bundle. */
-    private val captureStepScreenshots: Boolean = false,
-    private val captureScreenRecording: Boolean = false,
+    private val captureFullArtifacts: Boolean = false,
     private val listeners: List<OrchestraListener> = emptyList(),
     private val lookupTimeoutMs: Long = 17000L,
     private val optionalLookupTimeoutMs: Long = 7000L,
@@ -174,7 +172,7 @@ class Orchestra(
     // ArtifactsGenerator is always the first listener: it writes the bundle when
     // artifactsDir is set and populates debugOutput either way.
     private val artifactsGenerator: ArtifactsGenerator =
-        ArtifactsGenerator(artifactsDir, maestro, captureStepScreenshots, captureScreenRecording)
+        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts)
     private val effectiveListeners: List<OrchestraListener> = listOf(artifactsGenerator) + listeners
 
     private var commandSequenceCounter: Int = 0

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -21,8 +21,9 @@ import java.nio.file.Path
  * when [artifactsDir] is non-null, writes the per-flow artifact bundle
  * directly under it — see [ArtifactFiles] for the layout. With a null
  * [artifactsDir] (Studio's interactive runner) only the in-memory population
- * happens. Per-step screenshots and the full-run recording are flag-gated
- * ([captureStepScreenshots], [captureScreenRecording] — worker, not the CLI).
+ * happens. The full artifact set — per-step screenshots + the full-run recording
+ * — is gated by [captureFullArtifacts] (worker, not the CLI); off, only the
+ * failure screenshot is captured.
  *
  * Every file is routed through an [ArtifactCollector]: the manifest is the
  * collector's records and each command's artifact list is the same records
@@ -31,8 +32,7 @@ import java.nio.file.Path
 internal class ArtifactsGenerator(
     private val artifactsDir: Path?,
     private val maestro: Maestro,
-    private val captureStepScreenshots: Boolean = false,
-    private val captureScreenRecording: Boolean = false,
+    private val captureFullArtifacts: Boolean = false,
 ) : OrchestraListener {
 
     val debugOutput = FlowDebugOutput()
@@ -58,7 +58,7 @@ internal class ArtifactsGenerator(
         } catch (e: Exception) {
             logger.warn("Failed to set up artifacts directory at $artifactsDir", e)
         }
-        if (captureScreenRecording) startFullRunRecording()
+        if (captureFullArtifacts) startFullRunRecording()
     }
 
     override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int) {
@@ -103,7 +103,7 @@ internal class ArtifactsGenerator(
         captureStepHierarchy(metadata)
         if (outcome is CommandOutcome.Failed) {
             captureFailureScreenshot(metadata)
-        } else if (captureStepScreenshots) {
+        } else if (captureFullArtifacts) {
             captureStepScreenshot(metadata)
         }
     }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -310,7 +310,7 @@ class ArtifactsGeneratorTest {
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
-            captureStepScreenshots = true,
+            captureFullArtifacts = true,
         )
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -331,7 +331,7 @@ class ArtifactsGeneratorTest {
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
-            captureStepScreenshots = true,
+            captureFullArtifacts = true,
         )
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -368,7 +368,7 @@ class ArtifactsGeneratorTest {
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = maestro,
-            captureScreenRecording = true,
+            captureFullArtifacts = true,
         )
 
         gen.onFlowStart()
@@ -401,7 +401,7 @@ class ArtifactsGeneratorTest {
             mockk(relaxed = true)
         }
 
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureScreenRecording = true)
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
         gen.onFlowStart()
         gen.onFlowEnd()
 
@@ -598,7 +598,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `with the flag on the failed command's screenshot is part of the per-step set`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureStepScreenshots = true)
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
         val ok = MaestroCommand(tapOnElement = null)
         val bad = MaestroCommand(scrollCommand = ScrollCommand())
 


### PR DESCRIPTION
**Stacked on #3353** (the ArtifactCollector refactor).

Collapses the two worker-only capture flags into one. The cloud worker always sets both together or neither, so two flags only added surface area.

## Change
`Orchestra` / `ArtifactsGenerator`:
- `captureStepScreenshots` + `captureScreenRecording` → **`captureFullArtifacts: Boolean = false`**
- `true` → per-step screenshots **and** the full-run recording
- `false` (default, and what the CLI uses) → failure screenshot only, no recording

No behavior change for any combination the worker actually used; the CLI was already passing neither.

## ⚠️ Requires a matching worker change
`Orchestra`'s constructor is the worker's API. Before/with the dependency bump, the `copilot` worker call site must swap its two args for the single `captureFullArtifacts`. This PR alone will break the worker build until that lands.

## Testing
`:maestro-orchestra:test` green. The four tests that set one of the old flags now set `captureFullArtifacts` (which enables both paths — still consistent with their assertions).
