### PR TITLE
Improve flutter CI for demo_app

### DIFF
--- a/.github/actions/build-demo-app/action.yml
+++ b/.github/actions/build-demo-app/action.yml
@@ -1,0 +1,99 @@
+name: Build demo_app
+description: >
+  Build the demo_app Flutter binary for the given platform, caching the output so
+  the build is skipped when the app source is unchanged. Single source of truth for
+  the cache key — used by the PR e2e jobs and the main warming workflow, so the key
+  MUST stay identical across callers (a divergent key = permanent cache miss, silently).
+
+inputs:
+  platform:
+    description: "android (builds e2e/apps/demo_app.apk) or ios (builds e2e/apps/demo_app.app)"
+    required: true
+
+outputs:
+  binary-path:
+    description: "Path to the built binary (e2e/apps/demo_app.apk for android, .app for ios)"
+    value: ${{ steps.resolve.outputs.binary-path }}
+
+runs:
+  using: composite
+  steps:
+    # Single source of truth for where the binary lands — consumed by the cache step's
+    # path:, the copy destination below, and exposed as the binary-path output so callers
+    # don't re-state it. Writes only to $GITHUB_OUTPUT, so it doesn't touch e2e/demo_app
+    # and is safe to run before the hashFiles-based cache step.
+    - name: Resolve binary path
+      id: resolve
+      shell: bash
+      run: |
+        if [ "${{ inputs.platform }}" = "android" ]; then
+          echo "binary-path=e2e/apps/demo_app.apk" >> "$GITHUB_OUTPUT"
+        else
+          echo "binary-path=e2e/apps/demo_app.app" >> "$GITHUB_OUTPUT"
+        fi
+
+    # MUST run before anything generates files under e2e/demo_app, on a FRESH checkout.
+    # hashFiles hashes the working tree at step-execution time and has no exclusion syntax,
+    # so the broad android/** | ios/** globs would hash generated/restored dirs (.gradle,
+    # .dart_tool, Pods, build/) if pub get / gradle restore had already run. Keep this
+    # before "Cache pub" / "Cache Gradle" / "Set up Flutter" below. Reordering breaks the
+    # key SILENTLY (no error, just permanent misses). The globs deliberately exclude
+    # .maestro/** (and test/, docs) so flow-only PRs hit the cache. No restore-keys: a
+    # partial match must never skip the build and serve a stale binary. Bump the v1- prefix
+    # HERE only to invalidate.
+    - name: Cache demo_app build
+      id: cache-demo-app
+      uses: actions/cache@v5
+      with:
+        path: ${{ steps.resolve.outputs.binary-path }}
+        key: ${{ inputs.platform == 'android'
+          && format('v1-demo-app-apk-{0}', hashFiles('e2e/demo_app/lib/**', 'e2e/demo_app/android/**', 'e2e/demo_app/assets/**', 'e2e/demo_app/assets_in_root/**', 'e2e/demo_app/pubspec.yaml', 'e2e/demo_app/pubspec.lock'))
+          || format('v1-demo-app-app-{0}', hashFiles('e2e/demo_app/lib/**', 'e2e/demo_app/ios/**', 'e2e/demo_app/assets/**', 'e2e/demo_app/assets_in_root/**', 'e2e/demo_app/pubspec.yaml', 'e2e/demo_app/pubspec.lock')) }}
+
+    - name: Cache pub
+      if: steps.cache-demo-app.outputs.cache-hit != 'true'
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.pub-cache
+          e2e/demo_app/.dart_tool
+        key: pub-${{ runner.os }}-${{ hashFiles('e2e/demo_app/pubspec.lock') }}
+        restore-keys: |
+          pub-${{ runner.os }}-
+
+    - name: Cache Gradle
+      if: inputs.platform == 'android' && steps.cache-demo-app.outputs.cache-hit != 'true'
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+          e2e/demo_app/android/.gradle
+        key: gradle-${{ runner.os }}-${{ hashFiles('e2e/demo_app/android/**/*.gradle*', 'e2e/demo_app/android/gradle/wrapper/gradle-wrapper.properties') }}
+        restore-keys: |
+          gradle-${{ runner.os }}-
+
+    - name: Set up Flutter
+      if: steps.cache-demo-app.outputs.cache-hit != 'true'
+      uses: subosito/flutter-action@v2
+      with:
+        channel: stable
+        flutter-version-file: e2e/demo_app/pubspec.yaml
+        cache: true # cache the Flutter SDK download
+        pub-cache: false # "Cache pub" step owns ~/.pub-cache
+
+    - name: Build demo_app
+      if: steps.cache-demo-app.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: ${{ github.workspace }}/e2e/demo_app
+      run: |
+        dest="${{ github.workspace }}/${{ steps.resolve.outputs.binary-path }}"
+        flutter pub get
+        mkdir -p "$(dirname "$dest")"
+        if [ "${{ inputs.platform }}" = "android" ]; then
+          flutter build apk
+          cp build/app/outputs/flutter-apk/app-release.apk "$dest"
+        else
+          flutter build ios --simulator
+          cp -r build/ios/iphonesimulator/Runner.app "$dest"
+        fi

