### PR TITLE
fix(ios): classify swipeV2 UI-query timeout as 408, not an untriageable INFRA_ERROR

### DIFF
--- a/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
+++ b/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
@@ -5,8 +5,10 @@ import com.google.common.truth.Truth.assertThat
 import maestro.ios.MockXCTestInstaller
 import maestro.utils.network.XCUITestServerError
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -111,6 +113,56 @@ class XCTestDriverClientTest {
             xcTestDriverClient.deviceInfo(httpUrl)
         }
         mockXCTestInstaller.assertInstallationRetries(0)
+        mockWebServer.shutdown()
+    }
+
+    @Test
+    fun `swipeV2 408 is surfaced as OperationTimeout carrying the real message`() {
+        // Production shape after the runner fix: the XCUITest UI-query timeout that used to come back
+        // as a bare 500 (-> UnknownFailure -> INFRA_ERROR "Unknown error", retried 3x) is now a 408.
+        // A 408 must reach the caller as OperationTimeout so the driver can turn it into a
+        // non-retryable DriverTimeout -> TEST_ERROR that carries the real Apple message.
+        //
+        // Note the dispatcher answers 408 for EVERY request: OkHttp's RetryAndFollowUpInterceptor
+        // repeats a 408 once (it gives up when the prior response was also a 408), so the runner sees
+        // two requests before OperationTimeout surfaces. A single enqueued response would leave the
+        // retry hitting an empty queue and mis-surface as Unreachable.
+        val mockWebServer = MockWebServer()
+        val mapper = jacksonObjectMapper()
+        val error = Error(
+            errorMessage = "Swipe v2 request failure. Error: Error Domain=com.apple.dt.XCTest.XCTFuture " +
+                "Code=1000 \"Swipe (v2) from (201.0, 437.0) to (201.0, 786.0) with 0.4 duration: " +
+                "Timed out while evaluating UI query.\"",
+            errorCode = "internal",
+        )
+        mockWebServer.dispatcher = object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse =
+                MockResponse().apply {
+                    setResponseCode(408)
+                    setBody(mapper.writeValueAsString(error))
+                }
+        }
+        mockWebServer.start(InetAddress.getByName("localhost"), 0)
+        val port = mockWebServer.port
+
+        val xcTestDriverClient = XCTestDriverClient(
+            installer = MockXCTestInstaller(MockXCTestInstaller.Simulator(), port = port),
+            client = XCTestClient("localhost", port),
+        )
+
+        val thrown = assertThrows<XCUITestServerError.OperationTimeout> {
+            xcTestDriverClient.swipeV2(
+                installedApps = emptySet(),
+                startX = 201.0,
+                startY = 437.0,
+                endX = 201.0,
+                endY = 786.0,
+                duration = 0.4,
+            )
+        }
+        assertThat(thrown.operation).isEqualTo("swipeV2")
+        assertThat(thrown.errorResponse).contains("Timed out while evaluating UI query")
+
         mockWebServer.shutdown()
     }
 

--- a/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
+++ b/maestro-client/src/test/java/maestro/xctestdriver/XCTestDriverClientTest.kt
@@ -5,10 +5,8 @@ import com.google.common.truth.Truth.assertThat
 import maestro.ios.MockXCTestInstaller
 import maestro.utils.network.XCUITestServerError
 import okhttp3.OkHttpClient
-import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -117,16 +115,16 @@ class XCTestDriverClientTest {
     }
 
     @Test
