### PR TITLE
fix(cli): sanitize slash in flow name for AI HTML report filename

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/report/HtmlAITestSuiteReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/report/HtmlAITestSuiteReporter.kt
@@ -27,7 +27,10 @@ import java.io.File
 class HtmlAITestSuiteReporter {
 
     private val FlowAIOutput.htmlReportFilename
-        get() = "ai-report-${flowName}.html"
+        // Sanitize the flow name so a `/` (or other path separator) in it does not
+        // turn the report filename into a path pointing at a non-existent directory,
+        // which would crash with FileNotFoundException. See issue #2017.
+        get() = "ai-report-${flowName.replace("/", "_")}.html"
 
     private val reportCss: String
         get() = readResourceAsText(this::class, "/ai_report.css")

--- a/maestro-cli/src/test/kotlin/maestro/cli/report/HtmlAITestSuiteReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/report/HtmlAITestSuiteReporterTest.kt
@@ -1,0 +1,29 @@
+package maestro.cli.report
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class HtmlAITestSuiteReporterTest {
+
+    @Test
+    fun `report does not crash when the flow name contains a path separator`(@TempDir tempDir: File) {
+        // Given - a flow whose name contains a '/', which is a path separator on unix-like systems.
+        // See issue #2017: writing "ai-report-foo / bar.html" used to be interpreted as a path into
+        // a non-existent "foo " directory and crashed with FileNotFoundException.
+        val reporter = HtmlAITestSuiteReporter()
+        val output = FlowAIOutput(
+            flowName = "foo / bar",
+            flowFile = File(tempDir, "flow.yaml").apply { writeText("appId: com.example") },
+            screenOutputs = mutableListOf(),
+        )
+
+        // When
+        reporter.report(listOf(output), tempDir)
+
+        // Then - the report is written to a single, sanitized file inside the output directory.
+        val reportFile = File(tempDir, "ai-report-foo _ bar.html")
+        assertThat(reportFile.exists()).isTrue()
+    }
+}


### PR DESCRIPTION
## Problem
A flow whose name contains `/` crashes the run with `FileNotFoundException`, because the name is interpolated directly into the AI HTML report filename (`ai-report-<flowName>.html`), resolving to a non-existent directory (#2017).

## Root cause
`HtmlAITestSuiteReporter.kt` did not sanitize the flow name. `TestDebugReporter.kt` already does `flowName.replace("/", "_")` (added in #3345), but that fix missed this second call site — the exact frame in the issue's stack trace.

## Fix
Sanitize the flow name the same way (`replace("/", "_")`) when building the AI report filename, consistent with the existing convention.

## Testing
Added `HtmlAITestSuiteReporterTest` asserting the report does not crash when the flow name contains a path separator (reproduces the crash before the fix, passes after). `:maestro-cli:test` green.

Closes #2017
