### PR TITLE
Fix MA-4124: tap after scrollUntilVisible lands on the settled element position (iOS)

### DIFF
--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -91,6 +91,15 @@ interface Driver {
 
     fun waitUntilScreenIsStatic(timeoutMs: Long): Boolean
 
+    /**
+     * Waits for the app UI to settle and returns the hierarchy observed once settled.
+     *
+     * A null return means the driver could NOT confirm settling and offers no fresh
+     * hierarchy — it does not mean "settled". For example, the iOS screen-static check can
+     * pass while a scroll view is still slowly decelerating (MA-4124). Callers that aim
+     * gestures at element positions must not trust a pre-wait hierarchy after a null
+     * return; see Maestro.refreshElementUntilStable.
+     */
     fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int? = null): ViewHierarchy?
 
     fun capabilities(): List<Capability>

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -95,7 +95,7 @@ interface Driver {
      * Waits for the app UI to settle and returns the hierarchy observed once settled.
      *
      * A null return means the driver could NOT confirm settling and offers no fresh
-     * hierarchy — it does not mean "settled". For example, the iOS screen-static check can
+     * hierarchy; it does not mean "settled". For example, the iOS screen-static check can
      * pass while a scroll view is still slowly decelerating (MA-4124). Callers that aim
      * gestures at element positions must not trust a pre-wait hierarchy after a null
      * return; see Maestro.refreshElementUntilStable.

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory
 import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runInterruptible
@@ -202,15 +203,25 @@ class Maestro(
     ) {
         LOGGER.info("Tapping on element: ${tapRepeat ?: ""} $element")
 
-        val hierarchyBeforeTap = waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs) ?: initialHierarchy
+        val settledHierarchy = waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs)
 
-        val center = (
-                hierarchyBeforeTap
-                    .refreshElement(element.treeNode)
-                    ?.also { LOGGER.info("Refreshed element") }
-                    ?.toUiElementOrNull()
-                    ?: element
-                ).bounds
+        // A null settle result means the driver could not confirm that the screen has settled
+        // (e.g. the iOS screen-static check passed, which also happens while a scroll view is
+        // still slowly decelerating after a scroll; see MA-4124). In that case the pre-wait
+        // hierarchy may describe a screen that is still moving, so instead of aiming at where
+        // the element used to be, re-resolve its position from fresh hierarchy fetches until
+        // it stops changing.
+        val (hierarchyBeforeTap, refreshedElement) = if (settledHierarchy != null) {
+            settledHierarchy to settledHierarchy
+                .refreshElement(element.treeNode)
+                ?.also { LOGGER.info("Refreshed element") }
+                ?.toUiElementOrNull()
+        } else {
+            refreshElementUntilStable(element, initialHierarchy)
+        }
+
+        val center = (refreshedElement ?: element)
+            .bounds
             .center()
         performTap(
             x = center.x,
@@ -242,6 +253,81 @@ class Maestro(
                 )
             }
         }