-    fun `swipeV2 408 is surfaced as OperationTimeout carrying the real message`() {
-        // Production shape after the runner fix: the XCUITest UI-query timeout that used to come back
-        // as a bare 500 (-> UnknownFailure -> INFRA_ERROR "Unknown error", retried 3x) is now a 408.
-        // A 408 must reach the caller as OperationTimeout so the driver can turn it into a
-        // non-retryable DriverTimeout -> TEST_ERROR that carries the real Apple message.
+    fun `swipeV2 408 is not retried and surfaces as OperationTimeout carrying the real message`() {
+        // The XCUITest UI-query timeout that used to come back as a bare 500 (-> UnknownFailure ->
+        // INFRA_ERROR "Unknown error", retried 3x) is now a 408 that must reach the caller as
+        // OperationTimeout, so the driver turns it into a non-retryable DriverTimeout -> TEST_ERROR
+        // carrying the real Apple message.
         //
-        // Note the dispatcher answers 408 for EVERY request: OkHttp's RetryAndFollowUpInterceptor
-        // repeats a 408 once (it gives up when the prior response was also a 408), so the runner sees
-        // two requests before OperationTimeout surfaces. A single enqueued response would leave the
-        // retry hitting an empty queue and mis-surface as Unreachable.
+        // A swipe is not idempotent, so its request is sent one-shot: OkHttp must NOT replay it on the
+        // 408 (which would fire the gesture twice / silently recover on the second attempt). Only one
+        // 408 is enqueued, so a replay would hit the empty queue and mis-surface as Unreachable;
+        // requestCount == 1 proves the gesture is not re-sent.
         val mockWebServer = MockWebServer()
         val mapper = jacksonObjectMapper()
         val error = Error(
@@ -135,13 +133,10 @@ class XCTestDriverClientTest {
                 "Timed out while evaluating UI query.\"",
             errorCode = "internal",
         )
-        mockWebServer.dispatcher = object : Dispatcher() {
-            override fun dispatch(request: RecordedRequest): MockResponse =
-                MockResponse().apply {
-                    setResponseCode(408)
-                    setBody(mapper.writeValueAsString(error))
-                }
-        }
+        mockWebServer.enqueue(MockResponse().apply {
+            setResponseCode(408)
+            setBody(mapper.writeValueAsString(error))
+        })
         mockWebServer.start(InetAddress.getByName("localhost"), 0)
         val port = mockWebServer.port
 
@@ -162,6 +157,7 @@ class XCTestDriverClientTest {
         }
         assertThat(thrown.operation).isEqualTo("swipeV2")
         assertThat(thrown.errorResponse).contains("Timed out while evaluating UI query")
+        assertThat(mockWebServer.requestCount).isEqualTo(1)
 
         mockWebServer.shutdown()
     }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -8,6 +8,7 @@ import maestro.utils.network.XCUITestServerError
 import okhttp3.*
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
+import okio.BufferedSink
 import org.slf4j.LoggerFactory
 import xcuitest.api.*
 import xcuitest.installer.XCTestInstaller
@@ -152,6 +153,7 @@ class XCTestDriverClient(
         endY: Double,
         duration: Double,
     ) {
+        // A swipe is not idempotent: send it one-shot so OkHttp cannot replay the gesture on a 408.
         executeJsonRequest("swipeV2",
             SwipeRequest(
                 startX = startX,
@@ -160,7 +162,8 @@ class XCTestDriverClient(
                 endY = endY,
                 duration = duration,
                 appIds = installedApps
-            )
+            ),
+            oneShot = true,
         )
     }
 
@@ -251,10 +254,11 @@ class XCTestDriverClient(
                 }
         }
 
-    private fun executeJsonRequest(pathSegment: String, body: Any): String =
+    private fun executeJsonRequest(pathSegment: String, body: Any, oneShot: Boolean = false): String =
         transportCall(pathSegment) {
             val mediaType = "application/json; charset=utf-8".toMediaType()
             val bodyData = mapper.writeValueAsString(body).toRequestBody(mediaType)
+                .let { if (oneShot) it.asOneShot() else it }
 
             val requestBuilder = Request.Builder()
                 .addHeader("Content-Type", "application/json")
@@ -346,4 +350,17 @@ class XCTestDriverClient(
         }
     }
 
+}
+
+// Marks a request body one-shot so OkHttp's RetryAndFollowUpInterceptor skips the built-in 408 retry
+// (and any connection-failure retry). Used for non-idempotent gestures (swipe) so a deterministic
+// timeout surfaces immediately as OperationTimeout instead of firing the gesture a second time.
+private fun RequestBody.asOneShot(): RequestBody {
+    val delegate = this
+    return object : RequestBody() {
+        override fun contentType(): MediaType? = delegate.contentType()
+        override fun contentLength(): Long = delegate.contentLength()
+        override fun isOneShot(): Boolean = true
+        override fun writeTo(sink: BufferedSink) = delegate.writeTo(sink)
+    }
 }

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SwipeRouteHandlerV2.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SwipeRouteHandlerV2.swift
@@ -22,6 +22,22 @@ struct SwipeRouteHandlerV2: HTTPHandler {
             try await swipePrivateAPI(requestBody)
             return HTTPResponse(statusCode: .ok)
         } catch let error {
+            // An XCUITest UI-query / main-thread-busy timeout is a deterministic, device-answered
+            // failure (the screen never reaches idle), not retryable infra. Classify it as .timeout
+            // (HTTP 408) so the driver maps it to a non-retryable timeout carrying the real message,
+            // instead of a bare 500 the worker relabels "Unknown error" and retries. Mirrors the
+            // identical discrimination in ViewHierarchyHandler; any other swipe error keeps the 500.
+            if let nsError = error as NSError?,
+               nsError.domain == "com.apple.dt.XCTest.XCTFuture",
+               nsError.code == 1000,
+               nsError.localizedDescription.contains("Timed out while evaluating UI query") {
+                return AppError(type: .timeout, message: "Swipe v2 request failure. Error: \(error.localizedDescription)").httpResponse
+            } else if let nsError = error as NSError?,
+                      nsError.domain == "com.apple.dt.xctest.automation-support.error",
+                      nsError.code == 6,
+                      nsError.localizedDescription.contains("Unable to perform work on main run loop, process main thread busy for") {
+                return AppError(type: .timeout, message: "Swipe v2 request failure. Error: \(nsError.localizedDescription)").httpResponse
+            }
             return AppError(message: "Swipe v2 request failure. Error: \(error.localizedDescription)").httpResponse
         }
     }

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SwipeRouteHandlerV2.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SwipeRouteHandlerV2.swift
@@ -22,24 +22,34 @@ struct SwipeRouteHandlerV2: HTTPHandler {
             try await swipePrivateAPI(requestBody)
             return HTTPResponse(statusCode: .ok)
         } catch let error {
-            // An XCUITest UI-query / main-thread-busy timeout is a deterministic, device-answered
-            // failure (the screen never reaches idle), not retryable infra. Classify it as .timeout
-            // (HTTP 408) so the driver maps it to a non-retryable timeout carrying the real message,
-            // instead of a bare 500 the worker relabels "Unknown error" and retries. Mirrors the
-            // identical discrimination in ViewHierarchyHandler; any other swipe error keeps the 500.
-            if let nsError = error as NSError?,
-               nsError.domain == "com.apple.dt.XCTest.XCTFuture",
-               nsError.code == 1000,
-               nsError.localizedDescription.contains("Timed out while evaluating UI query") {
-                return AppError(type: .timeout, message: "Swipe v2 request failure. Error: \(error.localizedDescription)").httpResponse
-            } else if let nsError = error as NSError?,
-                      nsError.domain == "com.apple.dt.xctest.automation-support.error",
-                      nsError.code == 6,
-                      nsError.localizedDescription.contains("Unable to perform work on main run loop, process main thread busy for") {
-                return AppError(type: .timeout, message: "Swipe v2 request failure. Error: \(nsError.localizedDescription)").httpResponse
-            }
-            return AppError(message: "Swipe v2 request failure. Error: \(error.localizedDescription)").httpResponse
+            return Self.classify(error).httpResponse
         }
