### PR TITLE
feat(orchestra): skip no-op step captures; 1-based, human-readable step artifact names

### DIFF
--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -64,6 +64,8 @@ internal class ArtifactsGenerator(
      * command, so a single reference (no stack) is enough to attribute them.
      */
     private var currentCommandMetadata: CommandDebugMetadata? = null
+    /** Highest sequence number that already captured a failure/warning frame this flow; -1 if none. */
+    private var lastFailureCaptureSeq: Int = -1
 
     override fun onFlowStart() {
         if (artifactsDir == null) return
@@ -73,6 +75,7 @@ internal class ArtifactsGenerator(
             logCapture = ScopedLogCapture.start(logFile)
             flowStartMs = System.currentTimeMillis()
             appUnderTest = null
+            lastFailureCaptureSeq = -1
             capturer = DeviceArtifactCapturer(maestro, artifactsDir.resolve(BundleLayout.LOGS_DIR)).also { it.start() }
         } catch (e: Exception) {
             logger.warn("Failed to set up artifacts directory at $artifactsDir", e)
@@ -133,10 +136,14 @@ internal class ArtifactsGenerator(
         if (artifactsDir == null || outcome is CommandOutcome.Skipped) return
         // Passing steps keep their pre-command shot from onCommandStart; nothing to do at finish.
         if (outcome !is CommandOutcome.Failed && outcome !is CommandOutcome.Warned) return
-        // A failing composite's own failing leaf still records the pair, so skipping no-ops loses nothing.
-        if (StepArtifactNaming.isNoOp(cmd)) return
+        // Non-visible leaves (defineVariables/applyConfiguration) and empty commands have no screen.
+        if (StepArtifactNaming.isNoOp(cmd) && !StepArtifactNaming.isComposite(cmd)) return
+        // A composite parent needs its own failure frame only when no descendant leaf already shot
+        // one (a while/when condition that throws fails the composite before any child runs).
+        // Descendants finish first and carry higher sequence numbers, so a later capture means done.
+        if (StepArtifactNaming.isComposite(cmd) && lastFailureCaptureSeq > metadata.sequenceNumber) return
 
-        // Failed/warned leaves pair screenshot + hierarchy at the outcome moment so both show the
+        // Failed/warned steps pair screenshot + hierarchy at the outcome moment so both show the
         // same screen (the viewer overlays them). viewHierarchy() is ~1s, so only these steps pay it.
         captureStepHierarchy(metadata)
         if (captureFullArtifacts) {
@@ -145,6 +152,7 @@ internal class ArtifactsGenerator(
         } else {
             captureStepScreenshot(metadata)
         }
+        lastFailureCaptureSeq = maxOf(lastFailureCaptureSeq, metadata.sequenceNumber)
     }
 
     override fun onCommandReset(cmd: MaestroCommand) {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -64,8 +64,6 @@ internal class ArtifactsGenerator(
      * command, so a single reference (no stack) is enough to attribute them.
      */
     private var currentCommandMetadata: CommandDebugMetadata? = null
-    /** Highest sequence number that already captured a failure screenshot this flow; -1 if none. */
-    private var lastFailureScreenshotSeq: Int = -1
 
     override fun onFlowStart() {
         if (artifactsDir == null) return
@@ -75,7 +73,6 @@ internal class ArtifactsGenerator(
             logCapture = ScopedLogCapture.start(logFile)
             flowStartMs = System.currentTimeMillis()
             appUnderTest = null
-            lastFailureScreenshotSeq = -1
             capturer = DeviceArtifactCapturer(maestro, artifactsDir.resolve(BundleLayout.LOGS_DIR)).also { it.start() }
         } catch (e: Exception) {
             logger.warn("Failed to set up artifacts directory at $artifactsDir", e)
@@ -99,8 +96,9 @@ internal class ArtifactsGenerator(
         // First launchApp wins (one flow tests one app); null ⇒ crash/ANR unscoped.
         if (appUnderTest == null) cmd.launchAppCommand?.appId?.let { appUnderTest = it }
 
-        // Pre-command shot: the screen the step is about to act on.
-        if (captureFullArtifacts) captureStepScreenshot(metadata)
+        // Pre-command shot: the screen the step is about to act on. No-op steps
+        // (composite parents, non-visible leaves) take no on-screen action — skip them.
+        if (captureFullArtifacts && !StepArtifactNaming.isNoOp(cmd)) captureStepScreenshot(metadata)
     }
 
     /**
@@ -136,15 +134,18 @@ internal class ArtifactsGenerator(
         if (artifactsDir == null || outcome is CommandOutcome.Skipped) return
         // Passing steps keep their pre-command shot from onCommandStart; nothing to do at finish.
         if (outcome !is CommandOutcome.Failed && outcome !is CommandOutcome.Warned) return
+        // No-op steps (composite parents, non-visible leaves) capture nothing; a failing
+        // composite's failing leaf still records the pair below.
+        if (StepArtifactNaming.isNoOp(cmd)) return
 
-        // Failed/warned steps pair screenshot + hierarchy at the outcome moment so both show the same
-        // screen (the viewer overlays them). viewHierarchy() is ~1s, so only these steps pay for it.
+        // Failed/warned leaves pair screenshot + hierarchy at the outcome moment so both show the
+        // same screen (the viewer overlays them). viewHierarchy() is ~1s, so only these steps pay it.
         captureStepHierarchy(metadata)
-        when {
+        if (captureFullArtifacts) {
             // Overwrite the pre-command shot with the at-outcome frame; its callback already fired.
-            captureFullArtifacts -> captureStepScreenshotFile(metadata)
-            outcome is CommandOutcome.Failed -> captureFailureScreenshot(metadata)
-            else -> captureStepScreenshot(metadata)
+            captureStepScreenshotFile(metadata)
+        } else {
+            captureStepScreenshot(metadata)
         }
     }
 
@@ -166,7 +167,7 @@ internal class ArtifactsGenerator(
             val destFile = collector.allocate(
                 ArtifactKind.AI_ANALYSIS,
                 ArtifactFormat.PNG,
-                "${BundleLayout.AI_ANALYSIS_DIR}/step-${meta.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
+                "${BundleLayout.AI_ANALYSIS_DIR}/${StepArtifactNaming.stem(meta.sequenceNumber, meta.command)}${BundleLayout.SCREENSHOT_EXTENSION}",
                 metadata = mapOf("defectCount" to defectCount.toString()),
                 sequenceNumber = meta.sequenceNumber,
             )
@@ -243,22 +244,13 @@ internal class ArtifactsGenerator(
             val destFile = collector.allocate(
                 ArtifactKind.SCREEN_HIERARCHY,
                 ArtifactFormat.JSON,
-                "${BundleLayout.SCREEN_HIERARCHY_DIR}/step-${metadata.sequenceNumber}.json",
+                "${BundleLayout.SCREEN_HIERARCHY_DIR}/${StepArtifactNaming.stem(metadata.sequenceNumber, metadata.command)}.json",
                 sequenceNumber = metadata.sequenceNumber,
             )
             TestOutputWriter.bundleWriter.writeValue(destFile, tree)
         } catch (e: Exception) {
             logger.warn("Failed to capture step hierarchy", e)
         }
-    }
-
-    /** Flag-off failure path only (captureFullArtifacts overwrites via captureStepScreenshotFile). */
-    private fun captureFailureScreenshot(metadata: CommandDebugMetadata) {
-        // Dedup a composite parent against the leaf that already shot the same screen.
-        if (metadata.sequenceNumber < lastFailureScreenshotSeq) return
-        val relativePath = captureStepScreenshotFile(metadata) ?: return
-        lastFailureScreenshotSeq = metadata.sequenceNumber
-        onStepScreenshotCaptured(metadata.sequenceNumber, relativePath)
     }
 
     private fun captureStepScreenshot(metadata: CommandDebugMetadata) {
@@ -268,7 +260,7 @@ internal class ArtifactsGenerator(
 
     private fun captureStepScreenshotFile(metadata: CommandDebugMetadata): String? =
         captureScreenshot(
-            "${BundleLayout.STEP_SCREENSHOTS_DIR}/step-${metadata.sequenceNumber}${BundleLayout.SCREENSHOT_EXTENSION}",
+            "${BundleLayout.STEP_SCREENSHOTS_DIR}/${StepArtifactNaming.stem(metadata.sequenceNumber, metadata.command)}${BundleLayout.SCREENSHOT_EXTENSION}",
             sequenceNumber = metadata.sequenceNumber,
         )
 

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -64,8 +64,6 @@ internal class ArtifactsGenerator(
      * command, so a single reference (no stack) is enough to attribute them.
      */
     private var currentCommandMetadata: CommandDebugMetadata? = null
-    /** Highest sequence number that already captured a failure/warning frame this flow; -1 if none. */
-    private var lastFailureCaptureSeq: Int = -1
 
     override fun onFlowStart() {
         if (artifactsDir == null) return
@@ -75,7 +73,6 @@ internal class ArtifactsGenerator(
             logCapture = ScopedLogCapture.start(logFile)
             flowStartMs = System.currentTimeMillis()
             appUnderTest = null
-            lastFailureCaptureSeq = -1
             capturer = DeviceArtifactCapturer(maestro, artifactsDir.resolve(BundleLayout.LOGS_DIR)).also { it.start() }
         } catch (e: Exception) {
             logger.warn("Failed to set up artifacts directory at $artifactsDir", e)
@@ -100,7 +97,7 @@ internal class ArtifactsGenerator(
         if (appUnderTest == null) cmd.launchAppCommand?.appId?.let { appUnderTest = it }
 
         // Pre-command shot: the screen the step is about to act on.
-        if (captureFullArtifacts && !StepArtifactNaming.isNoOp(cmd)) captureStepScreenshot(metadata)
+        if (captureFullArtifacts && StepArtifactNaming.capturesScreenshot(cmd)) captureStepScreenshot(metadata)
     }
 
     /**
@@ -137,22 +134,18 @@ internal class ArtifactsGenerator(
         // Passing steps keep their pre-command shot from onCommandStart; nothing to do at finish.
         if (outcome !is CommandOutcome.Failed && outcome !is CommandOutcome.Warned) return
         // Non-visible leaves (defineVariables/applyConfiguration) and empty commands have no screen.
-        if (StepArtifactNaming.isNoOp(cmd) && !StepArtifactNaming.isComposite(cmd)) return
-        // A composite parent needs its own failure frame only when no descendant leaf already shot
-        // one (a while/when condition that throws fails the composite before any child runs).
-        // Descendants finish first and carry higher sequence numbers, so a later capture means done.
-        if (StepArtifactNaming.isComposite(cmd) && lastFailureCaptureSeq > metadata.sequenceNumber) return
+        if (!StepArtifactNaming.capturesScreenshot(cmd)) return
 
-        // Failed/warned steps pair screenshot + hierarchy at the outcome moment so both show the
-        // same screen (the viewer overlays them). viewHierarchy() is ~1s, so only these steps pay it.
-        captureStepHierarchy(metadata)
+        // Visible leaves pair the screenshot with a view hierarchy at the outcome moment so both
+        // show the same screen (the viewer overlays them). viewHierarchy() is ~1s, so composites —
+        // which only wrap children — keep the screenshot but skip the hierarchy.
+        if (StepArtifactNaming.capturesHierarchy(cmd)) captureStepHierarchy(metadata)
         if (captureFullArtifacts) {
             // Overwrite the pre-command shot with the at-outcome frame; its callback already fired.
             captureStepScreenshotFile(metadata)
         } else {
             captureStepScreenshot(metadata)
         }
-        lastFailureCaptureSeq = maxOf(lastFailureCaptureSeq, metadata.sequenceNumber)
     }
 
     override fun onCommandReset(cmd: MaestroCommand) {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -96,8 +96,7 @@ internal class ArtifactsGenerator(
         // First launchApp wins (one flow tests one app); null ⇒ crash/ANR unscoped.
         if (appUnderTest == null) cmd.launchAppCommand?.appId?.let { appUnderTest = it }
 
-        // Pre-command shot: the screen the step is about to act on. No-op steps
-        // (composite parents, non-visible leaves) take no on-screen action — skip them.
+        // Pre-command shot: the screen the step is about to act on.
         if (captureFullArtifacts && !StepArtifactNaming.isNoOp(cmd)) captureStepScreenshot(metadata)
     }
 
@@ -134,8 +133,7 @@ internal class ArtifactsGenerator(
         if (artifactsDir == null || outcome is CommandOutcome.Skipped) return
         // Passing steps keep their pre-command shot from onCommandStart; nothing to do at finish.
         if (outcome !is CommandOutcome.Failed && outcome !is CommandOutcome.Warned) return
-        // No-op steps (composite parents, non-visible leaves) capture nothing; a failing
-        // composite's failing leaf still records the pair below.
+        // A failing composite's own failing leaf still records the pair, so skipping no-ops loses nothing.
         if (StepArtifactNaming.isNoOp(cmd)) return
 
         // Failed/warned leaves pair screenshot + hierarchy at the outcome moment so both show the

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
@@ -18,7 +18,7 @@ package maestro.orchestra.debug
  *     device logs, crash/ANR  ← worker/cloud only
  *   takeScreenshot/           ← takeScreenshot command output
  *   startRecording/           ← startRecording command output
- *   screenshots/              ← step screenshots (all steps + final.png when flag on; failed step only when off)
+ *   screenshots/              ← step screenshots, step-<NNN>-<type>[-<arg>].png (action steps + final.png; failed step only when flag off)
  *   screen-hierarchy/         ← per-step view hierarchy JSON
  *   screen-recording.mp4      ← full-run recording (flag-gated)
  *   ai-analysis/              ← screenshots an AI command analyzed (with defects)

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
@@ -26,14 +26,17 @@ internal object StepArtifactNaming {
     private val PATH_SEP_OR_WHITESPACE = Regex("""[/\\\s]+""")
     private val SEPARATOR_RUN = Regex("""([-_])\1+""")
 
-    /** No on-screen action: composite parents, non-visible leaves, or an unidentifiable command. */
-    fun isNoOp(command: MaestroCommand?): Boolean {
-        val leaf = command?.asCommand() ?: return true
-        return leaf is CompositeCommand || !leaf.visible()
+    /** Composites and visible leaves act on screen and get a screenshot; non-visible leaves don't. */
+    fun capturesScreenshot(command: MaestroCommand?): Boolean {
+        val leaf = command?.asCommand() ?: return false
+        return leaf is CompositeCommand || leaf.visible()
     }
 
-    /** Composite parents (runFlow/repeat/retry) that wrap children rather than act on screen. */
-    fun isComposite(command: MaestroCommand?): Boolean = command?.asCommand() is CompositeCommand
+    /** Only visible leaves pay the ~1s hierarchy round-trip; composites get a screenshot but no hierarchy. */
+    fun capturesHierarchy(command: MaestroCommand?): Boolean {
+        val leaf = command?.asCommand() ?: return false
+        return leaf !is CompositeCommand && leaf.visible()
+    }
 
     fun stem(sequenceNumber: Int, command: MaestroCommand?): String {
         val index = (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
@@ -1,0 +1,76 @@
+package maestro.orchestra.debug
+
+import maestro.orchestra.ClearStateCommand
+import maestro.orchestra.CompositeCommand
+import maestro.orchestra.InputTextCommand
+import maestro.orchestra.KillAppCommand
+import maestro.orchestra.LaunchAppCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.OpenLinkCommand
+import maestro.orchestra.PressKeyCommand
+import maestro.orchestra.StopAppCommand
+import maestro.orchestra.TapOnPointCommand
+import maestro.orchestra.TapOnPointV2Command
+
+/**
+ * File stem for a step's artifacts: `step-<NNN>[-<slug>]`, where NNN is the 1-based
+ * sequence number (min width 3) and the optional slug names the command type plus one
+ * salient argument. Screenshot and hierarchy for a step share this stem so the viewer's
+ * hierarchy-over-screenshot overlay keeps pairing them.
+ */
+internal object StepArtifactNaming {
+
+    private const val MIN_INDEX_WIDTH = 3
+    private const val MAX_SLUG_LENGTH = 40
+    private val ILLEGAL = Regex("""[<>:"|?*\p{Cntrl}]""")
+    private val PATH_SEP_OR_WHITESPACE = Regex("""[/\\\s]+""")
+    private val SEPARATOR_RUN = Regex("""([-_])\1+""")
+
+    /** No on-screen action: composite parents, non-visible leaves, or an unidentifiable command. */
+    fun isNoOp(command: MaestroCommand?): Boolean {
+        val leaf = command?.asCommand() ?: return true
+        return leaf is CompositeCommand || !leaf.visible()
+    }
+
+    fun stem(sequenceNumber: Int, command: MaestroCommand?): String {
+        val index = (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
+        val slug = command?.let(::slug)
+        return if (slug.isNullOrEmpty()) "step-$index" else "step-$index-$slug"
+    }
+
+    private fun slug(command: MaestroCommand): String? {
+        val type = typeToken(command) ?: return null
+        val arg = argToken(command)?.let(::sanitize)?.takeIf { it.isNotEmpty() }
+        val slug = if (arg == null) type else "$type-$arg"
+        return slug.take(MAX_SLUG_LENGTH).trim('-', '_', '.')
+    }
+
+    private fun typeToken(command: MaestroCommand): String? =
+        command.asCommand()?.let { it::class.simpleName }
+            ?.removeSuffix("Command")
+            ?.replaceFirstChar(Char::lowercaseChar)
+
+    private fun argToken(command: MaestroCommand): String? {
+        command.elementSelector()?.let { selector ->
+            return selector.textRegex ?: selector.idRegex ?: selector.description().ifEmpty { null }
+        }
+        return when (val leaf = command.asCommand()) {
+            is TapOnPointV2Command -> leaf.point
+            is TapOnPointCommand -> "${leaf.x},${leaf.y}"
+            is InputTextCommand -> leaf.text
+            is LaunchAppCommand -> leaf.appId
+            is StopAppCommand -> leaf.appId
+            is KillAppCommand -> leaf.appId
+            is ClearStateCommand -> leaf.appId
+            is OpenLinkCommand -> leaf.link
+            is PressKeyCommand -> leaf.code.name
+            else -> null
+        }
+    }
+
+    private fun sanitize(raw: String): String =
+        raw.replace(ILLEGAL, "")
+            .replace(PATH_SEP_OR_WHITESPACE, "_")
+            .replace(SEPARATOR_RUN, "$1")
+            .trim('-', '_', '.', ' ')
+}

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
@@ -32,6 +32,9 @@ internal object StepArtifactNaming {
         return leaf is CompositeCommand || !leaf.visible()
     }
 
+    /** Composite parents (runFlow/repeat/retry) that wrap children rather than act on screen. */
+    fun isComposite(command: MaestroCommand?): Boolean = command?.asCommand() is CompositeCommand
+
     fun stem(sequenceNumber: Int, command: MaestroCommand?): String {
         val index = (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
         val slug = command?.let(::slug)

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -926,8 +926,7 @@ class ArtifactsGeneratorTest {
         assertThat(content).doesNotContain("huge tree")
     }
 
-    // The old tapOnElement(null)-based composite tests moved to real RepeatCommand parents at the
-    // end of this file: composite no-op skip, the fail-with-no-leaf fallback, and the leaf dedup.
+    // Composite-parent behavior (screenshot kept, hierarchy skipped) lives at the end of this file.
 
     @Test
     fun `callback reports the step screenshot path for a completed step when captureFullArtifacts is true`() {
@@ -1103,9 +1102,7 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `composite failing with no failing leaf still captures its own screenshot and hierarchy`() {
-        // A while/when condition that throws fails the composite before any child runs, so no leaf
-        // records the failing screen — the composite must fall back to capturing it itself.
+    fun `composite failing captures its own screenshot but no hierarchy`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val composite = MaestroCommand(repeatCommand = RepeatCommand(commands = emptyList()))
 
@@ -1114,14 +1111,16 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(composite, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
         gen.onFlowEnd()
 
+        // A composite wraps children rather than acting on screen: keep its screenshot so the step
+        // renders in the viewer, but skip the ~1s hierarchy round-trip.
         assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isTrue()
-        assertThat(tempDir.resolve("screen-hierarchy/step-001-repeat.json").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-repeat.json").exists()).isFalse()
         assertThat(gen.debugOutput.commands[composite]!!.artifacts.map { it.type })
-            .containsExactly(ArtifactKind.SCREEN_HIERARCHY, ArtifactKind.SCREENSHOT)
+            .containsExactly(ArtifactKind.SCREENSHOT)
     }
 
     @Test
-    fun `composite failing after its leaf failed is deduped against the leaf's frame`() {
+    fun `composite failing after its leaf keeps its own screenshot and fires the callback`() {
         val captured = mutableListOf<Pair<Int, String>>()
         val gen = ArtifactsGenerator(
             artifactsDir = tempDir,
@@ -1138,19 +1137,28 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(composite, CommandOutcome.Failed(RuntimeException("boom")), 90L, 200L)
         gen.onFlowEnd()
 
-        // Leaf (seq 1) shot the failing screen; the parent (seq 0) is deduped out entirely —
-        // no redundant screenshot and no second ~1s hierarchy call.
+        // Both the leaf and its composite parent keep a screenshot and fire the callback so neither
+        // renders blank in the viewer; only the composite's hierarchy is skipped.
         assertThat(tempDir.resolve("screenshots/step-002-scroll.png").exists()).isTrue()
-        assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isTrue()
         assertThat(tempDir.resolve("screen-hierarchy/step-001-repeat.json").exists()).isFalse()
-        assertThat(gen.debugOutput.commands[composite]!!.artifacts).isEmpty()
-        // The deduped parent stays silent on the callback channel.
-        assertThat(captured).containsExactly(1 to "screenshots/step-002-scroll.png")
+        assertThat(gen.debugOutput.commands[composite]!!.artifacts.map { it.type })
+            .containsExactly(ArtifactKind.SCREENSHOT)
+        assertThat(captured).containsExactly(
+            1 to "screenshots/step-002-scroll.png",
+            0 to "screenshots/step-001-repeat.png",
+        )
     }
 
     @Test
-    fun `full-artifacts mode captures no pre-command shot for a composite parent`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+    fun `full-artifacts mode captures a pre-command shot for a composite parent`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            captureFullArtifacts = true,
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
+        )
         val composite = MaestroCommand(repeatCommand = RepeatCommand(commands = emptyList()))
         val leaf = MaestroCommand(scrollCommand = ScrollCommand())
 
@@ -1161,8 +1169,12 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(composite, CommandOutcome.Completed, 90L, 160L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isTrue()
         assertThat(tempDir.resolve("screenshots/step-002-scroll.png").exists()).isTrue()
+        assertThat(captured).containsExactly(
+            0 to "screenshots/step-001-repeat.png",
+            1 to "screenshots/step-002-scroll.png",
+        )
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -884,9 +884,8 @@ class ArtifactsGeneratorTest {
     @Test
     fun `the failed command's screenshot is part of the per-step set when captureFullArtifacts is true`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
-        // Distinct command types: ScrollCommand.equals() ignores its fields (always
-        // equal to any other ScrollCommand), so two `scrollCommand`-backed instances
-        // would collide as MaestroCommand map keys in debugOutput.commands.
+        // ScrollCommand.equals() ignores its fields, so two would collide as
+        // debugOutput.commands map keys — use distinct command types.
         val ok = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
         val bad = MaestroCommand(scrollCommand = ScrollCommand())
 
@@ -927,16 +926,9 @@ class ArtifactsGeneratorTest {
         assertThat(content).doesNotContain("huge tree")
     }
 
-    // The two tests that used to live here ("composite parent failing after its leaf
-    // does not duplicate the failure screenshot" / "a failed composite parent keeps
-    // its own screenshot when captureFullArtifacts is true") exercised the sequence-based
-    // `lastFailureScreenshotSeq` dedup that guarded composite parents against
-    // double-capturing their leaf's screen. That dedup is gone now that composite
-    // parents are gated out by `StepArtifactNaming.isNoOp` before any capture is
-    // attempted — the removed tests' hand-rolled "parent"/"leaf" (both ordinary,
-    // non-composite commands) no longer models real composite-vs-leaf behavior.
-    // Coverage for the real no-op-skip behavior is at the end of this file, using an
-    // actual RepeatCommand parent.
+    // Removed here: two tests for the old `lastFailureScreenshotSeq` dedup. Composite parents
+    // are now gated out by StepArtifactNaming.isNoOp, so that dedup is gone; real no-op-skip
+    // coverage lives at the end of this file with an actual RepeatCommand parent.
 
     @Test
     fun `callback reports the step screenshot path for a completed step when captureFullArtifacts is true`() {
@@ -1091,9 +1083,8 @@ class ArtifactsGeneratorTest {
         // Two sibling commands fail (continue-on-failure / optional) — both are real,
         // distinct failures, so each must keep its own screenshot.
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
-        // Distinct command types: ScrollCommand.equals() ignores its fields (always
-        // equal to any other ScrollCommand), so two `scrollCommand`-backed instances
-        // would collide as MaestroCommand map keys in debugOutput.commands.
+        // ScrollCommand.equals() ignores its fields, so two would collide as
+        // debugOutput.commands map keys — use distinct command types.
         val first = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
         val second = MaestroCommand(scrollCommand = ScrollCommand())
 

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -17,9 +17,12 @@ import maestro.device.DeviceArtifactFiles
 import maestro.orchestra.ArtifactFormat
 import maestro.orchestra.ArtifactKind
 import maestro.orchestra.ArtifactManifest
+import maestro.orchestra.DefineVariablesCommand
+import maestro.orchestra.EvalScriptCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.debug.CommandArtifact
+import maestro.orchestra.RepeatCommand
 import maestro.orchestra.ScrollCommand
 import okio.Buffer
 import okio.Sink
@@ -111,7 +114,7 @@ class ArtifactsGeneratorTest {
     fun `on failure with artifactsDir, captures hierarchy and screenshot independently`() {
         val maestro = mockMaestro()
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
         val error = RuntimeException("boom")
 
         gen.onFlowStart()
@@ -122,12 +125,12 @@ class ArtifactsGeneratorTest {
         val metadata = gen.debugOutput.commands[cmd]!!
         assertThat(metadata.status).isEqualTo(CommandStatus.FAILED)
         assertThat(metadata.error).isEqualTo(error)
-        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
 
         // Failure screenshot written under screenshots/.
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-001-scroll.png"))
     }
 
     @Test
@@ -140,16 +143,16 @@ class ArtifactsGeneratorTest {
             )
         }
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, 0)
         gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("test")), 100L, 200L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
         // No screenshot file landed (capture threw)
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isFalse()
     }
 
     @Test
@@ -165,15 +168,15 @@ class ArtifactsGeneratorTest {
             coEvery { viewHierarchy(any()) } throws RuntimeException("hierarchy boom")
         }
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, 0)
         gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("test")), 100L, 200L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isFalse()
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
     }
 
     @Test
@@ -227,7 +230,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `failed run yields a single SCREENSHOT folder entry for the screenshots dir`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, 0)
@@ -373,7 +376,7 @@ class ArtifactsGeneratorTest {
             maestro = mockMaestro(),
             captureFullArtifacts = true,
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 3)
@@ -382,7 +385,7 @@ class ArtifactsGeneratorTest {
 
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
             .containsExactly(
-                CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-3.png"),
+                CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-004-scroll.png"),
             )
     }
 
@@ -393,18 +396,18 @@ class ArtifactsGeneratorTest {
             maestro = mockMaestro(),
             captureFullArtifacts = true,
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 3)
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-3.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-004-scroll.png").exists()).isTrue()
 
         val steps = gen.artifactManifest.entries
             .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
-        assertThat(steps.count).isEqualTo(2)  // step-3 + final
+        assertThat(steps.count).isEqualTo(2)  // step-004 + final
         assertThat(steps.metadata).isEmpty()
     }
 
@@ -417,14 +420,14 @@ class ArtifactsGeneratorTest {
             captureFullArtifacts = true,
             onStepScreenshotCaptured = { seq, path -> captured += seq to path },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
 
         // Reported at command start — before the command runs.
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
-        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
+        assertThat(captured).containsExactly(0 to "screenshots/step-001-scroll.png")
     }
 
     @Test
@@ -442,7 +445,7 @@ class ArtifactsGeneratorTest {
             coEvery { viewHierarchy(any()) } returns ViewHierarchy(TreeNode(attributes = mutableMapOf("text" to "root")))
         }
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
@@ -450,8 +453,8 @@ class ArtifactsGeneratorTest {
         gen.onFlowEnd()
 
         // At-failure frame ({2}) overwrote the pre-command one; one record (same path), paired with hierarchy.
-        assertThat(Files.readAllBytes(tempDir.resolve("screenshots/step-0.png"))).isEqualTo(byteArrayOf(2))
-        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
+        assertThat(Files.readAllBytes(tempDir.resolve("screenshots/step-001-scroll.png"))).isEqualTo(byteArrayOf(2))
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
         val shots = gen.artifactManifest.entries
             .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
         assertThat(shots.count).isEqualTo(1)
@@ -479,7 +482,7 @@ class ArtifactsGeneratorTest {
             captureFullArtifacts = true,
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
@@ -487,9 +490,9 @@ class ArtifactsGeneratorTest {
         gen.onFlowEnd()
 
         // Pre-command frame survives — disk still matches the reported callback path.
-        assertThat(Files.readAllBytes(tempDir.resolve("screenshots/step-0.png"))).isEqualTo(byteArrayOf(1))
-        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
-        assertThat(tempDir.resolve("screenshots/step-0.png.tmp").exists()).isFalse()
+        assertThat(Files.readAllBytes(tempDir.resolve("screenshots/step-001-scroll.png"))).isEqualTo(byteArrayOf(1))
+        assertThat(captured).containsExactly(0 to "screenshots/step-001-scroll.png")
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png.tmp").exists()).isFalse()
     }
 
     @Test
@@ -499,18 +502,18 @@ class ArtifactsGeneratorTest {
             maestro = mockMaestro(),
             captureFullArtifacts = true,
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
         gen.onCommandFinished(cmd, CommandOutcome.Warned, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
-        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
         val shots = gen.artifactManifest.entries
             .single { it.kind == ArtifactKind.SCREENSHOT && it.relativePath == "screenshots" }
-        assertThat(shots.count).isEqualTo(2)  // step-0 (finish reuses its path) + final
+        assertThat(shots.count).isEqualTo(2)  // step-001 (finish reuses its path) + final
     }
 
     @Test
@@ -522,7 +525,7 @@ class ArtifactsGeneratorTest {
             captureFullArtifacts = true,
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
@@ -532,11 +535,11 @@ class ArtifactsGeneratorTest {
         // The resting screen lands as final.png alongside the per-step shots.
         assertThat(tempDir.resolve("screenshots/final.png").exists()).isTrue()
         val shots = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT }
-        assertThat(shots.count).isEqualTo(2)  // step-0 + final
+        assertThat(shots.count).isEqualTo(2)  // step-001 + final
         // Flow-level: owns no command and fires no per-step callback.
         assertThat(gen.debugOutput.executedSteps.single().artifacts)
             .doesNotContain(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/final.png"))
-        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+        assertThat(captured).containsExactly(0 to "screenshots/step-001-scroll.png")
     }
 
     @Test
@@ -686,7 +689,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `failure screenshot is attributed to the failed command's artifacts`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, 0)
@@ -698,7 +701,7 @@ class ArtifactsGeneratorTest {
         assertThat(artifacts.map { it.type })
             .containsExactly(ArtifactKind.SCREEN_HIERARCHY, ArtifactKind.SCREENSHOT)
         val screenshotArtifact = artifacts.single { it.type == ArtifactKind.SCREENSHOT }
-        assertThat(screenshotArtifact.path).isEqualTo("screenshots/step-0.png")
+        assertThat(screenshotArtifact.path).isEqualTo("screenshots/step-001-scroll.png")
         assertThat(tempDir.resolve(screenshotArtifact.path).exists()).isTrue()
     }
 
@@ -739,7 +742,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `passing command captures a screenshot but no hierarchy even when captureFullArtifacts is true`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 2)
@@ -750,9 +753,9 @@ class ArtifactsGeneratorTest {
         assertThat(tempDir.resolve("screen-hierarchy").exists()).isFalse()
         assertThat(gen.artifactManifest.entries.none { it.kind == ArtifactKind.SCREEN_HIERARCHY }).isTrue()
         // Screenshots stay per-step under captureFullArtifacts.
-        assertThat(tempDir.resolve("screenshots/step-2.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-003-scroll.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-2.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-003-scroll.png"))
     }
 
     @Test
@@ -784,14 +787,14 @@ class ArtifactsGeneratorTest {
     @Test
     fun `failed command gets a hierarchy file and commands_json has no inline hierarchy`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, 0)
         gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screen-hierarchy/step-0.json").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts.map { it.type })
             .containsExactly(ArtifactKind.SCREEN_HIERARCHY, ArtifactKind.SCREENSHOT)
         val content = Files.readString(tempDir.resolve("commands.json"))
@@ -801,38 +804,38 @@ class ArtifactsGeneratorTest {
     @Test
     fun `failed command gets a step screenshot even when captureFullArtifacts is false`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 4)
         gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-4.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-005-scroll.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-4.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-005-scroll.png"))
         assertThat(tempDir.toFile().listFiles { _, n -> n.startsWith("screenshot-") }).isEmpty()
     }
 
     @Test
     fun `warned command gets a step screenshot even when captureFullArtifacts is false`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
         gen.onCommandFinished(cmd, CommandOutcome.Warned, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-001-scroll.png"))
     }
 
     @Test
     fun `a re-run command yields one commands entry per execution, each with its own screenshot`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         // Two executions of the SAME command object — what repeat/retry does, incl.
@@ -851,9 +854,9 @@ class ArtifactsGeneratorTest {
         assertThat(gen.debugOutput.executedSteps.map { it.status })
             .containsExactly(CommandStatus.COMPLETED, CommandStatus.COMPLETED)
         assertThat(gen.debugOutput.executedSteps[0].artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-001-scroll.png"))
         assertThat(gen.debugOutput.executedSteps[1].artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-1.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-002-scroll.png"))
         // commands.json carries both executions, not one collapsed entry.
         val content = Files.readString(tempDir.resolve("commands.json"))
         assertThat(content.split("\"sequenceNumber\"").size - 1).isEqualTo(2)
@@ -870,18 +873,21 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("ai-analysis/step-3.png").exists()).isTrue()
+        assertThat(tempDir.resolve("ai-analysis/step-004.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[cmd]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.AI_ANALYSIS, "ai-analysis/step-3.png"))
+            .contains(CommandArtifact(ArtifactKind.AI_ANALYSIS, "ai-analysis/step-004.png"))
         val entry = gen.artifactManifest.entries.single { it.kind == ArtifactKind.AI_ANALYSIS }
-        assertThat(entry.relativePath).isEqualTo("ai-analysis/step-3.png")
+        assertThat(entry.relativePath).isEqualTo("ai-analysis/step-004.png")
         assertThat(entry.metadata["defectCount"]).isEqualTo("2")
     }
 
     @Test
     fun `the failed command's screenshot is part of the per-step set when captureFullArtifacts is true`() {
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
-        val ok = MaestroCommand(tapOnElement = null)
+        // Distinct command types: ScrollCommand.equals() ignores its fields (always
+        // equal to any other ScrollCommand), so two `scrollCommand`-backed instances
+        // would collide as MaestroCommand map keys in debugOutput.commands.
+        val ok = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
         val bad = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -891,11 +897,11 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(bad, CommandOutcome.Failed(RuntimeException("boom")), 150L, 200L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
-        assertThat(tempDir.resolve("screenshots/step-1.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-001-evalScript.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-002-scroll.png").exists()).isTrue()
         val steps = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT }
         assertThat(steps.relativePath).isEqualTo("screenshots")
-        assertThat(steps.count).isEqualTo(3)  // step-0 + step-1 + final
+        assertThat(steps.count).isEqualTo(3)  // step-001 + step-002 + final
     }
 
     @Test
@@ -921,63 +927,16 @@ class ArtifactsGeneratorTest {
         assertThat(content).doesNotContain("huge tree")
     }
 
-    @Test
-    fun `composite parent failing after its leaf does not duplicate the failure screenshot`() {
-        val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
-            artifactsDir = tempDir,
-            maestro = mockMaestro(),
-            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
-        )
-        val leaf = MaestroCommand(tapOnElement = null)
-        val parent = MaestroCommand(scrollCommand = ScrollCommand())
-
-        gen.onFlowStart()
-        gen.onCommandStart(parent, 0)
-        gen.onCommandStart(leaf, 1)
-        gen.onCommandFinished(leaf, CommandOutcome.Failed(RuntimeException("boom")), 100L, 150L)
-        gen.onCommandFinished(parent, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
-        gen.onFlowEnd()
-
-        assertThat(tempDir.resolve("screenshots/step-1.png").exists()).isTrue()
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isFalse()
-        // Parent gets hierarchy only — screenshot deduped because leaf already captured it.
-        assertThat(gen.debugOutput.commands[parent]!!.artifacts)
-            .containsExactly(CommandArtifact(ArtifactKind.SCREEN_HIERARCHY, "screen-hierarchy/step-0.json"))
-        // The dedup-skipped parent stays silent on the callback channel too.
-        assertThat(captured).containsExactly(1 to "screenshots/step-1.png")
-    }
-
-    @Test
-    fun `a failed composite parent keeps its own screenshot when captureFullArtifacts is true`() {
-        // Worker mode records every step individually, so the parent must not be
-        // deduped against its leaf — its RunStep needs its own screenshot.
-        val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
-            artifactsDir = tempDir,
-            maestro = mockMaestro(),
-            captureFullArtifacts = true,
-            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
-        )
-        val parent = MaestroCommand(scrollCommand = ScrollCommand())
-        val leaf = MaestroCommand(tapOnElement = null)
-
-        gen.onFlowStart()
-        gen.onCommandStart(parent, 0)
-        gen.onCommandStart(leaf, 1)
-        gen.onCommandFinished(leaf, CommandOutcome.Failed(RuntimeException("boom")), 100L, 150L)
-        gen.onCommandFinished(parent, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
-        gen.onFlowEnd()
-
-        assertThat(tempDir.resolve("screenshots/step-1.png").exists()).isTrue()
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
-        assertThat(gen.debugOutput.commands[parent]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
-        // Pre-command capture fires in start (seq) order: the parent shoots before its leaf enters.
-        assertThat(captured)
-            .containsExactly(0 to "screenshots/step-0.png", 1 to "screenshots/step-1.png")
-            .inOrder()
-    }
+    // The two tests that used to live here ("composite parent failing after its leaf
+    // does not duplicate the failure screenshot" / "a failed composite parent keeps
+    // its own screenshot when captureFullArtifacts is true") exercised the sequence-based
+    // `lastFailureScreenshotSeq` dedup that guarded composite parents against
+    // double-capturing their leaf's screen. That dedup is gone now that composite
+    // parents are gated out by `StepArtifactNaming.isNoOp` before any capture is
+    // attempted — the removed tests' hand-rolled "parent"/"leaf" (both ordinary,
+    // non-composite commands) no longer models real composite-vs-leaf behavior.
+    // Coverage for the real no-op-skip behavior is at the end of this file, using an
+    // actual RepeatCommand parent.
 
     @Test
     fun `callback reports the step screenshot path for a completed step when captureFullArtifacts is true`() {
@@ -988,14 +947,14 @@ class ArtifactsGeneratorTest {
             captureFullArtifacts = true,
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 3)
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(captured).containsExactly(3 to "screenshots/step-3.png")
+        assertThat(captured).containsExactly(3 to "screenshots/step-004-scroll.png")
     }
 
     @Test
@@ -1006,14 +965,14 @@ class ArtifactsGeneratorTest {
             maestro = mockMaestro(),
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 4)
         gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
         gen.onFlowEnd()
 
-        assertThat(captured).containsExactly(4 to "screenshots/step-4.png")
+        assertThat(captured).containsExactly(4 to "screenshots/step-005-scroll.png")
     }
 
     @Test
@@ -1024,14 +983,14 @@ class ArtifactsGeneratorTest {
             maestro = mockMaestro(),
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
         gen.onCommandFinished(cmd, CommandOutcome.Warned, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+        assertThat(captured).containsExactly(0 to "screenshots/step-001-scroll.png")
     }
 
     @Test
@@ -1044,14 +1003,14 @@ class ArtifactsGeneratorTest {
             captureFullArtifacts = true,
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
         gen.onCommandFinished(cmd, CommandOutcome.Skipped, 100L, 150L)
         gen.onFlowEnd()
 
-        assertThat(captured).containsExactly(0 to "screenshots/step-0.png")
+        assertThat(captured).containsExactly(0 to "screenshots/step-001-scroll.png")
     }
 
     @Test
@@ -1115,7 +1074,7 @@ class ArtifactsGeneratorTest {
             captureFullArtifacts = true,
             onStepScreenshotCaptured = { _, _ -> throw RuntimeException("consumer boom") },
         )
-        val cmd = MaestroCommand(tapOnElement = null)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
         val thrown = runCatching {
@@ -1124,15 +1083,18 @@ class ArtifactsGeneratorTest {
 
         assertThat(thrown).isInstanceOf(RuntimeException::class.java)
         assertThat(thrown!!.message).isEqualTo("consumer boom")
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
     }
 
     @Test
     fun `separate failures each keep their own screenshot, not just the first`() {
-        // Two sibling commands fail (continue-on-failure / optional): both are real,
-        // distinct failures, so the dedup must not swallow the second.
+        // Two sibling commands fail (continue-on-failure / optional) — both are real,
+        // distinct failures, so each must keep its own screenshot.
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
-        val first = MaestroCommand(tapOnElement = null)
+        // Distinct command types: ScrollCommand.equals() ignores its fields (always
+        // equal to any other ScrollCommand), so two `scrollCommand`-backed instances
+        // would collide as MaestroCommand map keys in debugOutput.commands.
+        val first = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
         val second = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -1142,11 +1104,73 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(second, CommandOutcome.Failed(RuntimeException("boom")), 150L, 200L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-0.png").exists()).isTrue()
-        assertThat(tempDir.resolve("screenshots/step-1.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-001-evalScript.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-002-scroll.png").exists()).isTrue()
         assertThat(gen.debugOutput.commands[first]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-0.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-001-evalScript.png"))
         assertThat(gen.debugOutput.commands[second]!!.artifacts)
-            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-1.png"))
+            .contains(CommandArtifact(ArtifactKind.SCREENSHOT, "screenshots/step-002-scroll.png"))
+    }
+
+    @Test
+    fun `composite parent captures no screenshot or hierarchy on failure`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val composite = MaestroCommand(repeatCommand = RepeatCommand(commands = emptyList()))
+
+        gen.onFlowStart()
+        gen.onCommandStart(composite, 0)
+        gen.onCommandFinished(composite, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("screenshots").toFile().exists()).isFalse()
+        assertThat(tempDir.resolve("screen-hierarchy").toFile().exists()).isFalse()
+    }
+
+    @Test
+    fun `full-artifacts mode captures no pre-command shot for a composite parent`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val composite = MaestroCommand(repeatCommand = RepeatCommand(commands = emptyList()))
+        val leaf = MaestroCommand(scrollCommand = ScrollCommand())
+
+        gen.onFlowStart()
+        gen.onCommandStart(composite, 0)
+        gen.onCommandStart(leaf, 1)
+        gen.onCommandFinished(leaf, CommandOutcome.Completed, 100L, 150L)
+        gen.onCommandFinished(composite, CommandOutcome.Completed, 90L, 160L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-002-scroll.png").exists()).isTrue()
+    }
+
+    @Test
+    fun `non-visible leaf captures no pre-command shot`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val defineVars = MaestroCommand(defineVariablesCommand = DefineVariablesCommand(mapOf("a" to "b")))
+
+        gen.onFlowStart()
+        gen.onCommandStart(defineVars, 0)
+        gen.onCommandFinished(defineVars, CommandOutcome.Completed, 100L, 150L)
+        gen.onFlowEnd()
+
+        // captureFullArtifacts always shoots the flow-level final.png, so the
+        // directory itself exists — the no-op skip is that no per-step file landed.
+        assertThat(tempDir.resolve("screenshots/step-001-defineVariables.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots").toFile().listFiles()?.map { it.name })
+            .containsExactly("final.png")
+    }
+
+    @Test
+    fun `failing leaf pairs screenshot and hierarchy under the same stem`() {
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val leaf = MaestroCommand(scrollCommand = ScrollCommand())
+
+        gen.onFlowStart()
+        gen.onCommandStart(leaf, 0)
+        gen.onCommandFinished(leaf, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
+        gen.onFlowEnd()
+
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
     }
 }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -926,9 +926,8 @@ class ArtifactsGeneratorTest {
         assertThat(content).doesNotContain("huge tree")
     }
 
-    // Removed here: two tests for the old `lastFailureScreenshotSeq` dedup. Composite parents
-    // are now gated out by StepArtifactNaming.isNoOp, so that dedup is gone; real no-op-skip
-    // coverage lives at the end of this file with an actual RepeatCommand parent.
+    // The old tapOnElement(null)-based composite tests moved to real RepeatCommand parents at the
+    // end of this file: composite no-op skip, the fail-with-no-leaf fallback, and the leaf dedup.
 
     @Test
     fun `callback reports the step screenshot path for a completed step when captureFullArtifacts is true`() {
@@ -1104,7 +1103,9 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `composite parent captures no screenshot or hierarchy on failure`() {
+    fun `composite failing with no failing leaf still captures its own screenshot and hierarchy`() {
+        // A while/when condition that throws fails the composite before any child runs, so no leaf
+        // records the failing screen — the composite must fall back to capturing it itself.
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val composite = MaestroCommand(repeatCommand = RepeatCommand(commands = emptyList()))
 
@@ -1113,8 +1114,38 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(composite, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots").toFile().exists()).isFalse()
-        assertThat(tempDir.resolve("screen-hierarchy").toFile().exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-repeat.json").exists()).isTrue()
+        assertThat(gen.debugOutput.commands[composite]!!.artifacts.map { it.type })
+            .containsExactly(ArtifactKind.SCREEN_HIERARCHY, ArtifactKind.SCREENSHOT)
+    }
+
+    @Test
+    fun `composite failing after its leaf failed is deduped against the leaf's frame`() {
+        val captured = mutableListOf<Pair<Int, String>>()
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = mockMaestro(),
+            onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
+        )
+        val composite = MaestroCommand(repeatCommand = RepeatCommand(commands = emptyList()))
+        val leaf = MaestroCommand(scrollCommand = ScrollCommand())
+
+        gen.onFlowStart()
+        gen.onCommandStart(composite, 0)
+        gen.onCommandStart(leaf, 1)
+        gen.onCommandFinished(leaf, CommandOutcome.Failed(RuntimeException("boom")), 100L, 150L)
+        gen.onCommandFinished(composite, CommandOutcome.Failed(RuntimeException("boom")), 90L, 200L)
+        gen.onFlowEnd()
+
+        // Leaf (seq 1) shot the failing screen; the parent (seq 0) is deduped out entirely —
+        // no redundant screenshot and no second ~1s hierarchy call.
+        assertThat(tempDir.resolve("screenshots/step-002-scroll.png").exists()).isTrue()
+        assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-repeat.json").exists()).isFalse()
+        assertThat(gen.debugOutput.commands[composite]!!.artifacts).isEmpty()
+        // The deduped parent stays silent on the callback channel.
+        assertThat(captured).containsExactly(1 to "screenshots/step-002-scroll.png")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -1139,7 +1139,7 @@ class ArtifactsGeneratorTest {
         gen.onCommandFinished(composite, CommandOutcome.Completed, 90L, 160L)
         gen.onFlowEnd()
 
-        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-001-repeat.png").exists()).isFalse()
         assertThat(tempDir.resolve("screenshots/step-002-scroll.png").exists()).isTrue()
     }
 

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -504,8 +504,9 @@ class OrchestraListenerDispatchTest {
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
         // maxRetries=2 -> 3 attempts of the reused leaf (step-002..004); the retry
-        // parent (step-000) is a composite — a no-op that captures nothing, leaving
-        // a gap at step-001 — plus the flow-level final.png captured at flow end.
+        // parent (seq 0) is a composite — a no-op that captures nothing, leaving
+        // a gap at step-001 (the file that parent would have produced) — plus the
+        // flow-level final.png captured at flow end.
         assertThat(stepScreenshotNames())
             .containsExactly(
                 "step-002-openLink-https_example.com.png",

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -458,11 +458,12 @@ class OrchestraListenerDispatchTest {
 
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
-        // Sequence numbers increment on every onCommandStart: the repeat parent is
-        // step-0, then each of the 3 iterations of the reused leaf is its own file,
-        // plus the flow-level final.png captured at flow end.
+        // Sequence numbers increment on every onCommandStart: the repeat parent
+        // (step-0) is a composite — a no-op that captures nothing, leaving a gap
+        // at step-001 — then each of the 3 iterations of the reused leaf is its
+        // own file, plus the flow-level final.png captured at flow end.
         assertThat(stepScreenshotNames())
-            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png", "final.png")
+            .containsExactly("step-002-evalScript.png", "step-003-evalScript.png", "step-004-evalScript.png", "final.png")
     }
 
     @Test
@@ -481,7 +482,7 @@ class OrchestraListenerDispatchTest {
         runBlocking { orchestra.runFlow(listOf(first, second)) }
 
         assertThat(captured)
-            .containsExactly(0 to "screenshots/step-0.png", 1 to "screenshots/step-1.png")
+            .containsExactly(0 to "screenshots/step-001-evalScript.png", 1 to "screenshots/step-002-evalScript.png")
             .inOrder()
     }
 
@@ -502,11 +503,16 @@ class OrchestraListenerDispatchTest {
 
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
-        // maxRetries=2 -> 3 attempts of the reused leaf (step-1..3); the retry parent
-        // that ultimately failed is step-0 (worker mode records every step), plus the
-        // flow-level final.png captured at flow end.
+        // maxRetries=2 -> 3 attempts of the reused leaf (step-002..004); the retry
+        // parent (step-000) is a composite — a no-op that captures nothing, leaving
+        // a gap at step-001 — plus the flow-level final.png captured at flow end.
         assertThat(stepScreenshotNames())
-            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png", "final.png")
+            .containsExactly(
+                "step-002-openLink-https_example.com.png",
+                "step-003-openLink-https_example.com.png",
+                "step-004-openLink-https_example.com.png",
+                "final.png",
+            )
     }
 
     @Test
@@ -532,10 +538,11 @@ class OrchestraListenerDispatchTest {
 
         // Hooks run through the same dispatch as regular commands, so each is a
         // numbered step in execution order: onFlowStart hook, the applyConfiguration
-        // command, the main command, then the onFlowComplete hook; final.png is the
+        // command (a non-visible no-op that captures nothing, leaving a gap at
+        // step-002), the main command, then the onFlowComplete hook; final.png is the
         // flow-level shot captured at flow end (after the onFlowComplete hook).
         assertThat(stepScreenshotNames())
-            .containsExactly("step-0.png", "step-1.png", "step-2.png", "step-3.png", "final.png")
+            .containsExactly("step-001-evalScript.png", "step-003-evalScript.png", "step-004-evalScript.png", "final.png")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -458,10 +458,16 @@ class OrchestraListenerDispatchTest {
 
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
-        // The repeat parent (seq 0) is a composite no-op — no file, gap at step-001;
-        // the 3 leaf iterations follow, plus the flow-level final.png.
+        // The repeat parent (seq 0) keeps its own screenshot; the 3 leaf iterations follow,
+        // plus the flow-level final.png.
         assertThat(stepScreenshotNames())
-            .containsExactly("step-002-evalScript.png", "step-003-evalScript.png", "step-004-evalScript.png", "final.png")
+            .containsExactly(
+                "step-001-repeat.png",
+                "step-002-evalScript.png",
+                "step-003-evalScript.png",
+                "step-004-evalScript.png",
+                "final.png",
+            )
     }
 
     @Test
@@ -501,10 +507,11 @@ class OrchestraListenerDispatchTest {
 
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
-        // maxRetries=2 -> 3 leaf attempts (step-002..004). The retry parent (seq 0) is a
-        // composite no-op — no file, gap at step-001 — plus the flow-level final.png.
+        // maxRetries=2 -> 3 leaf attempts (step-002..004). The retry parent (seq 0) keeps its own
+        // screenshot (step-001), plus the flow-level final.png.
         assertThat(stepScreenshotNames())
             .containsExactly(
+                "step-001-retry.png",
                 "step-002-openLink-https_example.com.png",
                 "step-003-openLink-https_example.com.png",
                 "step-004-openLink-https_example.com.png",

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -458,10 +458,8 @@ class OrchestraListenerDispatchTest {
 
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
-        // Sequence numbers increment on every onCommandStart: the repeat parent
-        // (step-0) is a composite — a no-op that captures nothing, leaving a gap
-        // at step-001 — then each of the 3 iterations of the reused leaf is its
-        // own file, plus the flow-level final.png captured at flow end.
+        // The repeat parent (seq 0) is a composite no-op — no file, gap at step-001;
+        // the 3 leaf iterations follow, plus the flow-level final.png.
         assertThat(stepScreenshotNames())
             .containsExactly("step-002-evalScript.png", "step-003-evalScript.png", "step-004-evalScript.png", "final.png")
     }
@@ -503,10 +501,8 @@ class OrchestraListenerDispatchTest {
 
         runBlocking { orchestra.runFlow(listOf(outer)) }
 
-        // maxRetries=2 -> 3 attempts of the reused leaf (step-002..004); the retry
-        // parent (seq 0) is a composite — a no-op that captures nothing, leaving
-        // a gap at step-001 (the file that parent would have produced) — plus the
-        // flow-level final.png captured at flow end.
+        // maxRetries=2 -> 3 leaf attempts (step-002..004). The retry parent (seq 0) is a
+        // composite no-op — no file, gap at step-001 — plus the flow-level final.png.
         assertThat(stepScreenshotNames())
             .containsExactly(
                 "step-002-openLink-https_example.com.png",
@@ -537,11 +533,8 @@ class OrchestraListenerDispatchTest {
 
         runBlocking { orchestra.runFlow(listOf(configCmd, mainCmd)) }
 
-        // Hooks run through the same dispatch as regular commands, so each is a
-        // numbered step in execution order: onFlowStart hook, the applyConfiguration
-        // command (a non-visible no-op that captures nothing, leaving a gap at
-        // step-002), the main command, then the onFlowComplete hook; final.png is the
-        // flow-level shot captured at flow end (after the onFlowComplete hook).
+        // Hooks are numbered steps in execution order: onFlowStart hook, applyConfiguration
+        // (non-visible no-op — gap at step-002), main command, onFlowComplete hook; then final.png.
         assertThat(stepScreenshotNames())
             .containsExactly("step-001-evalScript.png", "step-003-evalScript.png", "step-004-evalScript.png", "final.png")
     }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/StepArtifactNamingTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/StepArtifactNamingTest.kt
@@ -1,0 +1,82 @@
+package maestro.orchestra.debug
+
+import com.google.common.truth.Truth.assertThat
+import maestro.orchestra.DefineVariablesCommand
+import maestro.orchestra.ElementSelector
+import maestro.orchestra.EvalScriptCommand
+import maestro.orchestra.InputTextCommand
+import maestro.orchestra.LaunchAppCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.RepeatCommand
+import maestro.orchestra.ScrollCommand
+import maestro.orchestra.TapOnElementCommand
+import maestro.orchestra.TapOnPointV2Command
+import org.junit.jupiter.api.Test
+
+class StepArtifactNamingTest {
+
+    private fun tapOn(text: String? = null, id: String? = null) =
+        MaestroCommand(command = TapOnElementCommand(selector = ElementSelector(textRegex = text, idRegex = id)))
+
+    @Test
+    fun `isNoOp is true for composite, non-visible, and empty commands`() {
+        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(RepeatCommand(commands = emptyList())))).isTrue()
+        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(DefineVariablesCommand(mapOf("a" to "b"))))).isTrue()
+        assertThat(StepArtifactNaming.isNoOp(MaestroCommand())).isTrue()
+        assertThat(StepArtifactNaming.isNoOp(null)).isTrue()
+    }
+
+    @Test
+    fun `isNoOp is false for a visible leaf, including script commands`() {
+        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(ScrollCommand()))).isFalse()
+        assertThat(StepArtifactNaming.isNoOp(tapOn(text = "Submit"))).isFalse()
+        // evalScript/runScript are visible() == true, so they still capture (per design decision).
+        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(EvalScriptCommand("1")))).isFalse()
+    }
+
+    @Test
+    fun `stem is 1-based and zero-padded to width 3`() {
+        assertThat(StepArtifactNaming.stem(0, MaestroCommand(ScrollCommand()))).isEqualTo("step-001-scroll")
+        assertThat(StepArtifactNaming.stem(41, tapOn(text = "Submit"))).isEqualTo("step-042-tapOnElement-Submit")
+        assertThat(StepArtifactNaming.stem(999, MaestroCommand(ScrollCommand()))).isEqualTo("step-1000-scroll")
+    }
+
+    @Test
+    fun `stem omits slug when command is null`() {
+        assertThat(StepArtifactNaming.stem(2, null)).isEqualTo("step-003")
+        assertThat(StepArtifactNaming.stem(2, MaestroCommand())).isEqualTo("step-003")
+    }
+
+    @Test
+    fun `arg token comes from selector text, then id, then description`() {
+        assertThat(StepArtifactNaming.stem(0, tapOn(text = "Submit"))).isEqualTo("step-001-tapOnElement-Submit")
+        assertThat(StepArtifactNaming.stem(0, tapOn(id = "login_btn"))).isEqualTo("step-001-tapOnElement-login_btn")
+    }
+
+    @Test
+    fun `arg token for point, input text keeps readable chars`() {
+        assertThat(StepArtifactNaming.stem(0, MaestroCommand(TapOnPointV2Command(point = "30%,40%"))))
+            .isEqualTo("step-001-tapOnPointV2-30%,40%")
+        assertThat(StepArtifactNaming.stem(0, MaestroCommand(InputTextCommand(text = "sanchit"))))
+            .isEqualTo("step-001-inputText-sanchit")
+    }
+
+    @Test
+    fun `launchApp uses appId`() {
+        assertThat(StepArtifactNaming.stem(0, MaestroCommand(LaunchAppCommand(appId = "com.example.app"))))
+            .isEqualTo("step-001-launchApp-com.example.app")
+    }
+
+    @Test
+    fun `sanitize maps path separators and whitespace to underscore`() {
+        assertThat(StepArtifactNaming.stem(0, tapOn(text = "a/b c"))).isEqualTo("step-001-tapOnElement-a_b_c")
+    }
+
+    @Test
+    fun `long slug is truncated to 40 chars`() {
+        val longText = "x".repeat(80)
+        val stem = StepArtifactNaming.stem(0, tapOn(text = longText))
+        val slug = stem.removePrefix("step-001-")
+        assertThat(slug.length).isEqualTo(40)
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/StepArtifactNamingTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/StepArtifactNamingTest.kt
@@ -19,19 +19,29 @@ class StepArtifactNamingTest {
         MaestroCommand(command = TapOnElementCommand(selector = ElementSelector(textRegex = text, idRegex = id)))
 
     @Test
-    fun `isNoOp is true for composite, non-visible, and empty commands`() {
-        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(RepeatCommand(commands = emptyList())))).isTrue()
-        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(DefineVariablesCommand(mapOf("a" to "b"))))).isTrue()
-        assertThat(StepArtifactNaming.isNoOp(MaestroCommand())).isTrue()
-        assertThat(StepArtifactNaming.isNoOp(null)).isTrue()
+    fun `capturesScreenshot is true for composites and visible leaves`() {
+        assertThat(StepArtifactNaming.capturesScreenshot(MaestroCommand(RepeatCommand(commands = emptyList())))).isTrue()
+        assertThat(StepArtifactNaming.capturesScreenshot(MaestroCommand(ScrollCommand()))).isTrue()
+        assertThat(StepArtifactNaming.capturesScreenshot(tapOn(text = "Submit"))).isTrue()
+        // evalScript/runScript are visible() == true, so they still capture (per design decision).
+        assertThat(StepArtifactNaming.capturesScreenshot(MaestroCommand(EvalScriptCommand("1")))).isTrue()
     }
 
     @Test
-    fun `isNoOp is false for a visible leaf, including script commands`() {
-        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(ScrollCommand()))).isFalse()
-        assertThat(StepArtifactNaming.isNoOp(tapOn(text = "Submit"))).isFalse()
-        // evalScript/runScript are visible() == true, so they still capture (per design decision).
-        assertThat(StepArtifactNaming.isNoOp(MaestroCommand(EvalScriptCommand("1")))).isFalse()
+    fun `capturesScreenshot is false for non-visible leaves and empty commands`() {
+        assertThat(StepArtifactNaming.capturesScreenshot(MaestroCommand(DefineVariablesCommand(mapOf("a" to "b"))))).isFalse()
+        assertThat(StepArtifactNaming.capturesScreenshot(MaestroCommand())).isFalse()
+        assertThat(StepArtifactNaming.capturesScreenshot(null)).isFalse()
+    }
+
+    @Test
+    fun `capturesHierarchy is true only for visible leaves, not composites`() {
+        assertThat(StepArtifactNaming.capturesHierarchy(MaestroCommand(ScrollCommand()))).isTrue()
+        assertThat(StepArtifactNaming.capturesHierarchy(tapOn(text = "Submit"))).isTrue()
+        // Composites get a screenshot but skip the ~1s hierarchy round-trip.
+        assertThat(StepArtifactNaming.capturesHierarchy(MaestroCommand(RepeatCommand(commands = emptyList())))).isFalse()
+        assertThat(StepArtifactNaming.capturesHierarchy(MaestroCommand(DefineVariablesCommand(mapOf("a" to "b"))))).isFalse()
+        assertThat(StepArtifactNaming.capturesHierarchy(null)).isFalse()
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #3418, addressing review feedback on per-step artifacts.

- **Screenshots for every step that touches the screen; hierarchy only where it helps.** Non-visible leaves (`defineVariables`/`applyConfiguration`) take no on-screen action, so they capture neither screenshot nor hierarchy. Composite parents (`runFlow`/`repeat`/`retry`) **keep their own screenshot** and fire `onStepScreenshotCaptured`, so their step never renders blank in the viewer — but they skip the ~1s `viewHierarchy` round-trip, since they only wrap children. Visible leaves capture both. (Per @pedro18x's review: composites no longer get deduped out of their screenshot.)
- **1-based numbering.** Step files start at `step-001` (was `step-0`). No-op steps still consume a sequence number, so numbering can have gaps by design; `step-<N>` stays a stable identity for command N in `commands.json`.
- **Human-readable names.** `step-<NNN>-<type>[-<arg>]`, e.g. `step-003-tapOnElement-submit.png`, `step-005-inputText-sanchit.png`, `step-007-tapOnPointV2-30%,40%.png`.

Notes:
- The `onStepScreenshotCaptured` callback keeps its **0-based** `sequenceNumber`; only the reported path changes. Composite steps now report a screenshot like any other step; only non-visible leaves emit no callback / empty artifact list.
- The slug is built from the **raw pre-evaluation** command, so a `${var}` argument appears verbatim in the filename (e.g. `step-002-inputText-${name}.png`) rather than the resolved value — this deliberately keeps evaluated secrets out of filenames. `$`, `{`, `}` are filesystem-legal and the sanitizer still strips path separators and OS-reserved characters, so the names pose no filesystem issue. `commands.json` carries the fully-evaluated command.
- Script commands (`evalScript`/`runScript`) still capture, because they are `visible() == true`. Making them non-visible would also hide them from the CLI result view, so their capture is left as-is for now.
- Trade-off: with the composite/leaf screenshot dedup removed, a leaf failing inside a `repeat`/`runFlow` in CLI (flag-off) mode now yields two failure screenshots of ~the same screen (leaf + composite parent). This is deliberate — a duplicate frame is better than a blank composite row.

Tests: `:maestro-orchestra:test` green.
