### PR TITLE
fix(web): fail fast without DevTools and drop empty recording placeholders

### DIFF
--- a/maestro-client/src/test/java/maestro/drivers/WebDriverTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/WebDriverTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import maestro.web.selenium.SeleniumFactory
 import okio.blackholeSink
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.StaleElementReferenceException
 import org.openqa.selenium.WebElement
@@ -54,6 +55,17 @@ class WebDriverTest {
         )
 
         driver.open()
+    }
+
+    @Test
+    fun `startScreenRecording fails fast when the driver does not support DevTools`() {
+        // A remote driver that doesn't advertise se:cdp isn't HasDevTools.
+        val driver = makeDriver()
+        driver.open()
+
+        assertThrows<UnsupportedOperationException> {
+            driver.startScreenRecording(blackholeSink())
+        }
     }
 
     @Test

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -56,6 +56,7 @@ internal class ArtifactsGenerator(
     private var collector: ArtifactCollector? = null
     private var logCapture: ScopedLogCapture? = null
     private var fullRunRecording: ScreenRecording? = null
+    private var fullRunRecordingFile: File? = null
     private var capturer: DeviceArtifactCapturer? = null
     private var flowStartMs: Long = 0L
     private var appUnderTest: String? = null
@@ -300,6 +301,7 @@ internal class ArtifactsGenerator(
         val collector = collector ?: return
         try {
             val destFile = collector.allocate(ArtifactKind.SCREEN_RECORDING, ArtifactFormat.MP4, BundleLayout.SCREEN_RECORDING)
+            fullRunRecordingFile = destFile
             fullRunRecording = runBlocking { maestro.startScreenRecording(destFile.sink()) }
         } catch (e: Exception) {
             logger.warn("Failed to start full-run screen recording", e)
@@ -313,6 +315,9 @@ internal class ArtifactsGenerator(
             logger.warn("Failed to stop full-run screen recording", e)
         } finally {
             fullRunRecording = null
+            // The collector drops records whose file is gone, keeping 0-byte recordings out of the manifest.
+            fullRunRecordingFile?.takeIf { it.length() == 0L }?.delete()
+            fullRunRecordingFile = null
         }
     }
 

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -633,6 +633,32 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
+    fun `drops an empty full-run recording instead of surfacing a 0-byte placeholder`() {
+        val maestro = mockMaestro() // relaxed startScreenRecording writes no bytes
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
+
+        gen.onFlowStart()
+        gen.onFlowEnd()
+
+        assertThat(gen.artifactManifest.entries.none { it.kind == ArtifactKind.SCREEN_RECORDING }).isTrue()
+        assertThat(tempDir.resolve("screen-recording.mp4").exists()).isFalse()
+    }
+
+    @Test
+    fun `drops the full-run recording when starting it fails`() {
+        val maestro = mockMaestro()
+        coEvery { maestro.startScreenRecording(any()) } throws
+            UnsupportedOperationException("driver does not support screen recording")
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
+
+        gen.onFlowStart()
+        gen.onFlowEnd()
+
+        assertThat(gen.artifactManifest.entries.none { it.kind == ArtifactKind.SCREEN_RECORDING }).isTrue()
+        assertThat(tempDir.resolve("screen-recording.mp4").exists()).isFalse()
+    }
+
+    @Test
     fun `command output is attributed to the running command`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)

--- a/maestro-web/src/main/kotlin/maestro/web/record/WebScreenRecorder.kt
+++ b/maestro-web/src/main/kotlin/maestro/web/record/WebScreenRecorder.kt
@@ -22,6 +22,9 @@ class WebScreenRecorder(
     fun startScreenRecording(out: Sink) {
         ensureNotClosed()
 
+        // Must precede videoEncoder.start: opening the sink first leaves a 0-byte file behind.
+        requireDevTools()
+
         recordingExecutor = Executors.newSingleThreadExecutor()
         videoEncoder.start(out)
 
@@ -53,9 +56,7 @@ class WebScreenRecorder(
     private fun startScreenRecordingForCurrentWindow() {
         closeScreenRecordingSessions()
 
-        val driver = seleniumDriver as HasDevTools
-
-        val seleniumDevTools = driver.devTools
+        val seleniumDevTools = requireDevTools().devTools
 
         seleniumDevTools.createSessionIfThereIsNotOne()
 
@@ -92,6 +93,13 @@ class WebScreenRecorder(
         }
         screenRecordingSessions.clear()
     }
+
+    private fun requireDevTools(): HasDevTools =
+        seleniumDriver as? HasDevTools
+            ?: throw UnsupportedOperationException(
+                "Screen recording requires a DevTools-capable driver, but " +
+                    "${seleniumDriver.javaClass.name} does not implement HasDevTools"
+            )
 
     private fun ensureNotClosed() {
         if (closed) {


### PR DESCRIPTION
## Problem

`WebScreenRecorder` cast `seleniumDriver as HasDevTools` unsafely. A web driver that does not advertise CDP (e.g. a remote Browserbase `RemoteWebDriver` without `se:cdp`) is **not** `HasDevTools`, so the cast threw a raw `ClassCastException` mid-stream — *after* the recording sink had already been opened. The result: a **0-byte `screen-recording.mp4` plus a manifest entry**, i.e. a broken placeholder rather than a real recording.

Core already uses the safe `as?` cast elsewhere (`WebDriver.open()`), so it anticipates non-DevTools drivers; the recorder just hadn't been brought in line.

## Fix

- **`WebScreenRecorder`** — uses the safe `as?` cast (matching `WebDriver`'s existing pattern) and fails fast with a clear `UnsupportedOperationException` *before* touching the output sink, so nothing is written when recording can't work.
- **`ArtifactsGenerator`** — deletes the recording file when it is still empty after stop. The `ArtifactCollector` already drops records whose file is gone, so no 0-byte placeholder surfaces in the manifest.

This does **not** add web recording for non-CDP drivers — it only makes that case fail cleanly instead of leaving a broken artifact behind. CDP-capable drivers (local ChromeDriver) are unaffected and still record.

## Testing

- **Unit tests**
  - `WebDriverTest` — driver without `HasDevTools` → `UnsupportedOperationException` (not `ClassCastException`).
  - `ArtifactsGeneratorTest` — empty/failed recording → no 0-byte file and no `SCREEN_RECORDING` manifest entry.
- **Local e2e** — ran a 9-interaction web flow (`saucedemo.com`) with `--analyze`; local ChromeDriver is DevTools-capable, so it produced a real 3.4 MB h264 mp4 with a valid manifest entry, confirming the happy path is unaffected.