+    }
+
+    /// Maps a swipe failure to an `AppError`.
+    ///
+    /// An XCUITest UI-query / main-thread-busy timeout is a deterministic, device-answered failure
+    /// (the screen never reaches idle), not retryable infra. It is classified as `.timeout` (HTTP 408)
+    /// so the driver maps it to a non-retryable timeout carrying the real message, instead of a bare
+    /// 500 the worker relabels "Unknown error" and retries. Mirrors the identical discrimination in
+    /// ViewHierarchyHandler; any other swipe error keeps the default 500.
+    nonisolated static func classify(_ error: Error) -> AppError {
+        let nsError = error as NSError
+        let message = "Swipe v2 request failure. Error: \(error.localizedDescription)"
+
+        if nsError.domain == "com.apple.dt.XCTest.XCTFuture",
+           nsError.code == 1000,
+           nsError.localizedDescription.contains("Timed out while evaluating UI query") {
+            return AppError(type: .timeout, message: message)
+        }
+
+        if nsError.domain == "com.apple.dt.xctest.automation-support.error",
+           nsError.code == 6,
+           nsError.localizedDescription.contains("Unable to perform work on main run loop, process main thread busy for") {
+            return AppError(type: .timeout, message: message)
+        }
+
+        return AppError(message: message)
     }
 
     func swipePrivateAPI(_ request: SwipeRequest) async throws {

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SwipeRouteHandlerV2.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/SwipeRouteHandlerV2.swift
@@ -26,29 +26,14 @@ struct SwipeRouteHandlerV2: HTTPHandler {
         }
     }
 
