### PR TITLE
fix(artifacts): don't capture view hierarchy on passing steps

### DIFF
--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -123,13 +123,11 @@ internal class ArtifactsGenerator(
         }
         if (artifactsDir == null || outcome is CommandOutcome.Skipped) return
 
-        // Hierarchy and screenshots are synchronous device round-trips. Failed and
-        // warned steps always capture into the bundle (both run modes); passing
-        // steps only when captureFullArtifacts is on (worker) — otherwise a local
-        // run pays one viewHierarchy() round-trip per command (~100 for 100).
-        // Failed uses the dedup-aware failure capture; the rest take a plain step shot.
+        // viewHierarchy() is an expensive per-command round-trip (~1s on iOS/Android), so only
+        // failed/warned steps capture it — passing steps never do, even under captureFullArtifacts.
+        // Screenshots are cheap and stay per-step.
         if (outcome is CommandOutcome.Failed || outcome is CommandOutcome.Warned || captureFullArtifacts) {
-            captureStepHierarchy(metadata)
+            if (outcome is CommandOutcome.Failed || outcome is CommandOutcome.Warned) captureStepHierarchy(metadata)
             if (outcome is CommandOutcome.Failed) captureFailureScreenshot(metadata)
             else captureStepScreenshot(metadata)
         }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -382,7 +382,6 @@ class ArtifactsGeneratorTest {
 
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
             .containsExactly(
-                CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-3.json"),
                 CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-3.png"),
             )
     }
@@ -582,7 +581,7 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `writes a hierarchy file per executed command and attributes it when captureFullArtifacts is true`() {
+    fun `passing command captures a screenshot but no hierarchy even when captureFullArtifacts is true`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -591,13 +590,13 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screen-hierarchy/step-2.json").exists()).isTrue()
+        // Passing steps never pay the per-command viewHierarchy() round-trip.
+        assertThat(tempDir.resolve("screen-hierarchy").exists()).isFalse()
+        assertThat(gen.artifactManifest.entries.none { it.kind == ArtifactKind.SCREEN_HIERARCHY }).isTrue()
+        // Screenshots stay per-step under captureFullArtifacts.
+        assertThat(tempDir.resolve("screenshots/step-2.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-2.json"))
-        val folder = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREEN_HIERARCHY }
-        assertThat(folder.relativePath).isEqualTo("screen-hierarchy")
-        assertThat(folder.format).isEqualTo(ArtifactFormat.JSON)
-        assertThat(folder.count).isEqualTo(1)
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-2.png"))
     }
 
     @Test


### PR DESCRIPTION
## What

Under `captureFullArtifacts`, every passing step captured a full `viewHierarchy()` — an expensive synchronous device round-trip (~1s each on iOS/Android). On long flows this per-command overhead was enough to push runs past the 15-minute watchdog, causing **fleet-wide test timeouts (production incident)**.

Now only **failed/warned** steps capture the hierarchy (the diagnostically useful ones). Per-step **screenshots** and the **full-run recording** are unchanged.