### PR TITLE
fix(orchestra): bound failure/teardown artifact captures so a wedged device can't blow the run watchdog

### DIFF
--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -18,6 +18,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Internal listener Orchestra always installs. Populates [FlowDebugOutput]
@@ -46,6 +47,7 @@ internal class ArtifactsGenerator(
     private val maestro: Maestro,
     private val captureFullArtifacts: Boolean = false,
     private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
+    private val captureTimeoutMs: Long = DEFAULT_CAPTURE_TIMEOUT_MS,
 ) : OrchestraListener {
 
     val debugOutput = FlowDebugOutput()
@@ -239,7 +241,7 @@ internal class ArtifactsGenerator(
     private fun captureStepHierarchy(metadata: CommandDebugMetadata) {
         val collector = collector ?: return
         try {
-            val tree = runBlocking { maestro.viewHierarchy() }.root
+            val tree = withCaptureTimeout("hierarchy") { runBlocking { maestro.viewHierarchy() }.root } ?: return
             val destFile = collector.allocate(
                 ArtifactKind.SCREEN_HIERARCHY,
                 ArtifactFormat.JSON,
@@ -282,7 +284,10 @@ internal class ArtifactsGenerator(
         )
         val tempFile = File(destFile.parentFile, "${destFile.name}.tmp")
         return try {
-            if (ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = tempFile) == null) {
+            val taken = withCaptureTimeout("screenshot") {
+                ScreenshotUtils.takeDebugScreenshot(maestro = maestro, destFile = tempFile)
+            }
+            if (taken == null) {
                 logger.warn("Failed to capture screenshot $relativePath")
                 tempFile.delete()
                 return null
@@ -307,8 +312,9 @@ internal class ArtifactsGenerator(
     }
 
     private fun stopFullRunRecording() {
+        val recording = fullRunRecording ?: return
         try {
-            fullRunRecording?.close()
+            withCaptureTimeout("stop-recording") { recording.close() }
         } catch (e: Exception) {
             logger.warn("Failed to stop full-run screen recording", e)
         } finally {
@@ -316,7 +322,27 @@ internal class ArtifactsGenerator(
         }
     }
 
+    // Runs a best-effort device call on a throwaway daemon thread, waiting at most [captureTimeoutMs].
+    // A wedged device otherwise blocks each capture for the driver's full timeout and stacks across
+    // the failure path, blowing the run watchdog. Blocking dadb/gRPC I/O isn't interruptible on JDK 17,
+    // so on timeout we abandon the thread. Returns null (and logs) on timeout; rethrows what [block] threw.
+    private fun <T> withCaptureTimeout(what: String, block: () -> T): T? {
+        val result = AtomicReference<Result<T>>()
+        val worker = Thread({ result.set(runCatching(block)) }, "artifact-capture-$what").apply { isDaemon = true }
+        worker.start()
+        worker.join(captureTimeoutMs)
+        if (worker.isAlive) {
+            logger.warn("Capture '$what' exceeded ${captureTimeoutMs}ms; device unresponsive, skipping")
+            worker.interrupt() // best effort; blocking socket reads ignore it
+            return null
+        }
+        return result.get().getOrThrow()
+    }
+
     companion object {
         private val logger = LoggerFactory.getLogger(ArtifactsGenerator::class.java)
+
+        // Hard cap per best-effort capture; only bites once the device has wedged (normal ~1s).
+        const val DEFAULT_CAPTURE_TIMEOUT_MS = 15_000L
     }
 }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import maestro.Maestro
 import maestro.MaestroException
+import maestro.ScreenRecording
 import maestro.TreeNode
 import maestro.ViewHierarchy
 import maestro.device.CapturedDeviceArtifact
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
+import kotlin.system.measureTimeMillis
 
 class ArtifactsGeneratorTest {
 
@@ -1206,5 +1208,82 @@ class ArtifactsGeneratorTest {
 
         assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
         assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
+    }
+
+    // A wedged device must not block the failure/teardown path — captures are abandoned after the timeout.
+
+    @Test
+    fun `a wedged hierarchy capture is abandoned after the timeout, letting the failure path proceed`() {
+        val maestro: Maestro = mockk(relaxed = true) {
+            coEvery { takeScreenshot(any<Sink>(), any()) } answers {
+                val sink = firstArg<Sink>()
+                val buf = Buffer().write(byteArrayOf(1, 2, 3))
+                sink.write(buf, buf.size)
+                sink.flush()
+            }
+            coEvery { viewHierarchy(any()) } coAnswers { Thread.sleep(10_000); ViewHierarchy(TreeNode()) }
+        }
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureTimeoutMs = 200)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, 0)
+        val elapsed = measureTimeMillis {
+            gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
+        }
+        gen.onFlowEnd()
+
+        // Didn't ride the wedged hierarchy call.
+        assertThat(elapsed).isLessThan(5_000L)
+        // Hierarchy skipped on timeout; the screenshot (which the mock serves fast) still lands.
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isFalse()
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isTrue()
+    }
+
+    @Test
+    fun `a wedged screenshot capture is abandoned after the timeout, not blocking hierarchy`() {
+        val maestro: Maestro = mockk(relaxed = true) {
+            coEvery { takeScreenshot(any<Sink>(), any()) } coAnswers { Thread.sleep(10_000) }
+            coEvery { viewHierarchy(any()) } returns ViewHierarchy(
+                TreeNode(attributes = mutableMapOf("text" to "root"))
+            )
+        }
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureTimeoutMs = 200)
+        val cmd = MaestroCommand(scrollCommand = ScrollCommand())
+
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, 0)
+        val elapsed = measureTimeMillis {
+            gen.onCommandFinished(cmd, CommandOutcome.Failed(RuntimeException("boom")), 100L, 200L)
+        }
+        gen.onFlowEnd()
+
+        assertThat(elapsed).isLessThan(5_000L)
+        // Screenshot skipped on timeout; hierarchy (served fast) still lands.
+        assertThat(tempDir.resolve("screenshots/step-001-scroll.png").exists()).isFalse()
+        assertThat(tempDir.resolve("screen-hierarchy/step-001-scroll.json").exists()).isTrue()
+    }
+
+    @Test
+    fun `a wedged recording stop is abandoned after the timeout at flow end`() {
+        val maestro = mockMaestro()
+        coEvery { maestro.startScreenRecording(any()) } returns object : ScreenRecording {
+            override fun close() { Thread.sleep(10_000) }
+        }
+        val gen = ArtifactsGenerator(
+            artifactsDir = tempDir,
+            maestro = maestro,
+            captureFullArtifacts = true,
+            captureTimeoutMs = 200,
+        )
+
+        gen.onFlowStart()
+        val elapsed = measureTimeMillis { gen.onFlowEnd() }
+
+        // Teardown didn't ride the wedged recording.close().
+        assertThat(elapsed).isLessThan(5_000L)
+        // onFlowEnd still ran to completion — the manifest (written last) landed despite the abandon.
+        assertThat(tempDir.resolve("manifest.json").exists()).isTrue()
+        assertThat(gen.artifactManifest.entries).isNotEmpty()
     }
 }


### PR DESCRIPTION
## Why

Once the Android device server wedges mid-run, the failure/teardown captures in `ArtifactsGenerator` each ride the driver's full timeout — ~120s (gRPC `viewHierarchy`/screenshot) or ~10min (adb recording `close()`) — and run back-to-back. That's enough to blow the 15-min run watchdog and report `INFRA_ERROR` on a device that's already dead. Fleet-wide this drives ~120 watchdog timeouts/day.

## What

Bound each device-touching capture (`captureStepHierarchy`, `captureScreenshot`, `stopFullRunRecording`) with a short hard cap (15s, injectable for tests).

Blocking dadb/gRPC reads aren't interruptible on JDK 17, so `withTimeout` can't unblock them. Instead the call runs on a throwaway daemon thread and is **abandoned** on timeout — the caller stops waiting so teardown proceeds; the thread finishes on its own later. Captures stay best-effort (log and skip). Normal captures are ~1s, so the cap only bites on an already-wedged device.

Complements #3316 (gRPC `UNAVAILABLE` retry/rebuild, which leaves the 120s deadline untouched) and #3410 (WebView path, which excludes artifact capture).

## Tests

3 new tests (wedged hierarchy / screenshot / recording-stop) assert the path is bounded and teardown completes. `:maestro-orchestra:test` green.
