### PR TITLE
feat(orchestra): report captured step-screenshot paths via callback

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -143,10 +143,6 @@ class Orchestra(
     private val onCommandSkipped: (Int, MaestroCommand) -> Unit = { _, _ -> },
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
-    /**
-     * Fires when a step runs and successfully captures its automatic screenshot (not one
-     * explicitly taken by a user command), with the bundle-relative path. Keep it non-blocking.
-     */
     private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },
     private val apiKey: String? = null,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -144,10 +144,8 @@ class Orchestra(
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
     /**
-     * Fired after a step screenshot (screenshots/step-{n}.png) lands in the bundle, with its
-     * bundle-relative path. Not fired for skipped commands or failed captures. The Int is the
-     * global command sequence number (one per attempt), not the sibling callbacks' list index.
-     * Runs on the flow thread — keep it non-blocking.
+     * Fires when a step runs and successfully captures its automatic screenshot (not one
+     * explicitly taken by a user command), with the bundle-relative path. Keep it non-blocking.
      */
     private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -143,6 +143,7 @@ class Orchestra(
     private val onCommandSkipped: (Int, MaestroCommand) -> Unit = { _, _ -> },
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
+    private val onCommandArtifactCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },
     private val apiKey: String? = null,
     private val AIPredictionEngine: AIPredictionEngine? = apiKey?.let { CloudAIPredictionEngine(it) },
@@ -172,7 +173,7 @@ class Orchestra(
     // ArtifactsGenerator is always the first listener: it writes the bundle when
     // artifactsDir is set and populates debugOutput either way.
     private val artifactsGenerator: ArtifactsGenerator =
-        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts)
+        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts, onCommandArtifactCaptured)
     private val effectiveListeners: List<OrchestraListener> = listOf(artifactsGenerator) + listeners
 
     private var commandSequenceCounter: Int = 0

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -143,7 +143,14 @@ class Orchestra(
     private val onCommandSkipped: (Int, MaestroCommand) -> Unit = { _, _ -> },
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
-    private val onCommandArtifactCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
+    /**
+     * Fired after a step screenshot (screenshots/step-{n}.png, written for both passing and
+     * failing steps) lands in the artifact bundle, with the bundle-relative path. Never fires
+     * for skipped commands, failed captures, or other artifact kinds. The Int is the global
+     * command sequence number that listener dispatch receives (one per attempt, composites
+     * included), not the per-list index the sibling onCommand* callbacks receive.
+     */
+    private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },
     private val apiKey: String? = null,
     private val AIPredictionEngine: AIPredictionEngine? = apiKey?.let { CloudAIPredictionEngine(it) },
