### PR TITLE
Don't block forever on a failed emulator boot

### DIFF
--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -94,9 +94,12 @@ object DeviceService {
                 // close it once setup is done so its adb socket doesn't leak (the device stays booted).
                 return connection.use { conn ->
                     PrintUtils.message("Waiting for emulator ( ${device.modelId} ) to boot...")
-                    while (!bootComplete(conn)) {
-                        Thread.sleep(1000)
-                    }
+                    MaestroTimer.withTimeout(getDeviceBootTimeout()) {
+                        if (bootComplete(conn)) true else {
+                            Thread.sleep(1000)
+                            null
+                        }
+                    } ?: throw DeviceError("Emulator ${device.modelId} did not finish booting in time, consider increasing timeout by configuring $MAESTRO_DEVICE_BOOT_TIMEOUT env variable")
 
                     PrintUtils.message("Setting the device locale to ${androidSpec.locale.code}...")
                     val driver = AndroidDriver(conn)
@@ -720,6 +723,13 @@ object DeviceService {
     private fun requireAvdManagerBinary(): File = AndroidEnvUtils.requireCommandLineTools("avdmanager")
 
     private fun requireSdkManagerBinary(): File = AndroidEnvUtils.requireCommandLineTools("sdkmanager")
+
+    private fun getDeviceBootTimeout(): Long = runCatching {
+        System.getenv(MAESTRO_DEVICE_BOOT_TIMEOUT).toLong()
+    }.getOrDefault(DEVICE_BOOT_TIMEOUT_MS)
+
+    private const val MAESTRO_DEVICE_BOOT_TIMEOUT = "MAESTRO_DEVICE_BOOT_TIMEOUT"
+    private const val DEVICE_BOOT_TIMEOUT_MS = 180_000L
 
     private const val SET_LOCALE_RESULT_SUCCESS = 0
     private const val SET_LOCALE_RESULT_LOCALE_NOT_VALID = 1


### PR DESCRIPTION
## Proposed changes

Found whilst reviewing #3164.

Android emulator boot would wait forever if it failed to make it past boot (either a hang or an emulator crash). This wraps the sleep loop and adds a max time (default 3mins, configurable by a new `MAESTRO_DEVICE_BOOT_TIMEOUT` env var).
 
## Testing

Observe in CI. This is very hard to reproduce locally - it requires that a device boots and get `adb` (see DeviceService L80) but never makes to fully booted. The real risk is that the default isn't enough for slow envs like GHA.

## Issues fixed
