### PR TITLE
test(ios): compare view-hierarchy walk complexity before/after #3313

### DIFF
--- a/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/project.pbxproj
+++ b/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		52049BE0293503A200807AA3 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52049BDF293503A200807AA3 /* Assets.xcassets */; };
 		52049BE3293503A200807AA3 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 52049BE1293503A200807AA3 /* LaunchScreen.storyboard */; };
 		52049BF8293503A200807AA3 /* maestro_driver_iosUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52049BF7293503A200807AA3 /* maestro_driver_iosUITests.swift */; };
+		FED1C00000000000000000C2 /* ViewHierarchyComplexityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED1C00000000000000000C1 /* ViewHierarchyComplexityTests.swift */; };
 		521C1F032D8014410024EE42 /* AXClientProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C1F022D8014340024EE42 /* AXClientProxy.h */; };
 		521C1F052D8016950024EE42 /* XCAccessibilityElement.h in Headers */ = {isa = PBXBuildFile; fileRef = 521C1F042D8016950024EE42 /* XCAccessibilityElement.h */; };
 		521C1F072D8017480024EE42 /* AXClientProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 521C1F062D8017460024EE42 /* AXClientProxy.m */; };
@@ -177,6 +178,7 @@
 		52049BE4293503A200807AA3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52049BF3293503A200807AA3 /* maestro-driver-iosUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "maestro-driver-iosUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52049BF7293503A200807AA3 /* maestro_driver_iosUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = maestro_driver_iosUITests.swift; sourceTree = "<group>"; };
+		FED1C00000000000000000C1 /* ViewHierarchyComplexityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewHierarchyComplexityTests.swift; sourceTree = "<group>"; };
 		521C1F022D8014340024EE42 /* AXClientProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AXClientProxy.h; sourceTree = "<group>"; };
 		521C1F042D8016950024EE42 /* XCAccessibilityElement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCAccessibilityElement.h; sourceTree = "<group>"; };
 		521C1F062D8017460024EE42 /* AXClientProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AXClientProxy.m; sourceTree = "<group>"; };
@@ -470,6 +472,7 @@
 				52D8F8F12D6DCC150015FAB3 /* PrivateHeaders */,
 				943A907A293F5AF400C85136 /* Routes */,
 				52049BF7293503A200807AA3 /* maestro_driver_iosUITests.swift */,
+				FED1C00000000000000000C1 /* ViewHierarchyComplexityTests.swift */,
 			);
 			path = "maestro-driver-iosUITests";
 			sourceTree = "<group>";
@@ -1046,6 +1049,7 @@
 				52D8FA9D2D6DCFAF0015FAB3 /* XCUIApplicationProcess+FBQuiescence.m in Sources */,
 				32097965297092A800340282 /* InputTextRequest.swift in Sources */,
 				52049BF8293503A200807AA3 /* maestro_driver_iosUITests.swift in Sources */,
