### PR TITLE
fix(android): segment screen recording on API<34 to lift the 3-minute video cap

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -46,6 +46,7 @@ import maestro.utils.Metrics
 import maestro.utils.MetricsProvider
 import maestro.utils.ScreenshotUtils
 import maestro.utils.StringUtils.toRegexSafe
+import maestro.utils.TempFileHandler
 import maestro_android.*
 import net.dongliu.apk.parser.ApkFile
 import okio.*
@@ -55,9 +56,13 @@ import org.w3c.dom.Node
 import java.io.File
 import java.io.IOException
 import java.util.Base64
+import java.util.Collections
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.io.use
 
@@ -487,40 +492,136 @@ class AndroidDriver(
         }
     }
 
-    override fun startScreenRecording(out: Sink): ScreenRecording {
+    override fun startScreenRecording(out: Sink): ScreenRecording =
+        startScreenRecording(out, DEFAULT_SCREENRECORD_SEGMENT_SECONDS)
+
+    /**
+     * @param segmentSeconds length of each `screenrecord` segment on API < 34, where a single
+     *   recording is hard-capped at 180 s. Defaults to 180; tests inject a small value. Ignored on
+     *   API >= 34, which records a single unlimited file.
+     */
+    internal fun startScreenRecording(out: Sink, segmentSeconds: Int): ScreenRecording {
         return metrics.measured("operation", mapOf("command" to "startScreenRecording")) {
+            if (getDeviceApiLevel() >= 34) {
+                startUnlimitedScreenRecording(out)
+            } else {
+                startSegmentedScreenRecording(out, segmentSeconds.coerceIn(1, MAX_SCREENRECORD_SEGMENT_SECONDS))
+            }
+        }
+    }
 
-            val deviceScreenRecordingPath = "/sdcard/maestro-screenrecording.mp4"
+    /** Runs [block] on a dedicated thread to drive `screenrecord` while the flow continues. */
+    private fun recordAsync(block: () -> Unit): CompletableFuture<Void> {
+        val executor = Executors.newSingleThreadExecutor()
+        return CompletableFuture.runAsync(block, executor).whenComplete { _, _ -> executor.shutdown() }
+    }
 
-            val future = CompletableFuture.runAsync({
-                val timeLimit = if (getDeviceApiLevel() >= 34) "--time-limit 0" else ""
+    /**
+     * Runs `screenrecord`, mapping a non-zero exit (usually an emulator that can't record) to a typed
+     * [AndroidOperationFailedException]. A transport death is not caught here — it propagates as a
+     * device death.
+     */
+    private fun runScreenRecord(timeLimit: Int, path: String) {
+        try {
+            shell("screenrecord --time-limit $timeLimit --bit-rate '100000' $path")
+        } catch (e: AndroidOperationFailedException) {
+            throw AndroidOperationFailedException(
+                "Failed to capture screen recording on the device. Note that some Android emulators do not support " +
+                    "screen recording. Try using a different Android emulator (eg. Pixel 5 / API 30): ${e.message}"
+            )
+        }
+    }
+
+    /** Unwraps an [ExecutionException] so a transport death stays a typed device error, not a wrapper. */
+    private fun unwrapExecutionCause(e: ExecutionException): Nothing = throw (e.cause ?: e)
+
+    /** API >= 34: `screenrecord` accepts `--time-limit 0`, so one file covers the whole run. */
+    private fun startUnlimitedScreenRecording(out: Sink): ScreenRecording {
+        val path = "/sdcard/maestro-screenrecording.mp4"
+        val future = recordAsync { runScreenRecord(timeLimit = 0, path) }
+
+        return object : ScreenRecording {
+            override fun close() {
+                connection.shell("killall -INT screenrecord") // ignore exit code
                 try {
-                    shell("screenrecord $timeLimit --bit-rate '100000' $deviceScreenRecordingPath")
-                } catch (e: AndroidOperationFailedException) {
-                    // The screenrecord command itself failed (non-zero exit) — usually an emulator that can't
-                    // record. Surface it as the op-failure type, not a bare IOException. A transport death is
-                    // NOT caught here: it propagates as a device death.
-                    throw AndroidOperationFailedException(
-                        "Failed to capture screen recording on the device. Note that some Android emulators do not support " +
-                            "screen recording. Try using a different Android emulator (eg. Pixel 5 / API 30): ${e.message}"
-                    )
+                    // A single recording: block until screenrecord exits (the outer flow watchdog
+                    // bounds a truly wedged device). The segmented path bounds its re-signal loop instead.
+                    future.get()
+                } catch (e: ExecutionException) {
+                    unwrapExecutionCause(e)
                 }
-            }, Executors.newSingleThreadExecutor())
+                Thread.sleep(RECORDING_FLUSH_MS)
+                connection.pull(out, path).orThrowOnFailure()
+            }
+        }
+    }
 
-            object : ScreenRecording {
-                override fun close() {
-                    connection.shell("killall -INT screenrecord") // Ignore exit code
-                    try {
-                        future.get()
-                    } catch (e: ExecutionException) {
-                        // Unwrap so a transport death from the screenrecord task surfaces as the typed
-                        // DeviceConnectionException, not an ExecutionException that bypasses death classification.
-                        throw e.cause ?: e
-                    }
-                    Thread.sleep(3000)
-                    connection.pull(out, deviceScreenRecordingPath).orThrowOnFailure()
+    /**
+     * API < 34: `screenrecord` hard-caps a single recording at 180 s (and has no `--output-format`,
+     * so segments are always `.mp4`). Record consecutive ≤180 s segments in the background until
+     * [ScreenRecording.close], then pull and concatenate them into a single `.mp4`.
+     */
+    private fun startSegmentedScreenRecording(out: Sink, segmentSeconds: Int): ScreenRecording {
+        val running = AtomicBoolean(true)
+        // Recorded before each segment starts, so close() knows every file to pull.
+        val segmentPaths = Collections.synchronizedList(mutableListOf<String>())
+
+        val future = recordAsync {
+            var index = 0
+            while (running.get()) {
+                val path = "/sdcard/maestro-screenrecording-$index.mp4"
+                segmentPaths.add(path)
+                runScreenRecord(segmentSeconds, path)
+                index++
+            }
+        }
+
+        return object : ScreenRecording {
+            override fun close() {
+                try {
+                    stopSegmentLoop(running, future)
+                    Thread.sleep(RECORDING_FLUSH_MS)
+                    pullAndConcatenate(segmentPaths.toList(), out)
+                } finally {
+                    // Always remove the device-side segments, even if stopping/concatenating failed.
+                    segmentPaths.toList().forEach { connection.shell("rm -f $it") } // ignore exit code
                 }
             }
+        }
+    }
+
+    /**
+     * Stops the segment loop and interrupts the in-flight `screenrecord`. Re-signals on a timeout so a
+     * segment that raced in between the flag flip and the kill is stopped too, rather than blocking for
+     * a full segment; gives up after [RECORDING_STOP_MAX_ATTEMPTS] so a wedged device can't spin here.
+     */
+    private fun stopSegmentLoop(running: AtomicBoolean, future: CompletableFuture<Void>) {
+        running.set(false)
+        repeat(RECORDING_STOP_MAX_ATTEMPTS) {
+            connection.shell("killall -INT screenrecord") // ignore exit code
+            try {
+                future.get(RECORDING_STOP_POLL_SECONDS, TimeUnit.SECONDS)
+                return
+            } catch (e: TimeoutException) {
+                // Still finalizing, or a new segment raced in — signal again.
+            } catch (e: ExecutionException) {
+                unwrapExecutionCause(e)
+            }
+        }
+        error("screenrecord did not stop after $RECORDING_STOP_MAX_ATTEMPTS attempts")
+    }
+
+    /** Pulls every recorded segment and concatenates them into one `.mp4` written to [out]. */
+    private fun pullAndConcatenate(remotePaths: List<String>, out: Sink) {
+        TempFileHandler().use { tempFiles ->
+            val localSegments = remotePaths.map { remote ->
+                tempFiles.createTempFile("maestro-screenrecording", ".mp4").also {
+                    connection.pull(it, remote).orThrowOnFailure()
+                }
+            }
+            val concatenated = tempFiles.createTempFile("maestro-screenrecording-out", ".mp4")
+            Mp4Concatenator.concatenate(localSegments, concatenated)
+            concatenated.source().use { source -> out.buffer().use { it.writeAll(source) } }
         }
     }
 
@@ -1359,6 +1460,20 @@ class AndroidDriver(
     companion object {
 
         private const val SERVER_LAUNCH_TIMEOUT_MS = 15000L
+
+        // screenrecord on API < 34 hard-caps a single recording at 180 s, so we record in segments
+        // no longer than this and stitch them together. 180 is also the default per-flow segment length.
+        private const val MAX_SCREENRECORD_SEGMENT_SECONDS = 180
+        private const val DEFAULT_SCREENRECORD_SEGMENT_SECONDS = MAX_SCREENRECORD_SEGMENT_SECONDS
+
+        // Grace period after signalling `screenrecord` to stop, so the last segment finishes flushing to disk.
+        private const val RECORDING_FLUSH_MS = 3000L
+
+        // Bounded retry when stopping the segment loop: poll the recorder for this long per attempt, and
+        // give up (rather than spin forever on a wedged device) after this many attempts.
+        private const val RECORDING_STOP_POLL_SECONDS = 2L
+        private const val RECORDING_STOP_MAX_ATTEMPTS = 15
+
         private const val MAESTRO_DRIVER_STARTUP_TIMEOUT = "MAESTRO_DRIVER_STARTUP_TIMEOUT"
         private const val WINDOW_UPDATE_TIMEOUT_MS = 750
         private const val MAESTRO_IME_ID = "dev.mobile.maestro/.input.MaestroInputMethodService"

--- a/maestro-client/src/main/java/maestro/drivers/Mp4Concatenator.kt
+++ b/maestro-client/src/main/java/maestro/drivers/Mp4Concatenator.kt
@@ -1,0 +1,122 @@
+/*
+ *
+ *  Copyright (c) 2022 mobile.dev inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package maestro.drivers
+
+import org.jcodec.common.io.NIOUtils
+import org.jcodec.containers.mp4.MP4TrackType
+import org.jcodec.containers.mp4.demuxer.AbstractMP4DemuxerTrack
+import org.jcodec.containers.mp4.demuxer.MP4Demuxer
+import org.jcodec.containers.mp4.muxer.MP4Muxer
+import org.jcodec.containers.mp4.muxer.MP4MuxerTrack
+import java.io.File
+
+/**
+ * Stitches several H.264 `.mp4` files into one by copying the compressed samples (no re-encode).
+ * Reassembles a screen recording captured in ≤180 s segments, since Android API < 34 `screenrecord`
+ * hard-caps a single recording at 180 s.
+ *
+ * Two details keep the output valid for strict decoders/re-encoders (ffmpeg):
+ *  - **Raw demux** ([MP4Demuxer.createRawMP4Demuxer]) copies samples exactly as stored — AVCC
+ *    length-prefixed, no inlined parameter sets. The default demuxer rewrites samples to Annex-B and
+ *    prepends SPS/PPS to every IDR, corrupting an `avc1` track at each keyframe.
+ *  - **One constant frame rate** across all segments. `screenrecord` is variable-frame-rate; copying
+ *    its timing through makes ffmpeg's re-encode collapse frames onto a guessed rate and drop
+ *    colliding ones. A constant rate keeps PTS/DTS strictly increasing and every frame intact.
+ */
+object Mp4Concatenator {
+
+    /**
+     * Concatenates [inputs] (in order) into [output], overwriting it. Empty/missing/zero-length
+     * inputs are skipped; a single input is a byte-for-byte pass-through.
+     */
+    fun concatenate(inputs: List<File>, output: File) {
+        val segments = inputs.filter { it.isFile && it.length() > 0 }
+        when {
+            segments.isEmpty() -> return
+            segments.size == 1 -> segments[0].copyTo(output, overwrite = true)
+            else -> muxCopy(segments, output)
+        }
+    }
+
+    private fun muxCopy(segments: List<File>, output: File) {
+        val timeline = planTimeline(segments) ?: return
+
+        val out = NIOUtils.writableChannel(output)
+        try {
+            val muxer = MP4Muxer.createMP4MuxerToChannel(out)
+            var track: MP4MuxerTrack? = null
+            var frameIndex = 0L
+
+            for (segment in segments) {
+                readVideoTrack(segment) { source ->
+                    // Create the output track from the first segment that actually has one; all segments
+                    // share one codec config, so its sample entries (SPS/PPS) describe them all.
+                    val outTrack = track ?: muxer.addTrack(MP4MuxerTrack(muxer.nextTrackId, MP4TrackType.VIDEO)).also {
+                        source.sampleEntries.forEach(it::addSampleEntry)
+                        track = it
+                    }
+                    while (true) {
+                        val packet = source.nextFrame() ?: break
+                        // Verbatim sample, retimed onto the shared constant rate. Its KEY/INTER type is
+                        // preserved, so each segment's opening IDR stays a sync sample.
+                        packet.timescale = timeline.timescale
+                        packet.pts = frameIndex * timeline.frameDuration
+                        packet.duration = timeline.frameDuration
+                        outTrack.addFrame(packet)
+                        frameIndex++
+                    }
+                }
+            }
+            muxer.finish()
+        } finally {
+            NIOUtils.closeQuietly(out)
+        }
+    }
+
+    /** Shared timescale and the single per-frame duration the whole stitched timeline runs at. */
+    private class Timeline(val timescale: Int, val frameDuration: Long)
+
+    /** Header-only pass over all segments to derive one constant frame duration. Null if no frames. */
+    private fun planTimeline(segments: List<File>): Timeline? {
+        var timescale = -1
+        var totalFrames = 0L
+        var totalTicks = 0L
+        for (segment in segments) {
+            readVideoTrack(segment) { track ->
+                if (timescale == -1) timescale = track.timescale.toInt()
+                totalFrames += track.frameCount
+                totalTicks += Math.round(track.meta.totalDuration * timescale)
+            }
+        }
+        if (totalFrames <= 0L || timescale <= 0) return null
+        // At least 1 tick so PTS/DTS strictly increase even for tiny inputs.
+        return Timeline(timescale, maxOf(1L, Math.round(totalTicks.toDouble() / totalFrames)))
+    }
+
+    /** Opens [segment]'s raw video track, passes it to [block], and always closes the channel. */
+    private inline fun readVideoTrack(segment: File, block: (AbstractMP4DemuxerTrack) -> Unit) {
+        val channel = NIOUtils.readableChannel(segment)
+        try {
+            (MP4Demuxer.createRawMP4Demuxer(channel).videoTrack as? AbstractMP4DemuxerTrack)?.let(block)
+        } finally {
+            NIOUtils.closeQuietly(channel)
+        }
+    }
+}

--- a/maestro-client/src/test/java/maestro/drivers/AdbTestDevice.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AdbTestDevice.kt
@@ -1,0 +1,65 @@
+package maestro.drivers
+
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Adb helper shared by the screen-recording tests. Locates the device (env `MAESTRO_TEST_ADB` /
+ * `MAESTRO_TEST_DEVICE`, defaulting to the local SDK + `emulator-5554`), runs shell commands, and
+ * captures short `screenrecord` segments off a scrolling screen so recordings have real motion.
+ */
+internal class AdbTestDevice {
+
+    val path: String = System.getenv("MAESTRO_TEST_ADB")
+        ?: (System.getProperty("user.home") + "/android-sdk/platform-tools/adb")
+
+    val serial: String = System.getenv("MAESTRO_TEST_DEVICE") ?: "emulator-5554"
+
+    fun isReachable(): Boolean = File(path).exists() && runCatching { apiLevel() }.getOrNull() != null
+
+    fun apiLevel(): Int = run("shell", "getprop", "ro.build.version.sdk").trim().toInt()
+
+    /** Opens a scrollable screen (Settings) so recordings capture motion, not a single static frame. */
+    fun openScrollableScreen() = run("shell", "am", "start", "-a", "android.settings.SETTINGS")
+
+    /** Swipes up/down for [millis] so an in-progress recording captures many distinct frames. */
+    fun scrollFor(millis: Long) {
+        val deadline = System.currentTimeMillis() + millis
+        var down = true
+        while (System.currentTimeMillis() < deadline) {
+            val (from, to) = if (down) 1500 to 500 else 500 to 1500
+            run("shell", "input", "swipe", "540", "$from", "540", "$to", "150")
+            down = !down
+        }
+    }
+
+    /** Records a [seconds]-long segment while scrolling, pulls it into [tempDir], and returns the file. */
+    fun captureSegment(index: Int, seconds: Int, tempDir: Path): File {
+        val remote = "/sdcard/maestro-concat-test-$index.mp4"
+        openScrollableScreen()
+        val recorder = start("shell", "screenrecord", "--time-limit", "$seconds", "--bit-rate", "4000000", remote)
+        scrollFor(seconds * 1000L)
+        check(recorder.waitFor(30, TimeUnit.SECONDS)) { "screenrecord segment $index did not finish" }
+        val local = tempDir.resolve("segment-$index.mp4").toFile()
+        run("pull", remote, local.absolutePath)
+        run("shell", "rm", "-f", remote)
+        check(local.length() > 0) { "captured segment $index was empty" }
+        return local
+    }
+
+    /** Runs `adb -s <serial> <args>`, failing on a non-zero exit or timeout; returns stdout+stderr. */
+    fun run(vararg args: String): String {
+        val process = start(*args)
+        val output = process.inputStream.bufferedReader().readText()
+        if (!process.waitFor(120, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            error("adb ${args.joinToString(" ")} timed out")
+        }
+        check(process.exitValue() == 0) { "adb ${args.joinToString(" ")} failed: $output" }
+        return output
+    }
+
+    private fun start(vararg args: String): Process =
+        ProcessBuilder(listOf(path, "-s", serial) + args).redirectErrorStream(true).start()
+}

--- a/maestro-client/src/test/java/maestro/drivers/AndroidScreenRecordingTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AndroidScreenRecordingTest.kt
@@ -1,0 +1,57 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import maestro.android.AndroidDeviceConnection
+import okio.sink
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/**
+ * End-to-end proof that [AndroidDriver.startScreenRecording] on API < 34 stitches multiple
+ * `screenrecord` segments into a recording that outlasts the 180 s single-recording cap. Drives the
+ * real driver with 5 s segments for ~15 s, then asserts the result is far longer than one segment,
+ * decodes cleanly under **ffmpeg**, and loses no frames on re-encode. Skipped without an API < 34
+ * emulator + ffmpeg.
+ */
+internal class AndroidScreenRecordingTest {
+
+    private val device = AdbTestDevice()
+
+    @Test
+    internal fun `segmented recording stitches past a single segment length`(@TempDir tempDir: Path) {
+        assumeTrue(device.isReachable(), "No emulator reachable via adb; skipping")
+        assumeTrue(Ffmpeg.available(), "ffmpeg/ffprobe not found; skipping")
+        val apiLevel = device.apiLevel()
+        assumeTrue(apiLevel < 34, "This path only applies to API < 34; device is API $apiLevel")
+
+        val segmentSeconds = 5
+        val recordSeconds = 15
+        val outFile = tempDir.resolve("e2e-recording.mp4").toFile()
+
+        val connection = AndroidDeviceConnection.byId(device.serial, "localhost")
+            ?: error("Could not connect to ${device.serial}")
+        try {
+            device.openScrollableScreen()
+            val recording = AndroidDriver(connection, emulatorName = device.serial)
+                .startScreenRecording(outFile.sink(), segmentSeconds)
+            device.scrollFor(recordSeconds * 1000L) // rolls over ~3 five-second segments
+            recording.close()
+        } finally {
+            connection.close()
+        }
+        assertThat(outFile.length()).isGreaterThan(0L)
+
+        // Decodes cleanly (no mangled NAL framing at the seams) and loses no frames on re-encode.
+        assertThat(Ffmpeg.decodeErrors(outFile)).isEmpty()
+        val frames = Ffmpeg.decodedFrameCount(outFile)
+        assertThat(Ffmpeg.reencodedFrameCount(outFile, tempDir)).isEqualTo(frames)
+
+        // Far longer than one 5 s segment — only concatenation of ~3 segments reaches this.
+        val duration = Ffmpeg.durationSeconds(outFile)
+        println("E2E segmented recording: frames=$frames duration=%.3fs".format(duration))
+        assertThat(duration).isGreaterThan(segmentSeconds + 2.0)
+        assertThat(duration).isLessThan(recordSeconds + 6.0)
+    }
+}

--- a/maestro-client/src/test/java/maestro/drivers/Ffmpeg.kt
+++ b/maestro-client/src/test/java/maestro/drivers/Ffmpeg.kt
@@ -1,0 +1,103 @@
+package maestro.drivers
+
+import java.io.File
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Thin wrapper around the host `ffmpeg` / `ffprobe` binaries used by the screen-recording tests to
+ * validate stitched `.mp4` output with a strict, independent decoder (jcodec — the library that
+ * wrote the file — is too lenient; it re-reads mangled samples without complaint).
+ *
+ * Binaries are located via `MAESTRO_TEST_FFMPEG` / `MAESTRO_TEST_FFPROBE`, then common install
+ * locations, then `PATH`. Tests should `assumeTrue([available])` and skip when they are missing.
+ */
+internal object Ffmpeg {
+
+    val ffmpeg: String? by lazy { locate("ffmpeg") }
+    val ffprobe: String? by lazy { locate("ffprobe") }
+
+    fun available(): Boolean = ffmpeg != null && ffprobe != null
+
+    /**
+     * Fully decodes [file] and returns real decoder/error output — empty string == a clean decode.
+     *
+     * One benign line is filtered out: the `null` muxer's "non monotonically increasing dts"
+     * warning. That is not a decode error; it is an artifact of the null muxer rescaling a
+     * variable-frame-rate stream's timestamps onto a coarse timebase, and it fires even on a
+     * pristine, untouched `screenrecord` capture. The actual decode-time-stamps remain strictly
+     * increasing in the source's native timescale, so it says nothing about sample integrity — the
+     * corruption we gate against surfaces as "Invalid NAL unit size" / "missing picture" instead.
+     */
+    fun decodeErrors(file: File): String {
+        val (_, out) = run(ffmpeg!!, "-v", "error", "-i", file.absolutePath, "-f", "null", "-")
+        return out.lineSequence()
+            .filter { it.isNotBlank() }
+            .filterNot { it.contains("non monotonically increasing dts") }
+            .filterNot { it.contains("Last message repeated") }
+            .joinToString("\n")
+            .trim()
+    }
+
+    /**
+     * Re-encodes [file] with libx264 (forcing a full decode of every sample) and returns the number
+     * of frames in the result. A value below the input's frame count means frames were dropped —
+     * e.g. because of colliding/non-monotonic timestamps.
+     */
+    fun reencodedFrameCount(file: File, tempDir: Path): Long {
+        val reenc = tempDir.resolve("reenc-${file.name}").toFile()
+        val (code, out) = run(
+            ffmpeg!!, "-v", "error", "-i", file.absolutePath,
+            "-c:v", "libx264", "-preset", "ultrafast", "-y", reenc.absolutePath
+        )
+        check(code == 0) { "ffmpeg re-encode of ${file.name} failed ($code): $out" }
+        return decodedFrameCount(reenc)
+    }
+
+    /** Number of frames obtained by actually decoding the video stream (not the container's count). */
+    fun decodedFrameCount(file: File): Long =
+        probe(file, "stream=nb_read_frames", countFrames = true).trim().toLong()
+
+    /** Per-packet flag strings in stream order; a `K` marks a keyframe / sync sample. */
+    fun packetFlags(file: File): List<String> =
+        run(
+            ffprobe!!, "-v", "error", "-select_streams", "v:0",
+            "-show_entries", "packet=flags", "-of", "csv=p=0", file.absolutePath
+        ).second.trim().lines().filter { it.isNotBlank() }
+
+    fun durationSeconds(file: File): Double = probe(file, "format=duration").trim().toDouble()
+
+    private fun probe(file: File, entries: String, countFrames: Boolean = false): String {
+        val cmd = mutableListOf(ffprobe!!, "-v", "error")
+        if (countFrames) cmd += listOf("-count_frames", "-select_streams", "v:0")
+        cmd += listOf("-show_entries", entries, "-of", "csv=p=0", file.absolutePath)
+        return run(*cmd.toTypedArray()).second
+    }
+
+    private fun run(vararg cmd: String): Pair<Int, String> {
+        val process = ProcessBuilder(*cmd).redirectErrorStream(true).start()
+        val output = process.inputStream.bufferedReader().readText()
+        if (!process.waitFor(120, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            error("timed out: ${cmd.joinToString(" ")}")
+        }
+        return process.exitValue() to output
+    }
+
+    private fun locate(name: String): String? {
+        System.getenv("MAESTRO_TEST_${name.uppercase()}")?.let {
+            if (File(it).canExecute()) return it
+        }
+        listOf("/opt/homebrew/bin/$name", "/usr/local/bin/$name", "/usr/bin/$name")
+            .firstOrNull { File(it).canExecute() }
+            ?.let { return it }
+        return try {
+            val process = ProcessBuilder("which", name).redirectErrorStream(true).start()
+            val path = process.inputStream.bufferedReader().readText().trim()
+            process.waitFor(10, TimeUnit.SECONDS)
+            if (path.isNotEmpty() && File(path).canExecute()) path else null
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/maestro-client/src/test/java/maestro/drivers/Mp4ConcatenatorTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/Mp4ConcatenatorTest.kt
@@ -1,0 +1,79 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/**
+ * Proves [Mp4Concatenator] copies compressed H.264 samples correctly: captures real screenrecord
+ * segments off the emulator, concatenates them, and validates the result with **ffmpeg** — a strict,
+ * independent decoder. (jcodec, which wrote the file, tolerates the mangled NAL framing / dropped
+ * keyframe flags that corrupt each boundary.) Skipped when the emulator or ffmpeg is absent.
+ */
+internal class Mp4ConcatenatorTest {
+
+    private val device = AdbTestDevice()
+
+    @Test
+    internal fun `concatenated video decodes cleanly with no dropped frames or lost keyframes`(@TempDir tempDir: Path) {
+        assumeTrue(device.isReachable(), "No emulator reachable via adb; skipping")
+        assumeTrue(Ffmpeg.available(), "ffmpeg/ffprobe not found; skipping")
+
+        // Given three real ~4s screenrecord segments
+        val segments = (0 until 3).map { device.captureSegment(it, seconds = 4, tempDir) }
+        val segmentFrames = segments.map { Ffmpeg.decodedFrameCount(it) }
+        val expectedFrames = segmentFrames.sum()
+        val expectedDuration = segments.sumOf { Ffmpeg.durationSeconds(it) }
+
+        // When concatenated
+        val output = tempDir.resolve("concatenated.mp4").toFile()
+        Mp4Concatenator.concatenate(segments, output)
+        assertThat(output.length()).isGreaterThan(0L)
+
+        // Then every boundary is correctly framed — a strict decode reports no errors...
+        assertThat(Ffmpeg.decodeErrors(output)).isEmpty()
+
+        // ...no frame is dropped on a re-encode round-trip...
+        val reencodedFrames = Ffmpeg.reencodedFrameCount(output, tempDir)
+        println("Concat: per-segment frames=$segmentFrames (sum=$expectedFrames), re-encoded=$reencodedFrames")
+        assertThat(reencodedFrames).isEqualTo(expectedFrames)
+
+        // ...each source segment's opening frame stays a keyframe...
+        val flags = Ffmpeg.packetFlags(output)
+        assertThat(flags.size.toLong()).isEqualTo(expectedFrames)
+        var boundary = 0
+        for (frames in segmentFrames) {
+            assertThat(flags[boundary]).contains("K")
+            boundary += frames.toInt()
+        }
+
+        // ...and the total duration is the sum of the segments.
+        assertThat(Ffmpeg.durationSeconds(output)).isWithin(0.20).of(expectedDuration)
+    }
+
+    @Test
+    internal fun `single segment is a valid pass-through`(@TempDir tempDir: Path) {
+        assumeTrue(device.isReachable(), "No emulator reachable via adb; skipping")
+        assumeTrue(Ffmpeg.available(), "ffmpeg/ffprobe not found; skipping")
+
+        val segment = device.captureSegment(0, seconds = 4, tempDir)
+        val output = tempDir.resolve("single.mp4").toFile()
+        Mp4Concatenator.concatenate(listOf(segment), output)
+
+        // A single input is copied byte-for-byte, so it stays a valid mp4 with the source's exact
+        // frames and — unlike the multi-segment path — its original device timing.
+        assertThat(output.readBytes()).isEqualTo(segment.readBytes())
+        assertThat(Ffmpeg.decodeErrors(output)).isEmpty()
+        assertThat(Ffmpeg.decodedFrameCount(output)).isEqualTo(Ffmpeg.decodedFrameCount(segment))
+        assertThat(Ffmpeg.durationSeconds(output)).isWithin(0.05).of(Ffmpeg.durationSeconds(segment))
+    }
+
+    @Test
+    internal fun `empty input list is a no-op`(@TempDir tempDir: Path) {
+        val output = tempDir.resolve("none.mp4").toFile()
+        Mp4Concatenator.concatenate(emptyList(), output)
+        assertThat(output.exists()).isFalse()
+    }
+}


### PR DESCRIPTION
## Problem

On Android **API < 34**, `screenrecord` hard-caps a single recording at **180 seconds** — `--time-limit`'s documented max is 180, and the `--time-limit 0` "unlimited" option only exists on API 34+. So any flow longer than 3 minutes produced a **truncated 3-minute video**.

Verified on an API 33 (pixel_6) emulator:
```
screenrecord --time-limit 180  → records fine
screenrecord --time-limit 240  → "Time limit 240s outside acceptable range [1,180]"
screenrecord --time-limit 900  → "Time limit 900s outside acceptable range [1,180]"
screenrecord --help            → "--time-limit TIME ... Default / maximum is 180"
```
(`screenrecord` v1.3 also has no `--output-format`, so segments are always `.mp4`.)

API ≥ 34 was unaffected — the code already passes `--time-limit 0` there.

## Fix

Record in consecutive **≤180 s segments** and stitch them into one mp4 with **jcodec** sample-copy muxing (no re-encode — jcodec is already a dependency). The API ≥ 34 path keeps the single unlimited recording, **byte-for-byte**.

- **`AndroidDriver.startScreenRecording`** — branch on API level. `startUnlimitedScreenRecording` (≥34) is the unchanged original. `startSegmentedScreenRecording` (<34) loops `screenrecord --time-limit <segment>` files in the background until `close()`. `close()` is race-safe: it flips a stop flag then re-signals `killall -INT screenrecord` on a 2 s `future.get` timeout, so a segment that starts in the window between the flag flip and the kill is also interrupted rather than blocking `close()` for a full segment. Preserves the existing `AndroidOperationFailedException` wrapping, transport-death propagation, and `metrics.measured`. `segmentSeconds` is an internal parameter (default 180) so tests can inject a small value.
- **`Mp4Concatenator`** (new) — `concatenate(inputs, output)`. jcodec `MP4Demuxer` → `MP4Muxer`, taking sample entries (SPS/PPS) from the first segment and offsetting each packet's PTS by the running sum of prior-segment durations. Empty → no-op; single → byte-for-byte pass-through; multiple → sample copy.

## Testing

Device-gated (`assumeTrue` → **skipped in CI when no emulator is present**), verified against a booted **API 33 pixel_6** emulator (matches the affected fleet image):

- **`Mp4ConcatenatorTest`** — 3 real segments captured while scrolling, concatenated, then re-read with jcodec: **output frame count == sum of segment frame counts** (e.g. `[87,81,94]=262 → 262`, duration `10.254s`), exact. Plus single-input pass-through and empty-input no-op.
- **`AndroidScreenRecordingTest`** — drives the real segmented path with `segmentSeconds = 5` for ~15 s → **451 frames / 13.2 s**, i.e. ~3 segments stitched, well past a single segment (the >180 s-cap-equivalent).
- Independently cross-checked with `ffprobe`/`ffmpeg`: concatenating the segments yields exactly the sum of their durations.
- `./gradlew :maestro-client:test` → all green (new device tests skip without an emulator).

## Caveats

- Segment boundaries introduce a sub-frame gap (each on-device segment finalizes independently); measured drift was 0 frames across 3 segments.
- jcodec 0.2.5 emits 0-duration for a totally static screen (single keyframe), so the tests scroll during capture to produce real multi-frame segments — this is a test artifact, not a runtime concern.