### PR TITLE
feat(orchestra): per-execution commands.json with nesting depth

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/CliConsoleListener.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/CliConsoleListener.kt
@@ -10,7 +10,7 @@ class CliConsoleListener(private val shardPrefix: String = "") : OrchestraListen
 
     private val logger = LoggerFactory.getLogger(CliConsoleListener::class.java)
 
-    override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int) {
+    override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int, depth: Int) {
         logger.info("${shardPrefix}${cmd.description()} RUNNING")
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -177,6 +177,9 @@ class Orchestra(
 
     private var commandSequenceCounter: Int = 0
 
+    // Dispatched to listeners as `depth`: 0 at the flow top, bumped inside each subflow.
+    private var subflowDepth: Int = 0
+
     // Keyed by sequence number, not MaestroCommand: the latter has structural
     // equality, so two identical commands would collide as map keys.
     private val commandStartTimes = mutableMapOf<Int, Long>()
@@ -277,7 +280,7 @@ class Orchestra(
                 val sequenceNumber = commandSequenceCounter++
                 val startedAt = System.currentTimeMillis()
                 commandStartTimes[sequenceNumber] = startedAt
-                dispatch("onCommandStart") { it.onCommandStart(command, sequenceNumber) }
+                dispatch("onCommandStart") { it.onCommandStart(command, sequenceNumber, subflowDepth) }
 
                 jsEngine.onLogMessage { msg ->
                     val metadata = getMetadata(command)
@@ -1034,6 +1037,7 @@ class Orchestra(
 
     private suspend fun executeSubflowCommands(commands: List<MaestroCommand>, config: MaestroConfig?): Boolean {
         jsEngine.enterScope()
+        subflowDepth++
 
         return try {
             commands
@@ -1043,7 +1047,7 @@ class Orchestra(
                     val sequenceNumber = commandSequenceCounter++
                     val startedAt = System.currentTimeMillis()
                     commandStartTimes[sequenceNumber] = startedAt
-                    dispatch("onCommandStart") { it.onCommandStart(command, sequenceNumber) }
+                    dispatch("onCommandStart") { it.onCommandStart(command, sequenceNumber, subflowDepth) }
 
                     val evaluatedCommand = command.evaluateScripts(jsEngine)
                     val metadata = getMetadata(command)
@@ -1093,6 +1097,7 @@ class Orchestra(
                 }
                 .any { it }
         } finally {
+            subflowDepth--
             jsEngine.leaveScope()
         }
     }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
@@ -38,6 +38,8 @@ internal class ArtifactCollector(private val runRoot: Path) {
         val relativePath: String,
         val metadata: Map<String, String>,
         val command: MaestroCommand?,
+        /** Executing command's sequence number; null for flow-level artifacts. */
+        val sequenceNumber: Int? = null,
     )
 
     private val records = mutableListOf<Record>()
@@ -54,17 +56,18 @@ internal class ArtifactCollector(private val runRoot: Path) {
         relativePath: String,
         metadata: Map<String, String> = emptyMap(),
         command: MaestroCommand? = null,
+        sequenceNumber: Int? = null,
     ): File {
         val file = runRoot.resolve(relativePath).toFile()
         file.parentFile?.mkdirs()
-        records += Record(kind, format, relativePath, metadata, command)
+        records += Record(kind, format, relativePath, metadata, command, sequenceNumber)
         return file
     }
 
     /** Allocate [fileName] inside the folder this collector owns for [kind]; callers pass only the leaf name. */
-    fun allocateInCollection(kind: ArtifactKind, fileName: String, command: MaestroCommand?): File {
+    fun allocateInCollection(kind: ArtifactKind, fileName: String, command: MaestroCommand?, sequenceNumber: Int? = null): File {
         val collection = collectionKinds.getValue(kind)
-        return allocate(kind, collection.format, "${collection.dir}/$fileName", command = command)
+        return allocate(kind, collection.format, "${collection.dir}/$fileName", command = command, sequenceNumber = sequenceNumber)
     }
 
     /** Record a file written outside the generator's own path (device logs, crash/ANR) that already lives under the run root. */
@@ -79,10 +82,15 @@ internal class ArtifactCollector(private val runRoot: Path) {
     }
 
     /**
-     * Individual files owned by [command], in allocation order, that landed on
-     * disk. Deduped by path: a command re-run in a repeat/retry loop overwrites
-     * the same file, which is one artifact, not one per iteration.
+     * Files from the execution with [sequenceNumber], on disk, deduped by path —
+     * so a retry/repeat attempt gets only its own. What commands.json reads.
      */
+    fun artifactsForStep(sequenceNumber: Int): List<CommandArtifact> =
+        records.filter { it.sequenceNumber == sequenceNumber && it.fileExists() }
+            .distinctBy { it.relativePath }
+            .map { CommandArtifact(it.kind, it.relativePath) }
+
+    /** Files owned by [command] across all its executions, on disk, deduped by path. */
     fun artifactsFor(command: MaestroCommand): List<CommandArtifact> =
         records.filter { it.command === command && it.fileExists() }
             .distinctBy { it.relativePath }
@@ -91,7 +99,9 @@ internal class ArtifactCollector(private val runRoot: Path) {
     /** Collection kinds folded to one folder entry with a member count; everything else 1:1. */
     fun manifest(): ArtifactManifest {
         val entries = buildList {
-            // Dedup by path: a file overwritten across loop iterations is one artifact.
+            // Dedup by path: a name-stable file overwritten across iterations (e.g.
+            // takeScreenshot) is one artifact. Per-step kinds key path on sequence, so
+            // each iteration is already a distinct path.
             records.filter { it.fileExists() }
                 .distinctBy { it.relativePath }
                 .groupBy { it.kind }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
@@ -4,7 +4,6 @@ import maestro.orchestra.ArtifactEntry
 import maestro.orchestra.ArtifactFormat
 import maestro.orchestra.ArtifactKind
 import maestro.orchestra.ArtifactManifest
-import maestro.orchestra.MaestroCommand
 import java.io.File
 import java.nio.file.Path
 
@@ -37,7 +36,6 @@ internal class ArtifactCollector(private val runRoot: Path) {
         val format: ArtifactFormat?,
         val relativePath: String,
         val metadata: Map<String, String>,
-        val command: MaestroCommand?,
         /** Executing command's sequence number; null for flow-level artifacts. */
         val sequenceNumber: Int? = null,
     )
@@ -55,19 +53,18 @@ internal class ArtifactCollector(private val runRoot: Path) {
         format: ArtifactFormat?,
         relativePath: String,
         metadata: Map<String, String> = emptyMap(),
-        command: MaestroCommand? = null,
         sequenceNumber: Int? = null,
     ): File {
         val file = runRoot.resolve(relativePath).toFile()
         file.parentFile?.mkdirs()
-        records += Record(kind, format, relativePath, metadata, command, sequenceNumber)
+        records += Record(kind, format, relativePath, metadata, sequenceNumber)
         return file
     }
 
     /** Allocate [fileName] inside the folder this collector owns for [kind]; callers pass only the leaf name. */
-    fun allocateInCollection(kind: ArtifactKind, fileName: String, command: MaestroCommand?, sequenceNumber: Int? = null): File {
+    fun allocateInCollection(kind: ArtifactKind, fileName: String, sequenceNumber: Int? = null): File {
         val collection = collectionKinds.getValue(kind)
-        return allocate(kind, collection.format, "${collection.dir}/$fileName", command = command, sequenceNumber = sequenceNumber)
+        return allocate(kind, collection.format, "${collection.dir}/$fileName", sequenceNumber = sequenceNumber)
     }
 
     /** Record a file written outside the generator's own path (device logs, crash/ANR) that already lives under the run root. */
@@ -76,9 +73,8 @@ internal class ArtifactCollector(private val runRoot: Path) {
         relativePath: String,
         format: ArtifactFormat?,
         metadata: Map<String, String> = emptyMap(),
-        command: MaestroCommand? = null,
     ) {
-        records += Record(kind, format, relativePath, metadata, command)
+        records += Record(kind, format, relativePath, metadata)
     }
 
     /**
@@ -87,12 +83,6 @@ internal class ArtifactCollector(private val runRoot: Path) {
      */
     fun artifactsForStep(sequenceNumber: Int): List<CommandArtifact> =
         records.filter { it.sequenceNumber == sequenceNumber && it.fileExists() }
-            .distinctBy { it.relativePath }
-            .map { CommandArtifact(it.kind, it.relativePath) }
-
-    /** Files owned by [command] across all its executions, on disk, deduped by path. */
-    fun artifactsFor(command: MaestroCommand): List<CommandArtifact> =
-        records.filter { it.command === command && it.fileExists() }
             .distinctBy { it.relativePath }
             .map { CommandArtifact(it.kind, it.relativePath) }
 

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -74,13 +74,19 @@ internal class ArtifactsGenerator(
         if (captureFullArtifacts) startFullRunRecording()
     }
 
-    override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int) {
-        debugOutput.commands[cmd] = CommandDebugMetadata(
+    override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int, depth: Int) {
+        val metadata = CommandDebugMetadata(
             timestamp = System.currentTimeMillis(),
             status = CommandStatus.RUNNING,
             sequenceNumber = sequenceNumber,
+            depth = depth,
             command = cmd,
-        ).also { currentCommandMetadata = it }
+        )
+        // Same object in both: identity map for live attribution, executedSteps for
+        // the per-execution record (one entry per attempt).
+        debugOutput.commands[cmd] = metadata
+        debugOutput.executedSteps.add(metadata)
+        currentCommandMetadata = metadata
         // First launchApp wins (one flow tests one app); null ⇒ crash/ANR unscoped.
         if (appUnderTest == null) cmd.launchAppCommand?.appId?.let { appUnderTest = it }
     }
@@ -92,7 +98,9 @@ internal class ArtifactsGenerator(
      */
     fun allocateCommandArtifact(kind: ArtifactKind, fileName: String): File? {
         val collector = collector ?: return null
-        return collector.allocateInCollection(kind, fileName, currentCommandMetadata?.command)
+        return collector.allocateInCollection(
+            kind, fileName, currentCommandMetadata?.command, currentCommandMetadata?.sequenceNumber,
+        )
     }
 
     override fun onCommandFinished(
@@ -128,7 +136,8 @@ internal class ArtifactsGenerator(
     }
 
     override fun onCommandReset(cmd: MaestroCommand) {
-        debugOutput.commands[cmd]?.let { it.status = CommandStatus.PENDING }
+        // No-op: a reset precedes the next execution's own entry. Mutating the current
+        // one would downgrade the execution that just finished (shared via the map).
     }
 
     override fun onCommandMetadataUpdate(cmd: MaestroCommand, metadata: Orchestra.CommandMetadata) {
@@ -147,6 +156,7 @@ internal class ArtifactsGenerator(
                 "${BundleLayout.AI_ANALYSIS_DIR}/step-${meta.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
                 metadata = mapOf("defectCount" to defectCount.toString()),
                 command = meta.command,
+                sequenceNumber = meta.sequenceNumber,
             )
             destFile.writeBytes(screenshot.copy().readByteArray())
         } catch (e: Exception) {
@@ -158,13 +168,11 @@ internal class ArtifactsGenerator(
         stopFullRunRecording()
         val collector = collector
         if (artifactsDir != null && collector != null) {
-            // Each command's artifact list is its collector records — the same
-            // source the manifest reads from, so commands.json can't drift.
-            debugOutput.commands.values.forEach { meta ->
-                meta.command?.let { cmd ->
-                    meta.artifacts.clear()
-                    meta.artifacts.addAll(collector.artifactsFor(cmd))
-                }
+            // Per execution, keyed by sequence number — the same records the manifest
+            // reads, so commands.json can't drift and each attempt keeps its own shot.
+            debugOutput.executedSteps.forEach { step ->
+                step.artifacts.clear()
+                step.artifacts.addAll(collector.artifactsForStep(step.sequenceNumber))
             }
             try {
                 TestOutputWriter.saveCommands(
@@ -223,6 +231,7 @@ internal class ArtifactsGenerator(
                 ArtifactFormat.JSON,
                 "${BundleLayout.SCREEN_HIERARCHY_DIR}/step-${metadata.sequenceNumber}.json",
                 command = metadata.command,
+                sequenceNumber = metadata.sequenceNumber,
             )
             TestOutputWriter.bundleWriter.writeValue(destFile, tree)
         } catch (e: Exception) {
@@ -245,6 +254,7 @@ internal class ArtifactsGenerator(
                 ArtifactFormat.PNG,
                 "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
                 command = metadata.command,
+                sequenceNumber = metadata.sequenceNumber,
             )
             val taken = ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
             if (taken != null) lastFailureScreenshotSeq = metadata.sequenceNumber
@@ -261,6 +271,7 @@ internal class ArtifactsGenerator(
                 ArtifactFormat.PNG,
                 "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
                 command = metadata.command,
+                sequenceNumber = metadata.sequenceNumber,
             )
             runBlocking { maestro.takeScreenshot(destFile.sink(), false) }
         } catch (e: Exception) {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -99,7 +99,7 @@ internal class ArtifactsGenerator(
     fun allocateCommandArtifact(kind: ArtifactKind, fileName: String): File? {
         val collector = collector ?: return null
         return collector.allocateInCollection(
-            kind, fileName, currentCommandMetadata?.command, currentCommandMetadata?.sequenceNumber,
+            kind, fileName, currentCommandMetadata?.sequenceNumber,
         )
     }
 
@@ -155,7 +155,6 @@ internal class ArtifactsGenerator(
                 ArtifactFormat.PNG,
                 "${BundleLayout.AI_ANALYSIS_DIR}/step-${meta.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
                 metadata = mapOf("defectCount" to defectCount.toString()),
-                command = meta.command,
                 sequenceNumber = meta.sequenceNumber,
             )
             destFile.writeBytes(screenshot.copy().readByteArray())
@@ -230,7 +229,6 @@ internal class ArtifactsGenerator(
                 ArtifactKind.SCREEN_HIERARCHY,
                 ArtifactFormat.JSON,
                 "${BundleLayout.SCREEN_HIERARCHY_DIR}/step-${metadata.sequenceNumber}.json",
-                command = metadata.command,
                 sequenceNumber = metadata.sequenceNumber,
             )
             TestOutputWriter.bundleWriter.writeValue(destFile, tree)
@@ -253,7 +251,6 @@ internal class ArtifactsGenerator(
                 ArtifactKind.SCREENSHOT,
                 ArtifactFormat.PNG,
                 "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
-                command = metadata.command,
                 sequenceNumber = metadata.sequenceNumber,
             )
             val taken = ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
@@ -270,7 +267,6 @@ internal class ArtifactsGenerator(
                 ArtifactKind.SCREENSHOT,
                 ArtifactFormat.PNG,
                 "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
-                command = metadata.command,
                 sequenceNumber = metadata.sequenceNumber,
             )
             runBlocking { maestro.takeScreenshot(destFile.sink(), false) }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/FlowDebugOutput.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/FlowDebugOutput.kt
@@ -15,6 +15,8 @@ data class CommandDebugMetadata(
     var duration: Long? = null,
     var error: Throwable? = null,
     var sequenceNumber: Int = 0,
+    /** Nesting level: 0 at the flow top, +1 per runFlow/repeat/retry. The worker's subIndex. */
+    var depth: Int = 0,
     var evaluatedCommand: MaestroCommand? = null,
     val artifacts: MutableList<CommandArtifact> = mutableListOf(),
     /** Back-reference used to attribute collector records; excluded from commands.json (it keys this map). */
@@ -28,6 +30,9 @@ data class CommandDebugMetadata(
 }
 
 data class FlowDebugOutput(
+    /** Identity-keyed, last-write-wins: backs in-flight attribution. See [executedSteps] for the per-execution record. */
     val commands: IdentityHashMap<MaestroCommand, CommandDebugMetadata> = IdentityHashMap<MaestroCommand, CommandDebugMetadata>(),
+    /** One entry per execution, in order — a retry/repeat attempt is its own entry. Serialized to commands.json. */
+    val executedSteps: MutableList<CommandDebugMetadata> = mutableListOf(),
     var exception: MaestroException? = null,
 )

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/OrchestraListener.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/OrchestraListener.kt
@@ -12,8 +12,11 @@ interface OrchestraListener {
 
     fun onFlowStart() = Unit
 
-    /** @param sequenceNumber monotonic across the whole flow, nested commands included; distinct from Orchestra's per-frame `index`. */
-    fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int) = Unit
+    /**
+     * @param sequenceNumber monotonic across the whole flow, nested commands included.
+     * @param depth nesting level: 0 at the flow top, +1 per runFlow/repeat/retry.
+     */
+    fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int, depth: Int = 0) = Unit
 
     /** @param startedAt/[finishedAt] epoch millis bracketing the command. */
     fun onCommandFinished(

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/TestOutputWriter.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/TestOutputWriter.kt
@@ -52,10 +52,11 @@ object TestOutputWriter {
         logPrefix: String = "",
     ) {
         try {
-            val commandMetadata = debugOutput.commands
-            if (commandMetadata.isNotEmpty()) {
+            // Per execution, in order: a retry/repeat attempt is its own entry.
+            val steps = debugOutput.executedSteps
+            if (steps.isNotEmpty()) {
                 val file = File(path.absolutePathString(), commandsFilename)
-                commandMetadata.map { CommandDebugWrapper(it.key, it.value) }.let {
+                steps.mapNotNull { step -> step.command?.let { CommandDebugWrapper(it, step) } }.let {
                     mapper.writeValue(file, it)
                 }
             }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactCollectorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactCollectorTest.kt
@@ -3,7 +3,6 @@ package maestro.orchestra.debug
 import com.google.common.truth.Truth.assertThat
 import maestro.orchestra.ArtifactFormat
 import maestro.orchestra.ArtifactKind
-import maestro.orchestra.MaestroCommand
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
@@ -54,15 +53,13 @@ class ArtifactCollectorTest {
     }
 
     @Test
-    fun `records whose file was never written are dropped from manifest and per-command list`() {
+    fun `records whose file was never written are dropped from the manifest`() {
         val collector = ArtifactCollector(tempDir)
-        val cmd = MaestroCommand(tapOnElement = null)
 
         // Allocated but never written (e.g. the capture threw mid-write).
-        collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-0.png", command = cmd)
+        collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-0.png")
 
         assertThat(collector.manifest().entries.none { it.kind == ArtifactKind.SCREENSHOT }).isTrue()
-        assertThat(collector.artifactsFor(cmd)).isEmpty()
     }
 
     @Test
@@ -85,41 +82,17 @@ class ArtifactCollectorTest {
     }
 
     @Test
-    fun `artifactsFor returns this command's individual files in allocation order`() {
-        val collector = ArtifactCollector(tempDir)
-        val first = MaestroCommand(tapOnElement = null)
-        val second = MaestroCommand(tapOnElement = null)
-
-        tempDir.resolve("takeScreenshot").toFile().mkdirs()
-        tempDir.resolve("takeScreenshot/a.png").toFile().writeText("x")
-        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/a.png", ArtifactFormat.PNG, command = second)
-        collector.allocate(ArtifactKind.SCREEN_HIERARCHY, ArtifactFormat.JSON, "screen-hierarchy/step-0.json", command = first).writeText("{}")
-        collector.allocate(ArtifactKind.SCREEN_HIERARCHY, ArtifactFormat.JSON, "screen-hierarchy/step-1.json", command = second).writeText("{}")
-
-        assertThat(collector.artifactsFor(first))
-            .containsExactly(CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-0.json"))
-        assertThat(collector.artifactsFor(second))
-            .containsExactly(
-                CommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/a.png"),
-                CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-1.json"),
-            ).inOrder()
-    }
-
-    @Test
     fun `a path overwritten across loop iterations counts once, not per record`() {
         val collector = ArtifactCollector(tempDir)
-        val cmd = MaestroCommand(tapOnElement = null)
         tempDir.resolve("takeScreenshot").toFile().mkdirs()
         tempDir.resolve("takeScreenshot/shot.png").toFile().writeText("x")
 
         // Same command path re-run twice (repeat loop) overwrites the one file.
-        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png", ArtifactFormat.PNG, command = cmd)
-        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png", ArtifactFormat.PNG, command = cmd)
+        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png", ArtifactFormat.PNG)
+        collector.adopt(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png", ArtifactFormat.PNG)
 
         val entry = collector.manifest().entries.single { it.kind == ArtifactKind.TAKE_SCREENSHOT }
         assertThat(entry.count).isEqualTo(1)
-        assertThat(collector.artifactsFor(cmd))
-            .containsExactly(CommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "takeScreenshot/shot.png"))
     }
 
 }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -189,15 +189,16 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `onCommandReset transitions status to PENDING`() {
+    fun `onCommandReset leaves an already-recorded execution intact`() {
         val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onCommandStart(cmd, 0)
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 200L)
-        gen.onCommandReset(cmd)
+        gen.onCommandReset(cmd) // repeat/retry resets before the next iteration
 
-        assertThat(gen.debugOutput.commands[cmd]!!.status).isEqualTo(CommandStatus.PENDING)
+        // The finished execution must stay COMPLETED — reset precedes a new entry.
+        assertThat(gen.debugOutput.executedSteps.single().status).isEqualTo(CommandStatus.COMPLETED)
     }
 
     @Test
@@ -671,6 +672,36 @@ class ArtifactsGeneratorTest {
         assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
             .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
+    }
+
+    @Test
+    fun `a re-run command yields one commands entry per execution, each with its own screenshot`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        // Two executions of the SAME command object — what repeat/retry does, incl.
+        // the reset between iterations (must not downgrade the finished one).
+        gen.onCommandStart(cmd, sequenceNumber = 0, depth = 1)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, 0L, 1L)
+        gen.onCommandReset(cmd)
+        gen.onCommandStart(cmd, sequenceNumber = 1, depth = 1)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, 1L, 2L)
+        gen.onFlowEnd()
+
+        // Each execution is its own entry with its own screenshot — not collapsed.
+        assertThat(gen.debugOutput.executedSteps).hasSize(2)
+        assertThat(gen.debugOutput.executedSteps.map { it.sequenceNumber }).containsExactly(0, 1).inOrder()
+        assertThat(gen.debugOutput.executedSteps.map { it.depth }).containsExactly(1, 1)
+        assertThat(gen.debugOutput.executedSteps.map { it.status })
+            .containsExactly(CommandStatus.COMPLETED, CommandStatus.COMPLETED)
+        assertThat(gen.debugOutput.executedSteps[0].artifacts)
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
+        assertThat(gen.debugOutput.executedSteps[1].artifacts)
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-1.png"))
+        // commands.json carries both executions, not one collapsed entry.
+        val content = Files.readString(tempDir.resolve("commands.json"))
+        assertThat(content.split("\"sequenceNumber\"").size - 1).isEqualTo(2)
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -59,16 +59,20 @@ class OrchestraListenerDispatchTest {
         data class FinishedEvent(val cmd: MaestroCommand, val outcome: String)
         data class Timing(val cmd: MaestroCommand, val startedAt: Long, val finishedAt: Long)
 
+        data class Started(val cmd: MaestroCommand, val sequenceNumber: Int, val depth: Int)
+
         val events = mutableListOf<String>()
         val started = mutableListOf<MaestroCommand>()
+        val startEvents = mutableListOf<Started>()
         val finished = mutableListOf<FinishedEvent>()
         val timings = mutableListOf<Timing>()
         val resets = mutableListOf<MaestroCommand>()
 
         override fun onFlowStart() { events.add("flowStart") }
-        override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int) {
+        override fun onCommandStart(cmd: MaestroCommand, sequenceNumber: Int, depth: Int) {
             events.add("commandStart:$sequenceNumber")
             started.add(cmd)
+            startEvents.add(Started(cmd, sequenceNumber, depth))
         }
         override fun onCommandFinished(
             cmd: MaestroCommand,
@@ -509,6 +513,64 @@ class OrchestraListenerDispatchTest {
         // command, the main command, then the onFlowComplete hook.
         assertThat(stepScreenshotNames())
             .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png")
+    }
+
+    @Test
+    fun `nested commands dispatch depth +1, top-level and hooks stay 0`() {
+        val startHook = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
+        val leaf = MaestroCommand(evalScriptCommand = EvalScriptCommand("2"))
+        val outer = MaestroCommand(repeatCommand = RepeatCommand(times = "1", commands = listOf(leaf)))
+        val configCmd = MaestroCommand(
+            applyConfigurationCommand = ApplyConfigurationCommand(
+                config = MaestroConfig(onFlowStart = MaestroOnFlowStart(commands = listOf(startHook))),
+            ),
+        )
+        val recording = RecordingListener()
+        val orchestra = Orchestra(maestro = mockMaestro(), listeners = listOf(recording))
+
+        runBlocking { orchestra.runFlow(listOf(configCmd, outer)) }
+
+        val depthByCmd = recording.startEvents.associate { it.cmd to it.depth }
+        // top-level + the onFlowStart hook command run at depth 0
+        assertThat(depthByCmd[startHook]).isEqualTo(0)
+        assertThat(depthByCmd[configCmd]).isEqualTo(0)
+        assertThat(depthByCmd[outer]).isEqualTo(0)
+        // the command inside the repeat runs one level deeper
+        assertThat(depthByCmd[leaf]).isEqualTo(1)
+    }
+
+    @Test
+    fun `nested composites increment depth per level`() {
+        val leaf = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
+        val inner = MaestroCommand(runFlowCommand = RunFlowCommand(commands = listOf(leaf), config = null))
+        val outer = MaestroCommand(runFlowCommand = RunFlowCommand(commands = listOf(inner), config = null))
+        val recording = RecordingListener()
+        val orchestra = Orchestra(maestro = mockMaestro(), listeners = listOf(recording))
+
+        runBlocking { orchestra.runFlow(listOf(outer)) }
+
+        val depth = recording.startEvents.associate { it.cmd to it.depth }
+        assertThat(depth[outer]).isEqualTo(0)
+        assertThat(depth[inner]).isEqualTo(1)
+        assertThat(depth[leaf]).isEqualTo(2)
+    }
+
+    @Test
+    fun `composite children share depth +1 with distinct increasing sequence numbers`() {
+        val child1 = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
+        val child2 = MaestroCommand(evalScriptCommand = EvalScriptCommand("2"))
+        val outer = MaestroCommand(runFlowCommand = RunFlowCommand(commands = listOf(child1, child2), config = null))
+        val recording = RecordingListener()
+        val orchestra = Orchestra(maestro = mockMaestro(), listeners = listOf(recording))
+
+        runBlocking { orchestra.runFlow(listOf(outer)) }
+
+        val ev = recording.startEvents.associateBy { it.cmd }
+        assertThat(ev[outer]!!.depth).isEqualTo(0)
+        assertThat(ev[child1]!!.depth).isEqualTo(1)
+        assertThat(ev[child2]!!.depth).isEqualTo(1)
+        assertThat(ev[outer]!!.sequenceNumber).isLessThan(ev[child1]!!.sequenceNumber)
+        assertThat(ev[child1]!!.sequenceNumber).isLessThan(ev[child2]!!.sequenceNumber)
     }
 
 }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/TestOutputWriterTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/TestOutputWriterTest.kt
@@ -17,11 +17,14 @@ class TestOutputWriterTest {
         val outputDir = Files.createDirectories(tempDir.resolve("out"))
         val cmd = MaestroCommand(tapOnElement = null)
         val debug = FlowDebugOutput().apply {
-            commands[cmd] = CommandDebugMetadata(
-                status = CommandStatus.COMPLETED,
-                timestamp = 123L,
-                duration = 10L,
-                sequenceNumber = 0,
+            executedSteps.add(
+                CommandDebugMetadata(
+                    status = CommandStatus.COMPLETED,
+                    timestamp = 123L,
+                    duration = 10L,
+                    sequenceNumber = 0,
+                    command = cmd,
+                )
             )
         }
 
@@ -48,7 +51,7 @@ class TestOutputWriterTest {
         val outputDir = Files.createDirectories(tempDir.resolve("out"))
         val cmd = MaestroCommand(tapOnElement = null)
         val debug = FlowDebugOutput().apply {
-            commands[cmd] = CommandDebugMetadata(status = CommandStatus.COMPLETED)
+            executedSteps.add(CommandDebugMetadata(status = CommandStatus.COMPLETED, command = cmd))
         }
 
         TestOutputWriter.saveCommands(outputDir, debug, commandsFilename = "commands-shard-1-(my_flow).json")


### PR DESCRIPTION
**Stacked on #3343** (feat/orchestra-artifact-manifest).

Makes `commands.json` a faithful **per-execution** ledger so a consumer (the worker's `run_step` table) can drive itself off it — including retry/repeat attempts, each with its own screenshot and nesting depth.

## Problem
`commands.json` was serialized from an identity-keyed map (`FlowDebugOutput.commands`), one entry per command **object**. `retry`/`repeat` re-run the *same* objects, so a retried command collapsed into **one** entry with last-attempt status and all attempts' screenshots piled on. No per-attempt step, no nesting info — so the worker couldn't reconstruct its `run_step(index, subIndex, screenshot)` rows from it.

## What this does
Records **one entry per command execution**:

- **`FlowDebugOutput.executedSteps`** — one `CommandDebugMetadata` per `onCommandStart`, in execution order. The identity map stays for live in-flight attribution (metadata updates, the interactive CLI); the two share metadata objects so they can't drift. `commands.json` now serializes `executedSteps`.
- **Per-sequence artifact attribution** — `ArtifactCollector` records carry the executing `sequenceNumber`; `artifactsForStep(seq)` attributes each attempt's screenshot/hierarchy to that attempt alone (was by command identity).
- **Depth** — `OrchestraListener.onCommandStart` carries `depth`; Orchestra tracks a `subflowDepth` around `executeSubflowCommands`. `depth` is 0 at the top of the flow and +1 inside each `runFlow`/`repeat`/`retry` — i.e. the worker's `subIndex`.
- **`onCommandReset` no longer mutates the finished entry** — a repeat/retry reset shares the metadata object with the identity map; mutating it downgraded the execution that just finished. The reset now just precedes the next execution's fresh entry.

## Result
A `repeat: { times: 3 }` over one leaf → the leaf is **3 separate entries** (seq 4/5/6, `depth 1`, each `COMPLETED`, each with its own `screenshots/step-N.png`), the repeat parent its own `depth 0` entry. Maps 1:1 onto `run_step(index ⇐ sequenceNumber, subIndex ⇐ depth, screenshot)`.

**Live updates unchanged** — `commands.json` is the end-of-run reconciliation truth; live status still flows from the Orchestra callbacks + the per-step files (which land synchronously in `onCommandFinished`). This PR doesn't touch the live path.

## Contract change
`commands.json` grows from "per command" → "per execution" and each entry's `metadata` gains `depth`. Nothing consumes it per-attempt today, so this is the intended break; the CLI HTML report reads the same wrapper fields and is unaffected in shape.

## Tested
- Orchestra-driven unit tests: nested commands dispatch `depth +1` (top-level + hooks stay 0); a re-run command yields one entry per execution, each with its own screenshot, statuses intact across the reset.
- Existing `ArtifactsGeneratorTest` / `OrchestraListenerDispatchTest` / `TestOutputWriterTest` updated for the new signature + serialization. Full orchestra suite green (320).
- **Local e2e (web)** — `repeat` and `retry` both produce per-execution `commands.json` with correct depth, status, and one screenshot per iteration/attempt.

## Follow-up (worker, separate)
Once this lands and the worker bumps its Maestro dep, it reads `commands.json` as an ordered execution list (`sequenceNumber → index`, `depth → subIndex`, `artifacts[SCREENSHOT] → screenshot`) and drops its own `IndexTracker`/`compositeStack`.