### PR TITLE
fix(android-webview): bound WebView hierarchy augmentation so a stalled devtools endpoint can't hang a command (MA-4119)

### DIFF
--- a/maestro-client/src/main/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClient.kt
@@ -5,26 +5,71 @@ import maestro.TreeNode
 import maestro.UiElement
 import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.android.AndroidDeviceConnection
+import org.slf4j.LoggerFactory
 import java.io.Closeable
+import java.time.Duration
+import java.util.concurrent.Callable
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
-class AndroidWebViewHierarchyClient(connection: AndroidDeviceConnection): Closeable {
+class AndroidWebViewHierarchyClient(
+    private val devToolsClient: ChromeDevToolsClient,
+    private val timeout: Duration = DEFAULT_WEBVIEW_AUGMENT_TIMEOUT,
+): Closeable {
 
-    private val devToolsClient = DadbChromeDevToolsClient(connection)
+    constructor(connection: AndroidDeviceConnection) : this(DadbChromeDevToolsClient(connection))
+
+    // Single daemon thread so a hung fetch leaks at most one thread; a later fetch queued behind it
+    // is cancelled out of the queue when its own get() times out (see fetchWebViewNodes).
+    private val augmentExecutor = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "webview-hierarchy-augment").apply { isDaemon = true }
+    }
 
     fun augmentHierarchy(baseHierarchy: TreeNode, chromeDevToolsEnabled: Boolean): TreeNode {
         if (!chromeDevToolsEnabled) return baseHierarchy
         if (!hasWebView(baseHierarchy)) return baseHierarchy
         // TODO: Adapt to handle chrome in the same way
-        val webViewHierarchy = devToolsClient.getWebViewTreeNodes()
+        val webViewHierarchy = fetchWebViewNodes() ?: return baseHierarchy
         val merged = mergeHierarchies(baseHierarchy, webViewHierarchy)
         return merged
     }
 
