### PR TITLE
Fix detatched HEAD, and account for push conflicts

### DIFF
--- a/.github/workflows/update-drivers.yaml
+++ b/.github/workflows/update-drivers.yaml
@@ -99,8 +99,18 @@ jobs:
             exit 0
           fi
           git commit -m "chore: update Android driver APKs [skip ci] (source: ${GITHUB_SHA::7})"
-          git pull --rebase origin main
-          git push
+          # Android and iOS jobs (and concurrent PR merges) can push to the same
+          # branch in parallel, so retry rebase+push until it lands fast-forward.
+          for attempt in $(seq 1 5); do
+            git pull --rebase origin "${{ github.ref_name }}"
+            if git push origin "HEAD:${{ github.ref_name }}"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt) — remote advanced, retrying after rebase…"
+            sleep $((attempt * 3))
+          done
+          echo "Failed to push after 5 attempts"
+          exit 1
 
   update-ios-driver:
     name: Update iOS Driver
@@ -139,5 +149,15 @@ jobs:
             exit 0
           fi
           git commit -m "chore: update iOS driver [skip ci] (source: ${GITHUB_SHA::7})"
-          git pull --rebase origin main
-          git push
+          # Android and iOS jobs (and concurrent PR merges) can push to the same
+          # branch in parallel, so retry rebase+push until it lands fast-forward.
+          for attempt in $(seq 1 5); do
+            git pull --rebase origin "${{ github.ref_name }}"
+            if git push origin "HEAD:${{ github.ref_name }}"; then
+              exit 0
+            fi
+            echo "Push rejected (attempt $attempt) — remote advanced, retrying after rebase…"
+            sleep $((attempt * 3))
+          done
+          echo "Failed to push after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Proposed changes

#3365 fixed CI token generation from #3294
This does more fixing for #3294 
- fixes git push to a remote (previously, a detatched HEAD, so can't push anywhere)
- fixes git push when the jobs race each other, or another merge
- fixes workflow dispatch against a branch (in case, for some reason, folks want up-to-date drivers on the branch)

## Testing

Successful workflow dispatch: https://github.com/mobile-dev-inc/Maestro/actions/runs/27783663617

