### PR TITLE
Fix CSS selector failing to match

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -290,8 +290,14 @@ object Filters {
                 query = OnDeviceElementQuery.Css(css = cssSelector),
             ) }?.elements?.map { it.treeNode } ?: emptyList()
 
+            // The on-device CSS query traverses only the matched element (no descendants),
+            // whereas `nodes` come from the full hierarchy traversal and therefore carry their
+            // children. Comparing whole TreeNodes (a data class whose equality includes
+            // `children`) would never match any element that wraps other elements. Match on the
+            // node's own identity instead by ignoring `children`; `bounds` keeps this unique.
+            val matchingKeys = matchingNodes.mapTo(HashSet()) { it.copy(children = emptyList()) }
             nodes.filter { node ->
-                matchingNodes.any { it == node }
+                node.copy(children = emptyList()) in matchingKeys
             }
         }
     }

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -637,7 +637,9 @@ class CdpWebDriver(
     private fun queryCss(query: OnDeviceElementQuery.Css): List<TreeNode> {
         ensureOpen()
 
-        val jsResult: Any? = executeJS("window.maestro.queryCss('${query.css}')")
+        // Encode the selector as a JS string literal so selectors containing quotes
+        val cssArg = jacksonObjectMapper().writeValueAsString(query.css)
+        val jsResult: Any? = executeJS("window.maestro.queryCss($cssArg)")
 
         if (jsResult == null) {
             return emptyList()

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -624,7 +624,9 @@ class WebDriver(
     private fun queryCss(query: OnDeviceElementQuery.Css): List<TreeNode> {
         ensureOpen()
 
-        val jsResult: Any? = executeJS("return window.maestro.queryCss('${query.css}')")
+        // Encode the selector as a JS string literal so selectors containing quotes
+        val cssArg = jacksonObjectMapper().writeValueAsString(query.css)
+        val jsResult: Any? = executeJS("return window.maestro.queryCss($cssArg)")
 
         if (jsResult == null) {
             return emptyList()

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -433,7 +433,10 @@ open class FakeDriver : Driver {
         val result = mutableListOf<TreeNode>()
 
         if (element.matchesCssFilter == css) {
-            result.add(element.toTreeNode())
+            // Mirror the real web driver, whose on-device CSS query traverses only the matched
+            // element and omits its descendants. Keeping children here would hide regressions in
+            // how CSS matches are reconciled against the full hierarchy (see Filters.css).
+            result.add(element.toTreeNode().copy(children = emptyList()))
         }
 
         for (child in element.children) {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3949,6 +3949,42 @@ class IntegrationTest {
     }
 
     @Test
+    fun `Case 144 - Tap by CSS selector on element with children`() {
+        // Regression test for https://github.com/mobile-dev-inc/Maestro/issues/3263
+        // The on-device CSS query returns the matched element without its descendants, while the
+        // full hierarchy carries them. Matching whole TreeNodes (whose equality includes children)
+        // dropped any element that wraps others, so a quoted selector targeting a button with a
+        // nested <span> reported "Element not found". The selector also contains single quotes,
+        // which previously broke out of the JS string literal used to inject it.
+        val commands = readCommands("144_tap_by_css_on_element_with_children")
+
+        val driver = driver {
+            element {
+                text = "Open user menu"
+                bounds = Bounds(0, 0, 100, 100)
+                matchesCssFilter = "button[aria-label='Open user menu']"
+
+                element {
+                    text = "FR"
+                    bounds = Bounds(10, 10, 90, 90)
+                }
+            }
+        }
+
+        driver.addInstalledApp("http://example.com")
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then — the button (not its child) was tapped at its center
+        driver.assertEventCount(Event.Tap(Point(50, 50)), expectedCount = 1)
+    }
+
+    @Test
     fun `Case 126 - Set orientation`() {
         // Given
         val commands = readCommands("126_set_orientation")

--- a/maestro-test/src/test/resources/144_tap_by_css_on_element_with_children.yaml
+++ b/maestro-test/src/test/resources/144_tap_by_css_on_element_with_children.yaml
@@ -1,0 +1,5 @@
+url: http://example.com
+---
+- launchApp
+- tapOn:
+    css: "button[aria-label='Open user menu']"


### PR DESCRIPTION
## Proposed changes

In the original issue, a css selector was failing to match, even though it obviously should. 

Filters.css matched by full TreeNode equality (it == node). TreeNode is a data class, so equality includes children. But the on-device CSS query builds its node with traverse(el, false) (no descendants) while the live hierarchy builds it with children. Any element wrapping other elements — like the reporter's button with two nested <span>s — could never match → "Element not found", and tapOn retries until timeout (the "stuck for 5 min")

Additionally spotted that the selector was interpolated into a single-quoted JS string literal: queryCss('${query.css}'). A selector containing a single quote broke out of the string. Their selector might never have worked 😬 

## Testing

Unit + int tests, repro'd the linked issue before and couldn't afterwards.
Decided against an additional e2e test for this.

## Issues fixed

Fixes #3263