+    /**
+     * Reads the WebView hierarchy under a wall-clock [timeout]. Returns null when the fetch can't
+     * complete in time so the caller degrades to the native-only hierarchy — a stalled WebView
+     * devtools endpoint must not hang the command (MA-4119). Real device deaths surfaced by the
+     * fetch (e.g. [maestro.DeviceConnectionException]) are propagated unchanged.
+     */
+    private fun fetchWebViewNodes(): List<TreeNode>? {
+        val future = augmentExecutor.submit(Callable { devToolsClient.getWebViewTreeNodes() })
+        return try {
+            future.get(timeout.toMillis(), TimeUnit.MILLISECONDS)
+        } catch (e: TimeoutException) {
+            future.cancel(true)
+            logger.warn("WebView hierarchy augmentation timed out after {}; using native hierarchy only", timeout)
+            null
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        }
+    }
+
     override fun close() {
+        augmentExecutor.shutdownNow()
         devToolsClient.close()
     }
 
     companion object {
+
+        private val logger = LoggerFactory.getLogger(AndroidWebViewHierarchyClient::class.java)
+
+        // WebView DOM augmentation is best-effort: reading a live WebView over the Chrome DevTools
+        // ADB sockets can block for minutes if the WebView's devtools endpoint stops responding
+        // (MA-4119). Because this runs in the hot waitForAppToSettle → viewHierarchy poll path, an
+        // unbounded fetch hangs a single command until the device server dies. Bound it so a stalled
+        // WebView degrades to the native-only hierarchy instead of taking out the whole run.
+        val DEFAULT_WEBVIEW_AUGMENT_TIMEOUT: Duration = Duration.ofSeconds(10)
 
         fun mergeHierarchies(baseHierarchy: TreeNode, webViewHierarchy: List<TreeNode>): TreeNode {
             if (webViewHierarchy.isEmpty()) return baseHierarchy

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClient.kt
@@ -21,8 +21,9 @@ class AndroidWebViewHierarchyClient(
 
     constructor(connection: AndroidDeviceConnection) : this(DadbChromeDevToolsClient(connection))
 
-    // Single daemon thread: a hung fetch leaks at most one thread.
-    private val augmentExecutor = Executors.newSingleThreadExecutor { r ->
+    // Per-fetch daemon threads: cancel(true) can't interrupt the blocking dadb read, so a wedged
+    // fetch keeps its own thread rather than blocking later fetches; idle threads are reaped in 60s.
+    private val augmentExecutor = Executors.newCachedThreadPool { r ->
         Thread(r, "webview-hierarchy-augment").apply { isDaemon = true }
     }
 
@@ -51,6 +52,8 @@ class AndroidWebViewHierarchyClient(
 
     override fun close() {
         augmentExecutor.shutdownNow()
+        // Give an in-flight fetch a moment to unwind before closing the OkHttpClient it may be using.
+        augmentExecutor.awaitTermination(CLOSE_GRACE_SECONDS, TimeUnit.SECONDS)
         devToolsClient.close()
     }
 
@@ -60,6 +63,9 @@ class AndroidWebViewHierarchyClient(
 
         // Caps how long a stalled WebView devtools endpoint can block a command (MA-4119).
         val DEFAULT_WEBVIEW_AUGMENT_TIMEOUT: Duration = Duration.ofSeconds(10)
+
+        // Best-effort grace for an interrupted fetch to stop before close() tears down OkHttp.
+        private const val CLOSE_GRACE_SECONDS = 2L
 
         fun mergeHierarchies(baseHierarchy: TreeNode, webViewHierarchy: List<TreeNode>): TreeNode {
             if (webViewHierarchy.isEmpty()) return baseHierarchy

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClient.kt
@@ -21,8 +21,7 @@ class AndroidWebViewHierarchyClient(
 
     constructor(connection: AndroidDeviceConnection) : this(DadbChromeDevToolsClient(connection))
 
-    // Single daemon thread so a hung fetch leaks at most one thread; a later fetch queued behind it
-    // is cancelled out of the queue when its own get() times out (see fetchWebViewNodes).
+    // Single daemon thread: a hung fetch leaks at most one thread.
     private val augmentExecutor = Executors.newSingleThreadExecutor { r ->
         Thread(r, "webview-hierarchy-augment").apply { isDaemon = true }
     }
@@ -36,12 +35,7 @@ class AndroidWebViewHierarchyClient(
         return merged
     }
 
-    /**
-     * Reads the WebView hierarchy under a wall-clock [timeout]. Returns null when the fetch can't
-     * complete in time so the caller degrades to the native-only hierarchy — a stalled WebView
-     * devtools endpoint must not hang the command (MA-4119). Real device deaths surfaced by the
-     * fetch (e.g. [maestro.DeviceConnectionException]) are propagated unchanged.
-     */
+    // Null on timeout → caller falls back to the native hierarchy. Real fetch failures propagate.
     private fun fetchWebViewNodes(): List<TreeNode>? {
         val future = augmentExecutor.submit(Callable { devToolsClient.getWebViewTreeNodes() })
         return try {
@@ -64,11 +58,7 @@ class AndroidWebViewHierarchyClient(
 
         private val logger = LoggerFactory.getLogger(AndroidWebViewHierarchyClient::class.java)
 
-        // WebView DOM augmentation is best-effort: reading a live WebView over the Chrome DevTools
-        // ADB sockets can block for minutes if the WebView's devtools endpoint stops responding
-        // (MA-4119). Because this runs in the hot waitForAppToSettle → viewHierarchy poll path, an
-        // unbounded fetch hangs a single command until the device server dies. Bound it so a stalled
-        // WebView degrades to the native-only hierarchy instead of taking out the whole run.
+        // Caps how long a stalled WebView devtools endpoint can block a command (MA-4119).
         val DEFAULT_WEBVIEW_AUGMENT_TIMEOUT: Duration = Duration.ofSeconds(10)
 
         fun mergeHierarchies(baseHierarchy: TreeNode, webViewHierarchy: List<TreeNode>): TreeNode {

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/ChromeDevToolsClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/ChromeDevToolsClient.kt
@@ -1,0 +1,13 @@
+package maestro.android.chromedevtools
+
+import maestro.TreeNode
+import java.io.Closeable
+
+/**
+ * Reads the DOM of on-screen WebViews via the Chrome DevTools Protocol. Extracted so the
+ * hierarchy-augmentation path can be driven with a fake in tests (the production impl talks
+ * to a live device over ADB sockets). See [DadbChromeDevToolsClient].
+ */
+interface ChromeDevToolsClient : Closeable {
+    fun getWebViewTreeNodes(): List<TreeNode>
+}

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/ChromeDevToolsClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/ChromeDevToolsClient.kt
@@ -3,11 +3,7 @@ package maestro.android.chromedevtools
 import maestro.TreeNode
 import java.io.Closeable
 
-/**
- * Reads the DOM of on-screen WebViews via the Chrome DevTools Protocol. Extracted so the
- * hierarchy-augmentation path can be driven with a fake in tests (the production impl talks
- * to a live device over ADB sockets). See [DadbChromeDevToolsClient].
- */
+// Reads on-screen WebView DOMs via Chrome DevTools. Seam so the fetch can be faked in tests.
 interface ChromeDevToolsClient : Closeable {
     fun getWebViewTreeNodes(): List<TreeNode>
 }

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
@@ -22,7 +22,6 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.use
 import org.slf4j.LoggerFactory
-import java.io.Closeable
 import java.io.IOException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
@@ -80,7 +79,7 @@ internal class DummyDns : Dns {
     )
 }
 
-class DadbChromeDevToolsClient(private val connection: AndroidDeviceConnection): Closeable {
+class DadbChromeDevToolsClient(private val connection: AndroidDeviceConnection): ChromeDevToolsClient {
 
     private val json = jacksonObjectMapper().configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
 
@@ -101,7 +100,7 @@ class DadbChromeDevToolsClient(private val connection: AndroidDeviceConnection):
         okhttp.cache?.close()
     }
 
-    fun getWebViewTreeNodes(): List<TreeNode> {
+    override fun getWebViewTreeNodes(): List<TreeNode> {
         return getWebViewInfos()
             .filter { it.visible }
             .mapNotNull { info ->

--- a/maestro-client/src/test/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClientTest.kt
+++ b/maestro-client/src/test/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClientTest.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicInteger
 
 class AndroidWebViewHierarchyClientTest {
 
@@ -59,6 +61,75 @@ class AndroidWebViewHierarchyClientTest {
             client.augmentHierarchy(base, chromeDevToolsEnabled = true)
         }
         assertThat(thrown).isSameInstanceAs(boom)
+    }
+
+    @Test
+    fun augmentHierarchy_oneWedgedFetchDoesNotBlockLaterFetches() {
+        val base = TreeNode(
+            children = listOf(TreeNode(attributes = mutableMapOf("class" to "android.webkit.WebView")))
+        )
+        val calls = AtomicInteger(0)
+        val client = AndroidWebViewHierarchyClient(
+            object : ChromeDevToolsClient {
+                override fun getWebViewTreeNodes(): List<TreeNode> {
+                    // First fetch wedges and IGNORES interruption, like the real dadb socket read —
+                    // cancel(true) can't free its thread. Later fetches return immediately.
+                    if (calls.getAndIncrement() == 0) {
+                        val neverReleased = CountDownLatch(1)
+                        while (neverReleased.count > 0) {
+                            try { neverReleased.await() } catch (e: InterruptedException) { /* swallow */ }
+                        }
+                    }
+                    return emptyList()
+                }
+                override fun close() {}
+            },
+            timeout = Duration.ofSeconds(1),
+        )
+
+        client.augmentHierarchy(base, chromeDevToolsEnabled = true) // wedges, degrades after ~1s
+
+        // The wedged first fetch must not hold up this one: it runs on its own thread and returns
+        // well under the 1s timeout. (With a shared single worker thread this would queue and pay it.)
+        assertTimeoutPreemptively(Duration.ofMillis(700)) {
+            client.augmentHierarchy(base, chromeDevToolsEnabled = true)
+        }
+    }
+
+    @Test
+    fun close_waitsForInFlightFetchBeforeClosingDevToolsClient() {
+        val events = CopyOnWriteArrayList<String>()
+        val fetchStarted = CountDownLatch(1)
+
+        val devTools = object : ChromeDevToolsClient {
+            override fun getWebViewTreeNodes(): List<TreeNode> {
+                fetchStarted.countDown()
+                try {
+                    Thread.sleep(Long.MAX_VALUE)          // in-flight work, interrupted by shutdownNow()
+                } catch (e: InterruptedException) {
+                    events.add("fetch-ended")
+                }
+                return emptyList()
+            }
+            override fun close() {
+                events.add("client-closed")
+            }
+        }
+        val client = AndroidWebViewHierarchyClient(devTools, timeout = Duration.ofSeconds(30))
+
+        // Run a fetch on a background thread so one is genuinely in flight when we close().
+        val base = TreeNode(
+            children = listOf(TreeNode(attributes = mutableMapOf("class" to "android.webkit.WebView")))
+        )
+        val fetchThread = Thread { runCatching { client.augmentHierarchy(base, chromeDevToolsEnabled = true) } }
+            .apply { isDaemon = true; start() }
+        fetchStarted.await()
+
+        client.close()
+        fetchThread.join(5_000)
+
+        // close() must let the interrupted fetch unwind before it tears down the OkHttpClient.
+        assertThat(events).containsExactly("fetch-ended", "client-closed").inOrder()
     }
 
     @Test

--- a/maestro-client/src/test/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClientTest.kt
+++ b/maestro-client/src/test/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClientTest.kt
@@ -11,8 +11,7 @@ import java.util.concurrent.CountDownLatch
 
 class AndroidWebViewHierarchyClientTest {
 
-    /** A CDP client that never returns from [getWebViewTreeNodes] — simulates a dead WebView
-     *  devtools endpoint whose ADB socket read hangs (MA-4119). */
+    // Simulates a dead WebView devtools endpoint: the fetch never returns.
     private class HangingDevToolsClient : ChromeDevToolsClient {
         val started = CountDownLatch(1)
         override fun getWebViewTreeNodes(): List<TreeNode> {
@@ -34,8 +33,7 @@ class AndroidWebViewHierarchyClientTest {
         val hanging = HangingDevToolsClient()
         val client = AndroidWebViewHierarchyClient(hanging, timeout = Duration.ofSeconds(1))
 
-        // With an unbounded fetch this call blocks forever; the preemptive assert makes that an
-        // observable failure. The bound must return the native-only base hierarchy well within 5s.
+        // Unbounded, this blocks forever; the preemptive assert turns that into a failure.
         lateinit var result: TreeNode
         assertTimeoutPreemptively(Duration.ofSeconds(5)) {
             result = client.augmentHierarchy(base, chromeDevToolsEnabled = true)
@@ -47,8 +45,7 @@ class AndroidWebViewHierarchyClientTest {
 
     @Test
     fun augmentHierarchy_propagatesFetchFailures() {
-        // A real device death surfaced by the fetch must NOT be masked as a degrade-to-base — it has
-        // to propagate so the run is classified INFRA_ERROR and retried, not silently continued.
+        // A real device death must propagate (→ INFRA_ERROR + retry), not degrade to base.
         val boom = IllegalStateException("device server died")
         val client = AndroidWebViewHierarchyClient(object : ChromeDevToolsClient {
             override fun getWebViewTreeNodes(): List<TreeNode> = throw boom

--- a/maestro-client/src/test/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClientTest.kt
+++ b/maestro-client/src/test/java/maestro/android/chromedevtools/AndroidWebViewHierarchyClientTest.kt
@@ -3,9 +3,66 @@ package maestro.android.chromedevtools
 import com.google.common.truth.Truth.assertThat
 import maestro.TreeNode
 import maestro.UiElement.Companion.toUiElementOrNull
+import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
 
 class AndroidWebViewHierarchyClientTest {
+
+    /** A CDP client that never returns from [getWebViewTreeNodes] — simulates a dead WebView
+     *  devtools endpoint whose ADB socket read hangs (MA-4119). */
+    private class HangingDevToolsClient : ChromeDevToolsClient {
+        val started = CountDownLatch(1)
+        override fun getWebViewTreeNodes(): List<TreeNode> {
+            started.countDown()
+            Thread.sleep(Long.MAX_VALUE)
+            return emptyList()
+        }
+        override fun close() {}
+    }
+
+    @Test
+    fun augmentHierarchy_whenWebViewFetchHangs_degradesToBaseWithinTimeout() {
+        // Base hierarchy contains a WebView node, so augmentation is attempted.
+        val base = TreeNode(
+            children = listOf(
+                TreeNode(attributes = mutableMapOf("class" to "android.webkit.WebView"))
+            )
+        )
+        val hanging = HangingDevToolsClient()
+        val client = AndroidWebViewHierarchyClient(hanging, timeout = Duration.ofSeconds(1))
+
+        // With an unbounded fetch this call blocks forever; the preemptive assert makes that an
+        // observable failure. The bound must return the native-only base hierarchy well within 5s.
+        lateinit var result: TreeNode
+        assertTimeoutPreemptively(Duration.ofSeconds(5)) {
+            result = client.augmentHierarchy(base, chromeDevToolsEnabled = true)
+        }
+
+        assertThat(hanging.started.count).isEqualTo(0L) // the fetch was actually attempted
+        assertThat(result).isEqualTo(base)              // …then degraded to base on timeout
+    }
+
+    @Test
+    fun augmentHierarchy_propagatesFetchFailures() {
+        // A real device death surfaced by the fetch must NOT be masked as a degrade-to-base — it has
+        // to propagate so the run is classified INFRA_ERROR and retried, not silently continued.
+        val boom = IllegalStateException("device server died")
+        val client = AndroidWebViewHierarchyClient(object : ChromeDevToolsClient {
+            override fun getWebViewTreeNodes(): List<TreeNode> = throw boom
+            override fun close() {}
+        })
+        val base = TreeNode(
+            children = listOf(TreeNode(attributes = mutableMapOf("class" to "android.webkit.WebView")))
+        )
+
+        val thrown = assertThrows<IllegalStateException> {
+            client.augmentHierarchy(base, chromeDevToolsEnabled = true)
+        }
+        assertThat(thrown).isSameInstanceAs(boom)
+    }
 
     @Test
     fun testMergeHierarchies1() {


### PR DESCRIPTION
## Problem

On Android flows that interact with a WebView (e.g. bank/payment portals), a single command can hang for **many minutes** and then fail the whole run with `INFRA_ERROR "Execution Timed Out"`.

`AndroidDriver.contentDescriptor()` augments the native hierarchy by reading the WebView DOM over the Chrome DevTools ADB socket (`getWebViewInfos` → `open: localabstract:webview_devtools_remote_*`). When that endpoint stops responding the socket open/read blocks unboundedly — OkHttp's call timeout doesn't cover the socket-factory open (observed `360007ms since last byte`). Because this runs in the hot `waitForAppToSettle → viewHierarchy` poll path, one command burns 8+ min and cascades into the device server dying.

**Started with #3300** (DummyDns hostname fix): before it, augmentation opened `localabstract:localhost` and the IOException was swallowed (no-op, no hang); after it, it opens the real WebView socket and can hang. Gated by the per-flow opt-in `androidWebViewHierarchy: devtools`.

## Solution

WebView augmentation is best-effort (a stalled WebView can always fall back to the native hierarchy), so **bound it**: run the fetch under a wall-clock timeout (default 10s) and degrade to the native-only hierarchy on expiry. Genuine device deaths surfaced by the fetch still **propagate** (INFRA_ERROR + retry), not masked.

Introduced a small `ChromeDevToolsClient` interface seam so the fetch path is injectable.

## Tests

`AndroidWebViewHierarchyClientTest`:
- **hang → degrade:** a CDP client that never returns → `augmentHierarchy` returns the base hierarchy well within the bound (RED before the fix: blocked past the preemptive-timeout assert).
- **failure → propagate:** a CDP client that throws → the exception propagates unchanged.