--- a/.github/workflows/build-demo-app.yml
+++ b/.github/workflows/build-demo-app.yml
@@ -1,0 +1,60 @@
+name: Build demo_app
+
+# Builds the demo_app for both Android and iOS, caches each binary so future PRs skip the
+# build, and publishes them as downloadable artifacts.
+#
+# Runs on the DEFAULT branch so it writes a main-scoped actions/cache entry — the only way
+# PRs can share the cache (a run reads caches from its own branch + the default branch, and
+# default-branch caches are only written by runs triggered on the default branch;
+# test-e2e.yaml never runs on push). The published artifacts let developers download the
+# prebuilt binaries instead of building them locally.
+on:
+  push:
+    branches: [main]
+    # Only build when the app source actually changes: if only flows change, the source
+    # hash is unchanged so the existing main-scoped cache is still valid (negation on
+    # .maestro/** excludes flow-only pushes).
+    paths:
+      - 'e2e/demo_app/**'
+      - '!e2e/demo_app/.maestro/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build & publish demo_app (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: android
+            os: ubuntu-latest
+            artifact: demo_app-apk
+          - platform: ios
+            os: macos-26
+            artifact: demo_app-ios-app
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Build demo_app (warms main-scoped cache via the shared action's key)
+        id: build
+        uses: ./.github/actions/build-demo-app
+        with:
+          platform: ${{ matrix.platform }}
+
+      - name: Upload prebuilt demo_app
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ steps.build.outputs.binary-path }}
+          retention-days: 14
+          include-hidden-files: true

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -293,40 +293,10 @@ jobs:
           echo "$ANDROID_HOME/platform-tools" >> $GITHUB_PATH
           sdkmanager --install "$ANDROID_OS_IMAGE"
 
-      - name: Cache pub
-        uses: actions/cache@v5
+      - name: Build demo_app # Or fetch cached version
+        uses: ./.github/actions/build-demo-app
         with:
-          path: |
-            ~/.pub-cache
-            e2e/demo_app/.dart_tool
-          key: pub-${{ runner.os }}-${{ hashFiles('e2e/demo_app/pubspec.lock') }}
-          restore-keys: |
-            pub-${{ runner.os }}-
-
-      - name: Cache Gradle
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            e2e/demo_app/android/.gradle
-          key: gradle-${{ runner.os }}-${{ hashFiles('e2e/demo_app/android/**/*.gradle*', 'e2e/demo_app/android/gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            gradle-${{ runner.os }}-
-
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          channel: stable
-          flutter-version-file: e2e/demo_app/pubspec.yaml
-
-      - name: Build demo_app APK
-        working-directory: ${{ github.workspace }}/e2e/demo_app
-        run: |
-          flutter pub get
-          flutter build apk
-          mkdir -p ${{ github.workspace }}/e2e/apps
-          cp build/app/outputs/flutter-apk/app-release.apk ${{ github.workspace }}/e2e/apps/demo_app.apk
+          platform: android
 
       - name: Download Maestro build from previous job
         uses: actions/download-artifact@v8
@@ -425,19 +395,10 @@ jobs:
           distribution: zulu
           java-version: 17
 
-      - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+      - name: Build demo_app # Or fetch cached version
+        uses: ./.github/actions/build-demo-app
         with:
-          channel: stable
-          flutter-version-file: e2e/demo_app/pubspec.yaml
-
-      - name: Build demo_app for iOS Simulator
-        working-directory: ${{ github.workspace }}/e2e/demo_app
-        run: |
-          flutter pub get
-          flutter build ios --simulator
-          mkdir -p ${{ github.workspace }}/e2e/apps
-          cp -r build/ios/iphonesimulator/Runner.app ${{ github.workspace }}/e2e/apps/demo_app.app
+          platform: ios
 
       - name: Download artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Proposed changes

Reduces build times by caching artifacts. Reduces complexity by keeping it centralised in a single reusable action.

- Moves all flutter setup and flutter app building to a single action
- Implements a little more caching of dependencies
- Implements caching of the build artifact, to reduce time waiting on e2e tests
- Adds a job to main to update the cache for dependent PRs (and add an artifact, in case that's useful)

## Testing

This is all CI, let's see what happens when I open this PR...

## Issues fixed
