### PR TITLE
feat(orchestra): capture step screenshot pre-command; pair with hierarchy on failure

### DIFF
--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -31,6 +31,11 @@ import java.nio.file.StandardCopyOption
  * With the flag off, only failed/warned steps capture that pair. The ~1s hierarchy
  * round-trip is why only they ever pay for it.
  *
+ * Each per-step shot is the screen *before* that step, so step N+1's is also step N's
+ * end state; a single flow-end shot (`screenshots/final.png`, flow-level) closes the
+ * chain with the screen the run ended on — after any onFlowComplete teardown — giving
+ * complete start-and-end evidence.
+ *
  * Every file is routed through an [ArtifactCollector]: the manifest is the
  * collector's records and each command's artifact list is the same records
  * grouped by command, so the two can never disagree. Device logs + crash/ANR
@@ -172,6 +177,8 @@ internal class ArtifactsGenerator(
     }
 
     override fun onFlowEnd() {
+        // Capture the resting screen before the recording is torn down.
+        if (captureFullArtifacts) captureFinalScreenshot()
         stopFullRunRecording()
         val collector = collector
         if (artifactsDir != null && collector != null) {
@@ -259,27 +266,40 @@ internal class ArtifactsGenerator(
         onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
+    private fun captureStepScreenshotFile(metadata: CommandDebugMetadata): String? =
+        captureScreenshot(
+            "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
+            sequenceNumber = metadata.sequenceNumber,
+        )
+
+    /** Flow-end shot of the resting screen — flow-level (owns no step). */
+    private fun captureFinalScreenshot() {
+        captureScreenshot(BundleLayout.FINAL_SCREENSHOT, sequenceNumber = null)
+    }
+
     /**
-     * Captures step-{seq}.png (via a sibling temp moved into place on success, so a failed recapture
-     * never destroys a frame already there), returning its bundle-relative path or null on failure.
+     * Captures [relativePath] (via a sibling temp moved into place on success, so a failed recapture
+     * never destroys a frame already there), returning the bundle-relative path or null on failure.
      */
-    private fun captureStepScreenshotFile(metadata: CommandDebugMetadata): String? {
+    private fun captureScreenshot(relativePath: String, sequenceNumber: Int?): String? {
         val collector = collector ?: return null
-        val relativePath =
-            "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
         val destFile = collector.allocate(
             ArtifactKind.SCREENSHOT,
             ArtifactFormat.PNG,
             relativePath,
-            sequenceNumber = metadata.sequenceNumber,
+            sequenceNumber = sequenceNumber,
         )
         val tempFile = File(destFile.parentFile, "${destFile.name}.tmp")
         return try {
-            ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = tempFile) ?: return null
+            if (ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = tempFile) == null) {
+                logger.warn("Failed to capture screenshot $relativePath")
+                tempFile.delete()
+                return null
+            }
             Files.move(tempFile.toPath(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
             relativePath
         } catch (e: Exception) {
-            logger.warn("Failed to capture screenshot for step ${metadata.sequenceNumber}", e)
+            logger.warn("Failed to capture screenshot $relativePath", e)
             tempFile.delete()
             null
         }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -23,10 +23,12 @@ import java.nio.file.Path
  * when [artifactsDir] is non-null, writes the per-flow artifact bundle
  * directly under it — see [BundleLayout] for the layout. With a null
  * [artifactsDir] (Studio's interactive runner) only the in-memory population
- * happens. The full artifact set — per-step screenshots, per-step view
- * hierarchy, and the full-run recording — is gated by [captureFullArtifacts]
- * (worker, not the CLI); off, only the failed step's screenshot and hierarchy
- * are captured.
+ * happens. Under [captureFullArtifacts] (worker, not the CLI) every step gets a
+ * pre-command screenshot (the screen it is about to act on) plus a full-run
+ * recording; failed/warned steps instead capture their screenshot paired with a
+ * view hierarchy at the outcome moment. With the flag off, only failed/warned
+ * steps capture — that at-outcome screenshot + hierarchy. The ~1s hierarchy
+ * round-trip is why only failed/warned steps ever pay for it.
  *
  * Every file is routed through an [ArtifactCollector]: the manifest is the
  * collector's records and each command's artifact list is the same records
@@ -90,6 +92,9 @@ internal class ArtifactsGenerator(
         currentCommandMetadata = metadata
         // First launchApp wins (one flow tests one app); null ⇒ crash/ANR unscoped.
         if (appUnderTest == null) cmd.launchAppCommand?.appId?.let { appUnderTest = it }
+
+        // Pre-command shot: the screen the step is about to act on. Flag off shoots at finish instead.
+        if (captureFullArtifacts) captureStepScreenshot(metadata)
     }
 
     /**
@@ -124,13 +129,19 @@ internal class ArtifactsGenerator(
         }
         if (artifactsDir == null || outcome is CommandOutcome.Skipped) return
 
-        // viewHierarchy() is an expensive per-command round-trip (~1s on iOS/Android), so only
-        // failed/warned steps capture it — passing steps never do, even under captureFullArtifacts.
-        // Screenshots are cheap and stay per-step.
-        if (outcome is CommandOutcome.Failed || outcome is CommandOutcome.Warned || captureFullArtifacts) {
-            if (outcome is CommandOutcome.Failed || outcome is CommandOutcome.Warned) captureStepHierarchy(metadata)
-            if (outcome is CommandOutcome.Failed) captureFailureScreenshot(metadata)
-            else captureStepScreenshot(metadata)
+        // Passing steps keep their pre-command shot from onCommandStart (no hierarchy). Failed/warned
+        // steps instead pair screenshot AND hierarchy here, at the outcome moment, so both describe the
+        // same screen (the viewer overlays hierarchy on the shot). viewHierarchy() is a ~1s round-trip,
+        // which is why only failed/warned steps ever pay for it.
+        if (outcome is CommandOutcome.Failed || outcome is CommandOutcome.Warned) {
+            captureStepHierarchy(metadata)
+            when {
+                // Pre-command shot + callback already fired at onCommandStart; overwrite that file with
+                // the at-outcome frame to match the hierarchy, without a second record or callback.
+                captureFullArtifacts -> captureStepScreenshotFile(metadata)
+                outcome is CommandOutcome.Failed -> captureFailureScreenshot(metadata)
+                else -> captureStepScreenshot(metadata)
+            }
         }
     }
 
@@ -236,9 +247,10 @@ internal class ArtifactsGenerator(
         }
     }
 
+    /** Flag-off failure path only (under captureFullArtifacts the file is overwritten via captureStepScreenshotFile). */
     private fun captureFailureScreenshot(metadata: CommandDebugMetadata) {
-        // Flag off, dedup a composite parent against the leaf that already shot the same screen.
-        if (!captureFullArtifacts && metadata.sequenceNumber < lastFailureScreenshotSeq) return
+        // Dedup a composite parent against the leaf that already shot the same screen.
+        if (metadata.sequenceNumber < lastFailureScreenshotSeq) return
         val relativePath = captureStepScreenshotFile(metadata) ?: return
         lastFailureScreenshotSeq = metadata.sequenceNumber
         onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -15,7 +15,9 @@ import okio.Buffer
 import okio.sink
 import org.slf4j.LoggerFactory
 import java.io.File
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 
 /**
  * Internal listener Orchestra always installs. Populates [FlowDebugOutput]
@@ -24,11 +26,10 @@ import java.nio.file.Path
  * directly under it — see [BundleLayout] for the layout. With a null
  * [artifactsDir] (Studio's interactive runner) only the in-memory population
  * happens. Under [captureFullArtifacts] (worker, not the CLI) every step gets a
- * pre-command screenshot (the screen it is about to act on) plus a full-run
- * recording; failed/warned steps instead capture their screenshot paired with a
- * view hierarchy at the outcome moment. With the flag off, only failed/warned
- * steps capture — that at-outcome screenshot + hierarchy. The ~1s hierarchy
- * round-trip is why only failed/warned steps ever pay for it.
+ * pre-command screenshot plus a full-run recording; failed/warned steps overwrite
+ * theirs with an at-outcome frame paired with a view hierarchy (so the two match).
+ * With the flag off, only failed/warned steps capture that pair. The ~1s hierarchy
+ * round-trip is why only they ever pay for it.
  *
  * Every file is routed through an [ArtifactCollector]: the manifest is the
  * collector's records and each command's artifact list is the same records
@@ -93,7 +94,7 @@ internal class ArtifactsGenerator(
         // First launchApp wins (one flow tests one app); null ⇒ crash/ANR unscoped.
         if (appUnderTest == null) cmd.launchAppCommand?.appId?.let { appUnderTest = it }
 
-        // Pre-command shot: the screen the step is about to act on. Flag off shoots at finish instead.
+        // Pre-command shot: the screen the step is about to act on.
         if (captureFullArtifacts) captureStepScreenshot(metadata)
     }
 
@@ -128,20 +129,17 @@ internal class ArtifactsGenerator(
             }
         }
         if (artifactsDir == null || outcome is CommandOutcome.Skipped) return
+        // Passing steps keep their pre-command shot from onCommandStart; nothing to do at finish.
+        if (outcome !is CommandOutcome.Failed && outcome !is CommandOutcome.Warned) return
 
-        // Passing steps keep their pre-command shot from onCommandStart (no hierarchy). Failed/warned
-        // steps instead pair screenshot AND hierarchy here, at the outcome moment, so both describe the
-        // same screen (the viewer overlays hierarchy on the shot). viewHierarchy() is a ~1s round-trip,
-        // which is why only failed/warned steps ever pay for it.
-        if (outcome is CommandOutcome.Failed || outcome is CommandOutcome.Warned) {
-            captureStepHierarchy(metadata)
-            when {
-                // Pre-command shot + callback already fired at onCommandStart; overwrite that file with
-                // the at-outcome frame to match the hierarchy, without a second record or callback.
-                captureFullArtifacts -> captureStepScreenshotFile(metadata)
-                outcome is CommandOutcome.Failed -> captureFailureScreenshot(metadata)
-                else -> captureStepScreenshot(metadata)
-            }
+        // Failed/warned steps pair screenshot + hierarchy at the outcome moment so both show the same
+        // screen (the viewer overlays them). viewHierarchy() is ~1s, so only these steps pay for it.
+        captureStepHierarchy(metadata)
+        when {
+            // Overwrite the pre-command shot with the at-outcome frame; its callback already fired.
+            captureFullArtifacts -> captureStepScreenshotFile(metadata)
+            outcome is CommandOutcome.Failed -> captureFailureScreenshot(metadata)
+            else -> captureStepScreenshot(metadata)
         }
     }
 
@@ -247,7 +245,7 @@ internal class ArtifactsGenerator(
         }
     }
 
-    /** Flag-off failure path only (under captureFullArtifacts the file is overwritten via captureStepScreenshotFile). */
+    /** Flag-off failure path only (captureFullArtifacts overwrites via captureStepScreenshotFile). */
     private fun captureFailureScreenshot(metadata: CommandDebugMetadata) {
         // Dedup a composite parent against the leaf that already shot the same screen.
         if (metadata.sequenceNumber < lastFailureScreenshotSeq) return
@@ -261,28 +259,30 @@ internal class ArtifactsGenerator(
         onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
-    /** Allocates and captures step-{seq}.png, returning its bundle-relative path, or null on failure. */
+    /**
+     * Captures step-{seq}.png (via a sibling temp moved into place on success, so a failed recapture
+     * never destroys a frame already there), returning its bundle-relative path or null on failure.
+     */
     private fun captureStepScreenshotFile(metadata: CommandDebugMetadata): String? {
         val collector = collector ?: return null
         val relativePath =
             "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}"
-        val taken = try {
-            val destFile = collector.allocate(
-                ArtifactKind.SCREENSHOT,
-                ArtifactFormat.PNG,
-                relativePath,
-                sequenceNumber = metadata.sequenceNumber,
-            )
-            ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = destFile)
+        val destFile = collector.allocate(
+            ArtifactKind.SCREENSHOT,
+            ArtifactFormat.PNG,
+            relativePath,
+            sequenceNumber = metadata.sequenceNumber,
+        )
+        val tempFile = File(destFile.parentFile, "${destFile.name}.tmp")
+        return try {
+            ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = tempFile) ?: return null
+            Files.move(tempFile.toPath(), destFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            relativePath
         } catch (e: Exception) {
             logger.warn("Failed to capture screenshot for step ${metadata.sequenceNumber}", e)
-            return null
+            tempFile.delete()
+            null
         }
-        if (taken == null) {
-            logger.warn("Failed to capture screenshot for step ${metadata.sequenceNumber}")
-            return null
-        }
-        return relativePath
     }
 
     private fun startFullRunRecording() {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
@@ -18,7 +18,7 @@ package maestro.orchestra.debug
  *     device logs, crash/ANR  ← worker/cloud only
  *   takeScreenshot/           ← takeScreenshot command output
  *   startRecording/           ← startRecording command output
- *   screenshots/              ← step screenshots (all steps when flag on; failed step only when off)
+ *   screenshots/              ← step screenshots (all steps + final.png when flag on; failed step only when off)
  *   screen-hierarchy/         ← per-step view hierarchy JSON
  *   screen-recording.mp4      ← full-run recording (flag-gated)
  *   ai-analysis/              ← screenshots an AI command analyzed (with defects)
@@ -39,6 +39,9 @@ internal object BundleLayout {
     const val SCREENSHOT_EXTENSION = ".png"
 
     const val STEP_SCREENSHOTS_DIR = "screenshots"
+
+    /** Flow-level (no owning step) shot of the screen the run ended on, after any onFlowComplete teardown. */
+    const val FINAL_SCREENSHOT = "$STEP_SCREENSHOTS_DIR/final$SCREENSHOT_EXTENSION"
 
     const val SCREEN_HIERARCHY_DIR = "screen-hierarchy"
 

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -404,7 +404,7 @@ class ArtifactsGeneratorTest {
 
         val steps = gen.artifactManifest.entries
             .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
-        assertThat(steps.count).isEqualTo(1)
+        assertThat(steps.count).isEqualTo(2)  // step-3 + final
         assertThat(steps.metadata).isEmpty()
     }
 
@@ -510,7 +510,46 @@ class ArtifactsGeneratorTest {
         assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
         val shots = gen.artifactManifest.entries
             .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
-        assertThat(shots.count).isEqualTo(1)  // finish capture reuses the pre-command path, not a duplicate
+        assertThat(shots.count).isEqualTo(2)  // step-0 (finish reuses its path) + final
+    }
+
+    @Test
+    fun `under captureFullArtifacts a flow-end screenshot lands as final png, flow-level`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
+        gen.onFlowEnd()
+
+        // The resting screen lands as final.png alongside the per-step shots.
+        assertThat(tempDir.resolve("screenshots/final.png").exists()).isTrue()
+        val shots = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT }
+        assertThat(shots.count).isEqualTo(2)  // step-0 + final
+        // Flow-level: owns no command and fires no per-step callback.
+        assertThat(gen.debugOutput.executedSteps.single().artifacts)
+            .doesNotContain(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/final.png"))
+        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+    }
+
+    @Test
+    fun `with captureFullArtifacts off no flow-end screenshot is captured`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("screenshots/final.png").exists()).isFalse()
     }
 
     @Test
@@ -856,7 +895,7 @@ class ArtifactsGeneratorTest {
         assertThat(tempDir.resolve("screenshots/step-1.png").exists()).isTrue()
         val steps = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT }
         assertThat(steps.relativePath).isEqualTo("screenshots")
-        assertThat(steps.count).isEqualTo(2)
+        assertThat(steps.count).isEqualTo(3)  // step-0 + step-1 + final
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -422,14 +422,14 @@ class ArtifactsGeneratorTest {
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
 
-        // Reported at command start — before the command runs, so before any onCommandFinished.
+        // Reported at command start — before the command runs.
         assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
         assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
     }
 
     @Test
     fun `under captureFullArtifacts a failed step replaces the pre-command shot with the at-failure frame paired with hierarchy`() {
-        // takeScreenshot returns {1} at start (pre-command), then {2} at finish (at-failure).
+        // {1} at start (pre-command), {2} at finish (at-failure).
         val frames = arrayOf(byteArrayOf(1), byteArrayOf(2))
         var call = 0
         val maestro = mockk<Maestro>(relaxed = true) {
@@ -449,13 +449,47 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
         gen.onFlowEnd()
 
-        // The at-failure frame ({2}) overwrote the pre-command one, and pairs with the failure
-        // hierarchy — a single screenshot record (the finish capture reuses the same path).
+        // At-failure frame ({2}) overwrote the pre-command one; one record (same path), paired with hierarchy.
         assertThat(Files.readAllBytes(tempDir.resolve("screenshots/step-0.png"))).isEqualTo(byteArrayOf(2))
         assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
         val shots = gen.artifactManifest.entries
             .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
         assertThat(shots.count).isEqualTo(1)
+    }
+
+    @Test
+    fun `under captureFullArtifacts a failed step keeps its pre-command frame when the at-failure recapture fails`() {
+        // Start succeeds ({1}); the at-failure recapture throws.
+        var call = 0
+        val maestro = mockk<Maestro>(relaxed = true) {
+            coEvery { takeScreenshot(any<Sink>(), any()) } answers {
+                if (call++ == 0) {
+                    val sink = firstArg<Sink>()
+                    val buffer = Buffer().write(byteArrayOf(1))
+                    sink.write(buffer, buffer.size)
+                    sink.flush()
+                } else throw RuntimeException("device gone")
+            }
+            coEvery { viewHierarchy(any()) } returns ViewHierarchy(TreeNode(attributes = mutableMapOf("text" to "root")))
+        }
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = maestro,
+            captureFullArtifacts = true,
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
+        gen.onFlowEnd()
+
+        // Pre-command frame survives — disk still matches the reported callback path.
+        assertThat(Files.readAllBytes(tempDir.resolve("screenshots/step-0.png"))).isEqualTo(byteArrayOf(1))
+        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+        assertThat(tempDir.resolve("screenshots/step-0.png.tmp").exists()).isFalse()
     }
 
     @Test
@@ -1035,8 +1069,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `a throwing consumer propagates instead of being swallowed as a capture failure`() {
-        // Callback fires outside the capture try (at onCommandStart), so a throwing consumer
-        // propagates instead of reading as a capture failure; the screenshot is already on disk.
+        // Callback fires outside the capture try (at onCommandStart), so a throwing consumer propagates.
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -409,6 +409,89 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
+    fun `under captureFullArtifacts the step screenshot is captured before the command runs`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+            onStepScreenshotCaptured = { seq, path -> captured += seq to path },
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+
+        // Reported at command start — before the command runs, so before any onCommandFinished.
+        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
+        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+    }
+
+    @Test
+    fun `under captureFullArtifacts a failed step replaces the pre-command shot with the at-failure frame paired with hierarchy`() {
+        // takeScreenshot returns {1} at start (pre-command), then {2} at finish (at-failure).
+        val frames = arrayOf(byteArrayOf(1), byteArrayOf(2))
+        var call = 0
+        val maestro = mockk<Maestro>(relaxed = true) {
+            coEvery { takeScreenshot(any<Sink>(), any()) } answers {
+                val sink = firstArg<Sink>()
+                val buffer = Buffer().write(frames[call++])
+                sink.write(buffer, buffer.size)
+                sink.flush()
+            }
+            coEvery { viewHierarchy(any()) } returns ViewHierarchy(TreeNode(attributes = mutableMapOf("text" to "root")))
+        }
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
+        gen.onFlowEnd()
+
+        // The at-failure frame ({2}) overwrote the pre-command one, and pairs with the failure
+        // hierarchy — a single screenshot record (the finish capture reuses the same path).
+        assertThat(Files.readAllBytes(tempDir.resolve("screenshots/step-0.png"))).isEqualTo(byteArrayOf(2))
+        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
+        val shots = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
+        assertThat(shots.count).isEqualTo(1)
+    }
+
+    @Test
+    fun `under captureFullArtifacts a warned step pairs a single shot with its hierarchy`() {
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+        )
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.onCommandFinished(cmd, CommandOutcome.Warned, 100L, 150L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
+        val shots = gen.artifactManifest.entries
+            .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
+        assertThat(shots.count).isEqualTo(1)  // finish capture reuses the pre-command path, not a duplicate
+    }
+
+    @Test
+    fun `with captureFullArtifacts off no screenshot is captured at command start`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val cmd = MaestroCommand(tapOnElement = null)
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+
+        // Flag off: no pre-command shot.
+        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isFalse()
+    }
+
+    @Test
     fun `does not capture per-step screenshots by default`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
@@ -817,9 +900,9 @@ class ArtifactsGeneratorTest {
         assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[parent]!!.artifacts)
             .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
-        // Parent fires after its leaf with a lower seq — consumers must tolerate out-of-order arrival.
+        // Pre-command capture fires in start (seq) order: the parent shoots before its leaf enters.
         assertThat(captured)
-            .containsExactly(1 to "screenshots/step-1.png", 0 to "screenshots/step-0.png")
+            .containsExactly(0 to "screenshots/step-0.png", 1 to "screenshots/step-1.png")
             .inOrder()
     }
 
@@ -879,7 +962,8 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `callback does not fire for a skipped command`() {
+    fun `a skipped command still carries its pre-command screenshot`() {
+        // Shot taken at onCommandStart, before the skip is decided.
         val captured = mutableListOf<Pair<Int, String>>()
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
@@ -894,7 +978,7 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(cmd, CommandOutcome.Skipped, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(captured).isEmpty()
+        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
     }
 
     @Test
@@ -951,8 +1035,8 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `a throwing consumer propagates instead of being swallowed as a capture failure`() {
-        // Fired outside the capture try, so a consumer throw propagates instead of reading as a
-        // capture failure; the screenshot is already on disk.
+        // Callback fires outside the capture try (at onCommandStart), so a throwing consumer
+        // propagates instead of reading as a capture failure; the screenshot is already on disk.
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
@@ -962,9 +1046,8 @@ class ArtifactsGeneratorTest {
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
-        gen.onCommandStart(cmd, sequenceNumber = 0)
         val thrown = runCatching {
-            gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
+            gen.onCommandStart(cmd, sequenceNumber = 0)
         }.exceptionOrNull()
 
         assertThat(thrown).isInstanceOf(RuntimeException::class.java)

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -459,9 +459,10 @@ class OrchestraListenerDispatchTest {
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
         // Sequence numbers increment on every onCommandStart: the repeat parent is
-        // step-0, then each of the 3 iterations of the reused leaf is its own file.
+        // step-0, then each of the 3 iterations of the reused leaf is its own file,
+        // plus the flow-level final.png captured at flow end.
         assertThat(stepScreenshotNames())
-            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png")
+            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png", "final.png")
     }
 
     @Test
@@ -502,9 +503,10 @@ class OrchestraListenerDispatchTest {
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
         // maxRetries=2 -> 3 attempts of the reused leaf (step-1..3); the retry parent
-        // that ultimately failed is step-0 (worker mode records every step).
+        // that ultimately failed is step-0 (worker mode records every step), plus the
+        // flow-level final.png captured at flow end.
         assertThat(stepScreenshotNames())
-            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png")
+            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png", "final.png")
     }
 
     @Test
@@ -530,9 +532,10 @@ class OrchestraListenerDispatchTest {
 
         // Hooks run through the same dispatch as regular commands, so each is a
         // numbered step in execution order: onFlowStart hook, the applyConfiguration
-        // command, the main command, then the onFlowComplete hook.
+        // command, the main command, then the onFlowComplete hook; final.png is the
+        // flow-level shot captured at flow end (after the onFlowComplete hook).
         assertThat(stepScreenshotNames())
-            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png")
+            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png", "final.png")
     }
 
     @Test


### PR DESCRIPTION
## Why

Per-step screenshots were captured in `onCommandFinished` — **after** the command ran. For a passing `tapOn` that navigates, `step-N.png` showed the *destination* screen, not the element the command acted on. A step's screenshot should be the screen it was about to act on.

The view hierarchy has the same problem and must stay consistent with the screenshot: the run viewer overlays hierarchy element-bounds on the shot, so the two must describe the same screen.

## What

- **Passing/skipped steps** → screenshot captured in `onCommandStart` (pre-command). No hierarchy (unchanged — `viewHierarchy()` is ~1s, so passing steps never pay for it).
- **Failed/warned steps** → screenshot **and** hierarchy captured together at the outcome moment, so they match. Under `captureFullArtifacts` this overwrites the pre-command `step-N.png` at the same path, so there's no duplicate manifest record or extra callback.
- **CLI (`captureFullArtifacts` off)** is unchanged: failed/warned steps still shoot at finish.

Delivered via the existing `onStepScreenshotCaptured(seq, relativePath)` callback — the path mapping is unchanged, so consumers need no change.

## Trade-offs (intentional)

- Failed steps under `captureFullArtifacts` now show the at-failure frame (paired with the hierarchy) rather than a pre-command one; the full-run recording still holds the moment-by-moment view.
- Skipped steps now carry a pre-command screenshot (their `onCommandStart` fires before the skip is decided) — one shot each; uniform "every step has one screenshot, no nulls".

## Tests

`ArtifactsGeneratorTest` covers: pre-command capture before finish; failed step's at-failure frame overwriting the pre-command one paired with hierarchy (single record); warned + full-artifacts pairing; flag-off failed/warned unchanged; skipped keeps its pre-command shot. `:maestro-orchestra:test` + `:maestro-test:test` green.