### PR TITLE
fix(mcp): rebuild a dead device session instead of failing forever

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/McpMaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/McpMaestroSessionManager.kt
@@ -37,7 +37,34 @@ internal class McpMaestroSessionManager : AutoCloseable {
         val session = sessions.computeIfAbsent(deviceId) {
             createSession(deviceId).also { publishConnected(it) }
         }
-        return block(session)
+        return try {
+            block(session)
+        } catch (e: Exception) {
+            // The cached session can be killed out-of-band — e.g. another Maestro process
+            // (Maestro Studio, a second CLI) reinstalls/restarts the shared on-device driver,
+            // or the device reboots. The connection is then permanently DEAD and every later
+            // call fails until the server is restarted. Detect that, drop the dead session,
+            // and rebuild once so the next on-device-driver install heals the session in place.
+            if (!isSessionDead(session)) throw e
+            val fresh = rebuildSession(deviceId, dead = session)
+            block(fresh)
+        }
+    }
+
+    /**
+     * A driver whose transport died reports [isShutdown]; the cached session is then unusable.
+     * Skip web sessions: [CdpWebDriver.isShutdown] has the side effect of closing the browser,
+     * so probing it would tear down an otherwise-recoverable session.
+     */
+    private fun isSessionDead(session: McpMaestroSession): Boolean =
+        session.platform != WEB_PLATFORM && runCatching { session.maestro.driver.isShutdown() }.getOrDefault(true)
+
+    private fun rebuildSession(deviceId: String, dead: McpMaestroSession): McpMaestroSession {
+        sessions.remove(deviceId, dead)
+        runCatching { dead.close() }
+        return sessions.computeIfAbsent(deviceId) {
+            createSession(deviceId).also { publishConnected(it) }
+        }
     }
 
     private fun publishConnected(session: McpMaestroSession) {
@@ -180,5 +207,6 @@ internal class McpMaestroSessionManager : AutoCloseable {
         private const val DEFAULT_XCTEST_HOST = "127.0.0.1"
         private const val DEFAULT_XCTEST_PORT = 22087
         private const val WEB_DEVICE_ID = "chromium"
+        private const val WEB_PLATFORM = "web"
     }
 }


### PR DESCRIPTION
## Problem

Fixes #2839 ("launchApp works only the first time when using Maestro MCP").

The MCP server caches **one device session per device** (`McpMaestroSessionManager`) and reuses it for every `run` / `inspect_screen` / `take_screenshot` call. That session wraps a live connection to the on-device driver (`dev.mobile.maestro`).

If that on-device driver dies **out-of-band** while the session is cached — e.g. a second Maestro process (Maestro Studio Desktop, another CLI) reinstalls/restarts the shared on-device driver, or the device reboots — the connection goes permanently `DEAD`. The manager kept handing back that dead session, so:

- the **first** `launchApp` succeeds, and
- **every** subsequent call fails (`Failed to run flow: Unable to launch app …`, and `inspect_screen` → `UNAVAILABLE`)

…until the MCP server is manually restarted/reconnected. `maestro test` from the CLI never shows this because it's a fresh process (fresh session) per run; only the long-lived `maestro mcp` server caches across calls.

## Root cause

`McpMaestroSessionManager.withSession(...)` did `computeIfAbsent` then ran the block on the cached session, with no recovery path if that session's underlying connection had died.

## Fix

`withSession` now self-heals. If the block throws **and** the cached session's driver reports `isShutdown()` (i.e. `AndroidDeviceConnection.state == DEAD`), it evicts + closes the stale session, rebuilds a fresh one — which re-runs `driver.open()` and **reinstalls the on-device driver** — and retries the call once.

```kotlin
return try {
    block(session)
} catch (e: Exception) {
    if (!isSessionDead(session)) throw e
    val fresh = rebuildSession(deviceId, dead = session)
    block(fresh)
}
```

Design notes:
- **Authoritative death signal**, not string matching: uses `driver.isShutdown()` (Android: connection `state == DEAD`, set on transport deaths like gRPC `UNAVAILABLE`/`DEADLINE_EXCEEDED`). A normal flow failure (failed assertion, element not found) leaves the driver alive → `isSessionDead` is false → the original exception propagates **unchanged**.
- **Web is skipped** from the liveness probe because `CdpWebDriver.isShutdown()` has the side effect of closing the browser, which would tear down an otherwise-recoverable session.
- **Retries exactly once** (no loop): one rebuild heals the eviction; a genuinely-down device still surfaces a real failure fast.
- `rebuildSession` removes the dead entry with the two-arg `ConcurrentHashMap.remove(key, value)` so it only drops *that* instance, never one another thread just inserted.

## Reproduction

A self-contained reproducer is attached to #2839. It targets the **Wikipedia sample app** from the docs (`org.wikipedia`, via `maestro download-samples`), drives the real `maestro mcp` server over stdio JSON-RPC, launches once (succeeds), simulates the eviction deterministically with `adb uninstall dev.mobile.maestro` (the exact state a competing Maestro process leaves behind — no second install required), then launches again.

The same script, run unchanged, against two builds:

| Build | 1st launch | After eviction, 2nd launch | Exit |
|-------|-----------|----------------------------|------|
| current `main` | OK | `Failed to run flow: Unable to launch app org.wikipedia` (and `inspect_screen` → `UNAVAILABLE`) | 1 (bug) |
| this PR | OK | `success: true` — session rebuilt + driver reinstalled transparently | 0 (healed) |

On the fixed build the heal is a one-time cost on the first call after the eviction (the driver reinstall); subsequent calls run at normal speed.

## Notes
- Single file changed: `maestro-cli/src/main/java/maestro/cli/mcp/McpMaestroSessionManager.kt`.
- Per CONTRIBUTING this is a Type A bug fix. Built and verified locally via `./gradlew :maestro-cli:installDist` and exercised through a live `maestro mcp` server on an Android emulator.
- A follow-up could add a unit test for the rebuild-on-dead-session path; that needs a small refactor to inject the session factory into `McpMaestroSessionManager` (session creation currently touches real devices). Happy to add it here or in a follow-up — let me know your preference.
