### PR TITLE
Fix inputs for driver build job

### DIFF
--- a/.github/workflows/update-drivers.yaml
+++ b/.github/workflows/update-drivers.yaml
@@ -65,10 +65,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.CI_BOT_APP_ID }}
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
@@ -112,10 +112,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.CI_BOT_APP_ID }}
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Proposed changes

#3294 introduced a job that only runs on main, but fails because of some job config

This fixes the typo, and bumps the action version.

## Testing

A run here: https://github.com/mobile-dev-inc/Maestro/actions/runs/27782028618 (iOS commit failed because this wasn't on main)
