### PR TITLE
Set locale on correct emulator after start-device

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -128,10 +128,19 @@ class StartDeviceCommand : Callable<Int> {
             forceCreate
         )
 
+        // Snapshot the devices that are already connected so the freshly launched emulator can be
+        // told apart from them. Without this, locale setup may be applied to a pre-existing device
+        // (e.g. a physical phone or another emulator) instead of the one we just started (#2209).
+        val connectedDevices = DeviceService.listConnectedDevices(
+            host = parent?.host,
+            port = parent?.port,
+        ).map { it.instanceId }.toSet()
+
         // Start Device
         DeviceService.startDevice(
             device = device,
-            driverHostPort = parent?.port
+            driverHostPort = parent?.port,
+            connectedDevices = connectedDevices,
         )
 
         return 0

--- a/maestro-cli/src/main/java/maestro/cli/device/PickDeviceInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/PickDeviceInteractor.kt
@@ -34,7 +34,13 @@ object PickDeviceInteractor {
                         Platform.WEB -> PrintUtils.message("Launching ${result.description}")
                     }
 
-                    result = DeviceService.startDevice(result, driverHostPort)
+                    // Snapshot already-connected devices so the freshly launched one can be told
+                    // apart from them, avoiding configuring the wrong device (#2209).
+                    val connectedDevices = DeviceService.listConnectedDevices()
+                        .map { it.instanceId }
+                        .toSet()
+
+                    result = DeviceService.startDevice(result, driverHostPort, connectedDevices)
                 }
 
                 if (result !is Device.Connected) {

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -61,34 +61,50 @@ object DeviceService {
             }
 
             Platform.ANDROID -> {
-                PrintUtils.message("Launching Emulator...")
                 val androidSpec = device.deviceSpec as DeviceSpec.Android
-                val emulatorBinary = requireEmulatorBinary()
 
-                ProcessBuilder(
-                    emulatorBinary.absolutePath,
-                    "-avd",
-                    device.modelId,
-                    "-netdelay",
-                    "none",
-                    "-netspeed",
-                    "full"
-                ).start().waitFor(10, TimeUnit.SECONDS)
+                // If the requested AVD is already running, reuse it: the emulator refuses to launch
+                // a duplicate of a running AVD (without -read-only), so we'd otherwise wait 60s for a
+                // device that never appears and then fail.
+                val runningSerial = listConnectedDevices()
+                    .firstOrNull { it.description == device.modelId }
+                    ?.instanceId
 
-                var lastException: Exception? = null
+                val connection = if (runningSerial != null) {
+                    PrintUtils.message("Device ${device.modelId} is already running, reusing it.")
+                    AndroidDeviceConnection.byId(
+                        deviceId = runningSerial,
+                        driverHostPort = driverHostPort ?: AndroidDeviceConnection.DEFAULT_DRIVER_HOST_PORT,
+                    ) ?: throw DeviceError("Unable to connect to already-running device: ${device.modelId}")
+                } else {
+                    PrintUtils.message("Launching Emulator...")
+                    val emulatorBinary = requireEmulatorBinary()
 
-                val connection = MaestroTimer.withTimeout(60000) {
-                    try {
-                        AndroidDeviceConnection.newestNotIn(
-                            connectedSerials = connectedDevices,
-                            driverHostPort = driverHostPort ?: AndroidDeviceConnection.DEFAULT_DRIVER_HOST_PORT,
-                        )
-                    } catch (ignored: Exception) {
-                        Thread.sleep(100)
-                        lastException = ignored
-                        null
-                    }
-                } ?: throw DeviceError("Unable to start device: ${device.modelId}", lastException)
+                    ProcessBuilder(
+                        emulatorBinary.absolutePath,
+                        "-avd",
+                        device.modelId,
+                        "-netdelay",
+                        "none",
+                        "-netspeed",
+                        "full"
+                    ).start().waitFor(10, TimeUnit.SECONDS)
+
+                    var lastException: Exception? = null
+
+                    MaestroTimer.withTimeout(60000) {
+                        try {
+                            AndroidDeviceConnection.newestNotIn(
+                                connectedSerials = connectedDevices,
+                                driverHostPort = driverHostPort ?: AndroidDeviceConnection.DEFAULT_DRIVER_HOST_PORT,
+                            )
+                        } catch (ignored: Exception) {
+                            Thread.sleep(100)
+                            lastException = ignored
+                            null
+                        }
+                    } ?: throw DeviceError("Unable to start device: ${device.modelId}", lastException)
+                }
 
                 // The boot/setup connection is only needed to install the driver app + set the locale;
                 // close it once setup is done so its adb socket doesn't leak (the device stays booted).


### PR DESCRIPTION
## Proposed changes

Stop the locale-setting happening to the "first" device, and instead to the correct device

## Testing

- Works launching a device with no locale
- Works launching a device with a locale
- Works launching a second device with a locale
- Works launching an already-running device, just changing the locale
- Works launching either of 2 already-running devices, just changing the locale

## Issues fixed

Fixes #2209 