### PR TITLE
fix(web): don't let a broken screen recorder break hierarchy retrieval

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -322,7 +322,14 @@ class CdpWebDriver(
 
                 driver.switchTo().window(newHandle)
 
-                webScreenRecorder?.onWindowChange()
+                try {
+                    webScreenRecorder?.onWindowChange()
+                } catch (e: Exception) {
+                    // Recording is best-effort and must never break hierarchy retrieval.
+                    LOGGER.warn("Screen recorder failed on window change, disabling recording", e)
+                    runCatching { webScreenRecorder?.close() }
+                    webScreenRecorder = null
+                }
             }
         }
     }
@@ -535,11 +542,14 @@ class CdpWebDriver(
 
     override fun startScreenRecording(out: Sink): ScreenRecording {
         val driver = ensureOpen()
-        webScreenRecorder = WebScreenRecorder(
+        val recorder = WebScreenRecorder(
             JcodecVideoEncoder(),
             driver
         )
-        webScreenRecorder?.startScreenRecording(out)
+        // Assign only after a successful start: a half-initialized recorder left
+        // behind would blow up in detectWindowChange().
+        recorder.startScreenRecording(out)
+        webScreenRecorder = recorder
 
         return object : ScreenRecording {
             override fun close() {

--- a/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/WebDriver.kt
@@ -292,7 +292,14 @@ class WebDriver(
 
                 driver.switchTo().window(newHandle)
 
-                webScreenRecorder?.onWindowChange()
+                try {
+                    webScreenRecorder?.onWindowChange()
+                } catch (e: Exception) {
+                    // Recording is best-effort and must never break hierarchy retrieval.
+                    LOGGER.warn("Screen recorder failed on window change, disabling recording", e)
+                    runCatching { webScreenRecorder?.close() }
+                    webScreenRecorder = null
+                }
             }
         }
     }
@@ -522,11 +529,14 @@ class WebDriver(
 
     override fun startScreenRecording(out: Sink): ScreenRecording {
         val driver = ensureOpen()
-        webScreenRecorder = WebScreenRecorder(
+        val recorder = WebScreenRecorder(
             JcodecVideoEncoder(),
             driver
         )
-        webScreenRecorder?.startScreenRecording(out)
+        // Assign only after a successful start: a half-initialized recorder left
+        // behind (e.g. no DevTools on Browserbase) would blow up in detectWindowChange().
+        recorder.startScreenRecording(out)
+        webScreenRecorder = recorder
 
         return object : ScreenRecording {
             override fun close() {

--- a/maestro-client/src/test/java/maestro/drivers/WebDriverTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/WebDriverTest.kt
@@ -4,10 +4,13 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import maestro.web.selenium.SeleniumFactory
+import okio.blackholeSink
 import org.junit.jupiter.api.Test
 import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.StaleElementReferenceException
 import org.openqa.selenium.WebElement
+import org.openqa.selenium.devtools.DevTools
+import org.openqa.selenium.devtools.DevToolsException
 import org.openqa.selenium.devtools.HasDevTools
 import java.lang.reflect.InvocationTargetException
 import java.util.ServiceConfigurationError
@@ -87,5 +90,83 @@ class WebDriverTest {
         }
 
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `contentDescriptor succeeds when screen recording failed to start`() {
+        // Browserbase: the augmented RemoteWebDriver implements HasDevTools but the
+        // CDP websocket cannot be established, so every devTools access throws.
+        val seleniumDriver = mockk<SeleniumWebDriver>(
+            relaxed = true,
+            moreInterfaces = arrayOf(JavascriptExecutor::class, HasDevTools::class),
+        )
+        every { (seleniumDriver as HasDevTools).devTools } throws
+            DevToolsException("Unable to create a DevTools connection")
+        every { seleniumDriver.windowHandles } returns setOf("window-1")
+
+        val executor = seleniumDriver as JavascriptExecutor
+        every {
+            executor.executeScript(match<String> { it.contains("getContentDescription") })
+        } returns mapOf(
+            "attributes" to mapOf("text" to "root", "bounds" to "[0,0][100,100]"),
+            "children" to emptyList<Map<String, Any>>(),
+        )
+
+        val driver = WebDriver(
+            isStudio = false,
+            isHeadless = true,
+            screenSize = null,
+            seleniumFactory = object : SeleniumFactory {
+                override fun create(): SeleniumWebDriver = seleniumDriver
+            },
+        )
+        driver.open()
+
+        // The caller (ArtifactsGenerator) still needs the failure signal.
+        assertThat(runCatching { driver.startScreenRecording(blackholeSink()) }.isFailure).isTrue()
+
+        // First hierarchy read of the session detects the initial window handle; the
+        // failed recorder must not break it.
+        val root = driver.contentDescriptor(excludeKeyboardElements = false)
+
+        assertThat(root.attributes["text"]).isEqualTo("root")
+    }
+
+    @Test
+    fun `contentDescriptor succeeds when recorder fails on window change`() {
+        val seleniumDriver = mockk<SeleniumWebDriver>(
+            relaxed = true,
+            moreInterfaces = arrayOf(JavascriptExecutor::class, HasDevTools::class),
+        )
+        val devTools = mockk<DevTools>(relaxed = true)
+        // devTools accesses in order: open(), startScreenRecording(), then the
+        // re-attach on window change, which fails.
+        every { (seleniumDriver as HasDevTools).devTools } returns
+            devTools andThen devTools andThenThrows
+            DevToolsException("Unable to create a DevTools connection")
+        every { seleniumDriver.windowHandles } returns setOf("window-1")
+
+        val executor = seleniumDriver as JavascriptExecutor
+        every {
+            executor.executeScript(match<String> { it.contains("getContentDescription") })
+        } returns mapOf(
+            "attributes" to mapOf("text" to "root", "bounds" to "[0,0][100,100]"),
+            "children" to emptyList<Map<String, Any>>(),
+        )
+
+        val driver = WebDriver(
+            isStudio = false,
+            isHeadless = true,
+            screenSize = null,
+            seleniumFactory = object : SeleniumFactory {
+                override fun create(): SeleniumWebDriver = seleniumDriver
+            },
+        )
+        driver.open()
+        driver.startScreenRecording(blackholeSink())
+
+        val root = driver.contentDescriptor(excludeKeyboardElements = false)
+
+        assertThat(root.attributes["text"]).isEqualTo("root")
     }
 }


### PR DESCRIPTION
## Problem

The copilot submodule bump to `2199f2a0` (mobile-dev-inc/copilot#2669, single commit in range: #3401) consistently fails copilot's Web E2E. The `advanced-web` flow dies seconds in: the first element interaction (`tapOn: Username`) fails with

```
CommandFailed: Unable to create DevTools connection (Selenium 4.43.0)
```

classified as INFRA_ERROR, retried 4 times, run dead. An A/B on `test/worker-e2e-devtools-control` in copilot confirmed the range: same branch, no-op commit (old pin) passes Web E2E, adding only the bump commit fails it.

#3401 is not the bug though. It exposed a latent one in the web drivers:

1. On Browserbase, the augmented `RemoteWebDriver` implements `HasDevTools` but the CDP websocket cannot be established. When the full-run recording starts, `WebScreenRecorder.startScreenRecording()` throws, but `WebDriver.startScreenRecording()` had **already assigned the recorder field**, leaving a half-initialized recorder behind. (The caller logs "Failed to start full-run screen recording" and moves on.)
2. `contentDescriptor()` calls `detectWindowChange()`, and `lastSeenWindowHandles` starts empty, so the **first hierarchy read of every session** detects a "window change" and calls `webScreenRecorder?.onWindowChange()`, which touches `driver.devTools` and throws `DevToolsException`.
3. Before #3401 the first hierarchy read happened inside per-step artifact capture (`captureStepHierarchy`), whose catch swallowed the exception, so the poisoned first call was absorbed invisibly and web flows passed. #3401 removed hierarchy capture for passing steps, so the first read now happens inside a real command (the tap), where the exception fails the job.

This mechanism also explains the pre-existing rare web flake with the same signature ("Failed after 4 attempts: Unable to create DevTools connection"): it fired whenever a real window change happened mid-flow outside a swallowed capture path. This PR fixes that flake too.

## Fix

Two small changes, mirrored in `WebDriver.kt` and `CdpWebDriver.kt` (the code is duplicated between them):

- `startScreenRecording()` assigns the recorder only after a successful start. A failed start still throws, so callers keep their failure signal; there is just no broken recorder left behind.
- `detectWindowChange()` guards `onWindowChange()`: recording is best-effort, so on failure it logs a warning, closes and drops the recorder instead of failing the flow.

## Testing

- Two new tests in `WebDriverTest` simulate the Browserbase condition (driver implements `HasDevTools`, DevTools access throws), one per failure mode: recording never started, and recorder dying on a window change. Both failed with `DevToolsException` propagating out of `contentDescriptor()` before the fix, both pass after.
- Full `maestro-client` suite green.

**Note for reviewers:** this repo's CI cannot exercise the failing path, since local Chrome has a working CDP connection and recording starts fine. The real validation is copilot's Worker E2E after the follow-up submodule bump: Web E2E green there is the proof. Evidence trail on the copilot side: mobile-dev-inc/copilot#2669 (Web E2E failed on attempts 1 and 6), control branch `test/worker-e2e-devtools-control` (pass at `e5d3900` without the bump, fail at `36d9211` with it).