+    }
+
+    /**
+     * Re-resolves [element]'s position from fresh view-hierarchy fetches until its bounds are
+     * unchanged between two consecutive fresh fetches (MA-4124).
+     *
+     * Used when the driver cannot confirm that the screen has settled: the iOS screen-static
+     * check compares consecutive screenshots, which can look identical while a scroll view is
+     * still slowly decelerating after a scroll. A tap aimed with a hierarchy captured during
+     * that deceleration lands where the element used to be, so the element is tracked until
+     * its observed position is stable (or the timeout elapses, in which case the last known
+     * position is used).
+     *
+     * The pre-wait [initialHierarchy] is never used for the stability comparison - it may
+     * describe a screen that was already moving when it was captured, and a spurious match
+     * between it and a single fresh fetch would re-introduce the original bug. Only two
+     * consecutive fresh fetches, [ELEMENT_STABILITY_POLL_INTERVAL_MS] apart, count as stable.
+     * If the element cannot be resolved in a fresh hierarchy (it can transiently detach from
+     * the accessibility tree while animating), polling continues until the deadline instead
+     * of falling back to a stale position right away.
+     *
+     * [MaestroTimer.withTimeoutSuspend] is deliberately not reused here: its deadline is built
+     * on wall-clock [System.currentTimeMillis], which can step backwards or forwards under NTP
+     * adjustment, while this loop needs a monotonic deadline ([System.nanoTime]).
+     *
+     * Scope note: this is a tap-scoped mitigation, not a fix of the underlying driver defect.
+     * The false "static" verdict originates in the iOS driver's settle check
+     * ([maestro.drivers.IOSDriver.waitForAppToSettle]), and other aim paths (swipe-on-element,
+     * relative-point taps in Orchestra) still aim with the pre-wait hierarchy. Fixing it in
+     * the driver would change settle timing for every iOS command, so that is deliberately a
+     * follow-up (see MA-4124).
+     */
+    private suspend fun refreshElementUntilStable(
+        element: UiElement,
+        initialHierarchy: ViewHierarchy,
+    ): Pair<ViewHierarchy, UiElement?> {
+        var lastHierarchy = initialHierarchy
+        var lastElement: UiElement? = null
+        val deadline = System.nanoTime() + ELEMENT_STABILITY_TIMEOUT_MS * 1_000_000
+
+        while (System.nanoTime() < deadline) {
+            val freshHierarchy = try {
+                viewHierarchy()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                LOGGER.warn("Failed to fetch view hierarchy while waiting for element to settle. Retrying.", e)
+                delay(ELEMENT_STABILITY_POLL_INTERVAL_MS)
+                continue
+            }
+            val freshElement = freshHierarchy.refreshElement(element.treeNode)?.toUiElementOrNull()
+
+            when {
+                freshElement == null ->
+                    LOGGER.info("Element is not present in the fresh hierarchy. Waiting for it to reappear.")
+                freshElement.bounds == lastElement?.bounds ->
+                    return freshHierarchy to freshElement
+                else -> {
+                    LOGGER.info(
+                        "Element is still moving (${lastElement?.bounds} -> ${freshElement.bounds}). " +
+                            "Waiting for its position to settle."
+                    )
+                    lastHierarchy = freshHierarchy
+                    lastElement = freshElement
+                }
+            }
+
+            delay(ELEMENT_STABILITY_POLL_INTERVAL_MS)
+        }
+
+        LOGGER.warn(
+            "Element position did not stabilise within ${ELEMENT_STABILITY_TIMEOUT_MS}ms. " +
+                "Tapping last known position ${lastElement?.bounds}"
+        )
+        return lastHierarchy to lastElement
     }
 
     suspend fun tapOnRelative(
@@ -684,6 +770,11 @@ class Maestro(
 
         private const val SCREENSHOT_DIFF_THRESHOLD = 0.005 // 0.5%
         private const val ANIMATION_TIMEOUT_MS: Long = 15000
+        // Mirrors IOSDriver.SCREEN_SETTLE_TIMEOUT_MS (3000ms): the element-stability wait
+        // stands in for the settle confirmation the iOS driver could not give, so keep the
+        // two budgets aligned when tuning either.
+        private const val ELEMENT_STABILITY_TIMEOUT_MS: Long = 3000
+        private const val ELEMENT_STABILITY_POLL_INTERVAL_MS: Long = 100
 
         fun ios(driver: Driver, openDriver: Boolean = true): Maestro {
             if (openDriver) {

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -205,12 +205,8 @@ class Maestro(
 
         val settledHierarchy = waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs)
 
-        // A null settle result means the driver could not confirm that the screen has settled
-        // (e.g. the iOS screen-static check passed, which also happens while a scroll view is
-        // still slowly decelerating after a scroll; see MA-4124). In that case the pre-wait
-        // hierarchy may describe a screen that is still moving, so instead of aiming at where
-        // the element used to be, re-resolve its position from fresh hierarchy fetches until
-        // it stops changing.
+        // Null means the driver could not confirm the screen has settled (see the
+        // Driver.waitForAppToSettle contract), so the pre-wait hierarchy may be stale.
         val (hierarchyBeforeTap, refreshedElement) = if (settledHierarchy != null) {
             settledHierarchy to settledHierarchy
                 .refreshElement(element.treeNode)
@@ -257,33 +253,14 @@ class Maestro(
 
     /**
      * Re-resolves [element]'s position from fresh view-hierarchy fetches until its bounds are
-     * unchanged between two consecutive fresh fetches (MA-4124).
+     * unchanged between two consecutive fetches, falling back to the last known position if
+     * they never stabilise within [ELEMENT_STABILITY_TIMEOUT_MS].
      *
      * Used when the driver cannot confirm that the screen has settled: the iOS screen-static
-     * check compares consecutive screenshots, which can look identical while a scroll view is
-     * still slowly decelerating after a scroll. A tap aimed with a hierarchy captured during
-     * that deceleration lands where the element used to be, so the element is tracked until
-     * its observed position is stable (or the timeout elapses, in which case the last known
-     * position is used).
-     *
-     * The pre-wait [initialHierarchy] is never used for the stability comparison - it may
-     * describe a screen that was already moving when it was captured, and a spurious match
-     * between it and a single fresh fetch would re-introduce the original bug. Only two
-     * consecutive fresh fetches, [ELEMENT_STABILITY_POLL_INTERVAL_MS] apart, count as stable.
-     * If the element cannot be resolved in a fresh hierarchy (it can transiently detach from
-     * the accessibility tree while animating), polling continues until the deadline instead
-     * of falling back to a stale position right away.
-     *
-     * [MaestroTimer.withTimeoutSuspend] is deliberately not reused here: its deadline is built
-     * on wall-clock [System.currentTimeMillis], which can step backwards or forwards under NTP
-     * adjustment, while this loop needs a monotonic deadline ([System.nanoTime]).
-     *
-     * Scope note: this is a tap-scoped mitigation, not a fix of the underlying driver defect.
-     * The false "static" verdict originates in the iOS driver's settle check
-     * ([maestro.drivers.IOSDriver.waitForAppToSettle]), and other aim paths (swipe-on-element,
-     * relative-point taps in Orchestra) still aim with the pre-wait hierarchy. Fixing it in
-     * the driver would change settle timing for every iOS command, so that is deliberately a
-     * follow-up (see MA-4124).
+     * check can pass while a scroll view is still slowly decelerating, so a tap aimed with a
+     * hierarchy captured during that deceleration lands where the element used to be (MA-4124).
+     * For the same reason the pre-wait [initialHierarchy] is never used for the stability
+     * comparison: only two consecutive fresh fetches count as stable.
      */
     private suspend fun refreshElementUntilStable(
         element: UiElement,

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -385,7 +385,9 @@ open class FakeDriver : Driver {
         }
     }
 
-    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int?): ViewHierarchy {
+    // Return type matches the nullable Driver interface signature so that fakes can
+    // mimic drivers (e.g. IOSDriver) that return null when the screen-static check passes.
+    override fun waitForAppToSettle(initialHierarchy: ViewHierarchy?, appId: String?, timeoutMs: Int?): ViewHierarchy? {
         return ScreenshotUtils.waitForAppToSettle(initialHierarchy, this, timeoutMs)
     }
 

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -1,6 +1,7 @@
 package maestro.test
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -5072,6 +5073,66 @@ class IntegrationTest {
         }
     }
 
+    @Test
+    fun `Case 145 - tap after scrollUntilVisible lands on settled element position (MA-4124)`() {
+        // Repro for MA-4124: on iOS, scrollUntilVisible can return while the scroll view
+        // is still decelerating from momentum. During slow deceleration the screen-static
+        // check reports "static" (consecutive screenshots look near-identical), the
+        // iOS-style waitForAppToSettle returns null, and the tap is aimed using the
+        // hierarchy captured mid-deceleration, landing where the element used to be.
+        val root = FakeLayoutElement()
+        val target = root.element {
+            text = "Confirm"
+            // Starts just below the visible screen (heightGrid = 960)
+            bounds = Bounds(220, 1100, 320, 1160)
+        }
+
+        // One swipe translates content by -300; momentum then keeps drifting content up
+        // by 12 more units on every subsequent screen observation, for 14 steps total.
+        val driver = DeceleratingIosFakeDriver(root, driftStepPx = -12, driftStepsPerSwipe = 14)
+        driver.open()
+
+        Maestro(driver).use { maestro ->
+            runBlocking {
+                orchestra(maestro).runFlow(
+                    listOf(
+                        MaestroCommand(
+                            scrollUntilVisible = ScrollUntilVisibleCommand(
+                                selector = ElementSelector(textRegex = "Confirm"),
+                                direction = ScrollDirection.DOWN,
+                                timeout = "10000",
+                                visibilityPercentage = 100,
+                                centerElement = false,
+                            )
+                        ),
+                        MaestroCommand(
+                            tapOnElement = TapOnElementCommand(
+                                selector = ElementSelector(textRegex = "Confirm"),
+                            )
+                        ),
+                    )
+                )
+            }
+        }
+
+        // Sanity: the scroll actually happened.
+        driver.assertAnyEvent { it is Event.SwipeElementWithDirection }
+
+        // The tap must have been aimed at the element's settled position, not at the
+        // position from the stale mid-deceleration hierarchy snapshot.
+        val settledBounds = checkNotNull(target.bounds) {
+            "Target element lost its bounds during the flow"
+        }
+        val tapPoint = checkNotNull(driver.lastTapPoint) {
+            "No tap was delivered to the driver"
+        }
+        assertWithMessage(
+            "Tap after scrollUntilVisible was aimed at $tapPoint, outside the settled " +
+                "element position $settledBounds: the tap used a mid-deceleration " +
+                "hierarchy snapshot instead of the settled one"
+        ).that(settledBounds.contains(tapPoint.x, tapPoint.y)).isTrue()
+    }
+
     private fun readCommands(
         caseName: String,
         deviceId: String? = null,
@@ -5083,5 +5144,84 @@ class IntegrationTest {
         val flowPath = Paths.get(resource.toURI())
         return YamlCommandReader.readCommands(flowPath)
             .withEnv(withEnv().withDefaultEnvVars(flowPath.toFile(), deviceId, shardIndex))
+    }
+}
+
+/**
+ * Fake driver that mimics the iOS driver's behaviour around scroll momentum (MA-4124).
+ *
+ * After a swipe gesture ends, an iOS scroll view keeps decelerating:
+ *
+ * - every subsequent observation of the screen (view-hierarchy fetch or settle check)
+ *   sees content that has drifted a little further;
+ * - during slow deceleration two consecutive screenshots differ by less than the
+ *   similarity threshold, so the iOS static-screen settle check "passes" while content
+ *   is still moving; mirroring IOSDriver.waitForAppToSettle, this driver then
+ *   returns null so that callers fall back to the hierarchy captured earlier;
+ * - by the time a tap gesture is physically delivered, deceleration has finished.
+ *
+ * Drift is consumed per screen observation rather than per unit of wall-clock time, which
+ * keeps the test deterministic but couples it to how often production code observes the
+ * screen: if hierarchy fetching ever calls contentDescriptor more than once per
+ * observation, the step counts here need revisiting.
+ */
+private class DeceleratingIosFakeDriver(
+    private val root: FakeLayoutElement,
+    private val driftStepPx: Int,
+    private val driftStepsPerSwipe: Int,
+) : FakeDriver() {
+
+    private var remainingDriftSteps = 0
+
+    /** FakeDriver's event list is private; captured so the assertion can print the point. */
+    var lastTapPoint: Point? = null
+        private set
+
+    init {
+        setLayout(root)
+    }
+
+    override fun swipe(elementPoint: Point, direction: SwipeDirection, durationMs: Long) {
+        super.swipe(elementPoint, direction, durationMs)
+        // The gesture has ended, but the scroll view keeps moving with momentum.
+        remainingDriftSteps = driftStepsPerSwipe
+    }
+
+    override fun contentDescriptor(excludeKeyboardElements: Boolean): maestro.TreeNode {
+        driftOneStep()
+        return super.contentDescriptor(excludeKeyboardElements)
+    }
+
+    override fun waitForAppToSettle(
+        initialHierarchy: maestro.ViewHierarchy?,
+        appId: String?,
+        timeoutMs: Int?,
+    ): maestro.ViewHierarchy? {
+        // Mirrors IOSDriver.waitForAppToSettle during slow deceleration: the screen-static
+        // check false-positives (consecutive screenshots look near-identical), so the driver
+        // returns null without a settled hierarchy. The check observes the still-moving
+        // screen once, consuming one drift step.
+        driftOneStep()
+        return null
+    }
+
+    override fun tap(point: Point) {
+        // By the time the tap is physically delivered, deceleration has completed.
+        while (remainingDriftSteps > 0) {
+            driftOneStep()
+        }
+        lastTapPoint = point
+        super.tap(point)
+    }
+
+    private fun driftOneStep() {
+        if (remainingDriftSteps <= 0) return
+        remainingDriftSteps--
+        translateAll(root, driftStepPx)
+    }
+
+    private fun translateAll(element: FakeLayoutElement, dy: Int) {
+        element.bounds = element.bounds?.translate(y = dy)
+        element.children.forEach { translateAll(it, dy) }
     }
 }


### PR DESCRIPTION
## TL;DR
On iOS, a `tapOn` right after `scrollUntilVisible` could land where the element **used to be**, because the tap was aimed with a view hierarchy captured while the scroll view was still decelerating. When the driver cannot confirm the screen has settled, `tapOnElement` now re-resolves the element from fresh hierarchy fetches until its position is stable, then taps.

Fixes [MA-4124](https://linear.app/mobile-dev/issue/MA-4124/betterment-tap-after-scrolluntilvisible-has-no-effect-on-ios).

## The bug
`scrollUntilVisible` + `tapOn` flows on iOS intermittently produced taps with no effect. The tap was delivered — but at coordinates a few dozen pixels away from where the target element actually ended up.

## Root cause
1. `scrollUntilVisible` returns as soon as the target element is visible — but the scroll view **keeps decelerating from momentum** after the gesture ends.
2. Before tapping, `Maestro.tapOnElement` calls `waitForAppToSettle`. On iOS this runs a screenshot-based static check (`waitUntilScreenIsStatic`): during *slow* deceleration, two consecutive screenshots differ by less than the similarity threshold, so the check **false-positives** ("static") and `IOSDriver.waitForAppToSettle` returns `null`.
3. On `null`, the old code fell back to the **pre-wait hierarchy** — a snapshot taken mid-deceleration — and aimed the tap at the element's stale bounds. By the time the tap was physically delivered, the element had drifted away.

## The fix
When `waitForAppToSettle` returns `null` (driver could not confirm settling), a new `refreshElementUntilStable` loop:

- fetches fresh view hierarchies and re-resolves the target element,
- returns as soon as the element's bounds are **unchanged between two consecutive fresh fetches** (100ms apart),
- keeps polling if the element transiently detaches from the accessibility tree while animating,
- gives up after a **monotonic 3s deadline** (matching `IOSDriver.SCREEN_SETTLE_TIMEOUT_MS`) and falls back to the last known position.

The settled path (Android, and any driver that returns a hierarchy) is completely unchanged.

## Why this shape (alternatives considered and rejected)
- **Compare one fresh fetch against the pre-wait hierarchy** (1 fetch instead of 2): a match against a snapshot that may itself be mid-deceleration is exactly the stale-snapshot trap that caused the bug. Only two *consecutive fresh* fetches count.
- **Reuse `ScreenshotUtils.waitForAppToSettle`**: it compares whole-hierarchy equality — the same class of check that already fails to notice a slowly-drifting screen — and is blocking/wall-clock. The new loop narrows the comparison to the single target element's bounds.
- **Reuse `MaestroTimer.withTimeoutSuspend`**: its deadline is wall-clock (`System.currentTimeMillis`), which can step under NTP adjustment; this loop needs a monotonic deadline (`System.nanoTime`).
- **Fix inside `IOSDriver.waitForAppToSettle`**: the right long-term altitude (the false "static" verdict is the true root cause), but it changes settle timing for *every* iOS command, not just tap — too risky to bundle here. See follow-ups.

## Cost
- **Android / settled path:** zero change.
- **iOS steady-state tap:** ~2 extra hierarchy fetches + 100ms (null is iOS's *normal* settle outcome). This is the floor for confirming stability without trusting a pre-wait snapshot; worst case is bounded by the 3s deadline.

## Testing
- New deterministic regression test: `Case 145 - tap after scrollUntilVisible lands on settled element position (MA-4124)`.
  - `DeceleratingIosFakeDriver` mirrors the iOS failure mode: after a swipe, content keeps drifting a step per screen observation, the settle check "passes" and returns `null`, and drift only completes when the tap is physically delivered.
  - The old code fails this test (tap lands outside the settled bounds); the fixed code passes. No simulator needed.
- Full `:maestro-test` IntegrationTest suite green.

## Explicitly out of scope (follow-ups)
- **Driver-level root cause:** repair the false-static verdict in `IOSDriver.waitForAppToSettle` so *all* commands benefit (behavior change for every iOS command → separate, carefully reviewed PR).
- **Sibling aim paths with the same exposure:** `swipe`-on-element (`Maestro.kt`) and the relative-point tap branch (`Orchestra.kt`) still aim using pre-wait hierarchies. Documented in the new KDoc.
- The previously-implicit `null` contract of `Driver.waitForAppToSettle` ("null = could **not** confirm settling") is now documented on the interface so future callers stop inventing opposite interpretations.

## Files touched
| File | Change |
|---|---|
| `maestro-client/.../Maestro.kt` | `tapOnElement` null-settle branch + `refreshElementUntilStable` + stability constants |
| `maestro-client/.../Driver.kt` | KDoc: null contract of `waitForAppToSettle` |
| `maestro-test/.../FakeDriver.kt` | `waitForAppToSettle` return type aligned with the (nullable) interface |
| `maestro-test/.../IntegrationTest.kt` | Case 145 regression test + `DeceleratingIosFakeDriver` |