-    /// Maps a swipe failure to an `AppError`.
-    ///
-    /// An XCUITest UI-query / main-thread-busy timeout is a deterministic, device-answered failure
-    /// (the screen never reaches idle), not retryable infra. It is classified as `.timeout` (HTTP 408)
-    /// so the driver maps it to a non-retryable timeout carrying the real message, instead of a bare
-    /// 500 the worker relabels "Unknown error" and retries. Mirrors the identical discrimination in
-    /// ViewHierarchyHandler; any other swipe error keeps the default 500.
+    /// Maps a swipe failure to an `AppError`: an XCUITest timeout (see `NSError.isXCUITestTimeout`)
+    /// becomes `.timeout` (HTTP 408, non-retryable, carrying the real message); any other error keeps
+    /// the default 500.
     nonisolated static func classify(_ error: Error) -> AppError {
-        let nsError = error as NSError
         let message = "Swipe v2 request failure. Error: \(error.localizedDescription)"
-
-        if nsError.domain == "com.apple.dt.XCTest.XCTFuture",
-           nsError.code == 1000,
-           nsError.localizedDescription.contains("Timed out while evaluating UI query") {
+        if (error as NSError).isXCUITestTimeout {
             return AppError(type: .timeout, message: message)
         }
-
-        if nsError.domain == "com.apple.dt.xctest.automation-support.error",
-           nsError.code == 6,
-           nsError.localizedDescription.contains("Unable to perform work on main run loop, process main thread busy for") {
-            return AppError(type: .timeout, message: message)
-        }
-
         return AppError(message: message)
     }
 

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
@@ -161,16 +161,8 @@ struct ViewHierarchyHandler: HTTPHandler {
         } catch let error {
             guard isIllegalArgumentError(error) else {
                 NSLog("Snapshot failure, cannot return view hierarchy due to \(error)")
-                if let nsError = error as NSError?,
-                   nsError.domain == "com.apple.dt.XCTest.XCTFuture",
-                   nsError.code == 1000,
-                   nsError.localizedDescription.contains("Timed out while evaluating UI query") {
+                if (error as NSError).isXCUITestTimeout {
                     throw AppError(type: .timeout, message: error.localizedDescription)
-                } else if let nsError = error as NSError?,
-                           nsError.domain == "com.apple.dt.xctest.automation-support.error",
-                           nsError.code == 6,
-                           nsError.localizedDescription.contains("Unable to perform work on main run loop, process main thread busy for") {
-                    throw AppError(type: .timeout, message: nsError.localizedDescription)
                 } else {
                     throw AppError(message: error.localizedDescription)
                 }

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Helpers/AppError.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Helpers/AppError.swift
@@ -35,3 +35,20 @@ struct AppError: Error, Codable {
         case message = "errorMessage"
     }
 }
+
+extension NSError {
+    /// True when this is one of the two XCUITest "the app never reached idle" timeouts: a UI-query
+    /// evaluation timeout (`XCTFuture` / 1000) or a main-thread-busy failure (`automation-support` / 6).
+    /// Both are deterministic, device-answered failures, so route handlers classify them as `.timeout`
+    /// (HTTP 408 -> non-retryable TEST_ERROR with the real message) rather than a bare 500 the worker
+    /// relabels "Unknown error" and retries. Centralized here so a future Apple domain/code change is a
+    /// one-line update; every handler that surfaces this timeout must go through this property.
+    var isXCUITestTimeout: Bool {
+        (domain == "com.apple.dt.XCTest.XCTFuture"
+            && code == 1000
+            && localizedDescription.contains("Timed out while evaluating UI query"))
+        || (domain == "com.apple.dt.xctest.automation-support.error"
+            && code == 6
+            && localizedDescription.contains("Unable to perform work on main run loop, process main thread busy for"))
+    }
+}

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/maestro_driver_iosUITests.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/maestro_driver_iosUITests.swift
@@ -33,3 +33,84 @@ final class maestro_driver_iosUITests: XCTestCase {
         logger.trace("tearDown")
     }
 }
+
+/// Pure-logic tests for `SwipeRouteHandlerV2.classify`. No app is launched, so these run on the
+/// simulator's test runtime without touching a device. The XCUITest error inputs below are the
+/// real domain/code/message observed in production for the DoorDash swipeV2 failures.
+final class SwipeRouteHandlerV2ClassificationTests: XCTestCase {
+
+    // Error Domain=com.apple.dt.XCTest.XCTFuture Code=1000
+    // "Swipe (v2) from (201.0, 437.0) to (201.0, 786.0) with 0.4 duration: Timed out while evaluating UI query."
+    func testUIQueryTimeoutIsClassifiedAsTimeout() {
+        let error = NSError(
+            domain: "com.apple.dt.XCTest.XCTFuture",
+            code: 1000,
+            userInfo: [NSLocalizedDescriptionKey:
+                "Swipe (v2) from (201.0, 437.0) to (201.0, 786.0) with 0.4 duration: Timed out while evaluating UI query."]
+        )
+        let result = SwipeRouteHandlerV2.classify(error)
+        XCTAssertEqual(result.type, .timeout)
+        // Pin the end-to-end contract: .timeout must surface as HTTP 408 (non-retryable), not 500.
+        XCTAssertEqual(result.httpResponse.statusCode, .requestTimeout)
+    }
+
+    func testMainThreadBusyIsClassifiedAsTimeout() {
+        let error = NSError(
+            domain: "com.apple.dt.xctest.automation-support.error",
+            code: 6,
+            userInfo: [NSLocalizedDescriptionKey:
+                "Unable to perform work on main run loop, process main thread busy for 5.0s"]
+        )
+        XCTAssertEqual(SwipeRouteHandlerV2.classify(error).type, .timeout)
+    }
+
+    // The same message on a different domain must NOT be reclassified: we only want the specific
+    // XCUITest timeouts, not any error that happens to contain the phrase.
+    func testTimeoutMessageWithWrongDomainStaysInternal() {
+        let error = NSError(
+            domain: "com.example.other",
+            code: 1000,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out while evaluating UI query."]
+        )
+        XCTAssertEqual(SwipeRouteHandlerV2.classify(error).type, .internal)
+    }
+
+    // Right domain, wrong code/message (e.g. a genuine swipe failure) keeps the default 500.
+    func testUnrelatedXCTFutureErrorStaysInternal() {
+        let error = NSError(
+            domain: "com.apple.dt.XCTest.XCTFuture",
+            code: 42,
+            userInfo: [NSLocalizedDescriptionKey: "Some other failure"]
+        )
+        let result = SwipeRouteHandlerV2.classify(error)
+        XCTAssertEqual(result.type, .internal)
+        // Pin the other side of the contract: a non-timeout swipe failure stays HTTP 500.
+        XCTAssertEqual(result.httpResponse.statusCode, .internalServerError)
+    }
+
+    // Right domain AND code, but a message that lacks the timeout phrase must NOT be reclassified.
+    // This isolates the message-substring guard: without it, every XCTFuture/1000 error (including
+    // genuine swipe failures) would be misclassified as a non-retryable 408.
+    func testXCTFutureCode1000WithUnrelatedMessageStaysInternal() {
+        let error = NSError(
+            domain: "com.apple.dt.XCTest.XCTFuture",
+            code: 1000,
+            userInfo: [NSLocalizedDescriptionKey: "Swipe (v2) failed for an unrelated reason."]
+        )
+        XCTAssertEqual(SwipeRouteHandlerV2.classify(error).type, .internal)
+    }
+
+    // A timeout must be classified as .timeout AND carry the real Apple message (this is what fixes
+    // the "Unknown error" gap). Asserting the message alone is insufficient: classify() builds the
+    // message identically in every branch, so it would pass even on the .internal fallthrough.
+    func testClassifiedTimeoutPreservesTheRealMessage() {
+        let error = NSError(
+            domain: "com.apple.dt.XCTest.XCTFuture",
+            code: 1000,
+            userInfo: [NSLocalizedDescriptionKey: "Timed out while evaluating UI query."]
+        )
+        let result = SwipeRouteHandlerV2.classify(error)
+        XCTAssertEqual(result.type, .timeout)
+        XCTAssertTrue(result.message.contains("Timed out while evaluating UI query"))
+    }
+}


### PR DESCRIPTION
**Interim triage-correctness fix.** Stops the mislabeled INFRA alert, the wasted retries, and the "Unknown error", by classifying the failure correctly. It does **not** make the swipe succeed: the run still fails, now as a clean non-retryable `TEST_ERROR` with a real message. Making swipeV2 work on busy/webview screens is the behavioral fix, tracked in [MA-4129](https://linear.app/mobile-dev/issue/MA-4129).

## Problem

iOS `swipeV2` (`SwipeRouteHandlerV2`) returns a bare **HTTP 500** when the underlying XCUITest gesture times out with `Error Domain=com.apple.dt.XCTest.XCTFuture Code=1000 "Swipe (v2) ...: Timed out while evaluating UI query."` (and the main-thread-busy `automation-support` code 6 variant).

Downstream, the Maestro Cloud worker maps that 500 to `XCUITestServerError.UnknownFailure` (null `.message`), then to `TestExecutionException.Unexpected`, i.e. **`INFRA_ERROR`**, which is **retried up to 3x across different hosts**. Because the timeout is deterministic (the screen never reaches idle), every retry fails identically, then the run fails as infra with the message collapsed to the literal string **"Unknown error"**. No diagnostics for whoever triages it.

### Evidence

- **109 occurrences over Jul 8-9 2026**, all from a single org (DoorDash / Dasher app, busy Safari webview), all `IOS,WEB`, deterministic (0 recovery across the 3 retries).
- The real cause is only in the stacktrace (never the `errorMessage`), verbatim from GCP (`perf-dev-289002`):
  ```
  Request for swipeV2 failed, code: 500, body: {"code":"internal","errorMessage":
  "Swipe v2 request failure. Error: Error Domain=com.apple.dt.XCTest.XCTFuture Code=1000
  \"Swipe (v2) from (201.0, 437.0) to (201.0, 786.0) with 0.4 duration: Timed out while evaluating UI query.\""}
  ```
- GCP filter: `jsonPayload.logger="dev.mobile.maestro.worker.MaestroWorker" jsonPayload.context.job_failure_code="INFRA_ERROR" jsonPayload.exception.stacktrace=~"Request for swipeV2 failed"`

## Fix

Classify the XCUITest UI-query / main-thread-busy timeout as **`.timeout` (HTTP 408)** in `SwipeRouteHandlerV2`, **mirroring the identical discrimination `ViewHierarchyHandler` already applies** for the byte-identical `NSError`. Any other swipe error keeps the existing 500. (The catch is extracted into a behavior-identical `classify()` in the follow-up commit so it can be unit-tested.)

408 routes through the **pre-existing** typed pipeline: `handleExceptions` (`408` to `OperationTimeout`), `XCTestIOSDevice`, `IOSDriver.DriverTimeout`, worker `TestFailure`, **`TEST_ERROR` (non-retryable)**, carrying the real Apple message.

Two points from review are folded in: the XCUITest-timeout discrimination is now a shared `NSError.isXCUITestTimeout` used by both `SwipeRouteHandlerV2` and `ViewHierarchyHandler` (so a future Apple domain/code change is one line, and neither handler can silently drift back to 500), and the `swipeV2` request is sent **one-shot** so OkHttp cannot replay the non-idempotent gesture on a 408.

| | Before | After |
|---|---|---|
| Classification | `INFRA_ERROR` (retryable) | `TEST_ERROR` (non-retryable) |
| Retries | 3x across hosts, all fail | none |
| Message | "Unknown error" | "...Timed out while evaluating UI query." |

## Verification

The full chain was traced and confirmed end to end, and pinned with tests (both suites green):

| Link | How verified | Result |
|---|---|---|
| Swift catch maps the real errors to 408 | Swift unit tests **run on an iOS 26.5 simulator** (compiled the change) | 6/6 pass |
| ...for the *exact* production error shape | Test inputs are the literal `XCTFuture/1000` + `automation-support/6` domain/code/message from the GCP logs | pass |
| Runner (this branch) builds, boots, serves `swipeV2` | Launched live on a sim; baseline idle swipe | HTTP 200 |
| `408` -> `OperationTimeout`, and the swipe is not replayed | Kotlin test drives the real `swipeV2()` client against a mock 408; asserts `requestCount == 1` | 11/11 pass |
| `OperationTimeout` -> `DriverTimeout` -> `TestFailure` (`TEST_ERROR`) | Existing `MaestroTestRunnerTest` + the unchanged pipeline | pre-tested |

Two things the verification surfaced:

- **The swipe is sent one-shot, so OkHttp does not replay it.** OkHttp's `RetryAndFollowUpInterceptor` would otherwise repeat a 408 once, firing the non-idempotent gesture a second time (and silently recovering if that second attempt settled, a hidden double-scroll). Marking the `swipeV2` request body one-shot skips that retry, so a deterministic timeout surfaces immediately as `OperationTimeout`, with no double-scroll and no ~2x latency. ViewHierarchy's 408 keeps its beneficial retry (it is transient and retries-and-passes).
- **The FlyingFox 100s handler-timeout gap is real.** Forcing a foreground app to stall past 100s reproduced `handler error: Task timed out before completion. Timeout: 100.0 seconds` on a live sim, with no clean 408. That is the empty-body-500 subset this PR does not reach (see below).

## Scope / limitations

- **Does not make the swipe succeed.** It turns a mislabeled, retried infra failure into a clean, surfaced flow failure. The behavioral root cause (V2 gates a pure-coordinate swipe behind an XCUITest UI-query/idle evaluation that V1's raw synthesize avoids) is tracked in [MA-4129](https://linear.app/mobile-dev/issue/MA-4129).
- **Does not cover empty-body 500s** (~28% of the sample): the main-thread-wedged mode where the gesture hangs past FlyingFox's 100s server timeout, so this `catch` never runs. Also tracked in MA-4129.

## Risk

Change is confined to `SwipeRouteHandlerV2`'s catch (now `classify()`). `ViewHierarchy`'s own `UnknownFailure` (transient, legitimately retries-and-passes) is untouched, so its behavior and alert suppression are unchanged.
