### PR TITLE
fix(android): record through the extended screenrecord entry point when present

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -1397,8 +1397,11 @@ class AndroidDriver(
         private const val CHUNK_SIZE = 1024L * 1024L * 3L
 
         // Extended screenrecord entry point baked into cloud worker AVDs by
-        // maestro-device's ScreenrecordStep. Its path and pass-through arg shape
-        // are a contract with that step; change them together or not at all.
+        // maestro-device's ScreenrecordStep. Three things are a contract with that
+        // step and must change together or not at all: this path, the pass-through
+        // arg shape, and the name of the process the entry point execs on patched
+        // images (screenrecord-bin, which close() must SIGINT for the moov atom
+        // to be flushed).
         private const val EXTENDED_SCREENRECORD_PATH = "/data/local/tmp/screenrecord"
     }
 }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -492,10 +492,24 @@ class AndroidDriver(
 
             val deviceScreenRecordingPath = "/sdcard/maestro-screenrecording.mp4"
 
+            // Cloud worker devices bake an extended screenrecord entry point that lifts the
+            // stock 180s time limit and pins encoder-safe dimensions (maestro-device's
+            // ScreenrecordStep). Record through it when present. On stock devices only
+            // API 34+ can disable the limit ("--time-limit 0"); below that, recordings
+            // stop at the stock 180s cap.
+            val extendedRecorder = EXTENDED_SCREENRECORD_PATH.takeIf {
+                connection.shell("test -x $it").exitCode == 0
+            }
+
             val future = CompletableFuture.runAsync({
-                val timeLimit = if (getDeviceApiLevel() >= 34) "--time-limit 0" else ""
+                val recorderCommand = if (extendedRecorder != null) {
+                    "$extendedRecorder --bit-rate '100000' $deviceScreenRecordingPath"
+                } else {
+                    val timeLimit = if (getDeviceApiLevel() >= 34) "--time-limit 0" else ""
+                    "screenrecord $timeLimit --bit-rate '100000' $deviceScreenRecordingPath"
+                }
                 try {
-                    shell("screenrecord $timeLimit --bit-rate '100000' $deviceScreenRecordingPath")
+                    shell(recorderCommand)
                 } catch (e: AndroidOperationFailedException) {
                     // The screenrecord command itself failed (non-zero exit) — usually an emulator that can't
                     // record. Surface it as the op-failure type, not a bare IOException. A transport death is
@@ -509,7 +523,10 @@ class AndroidDriver(
 
             object : ScreenRecording {
                 override fun close() {
-                    connection.shell("killall -INT screenrecord") // Ignore exit code
+                    // The extended entry point execs a patched copy named screenrecord-bin on
+                    // images whose stock binary caps the time limit; SIGINT both names so the
+                    // moov atom gets flushed regardless of which recorder ran.
+                    connection.shell("killall -INT screenrecord screenrecord-bin") // Ignore exit code
                     try {
                         future.get()
                     } catch (e: ExecutionException) {
@@ -1378,5 +1395,10 @@ class AndroidDriver(
         private const val TOAST_CLASS_NAME = "android.widget.Toast"
         private const val SCREENSHOT_DIFF_THRESHOLD = 0.005
         private const val CHUNK_SIZE = 1024L * 1024L * 3L
+
+        // Extended screenrecord entry point baked into cloud worker AVDs by
+        // maestro-device's ScreenrecordStep. Its path and pass-through arg shape
+        // are a contract with that step; change them together or not at all.
+        private const val EXTENDED_SCREENRECORD_PATH = "/data/local/tmp/screenrecord"
     }
 }


### PR DESCRIPTION
Cloud recordings on Android API <34 stop at exactly 180s no matter what the device golden carries (MA-4121). copilot#2681 fixed the golden side, the binary patcher really was broken, but recordings stayed capped because nothing in the recording path uses what the golden provides: `AndroidDriver.startScreenRecording` shells the stock `screenrecord` binary directly, and only API 34+ supports `--time-limit 0`. The extended entry point that maestro-device bakes at `/data/local/tmp/screenrecord` (patched binary, 3600s limit, encoder-safe `--size`) had zero callers.

This makes the driver probe for that entry point and record through it when present, passing `--bit-rate` through unchanged. Stock devices keep the exact current behavior, so local `maestro record` users are unaffected. Teardown now SIGINTs both `screenrecord` and `screenrecord-bin`: the entry point execs a patched copy under the second name on images whose stock binary caps the limit, and a missed signal would leave the mp4 without a moov atom.

One deliberate behavioral delta: wrapper-bearing devices on API 34+ move from unlimited recording to the wrapper's 3600s ceiling. Only cloud AVDs carry the wrapper and worker jobs are hard-capped at ~15.5 minutes, so the ceiling sits ~4x above any reachable recording duration.

Verification on a golden built by the current ScreenrecordStep (android-33, pixel_6):
- `maestro record --local` through this branch captured **197s continuously** (last-frame pts 197.0), stopped cleanly at flow end
- the same image's stock binary rejects any `--time-limit` over 180 (`Time limit 181s outside acceptable range [1,180]`), so the pre-change path caps at 180s there by construction
- three cloud verification runs on post-#[2681](https://github.com/mobile-dev-inc/copilot/pull/2681) goldens all capped at exactly 180s through the old path (recorder exit at start+180.4s in logcat)

Rollout: after merge, bump `maestro` in copilot; the worker deploy picks it up from there.