+				FED1C00000000000000000C2 /* ViewHierarchyComplexityTests.swift in Sources */,
 				52D8FAB02D6DD4100015FAB3 /* FBConfiguration.m in Sources */,
 				61C0AFE929C86378005D1FC5 /* PressButtonRequest.swift in Sources */,
 				6124329E2A4DA5BB00F5F619 /* AXElement.swift in Sources */,

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
@@ -304,7 +304,9 @@ struct ViewHierarchyHandler: HTTPHandler {
     /// (see `crossProcessWindowOffset`) and inherit it down the subtree so descendant
     /// frames are reported in screen coordinates rather than the foreign window's
     /// local coordinates.
-    private func elementHierarchy(
+    // `internal` (not `private`) so the complexity test can drive the walk directly with a
+    // fake `XCUIElementSnapshot` and count how many times it reads the screen.
+    func elementHierarchy(
         snapshot: XCUIElementSnapshot,
         inheritedOffset: CGVector,
         parentWindowContextID: Double?

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/ViewHierarchyComplexityTests.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/ViewHierarchyComplexityTests.swift
@@ -1,0 +1,131 @@
+//
+//  ViewHierarchyComplexityTests.swift
+//
+//  Compares the algorithmic complexity of the iOS view-hierarchy walk before and after #3313.
+//
+//  `elementHierarchy` runs on every Maestro iOS command (assert / tap / wait) to convert the
+//  XCTest snapshot into Maestro's `AXElement` tree. `XCUIElementSnapshot.dictionaryRepresentation`
+//  is a DEEP call — it serializes the element AND its entire subtree on every access.
+//
+//    • BEFORE #3313: read the screen ONCE at the root  -> Θ(N)        (deepReadCalls == 1, work == N)
+//    • AFTER  #3313: read the screen once PER NODE      -> Θ(N²)       (deepReadCalls == N, work == N·(N+1)/2)
+//
+//  Both sides are exercised against real production code (the pre-#3313 body uses the real
+//  `AXElement(_:)` initializer; the post-#3313 case drives the real `ViewHierarchyHandler`),
+//  with an instrumented fake `XCUIElementSnapshot` counting the work.
+//
+//  Run just this class:
+//    xcodebuild test -scheme maestro-driver-ios \
+//      -destination 'platform=iOS Simulator,name=iPhone 16' \
+//      -only-testing:maestro-driver-iosUITests/ViewHierarchyComplexityTests
+//
+
+import XCTest
+import CoreGraphics
+import MaestroDriverLib
+
+/// Minimal `XCUIElementSnapshot` whose deep `dictionaryRepresentation` is counted. The
+/// attributes the walk reads via KVC (`isRemote`, `visibleFrame`) are exposed as `@objc`
+/// members so `responds(to:)` / `value(forKey:)` behave like a real snapshot.
+final class FakeSnapshot: NSObject, XCUIElementSnapshot {
+    static var deepReadCalls = 0     // times `dictionaryRepresentation` was accessed
+    static var nodesSerialized = 0   // total nodes touched by deep serialization
+    static func resetCounters() { deepReadCalls = 0; nodesSerialized = 0 }
+
+    private let id: String
+    private let frameDict: AXFrame
+    private let windowCtxID: Double
+    private let visible: AXFrame?
+    private let remote: Bool
+    let childNodes: [FakeSnapshot]
+
+    init(id: String, frame: AXFrame = ["X": 0, "Y": 0, "Width": 100, "Height": 100],
+         windowContextID: Double = 0, visibleFrame: AXFrame? = nil, isRemote: Bool = false,
+         children: [FakeSnapshot] = []) {
+        self.id = id; self.frameDict = frame; self.windowCtxID = windowContextID
+        self.visible = visibleFrame; self.remote = isRemote; self.childNodes = children
+    }
+
+    var children: [XCUIElementSnapshot] { childNodes }
+    var elementType: XCUIElement.ElementType { .other }
+    var identifier: String { id }
+    var label: String { "" }
+    var title: String { "" }
+    var value: Any? { nil }
+    var placeholderValue: String? { nil }
+    var isEnabled: Bool { true }
+    var isSelected: Bool { false }
+    var hasFocus: Bool { false }
+    var frame: CGRect {
+        CGRect(x: frameDict["X"] ?? 0, y: frameDict["Y"] ?? 0,
+               width: frameDict["Width"] ?? 0, height: frameDict["Height"] ?? 0)
+    }
+    var horizontalSizeClass: XCUIElement.SizeClass { .unspecified }
+    var verticalSizeClass: XCUIElement.SizeClass { .unspecified }
+
+    var dictionaryRepresentation: [XCUIElement.AttributeName: Any] {
+        Self.deepReadCalls += 1
+        return serialize()
+    }
+    private func serialize() -> [XCUIElement.AttributeName: Any] {
+        Self.nodesSerialized += 1
+        return [
+            XCUIElement.AttributeName(rawValue: "identifier"): id,
+            XCUIElement.AttributeName(rawValue: "frame"): frameDict,
+            XCUIElement.AttributeName(rawValue: "windowContextID"): windowCtxID,
+            XCUIElement.AttributeName(rawValue: "children"): childNodes.map { $0.serialize() },
+        ]
+    }
+
+    @objc var isRemote: Bool { remote }
+    @objc var visibleFrame: NSValue {
+        let f = visible ?? frameDict
+        return NSValue(cgRect: CGRect(x: f["X"] ?? 0, y: f["Y"] ?? 0,
+                                      width: f["Width"] ?? 0, height: f["Height"] ?? 0))
+    }
+}
+
+@MainActor
+final class ViewHierarchyComplexityTests: XCTestCase {
+
+    /// A linear chain of `n` nodes (depth == n) — the worst case, and the realistic shape of
+    /// long scrollable document / list screens.
+    private func chain(_ n: Int) -> FakeSnapshot {
+        var node = FakeSnapshot(id: "n\(n - 1)")
+        for i in stride(from: n - 2, through: 0, by: -1) {
+            node = FakeSnapshot(id: "n\(i)", children: [node])
+        }
+        return node
+    }
+
+    /// BEFORE #3313: `elementHierarchy(xcuiElement:)` was simply
+    ///     `let dict = snapshot.dictionaryRepresentation; return AXElement(dict)`
+    /// i.e. ONE deep read at the root, then build the tree from that in-memory dictionary.
+    /// Total work: Θ(N). We exercise that exact body via the real `AXElement(_:)` initializer.
+    func test_before3313_readsScreenOnce_isLinear() {
+        for n in [16, 64, 256, 512] {
+            FakeSnapshot.resetCounters()
+            _ = AXElement(chain(n).dictionaryRepresentation) // the pre-#3313 conversion body
+            XCTAssertEqual(FakeSnapshot.deepReadCalls, 1,
+                           "before #3313: the screen is read once, at the root. n=\(n)")
+            XCTAssertEqual(FakeSnapshot.nodesSerialized, n,
+                           "before #3313: linear work == N. n=\(n)")
+        }
+    }
+
+    /// AFTER #3313 (current `main`): `elementHierarchy` calls the deep
+    /// `dictionaryRepresentation` once PER NODE, so total work is exactly N·(N+1)/2 -> Θ(N²).
+    /// We drive the real handler.
+    func test_after3313_readsScreenPerNode_isQuadratic() {
+        for n in [16, 64, 256, 512] {
+            FakeSnapshot.resetCounters()
+            _ = ViewHierarchyHandler().elementHierarchy(
+                snapshot: chain(n), inheritedOffset: .zero, parentWindowContextID: nil
+            )
+            XCTAssertEqual(FakeSnapshot.deepReadCalls, n,
+                           "after #3313: the screen is read once per node. n=\(n)")
+            XCTAssertEqual(FakeSnapshot.nodesSerialized, n * (n + 1) / 2,
+                           "after #3313: total work == N·(N+1)/2 -> Θ(N²). n=\(n)")
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a unit test that measures how much work the iOS view-hierarchy walk does, **before and after #3313**, both against real production code, plus a one-line `private → internal` change so the walk is reachable from the test.

## Why

`ViewHierarchyHandler.elementHierarchy` runs on **every** iOS command (assert / tap / wait) to convert the XCTest snapshot into Maestro's `AXElement` tree. `XCUIElementSnapshot.dictionaryRepresentation` is a **deep** call — it serializes the element *and its whole subtree* on every access.

- **Before #3313** the walk was `let dict = snapshot.dictionaryRepresentation; return AXElement(dict)` — one deep read at the root → **Θ(N)**.
- **After #3313** (current `main`) it calls `dictionaryRepresentation` **once per node** → **Θ(N²)**, exactly `N·(N+1)/2` deep serializations for a chain of `N` elements.

It is a **pure performance** change — the walk returns the same tree, just much slower on element-dense screens, which is why long iOS flows started tipping over the 15-minute execution cap.

## Result

`deepReadCalls` = times the screen is read; `nodesSerialized` = total work. Measured on a chain of N elements:

| N (elements) | before #3313 reads | before #3313 work | after #3313 reads | after #3313 work (= N·(N+1)/2) |
|---|---|---|---|---|
| 16  | 1 | 16  | 16  | 136 |
| 64  | 1 | 64  | 64  | 2,080 |
| 256 | 1 | 256 | 256 | 32,896 |
| 512 | 1 | 512 | 512 | 131,328 |

So #3313 turned a single read-per-command into one read **per element** — ~128× more work at 256 elements, ~256× at 512.

## Test

`-only-testing:maestro-driver-iosUITests/ViewHierarchyComplexityTests` — 2 tests (before / after #3313), green on iPhone 16 / iOS 18.2.

- `test_before3313_readsScreenOnce_isLinear` — exercises the pre-#3313 body via the real `AXElement(_:)` initializer → 1 read, N work.
- `test_after3313_readsScreenPerNode_isQuadratic` — drives the real `ViewHierarchyHandler` → N reads, N·(N+1)/2 work.