### PR TITLE
Additional links to the issue picker

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Issue with Maestro Studio
+    url:  https://github.com/mobile-dev-inc/maestro-studio/issues/new/choose
+    about: For all things related to the Maestro Studio Desktop application
+  - name: Ask on Slack
+    url: https://slack.maestro.dev
+    about: Questions, discussions, and community support


### PR DESCRIPTION
## Proposed changes

Adds 2 additional links to the [issue picker](https://github.com/mobile-dev-inc/Maestro/issues/new/choose)

* Maestro Studio issues should be in the other repo
* Link to Slack

### Feedback needed

What I _didn't_ add was `blank_issues_enabled: false` - WDYT? 
It makes it harder for folks to add useless issues, but also makes it harder for agents to add issues.