### PR TITLE
Clean up driver cruft left on iOS simulators

### DIFF
--- a/maestro-ios-driver/src/main/resources/driver-iPhoneSimulator/maestro-driver-ios-config.xctestrun
+++ b/maestro-ios-driver/src/main/resources/driver-iPhoneSimulator/maestro-driver-ios-config.xctestrun
@@ -78,7 +78,7 @@
 			<string>ViewHierarchyHandlerTests/testViewHierarchyHandlerReturnsNonEmptyHierarchy()</string>
 		</array>
 		<key>SystemAttachmentLifetime</key>
-		<string>deleteOnSuccess</string>
+		<string>keepNever</string>
 		<key>TestBundlePath</key>
 		<string>__TESTHOST__/PlugIns/maestro-driver-iosUITests.xctest</string>
 		<key>TestHostBundleIdentifier</key>
@@ -136,7 +136,7 @@
 		<key>UITargetAppPerformanceAntipatternCheckerEnabled</key>
 		<true/>
 		<key>UserAttachmentLifetime</key>
-		<string>deleteOnSuccess</string>
+		<string>keepNever</string>
 	</dict>
 </dict>
 </plist>

--- a/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/xcshareddata/xcschemes/maestro-driver-ios.xcscheme
+++ b/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/xcshareddata/xcschemes/maestro-driver-ios.xcscheme
@@ -26,7 +26,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      systemAttachmentLifetime = "keepNever"
+      userAttachmentLifetime = "keepNever">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
## Proposed changes

iOS's testmanagerd is leaving files behind when our driver runs. This change ensures they're always tidied up, not accumulating useless files that we never read on workstation or CI devices.

## Testing

Local e2e tests, validating that bloat that previously existed after a run no longer exist. Since this is driver config, there's no sensible permanent test to put into our CI bundle.

## Issues fixed

Fixes #3409 