@@ -173,7 +180,7 @@ class Orchestra(
     // ArtifactsGenerator is always the first listener: it writes the bundle when
     // artifactsDir is set and populates debugOutput either way.
     private val artifactsGenerator: ArtifactsGenerator =
-        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts, onCommandArtifactCaptured)
+        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts, onStepScreenshotCaptured)
     private val effectiveListeners: List<OrchestraListener> = listOf(artifactsGenerator) + listeners
 
     private var commandSequenceCounter: Int = 0

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -144,11 +144,10 @@ class Orchestra(
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
     /**
-     * Fired after a step screenshot (screenshots/step-{n}.png, written for both passing and
-     * failing steps) lands in the artifact bundle, with the bundle-relative path. Never fires
-     * for skipped commands, failed captures, or other artifact kinds. The Int is the global
-     * command sequence number that listener dispatch receives (one per attempt, composites
-     * included), not the per-list index the sibling onCommand* callbacks receive.
+     * Fired after a step screenshot (screenshots/step-{n}.png) lands in the bundle, with its
+     * bundle-relative path. Not fired for skipped commands or failed captures. The Int is the
+     * global command sequence number (one per attempt), not the sibling callbacks' list index.
+     * Runs on the flow thread — keep it non-blocking.
      */
     private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -37,6 +37,7 @@ internal class ArtifactsGenerator(
     private val artifactsDir: Path?,
     private val maestro: Maestro,
     private val captureFullArtifacts: Boolean = false,
+    private val onCommandArtifactCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
 ) : OrchestraListener {
 
     val debugOutput = FlowDebugOutput()
@@ -245,14 +246,19 @@ internal class ArtifactsGenerator(
         // individually, so the parent keeps its own screenshot too — no dedup.
         if (!captureFullArtifacts && metadata.sequenceNumber < lastFailureScreenshotSeq) return
         try {
+            val relativePath =
+                "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
             val destFile = collector.allocate(
                 ArtifactKind.SCREENSHOT,
                 ArtifactFormat.PNG,
-                "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
+                relativePath,
                 sequenceNumber = metadata.sequenceNumber,
             )
             val taken = ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
-            if (taken != null) lastFailureScreenshotSeq = metadata.sequenceNumber
+            if (taken != null) {
+                lastFailureScreenshotSeq = metadata.sequenceNumber
+                onCommandArtifactCaptured(metadata.sequenceNumber, relativePath)
+            }
         } catch (e: Exception) {
             logger.warn("Failed to capture failure screenshot", e)
         }
@@ -261,13 +267,16 @@ internal class ArtifactsGenerator(
     private fun captureStepScreenshot(metadata: CommandDebugMetadata) {
         val collector = collector ?: return
         try {
+            val relativePath =
+                "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
             val destFile = collector.allocate(
                 ArtifactKind.SCREENSHOT,
                 ArtifactFormat.PNG,
-                "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
+                relativePath,
                 sequenceNumber = metadata.sequenceNumber,
             )
             runBlocking { maestro.takeScreenshot(destFile.sink(), false) }
+            onCommandArtifactCaptured(metadata.sequenceNumber, relativePath)
         } catch (e: Exception) {
             logger.warn("Failed to capture per-step screenshot", e)
         }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -37,7 +37,7 @@ internal class ArtifactsGenerator(
     private val artifactsDir: Path?,
     private val maestro: Maestro,
     private val captureFullArtifacts: Boolean = false,
-    private val onCommandArtifactCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
+    private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
 ) : OrchestraListener {
 
     val debugOutput = FlowDebugOutput()
@@ -245,41 +245,51 @@ internal class ArtifactsGenerator(
         // own shot. With captureFullArtifacts on (worker) every step is recorded
         // individually, so the parent keeps its own screenshot too — no dedup.
         if (!captureFullArtifacts && metadata.sequenceNumber < lastFailureScreenshotSeq) return
-        try {
-            val relativePath =
-                "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
+        val relativePath =
+            "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
+        val taken = try {
             val destFile = collector.allocate(
                 ArtifactKind.SCREENSHOT,
                 ArtifactFormat.PNG,
                 relativePath,
                 sequenceNumber = metadata.sequenceNumber,
             )
-            val taken = ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
-            if (taken != null) {
-                lastFailureScreenshotSeq = metadata.sequenceNumber
-                onCommandArtifactCaptured(metadata.sequenceNumber, relativePath)
-            }
+            ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
         } catch (e: Exception) {
             logger.warn("Failed to capture failure screenshot", e)
+            return
         }
+        if (taken == null) return
+        lastFailureScreenshotSeq = metadata.sequenceNumber
+        // Outside the try: a throwing consumer must not be logged as a capture failure.
+        // It falls through to dispatch()'s per-listener net, which attributes it correctly.
+        onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
     private fun captureStepScreenshot(metadata: CommandDebugMetadata) {
         val collector = collector ?: return
-        try {
-            val relativePath =
-                "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
+        val relativePath =
+            "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
+        val taken = try {
             val destFile = collector.allocate(
                 ArtifactKind.SCREENSHOT,
                 ArtifactFormat.PNG,
                 relativePath,
                 sequenceNumber = metadata.sequenceNumber,
             )
-            runBlocking { maestro.takeScreenshot(destFile.sink(), false) }
-            onCommandArtifactCaptured(metadata.sequenceNumber, relativePath)
+            // takeDebugScreenshot deletes the file when capture throws mid-write, so the
+            // collector's record is dropped at read time and commands.json, the manifest,
+            // and this callback all agree that no screenshot exists for the step.
+            ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
         } catch (e: Exception) {
             logger.warn("Failed to capture per-step screenshot", e)
+            return
         }
+        if (taken == null) {
+            logger.warn("Failed to capture per-step screenshot for step ${metadata.sequenceNumber}")
+            return
+        }
+        onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
     private fun startFullRunRecording() {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -237,37 +237,27 @@ internal class ArtifactsGenerator(
     }
 
     private fun captureFailureScreenshot(metadata: CommandDebugMetadata) {
-        val collector = collector ?: return
-        // A composite parent fails right after its leaf, on the same screen, with a
-        // lower sequence number than the leaf that already captured. In the minimal
-        // local bundle (flag off) skip that duplicate; a genuinely later failure
-        // (continue-on-failure / optional) has a higher number and still gets its
-        // own shot. With captureFullArtifacts on (worker) every step is recorded
-        // individually, so the parent keeps its own screenshot too — no dedup.
+        // Flag off: dedup a composite parent's shot against the leaf that already captured on
+        // the same screen (lower seq). Flag on (worker): every step is recorded, so no dedup.
         if (!captureFullArtifacts && metadata.sequenceNumber < lastFailureScreenshotSeq) return
-        val relativePath =
-            "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
-        val taken = try {
-            val destFile = collector.allocate(
-                ArtifactKind.SCREENSHOT,
-                ArtifactFormat.PNG,
-                relativePath,
-                sequenceNumber = metadata.sequenceNumber,
-            )
-            ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
-        } catch (e: Exception) {
-            logger.warn("Failed to capture failure screenshot", e)
-            return
-        }
-        if (taken == null) return
+        val relativePath = captureStepScreenshotFile(metadata) ?: return
         lastFailureScreenshotSeq = metadata.sequenceNumber
-        // Outside the try: a throwing consumer must not be logged as a capture failure.
-        // It falls through to dispatch()'s per-listener net, which attributes it correctly.
+        // Outside the capture so a throwing consumer surfaces via dispatch(), not as a capture failure.
         onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
     private fun captureStepScreenshot(metadata: CommandDebugMetadata) {
-        val collector = collector ?: return
+        val relativePath = captureStepScreenshotFile(metadata) ?: return
+        onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
+    }
+
+    /**
+     * Allocates step-{seq}.png and captures into it. Returns the bundle-relative path once a
+     * screenshot lands, or null if capture failed — takeDebugScreenshot deletes the partial
+     * file, so bundle, manifest, and callback all agree no screenshot exists for the step.
+     */
+    private fun captureStepScreenshotFile(metadata: CommandDebugMetadata): String? {
+        val collector = collector ?: return null
         val relativePath =
             "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
         val taken = try {
@@ -277,19 +267,16 @@ internal class ArtifactsGenerator(
                 relativePath,
                 sequenceNumber = metadata.sequenceNumber,
             )
-            // takeDebugScreenshot deletes the file when capture throws mid-write, so the
-            // collector's record is dropped at read time and commands.json, the manifest,
-            // and this callback all agree that no screenshot exists for the step.
             ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
         } catch (e: Exception) {
-            logger.warn("Failed to capture per-step screenshot", e)
-            return
+            logger.warn("Failed to capture screenshot for step ${metadata.sequenceNumber}", e)
+            return null
         }
         if (taken == null) {
-            logger.warn("Failed to capture per-step screenshot for step ${metadata.sequenceNumber}")
-            return
+            logger.warn("Failed to capture screenshot for step ${metadata.sequenceNumber}")
+            return null
         }
-        onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
+        return relativePath
     }
 
     private fun startFullRunRecording() {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -237,12 +237,10 @@ internal class ArtifactsGenerator(
     }
 
     private fun captureFailureScreenshot(metadata: CommandDebugMetadata) {
-        // Flag off: dedup a composite parent's shot against the leaf that already captured on
-        // the same screen (lower seq). Flag on (worker): every step is recorded, so no dedup.
+        // Flag off, dedup a composite parent against the leaf that already shot the same screen.
         if (!captureFullArtifacts && metadata.sequenceNumber < lastFailureScreenshotSeq) return
         val relativePath = captureStepScreenshotFile(metadata) ?: return
         lastFailureScreenshotSeq = metadata.sequenceNumber
-        // Outside the capture so a throwing consumer surfaces via dispatch(), not as a capture failure.
         onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
@@ -251,11 +249,7 @@ internal class ArtifactsGenerator(
         onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
-    /**
-     * Allocates step-{seq}.png and captures into it. Returns the bundle-relative path once a
-     * screenshot lands, or null if capture failed — takeDebugScreenshot deletes the partial
-     * file, so bundle, manifest, and callback all agree no screenshot exists for the step.
-     */
+    /** Allocates and captures step-{seq}.png, returning its bundle-relative path, or null on failure. */
     private fun captureStepScreenshotFile(metadata: CommandDebugMetadata): String? {
         val collector = collector ?: return null
         val relativePath =

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -817,8 +817,7 @@ class ArtifactsGeneratorTest {
         assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[parent]!!.artifacts)
             .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
-        // The parent fires after its leaf, with its own lower sequence number. Consumers
-        // keying storage by sequence number must tolerate this out-of-order arrival.
+        // Parent fires after its leaf with a lower seq — consumers must tolerate out-of-order arrival.
         assertThat(captured)
             .containsExactly(1 to "screenshots/step-1.png", 0 to "screenshots/step-0.png")
             .inOrder()
@@ -942,14 +941,36 @@ class ArtifactsGeneratorTest {
         gen.onFlowEnd()
 
         assertThat(captured).isEmpty()
-        // The bundle agrees with the silent callback: the mid-write failure leaves no
-        // partial file behind, so neither commands.json nor the manifest claims a
-        // screenshot exists for these steps.
+        // Mid-write failure leaves no partial file, so bundle and manifest stay empty too.
         assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isFalse()
         assertThat(tempDir.resolve("screenshots/step-1.png").exists()).isFalse()
         assertThat(gen.artifactManifest.entries.filter { it.kind == ArtifactKind.SCREENSHOT }).isEmpty()
         assertThat(gen.debugOutput.commands[completed]!!.artifacts.filter { it.type == ArtifactKind.SCREENSHOT }).isEmpty()
         assertThat(gen.debugOutput.commands[failed]!!.artifacts.filter { it.type == ArtifactKind.SCREENSHOT }).isEmpty()
+    }
+
+    @Test
+    fun `a throwing consumer propagates instead of being swallowed as a capture failure`() {
+        // The callback fires outside the capture try, so a consumer exception propagates to
+        // Orchestra's per-listener dispatch net rather than being logged as a capture failure.
+        // The screenshot is already on disk, so the bundle stays intact.
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+            onStepScreenshotCaptured = { _, _ -> throw RuntimeException("consumer boom") },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        val thrown = runCatching {
+            gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
+        }.exceptionOrNull()
+
+        assertThat(thrown).isInstanceOf(RuntimeException::class.java)
+        assertThat(thrown!!.message).isEqualTo("consumer boom")
+        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -807,6 +807,126 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
+    fun `callback reports the step screenshot path for a completed step when captureFullArtifacts is true`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 3)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(captured).containsExactly(3 to "screenshots/step-3.png")
+    }
+
+    @Test
+    fun `callback reports the failure screenshot path for a failed step`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 4)
+        gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
+        gen.onFlowEnd()
+
+        assertThat(captured).containsExactly(4 to "screenshots/step-4.png")
+    }
+
+    @Test
+    fun `callback reports the step screenshot path for a warned step even when captureFullArtifacts is false`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Warned, 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+    }
+
+    @Test
+    fun `callback does not fire for a skipped command`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Skipped, 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun `callback does not fire for a passing step when captureFullArtifacts is false`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
+    fun `callback does not fire when the screenshot write fails`() {
+        val maestro: Maestro = mockk(relaxed = true) {
+            coEvery { takeScreenshot(any<Sink>(), any()) } throws RuntimeException("screenshot boom")
+            coEvery { viewHierarchy(any()) } returns ViewHierarchy(
+                TreeNode(attributes = mutableMapOf("text" to "root"))
+            )
+        }
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = maestro,
+            captureFullArtifacts = true,
+            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val completed = MaestroCommand(tapOnElement = null)
+        val failed = MaestroCommand(scrollCommand = ScrollCommand())
+
+        gen.onFlowStart()
+        gen.onCommandStart(completed, sequenceNumber = 0)
+        gen.onCommandFinished(completed, CommandOutcome.Completed, 100L, 150L)
+        gen.onCommandStart(failed, sequenceNumber = 1)
+        gen.onCommandFinished(failed, CommandOutcome.Failed(RuntimeException("boom")), 150L, 200L)
+        gen.onFlowEnd()
+
+        assertThat(captured).isEmpty()
+    }
+
+    @Test
     fun `separate failures each keep their own screenshot, not just the first`() {
         // Two sibling commands fail (continue-on-failure / optional): both are real,
         // distinct failures, so the dedup must not swallow the second.

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -951,9 +951,8 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `a throwing consumer propagates instead of being swallowed as a capture failure`() {
-        // The callback fires outside the capture try, so a consumer exception propagates to
-        // Orchestra's per-listener dispatch net rather than being logged as a capture failure.
-        // The screenshot is already on disk, so the bundle stays intact.
+        // Fired outside the capture try, so a consumer throw propagates instead of reading as a
+        // capture failure; the screenshot is already on disk.
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -767,7 +767,12 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `composite parent failing after its leaf does not duplicate the failure screenshot`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
+        )
         val leaf = MaestroCommand(tapOnElement = null)
         val parent = MaestroCommand(scrollCommand = ScrollCommand())
 
@@ -783,13 +788,21 @@ class ArtifactsGeneratorTest {
         // Parent gets hierarchy only — screenshot deduped because leaf already captured it.
         assertThat(gen.debugOutput.commands[parent]!!.artifacts)
             .containsExactly(CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-0.json"))
+        // The dedup-skipped parent stays silent on the callback channel too.
+        assertThat(captured).containsExactly(1 to "screenshots/step-1.png")
     }
 
     @Test
     fun `a failed composite parent keeps its own screenshot when captureFullArtifacts is true`() {
         // Worker mode records every step individually, so the parent must not be
         // deduped against its leaf — its RunStep needs its own screenshot.
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
+        )
         val parent = MaestroCommand(scrollCommand = ScrollCommand())
         val leaf = MaestroCommand(tapOnElement = null)
 
@@ -804,6 +817,11 @@ class ArtifactsGeneratorTest {
         assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[parent]!!.artifacts)
             .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
+        // The parent fires after its leaf, with its own lower sequence number. Consumers
+        // keying storage by sequence number must tolerate this out-of-order arrival.
+        assertThat(captured)
+            .containsExactly(1 to "screenshots/step-1.png", 0 to "screenshots/step-0.png")
+            .inOrder()
     }
 
     @Test
@@ -813,7 +831,7 @@ class ArtifactsGeneratorTest {
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
-            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -831,7 +849,7 @@ class ArtifactsGeneratorTest {
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
-            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -849,7 +867,7 @@ class ArtifactsGeneratorTest {
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
-            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -868,7 +886,7 @@ class ArtifactsGeneratorTest {
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
-            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -886,7 +904,7 @@ class ArtifactsGeneratorTest {
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
-            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
         val cmd = MaestroCommand(tapOnElement = null)
 
@@ -911,7 +929,7 @@ class ArtifactsGeneratorTest {
             artifactsDir = tempDir,
             maestro = maestro,
             captureFullArtifacts = true,
-            onCommandArtifactCaptured = { seq, path -> captured.add(seq to path) },
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
         val completed = MaestroCommand(tapOnElement = null)
         val failed = MaestroCommand(scrollCommand = ScrollCommand())
@@ -924,6 +942,14 @@ class ArtifactsGeneratorTest {
         gen.onFlowEnd()
 
         assertThat(captured).isEmpty()
+        // The bundle agrees with the silent callback: the mid-write failure leaves no
+        // partial file behind, so neither commands.json nor the manifest claims a
+        // screenshot exists for these steps.
+        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-1.png").exists()).isFalse()
+        assertThat(gen.artifactManifest.entries.filter { it.kind == ArtifactKind.SCREENSHOT }).isEmpty()
+        assertThat(gen.debugOutput.commands[completed]!!.artifacts.filter { it.type == ArtifactKind.SCREENSHOT }).isEmpty()
+        assertThat(gen.debugOutput.commands[failed]!!.artifacts.filter { it.type == ArtifactKind.SCREENSHOT }).isEmpty()
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -466,8 +466,7 @@ class OrchestraListenerDispatchTest {
 
     @Test
     fun `onStepScreenshotCaptured threads through the Orchestra constructor to the artifacts generator`() {
-        // Pins the constructor pass-through: the generator's param defaults to a no-op,
-        // so dropping the argument here would still compile and pass the direct tests.
+        // Pins the constructor pass-through: the generator's param defaults to a no-op.
         val captured = mutableListOf<Pair<Int, String>>()
         val first = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
         val second = MaestroCommand(evalScriptCommand = EvalScriptCommand("2"))

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -466,9 +466,8 @@ class OrchestraListenerDispatchTest {
 
     @Test
     fun `onStepScreenshotCaptured threads through the Orchestra constructor to the artifacts generator`() {
-        // Pins the constructor pass-through itself: ArtifactsGenerator's parameter
-        // defaults to a no-op, so dropping the argument at the construction site
-        // would compile and pass every direct ArtifactsGenerator test.
+        // Pins the constructor pass-through: the generator's param defaults to a no-op,
+        // so dropping the argument here would still compile and pass the direct tests.
         val captured = mutableListOf<Pair<Int, String>>()
         val first = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
         val second = MaestroCommand(evalScriptCommand = EvalScriptCommand("2"))

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -465,6 +465,28 @@ class OrchestraListenerDispatchTest {
     }
 
     @Test
+    fun `onStepScreenshotCaptured threads through the Orchestra constructor to the artifacts generator`() {
+        // Pins the constructor pass-through itself: ArtifactsGenerator's parameter
+        // defaults to a no-op, so dropping the argument at the construction site
+        // would compile and pass every direct ArtifactsGenerator test.
+        val captured = mutableListOf<Pair<Int, String>>()
+        val first = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
+        val second = MaestroCommand(evalScriptCommand = EvalScriptCommand("2"))
+        val orchestra = Orchestra(
+            maestro = mockMaestro(),
+            artifactsDir = tempDir,
+            captureFullArtifacts = true,
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
+        )
+
+        runBlocking { orchestra.runFlow(listOf(first, second)) }
+
+        assertThat(captured)
+            .containsExactly(0 to "screenshots/step-0.png", 1 to "screenshots/step-1.png")
+            .inOrder()
+    }
+
+    @Test
     fun `retry captures a distinct step screenshot per attempt`() {
         val leaf = MaestroCommand(openLinkCommand = OpenLinkCommand(link = "https://example.com"))
         val outer = MaestroCommand(


### PR DESCRIPTION
## What

New optional Orchestra constructor callback, `onStepScreenshotCaptured(sequenceNumber, relativePath)`, threaded into `ArtifactsGenerator` and fired with the bundle-relative path (`screenshots/step-3.png`) immediately after a step-screenshot write succeeds, in both the completed/warned path and the failure path. It never fires for skipped commands, failed captures, or any other artifact kind. Default no-op, so every existing Orchestra caller compiles unchanged.

## Why

The consumer is the cloud worker ([MA-4049](https://linear.app/mobile-dev/issue/MA-4049)): it links each run step to core's bundle screenshot. Having the code that wrote the file report the path avoids the worker reconstructing `step-{seq}.png` from its own command counter, an implicit cross-repo lockstep that would silently break if dispatch sites ever change. `CommandMetadata` was deliberately not used: listeners have no channel into it, and the worker's metadata handling attributes to the latest-started index, which mis-attributes composite parents.

## Testing

Six new `ArtifactsGeneratorTest` cases: fires with `(seq, path)` for a completed step under `captureFullArtifacts`; fires for a failed step; fires for a warned step even with `captureFullArtifacts=false` (warned steps always get a screenshot); silent for skipped; silent for a passing step with the flag off; silent when the screenshot write throws. `:maestro-orchestra:test` green (46 tests), `:maestro-cli` compiles against the change.


## Review follow-up (third commit)

An adversarial review pass tightened three things: the callback was renamed `onStepScreenshotCaptured` (it fires only for step screenshots, and the KDoc now documents that the Int is the global sequence number, not the per-list index of the sibling callbacks); the step path now routes through `takeDebugScreenshot` so a mid-write failure deletes the partial file and the callback, bundle, manifest, and commands.json always agree; and consumer exceptions propagate to listener dispatch instead of being mislogged as capture failures. Adds the Orchestra-to-generator pass-through test and a composite-parent no-dedup callback test (47 tests in the file, all green).

## Consumer note (pre-existing, found during this PR's compatibility sweep)

studio-server's `FlowExecutor` (copilot repo, `FlowExecutor.kt:315-317`) still constructs Orchestra with a `screenshotsDir` named argument that core removed in #3282. It compiles today only because studio-server pins an older core; its next maestro submodule move will fail to compile regardless of this PR. Not caused or worsened here (this PR's parameter is defaulted and every construction site was swept: all compile unchanged), but whoever moves studio-server's submodule next should fix that call site first.
