### PR TITLE
Defend against false app crash errors when iOS apps launch

### DIFF
--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTest/RunningApp.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTest/RunningApp.swift
@@ -29,13 +29,14 @@ struct RunningApp {
         
         NSLog("Detected running apps: \(runningAppIds)")
 
-        if runningAppIds.count == 1, let bundleId = runningAppIds.first {
-            return XCUIApplication(bundleIdentifier: bundleId)
-        } else {
-            return runningAppIds
-                .map { XCUIApplication(bundleIdentifier: $0) }
-                .first { $0.state == .runningForeground }
-        }
+        // Only return an app that is actually foreground for automation. A process can appear in
+        // activeAppsInfo() while its XCUIApplication state is not yet .runningForeground (e.g. showing
+        // a splash screen). Snapshotting it then throws "Application ... is not running", which callers
+        // escalate as a fatal AppCrash. Returning nil instead lets callers fall back to the springboard hierarchy
+        // and retry.
+        return runningAppIds
+            .map { XCUIApplication(bundleIdentifier: $0) }
+            .first { $0.state == .runningForeground }
     }
     
 }


### PR DESCRIPTION
## Proposed changes

We've seen iOS test flakiness recently:

https://github.com/mobile-dev-inc/Maestro/actions/runs/27822845786/job/82341061902 
https://github.com/mobile-dev-inc/Maestro/actions/runs/28005277960/job/82890542035 
https://github.com/mobile-dev-inc/Maestro/actions/runs/28154673218/job/83381822837 
https://github.com/mobile-dev-inc/Maestro/actions/runs/28155746282/job/83384799791
https://github.com/mobile-dev-inc/Maestro/actions/runs/28460742211/job/84348569370
https://github.com/mobile-dev-inc/Maestro/actions/runs/28460742211/job/84377258682

Here, Maestro stopped because the Wikipedia app was incorrectly deemed as crashed. It'd been launched, was showing the splash screen, but had no foreground hierarchy yet.

This change tightens the logic on selecting the foreground app to enable retrying during situations like this.

## Testing

Reran the CI 5x for confidence

## Issues fixed

n/a