### PR TITLE
fix(ios): recover from transient kAXErrorInvalidUIElement

### DIFF
--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/ViewHierarchyHandler.swift
@@ -159,7 +159,7 @@ struct ViewHierarchyHandler: HTTPHandler {
             hierarchy.children = children
             return hierarchy
         } catch let error {
-            guard isIllegalArgumentError(error) else {
+            guard isRecoverableSnapshotError(error) else {
                 NSLog("Snapshot failure, cannot return view hierarchy due to \(error)")
                 if (error as NSError).isXCUITestTimeout {
                     throw AppError(type: .timeout, message: error.localizedDescription)
@@ -168,7 +168,7 @@ struct ViewHierarchyHandler: HTTPHandler {
                 }
             }
 
-            NSLog("Snapshot failure, getting recovery element for fallback")
+            NSLog("Snapshot failure (\(error.localizedDescription)), getting recovery element for fallback")
             AXClientSwizzler.overwriteDefaultParameters["maxDepth"] = snapshotMaxDepth
             // In apps with bigger view hierarchys, calling
             // `XCUIApplication().snapshot().dictionaryRepresentation` or `XCUIApplication().allElementsBoundByIndex`
@@ -205,8 +205,18 @@ struct ViewHierarchyHandler: HTTPHandler {
         }
     }
 
-    private func isIllegalArgumentError(_ error: Error) -> Bool {
-        error.localizedDescription.contains("Error kAXErrorIllegalArgument getting snapshot for element")
+    /// Transient XCTest snapshot failures that the recovery path (walk from the
+    /// window child, skipping the racing app-level snapshot) can absorb. Both fire
+    /// when the tree is large or changing under `snapshot()`:
+    ///  - `kAXErrorIllegalArgument` — snapshotting a too-large element.
+    ///  - `kAXErrorInvalidUIElement` ("Error getting element frame") — an element
+    ///    went stale mid-snapshot while the UI was updating. Previously this fell
+    ///    through to a fatal 500 that aborted the whole flow; the smaller recovery
+    ///    subtree is far less likely to race, so route it through recovery instead.
+    private func isRecoverableSnapshotError(_ error: Error) -> Bool {
+        let description = error.localizedDescription
+        return description.contains("Error kAXErrorIllegalArgument getting snapshot for element")
+            || description.contains("kAXErrorInvalidUIElement")
     }
 
     private func keyboardHierarchy(_ element: XCUIApplication) -> AXElement? {


### PR DESCRIPTION
## Proposed changes

`XCUIElement.snapshot()` intermittently throws: `Error getting element frame kAXErrorInvalidUIElement` when an element goes stale mid-snapshot while the UI is updating.  This becomes a fatal HTTP 500 that surfaces to the client as an uncaught UnknownFailure and aborts the entire flow, often hanging the JVM rather than exiting cleanly. 

I use Maestro to test native builds of my ReactNative app (https://github.com/tinycld/tinycld) and it seems to occur about 25% of the time when running it's fairly large screenshot based test suite.

This PR routes the error through the recovery path that already exists for its sibling kAXErrorIllegalArgument, so a momentary stale element no longer kills the run.

I looked at the history around transient kAXErrorInvalidUIElement before writing this, and deliberately avoided repeating an approach that was already tried and reverted:

HTTP-client retry (#3291 and reverted in #3312).
*  #3291 wired an OkHttp interceptor that retried transient 5xx / IOException, explicitly citing kAXErrorInvalidUIElement from production logs. It was reverted six days later ( I think because it caused a 4.4× spike in 15-min outer-flow timeouts?),  the interceptor retried IOException at up to the full read timeout per attempt, producing 10–12 min silent gaps. 
* (The Android sibling,  #3290, was reverted alongside it in #3311) The revert explicitly called for "a  narrower retry surface / per-call wall-clock budget."

This PR takes the opposite approach from a retry by reusing the existing single-shot recovery walk, so there's no added wall-clock cost and no risk of re-introducing the timeout regression that got #3291 reverted.

## Testing

I ran tinycld tests repeatedly 10times without a crash.  I did consider adding a dart e2e test but wasn't sure you'd want that since:
 * it's _very_ non deterministic, because the bug is a timing race in XCTest's snapshot
 * I think the failure may be something around ReactNative specifically, in which case the e2e test might not catch it at all

With that said I'm happy to add a e2e test if you do think it'd be valuable to have.

## Issues fixed

I found 3 issues that are likely caused by this: #2617 #3148 #3137 

Fixes #2617