### PR TITLE
fix(cli): respect --no-ansi for cloud promo banners

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -708,6 +708,11 @@ class TestCommand : Callable<Int> {
     }
 
     private fun showCloudFasterResultsPromotionMessageIfNeeded() {
+        // Don't show when ANSI/decorated output is disabled (e.g. --no-ansi)
+        if (!DisableAnsiMixin.ansiEnabled) {
+            return
+        }
+
         // Don't show in CI environments
         if (CiUtils.getCiProvider() != null) {
             return
@@ -733,6 +738,11 @@ class TestCommand : Callable<Int> {
     }
 
     private fun showCloudDebugPromotionMessageIfNeeded() {
+        // Don't show when ANSI/decorated output is disabled (e.g. --no-ansi)
+        if (!DisableAnsiMixin.ansiEnabled) {
+            return
+        }
+
         // Don't show in CI environments
         if (CiUtils.getCiProvider() != null) {
             return


### PR DESCRIPTION
## Problem

`maestro test --no-ansi` (and `--no-color`) still printed the decorated "Maestro Cloud" promo banners. Both promo helpers in `TestCommand.kt` build their message with the ANSI color helpers `.cyan()` / `.green()` and wrap it in `.greenBox()` (box-drawing chars), then print it, but neither checked `DisableAnsiMixin.ansiEnabled` first:

- `showCloudDebugPromotionMessageIfNeeded()` — shown when a run has failures.
- `showCloudFasterResultsPromotionMessageIfNeeded()` — shown when `flowCount > 5`.

Both already guard on CI / already-shown-today / recent-cloud-use, but not on the ANSI flag. So under `--no-ansi` they still emit a decorated, boxed banner, which is exactly the kind of output that flag is meant to suppress. The rest of the CLI (e.g. `ProgressBar`, `TestSuiteStatusView`) already gates on `DisableAnsiMixin.ansiEnabled`; these two promos had just been missed.

This is noise for anything consuming maestro's stdout under `--no-ansi`: CI systems and tools that shell out to `maestro test --no-ansi` and parse the per-step output.

Before (`maestro test --no-ansi`, on a failing flow): the flow output is followed by a green-boxed, cyan/green "Debug tests faster … Run your flows on Maestro Cloud" banner drawn with box characters.

After: the flow output ends where it should; no banner is printed.

## Fix

- **`TestCommand`** — add an early `if (!DisableAnsiMixin.ansiEnabled) return` guard to both promo functions, matching how the rest of the CLI gates ANSI output. No new imports (`TestCommand` already imports `DisableAnsiMixin`).

This only suppresses the promo when ANSI is disabled. Normal (TTY) runs are unaffected and still show both banners under all their existing conditions.

## Testing

Built the CLI and ran it against a failing flow under a PTY (so stdout is a TTY and ANSI is enabled by default), comparing default vs `--no-ansi`:

```
./gradlew :maestro-cli:installDist

# default: banner IS printed
script -q /tmp/out.txt maestro-cli/build/install/maestro/bin/maestro test flow.yaml
grep -c "Maestro Cloud" /tmp/out.txt   # -> 1

# --no-ansi: banner is NOT printed
script -q /tmp/out.txt maestro-cli/build/install/maestro/bin/maestro test --no-ansi flow.yaml
grep -c "Maestro Cloud" /tmp/out.txt   # -> 0
```

(The promotion state is reset between runs so the banner is eligible each time.)

## Issues fixed

Fixes #3408
