### PR TITLE
Switch demo_app to 3 column layout

### DIFF
--- a/e2e/demo_app/lib/main.dart
+++ b/e2e/demo_app/lib/main.dart
@@ -116,16 +116,27 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text(widget.title),
       ),
       body: SingleChildScrollView(
-        padding: const EdgeInsets.all(8),
+        padding: const EdgeInsets.all(6),
         child: Column(
           children: [
-            GridView.count(
-              crossAxisCount: 2,
+            Theme(
+              data: Theme.of(context).copyWith(
+                elevatedButtonTheme: ElevatedButtonThemeData(
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    textStyle: const TextStyle(fontSize: 12),
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    minimumSize: Size.zero,
+                  ),
+                ),
+              ),
+              child: GridView.count(
+              crossAxisCount: 3,
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),
-              childAspectRatio: 3,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
+              childAspectRatio: 2.6,
+              mainAxisSpacing: 6,
+              crossAxisSpacing: 6,
               children: [
                 if (!kIsWeb)
                   ElevatedButton(
@@ -298,11 +309,20 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
               ],
             ),
-            const SizedBox(height: 16),
-            const Text('You have pushed the button this many times'),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
+            ),
+            const SizedBox(height: 12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Flexible(
+                  child: Text('You have pushed the button this many times'),
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '$_counter',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                ),
+              ],
             ),
           ],
         ),


### PR DESCRIPTION
## Proposed changes

More e2e tests are being added, which requires more home screen options in demo_app. This has started breaking tests, as options are sliding out of view.

This PR alters the layout to be more economical with the screen space, switching to 3 columns. This app was never gonna win design awards anyway :)

<img width="804" height="1810" alt="image" src="https://github.com/user-attachments/assets/1ef59bef-78ad-412f-8ea5-1043ea639b3a" />

## Testing

e2e in CI

## Issues fixed
