### PR TITLE
fix(ios): only re-stabilise a tap that follows a scroll (MA-4135)

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -74,8 +74,8 @@ class Maestro(
     private var screenRecordingInProgress = false
 
     // A scroll/swipe can leave the app decelerating past the screen-static check, so the next tap
-    // must re-stabilise the element (MA-4124). Any tap clears it (see performTap) so ordinary taps
-    // on a settled screen skip the extra hierarchy fetches (MA-4135).
+    // must re-stabilise the element (MA-4124). Cleared by the next tap (performTap) and by launchApp;
+    // it survives other commands until then.
     private var recentScroll = false
 
     suspend fun launchApp(
@@ -84,6 +84,8 @@ class Maestro(
         stopIfRunning: Boolean = true
     ) = runInterruptible(Dispatchers.IO) {
         LOGGER.info("Launching app $appId")
+
+        recentScroll = false
 
         if (stopIfRunning) {
             LOGGER.info("Stopping $appId app during launch")
@@ -130,6 +132,8 @@ class Maestro(
     suspend fun hideKeyboard() = runInterruptible(Dispatchers.IO) {
         LOGGER.info("Hiding Keyboard")
 
+        // iOS dismisses the keyboard with real content drags that can leave the screen decelerating.
+        recentScroll = true
         driver.hideKeyboard()
     }
 
@@ -218,13 +222,16 @@ class Maestro(
 
         val settledHierarchy = waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs)
 
-        // A null settle can't confirm the screen is static. Scroll momentum is the one motion that
-        // routinely outlives the check, so re-stabilise only after a scroll (MA-4124); otherwise
-        // trust the hierarchy we have (MA-4135) — pre-MA-4124 behaviour for non-scroll animation.
-        // performTap clears recentScroll, so the hint only affects the tap that immediately follows.
+        // Scroll momentum is the one motion that routinely outlives a null settle, so re-stabilise
+        // only after a scroll (MA-4124); otherwise trust the hierarchy we have (MA-4135).
         val (hierarchyBeforeTap, refreshedElement) = if (settledHierarchy == null && recentScroll) {
+            LOGGER.info("Tap aimed via stabilised hierarchy (null settle after a scroll)")
             refreshElementUntilStable(element, initialHierarchy)
         } else {
+            LOGGER.info(
+                if (settledHierarchy != null) "Tap aimed via settled hierarchy"
+                else "Tap aimed via trusted pre-wait hierarchy (null settle, no recent scroll)"
+            )
             val hierarchy = settledHierarchy ?: initialHierarchy
             hierarchy to hierarchy.refreshElement(element.treeNode)?.toUiElementOrNull()
         }
@@ -372,8 +379,7 @@ class Maestro(
         tapRepeat: TapRepeat? = null,
         waitToSettleTimeoutMs: Int? = null
     ) {
-        // Every tap consumes the scroll-momentum hint, so it only ever affects the next tap.
-        recentScroll = false
+        recentScroll = false // consume the scroll hint (MA-4135)
 
         val capabilities = runInterruptible(Dispatchers.IO) { driver.capabilities() }
 

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -73,6 +73,11 @@ class Maestro(
 
     private var screenRecordingInProgress = false
 
+    // A scroll/swipe can leave the app decelerating past the screen-static check, so the next tap
+    // must re-stabilise the element (MA-4124). Any tap clears it (see performTap) so ordinary taps
+    // on a settled screen skip the extra hierarchy fetches (MA-4135).
+    private var recentScroll = false
+
     suspend fun launchApp(
         appId: String,
         launchArguments: Map<String, Any> = emptyMap(),
@@ -143,6 +148,10 @@ class Maestro(
     ) {
         val deviceInfo = deviceInfo()
 
+        val gestured = swipeDirection != null ||
+            (startPoint != null && endPoint != null) ||
+            (startRelative != null && endRelative != null)
+
         runInterruptible(Dispatchers.IO) {
             when {
                 swipeDirection != null -> driver.swipe(swipeDirection, duration)
@@ -165,6 +174,7 @@ class Maestro(
             }
         }
 
+        if (gestured) recentScroll = true
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
@@ -172,6 +182,7 @@ class Maestro(
         LOGGER.info("Swiping ${swipeDirection.name} on element: $uiElement")
         runInterruptible(Dispatchers.IO) { driver.swipe(uiElement.bounds.center(), swipeDirection, durationMs) }
 
+        recentScroll = true
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
@@ -181,6 +192,7 @@ class Maestro(
         LOGGER.info("Swiping ${swipeDirection.name} from center")
         val center = Point(x = deviceInfo.widthGrid / 2, y = deviceInfo.heightGrid / 2)
         runInterruptible(Dispatchers.IO) { driver.swipe(center, swipeDirection, durationMs) }
+        recentScroll = true
         waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
     }
 
@@ -188,6 +200,7 @@ class Maestro(
         LOGGER.info("Scrolling vertically")
 
         runInterruptible(Dispatchers.IO) { driver.scrollVertical() }
+        recentScroll = true
         waitForAppToSettle()
     }
 
@@ -205,15 +218,15 @@ class Maestro(
 
         val settledHierarchy = waitForAppToSettle(initialHierarchy, appId, waitToSettleTimeoutMs)
 
-        // Null means the driver could not confirm the screen has settled (see the
-        // Driver.waitForAppToSettle contract), so the pre-wait hierarchy may be stale.
-        val (hierarchyBeforeTap, refreshedElement) = if (settledHierarchy != null) {
-            settledHierarchy to settledHierarchy
-                .refreshElement(element.treeNode)
-                ?.also { LOGGER.info("Refreshed element") }
-                ?.toUiElementOrNull()
-        } else {
+        // A null settle can't confirm the screen is static. Scroll momentum is the one motion that
+        // routinely outlives the check, so re-stabilise only after a scroll (MA-4124); otherwise
+        // trust the hierarchy we have (MA-4135) — pre-MA-4124 behaviour for non-scroll animation.
+        // performTap clears recentScroll, so the hint only affects the tap that immediately follows.
+        val (hierarchyBeforeTap, refreshedElement) = if (settledHierarchy == null && recentScroll) {
             refreshElementUntilStable(element, initialHierarchy)
+        } else {
+            val hierarchy = settledHierarchy ?: initialHierarchy
+            hierarchy to hierarchy.refreshElement(element.treeNode)?.toUiElementOrNull()
         }
 
         val center = (refreshedElement ?: element)
@@ -359,6 +372,9 @@ class Maestro(
         tapRepeat: TapRepeat? = null,
         waitToSettleTimeoutMs: Int? = null
     ) {
+        // Every tap consumes the scroll-momentum hint, so it only ever affects the next tap.
+        recentScroll = false
+
         val capabilities = runInterruptible(Dispatchers.IO) { driver.capabilities() }
 
         if (Capability.FAST_HIERARCHY in capabilities) {

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -5229,6 +5229,9 @@ class IntegrationTest {
             }
         }
 
+        // Sanity: the swipe actually reached the driver, so the test can't pass on a static screen.
+        driver.assertAnyEvent { it is Event.SwipeWithDirection }
+
         val settledBounds = checkNotNull(target.bounds) { "Target element lost its bounds" }
         val tapPoint = checkNotNull(driver.lastTapPoint) { "No tap was delivered to the driver" }
         assertWithMessage(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -39,6 +39,8 @@ import maestro.orchestra.RunFlowCommand
 import maestro.orchestra.RetryCommand
 import maestro.orchestra.ScrollUntilVisibleCommand
 import maestro.orchestra.TapOnElementCommand
+import maestro.orchestra.TapOnPointV2Command
+import maestro.orchestra.SwipeCommand
 import maestro.ScrollDirection
 import kotlinx.coroutines.TimeoutCancellationException
 import maestro.js.JsEngine
@@ -5133,6 +5135,107 @@ class IntegrationTest {
         ).that(settledBounds.contains(tapPoint.x, tapPoint.y)).isTrue()
     }
 
+    @Test
+    fun `Case 146 - tap not preceded by a scroll skips element stabilisation (MA-4135)`() {
+        // iOS waitForAppToSettle returns null even on a settled screen, so MA-4124 re-stabilised
+        // every tap (two extra fetches each), regressing long flows. A tap with no scroll before it
+        // trusts the pre-wait hierarchy and skips the stabilisation loop.
+        val root = FakeLayoutElement()
+        val target = root.element {
+            text = "Confirm"
+            bounds = Bounds(220, 400, 320, 460)
+        }
+        val driver = StaticNullSettleFakeDriver(root)
+        driver.open()
+
+        Maestro(driver).use { maestro ->
+            runBlocking {
+                orchestra(maestro).runFlow(
+                    listOf(
+                        MaestroCommand(
+                            tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "Confirm"))
+                        ),
+                    )
+                )
+            }
+        }
+
+        val bounds = checkNotNull(target.bounds) { "Target element lost its bounds" }
+        val tap = checkNotNull(driver.lastTapPoint) { "No tap was delivered to the driver" }
+        assertThat(bounds.contains(tap.x, tap.y)).isTrue()
+        // Only findElement observes the screen; the stabilisation loop is skipped. Re-stabilising
+        // unconditionally (the MA-4124 regression) would add fetches here.
+        assertWithMessage("no-scroll tap observed the hierarchy ${driver.contentDescriptorCount} times")
+            .that(driver.contentDescriptorCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `Case 147 - a tap between a scroll and the target clears the scroll hint (MA-4135)`() {
+        // The scroll hint must be consumed by the *next* tap of any kind. A coordinate tap between
+        // a scroll and an element tap absorbs it, so the element tap (no longer the tap that
+        // immediately follows the scroll) skips stabilisation instead of leaking a stale hint.
+        val root = FakeLayoutElement()
+        val target = root.element {
+            text = "Confirm"
+            bounds = Bounds(220, 400, 320, 460)
+        }
+        val driver = StaticNullSettleFakeDriver(root)
+        driver.open()
+
+        Maestro(driver).use { maestro ->
+            runBlocking {
+                orchestra(maestro).runFlow(
+                    listOf(
+                        MaestroCommand(swipeCommand = SwipeCommand(direction = SwipeDirection.UP)),
+                        MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "10,10")),
+                        MaestroCommand(
+                            tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "Confirm"))
+                        ),
+                    )
+                )
+            }
+        }
+
+        // Observations: the coordinate tap fetches once, the element tap fetches once (findElement)
+        // and does NOT stabilise — proving the coordinate tap cleared the scroll hint. A leaked hint
+        // would stabilise the element tap and add two fetches (total 4).
+        assertWithMessage("element tap after an intervening coordinate tap should not stabilise")
+            .that(driver.contentDescriptorCount).isEqualTo(2)
+    }
+
+    @Test
+    fun `Case 148 - tap after a bare swipe stabilises via the general-swipe path (MA-4124)`() {
+        // The general swipe() also sets the scroll hint, so a tap after a plain SwipeCommand still
+        // waits out deceleration and lands on the settled position (not the swipe(uiElement) path
+        // Case 145 covers).
+        val root = FakeLayoutElement()
+        val target = root.element {
+            text = "Confirm"
+            bounds = Bounds(220, 400, 320, 460)
+        }
+        val driver = DeceleratingIosFakeDriver(root, driftStepPx = -12, driftStepsPerSwipe = 14)
+        driver.open()
+
+        Maestro(driver).use { maestro ->
+            runBlocking {
+                orchestra(maestro).runFlow(
+                    listOf(
+                        MaestroCommand(swipeCommand = SwipeCommand(direction = SwipeDirection.DOWN)),
+                        MaestroCommand(
+                            tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "Confirm"))
+                        ),
+                    )
+                )
+            }
+        }
+
+        val settledBounds = checkNotNull(target.bounds) { "Target element lost its bounds" }
+        val tapPoint = checkNotNull(driver.lastTapPoint) { "No tap was delivered to the driver" }
+        assertWithMessage(
+            "tap after a bare swipe was aimed at $tapPoint, outside the settled position $settledBounds"
+        ).that(settledBounds.contains(tapPoint.x, tapPoint.y)).isTrue()
+    }
+
     private fun readCommands(
         caseName: String,
         deviceId: String? = null,
@@ -5187,6 +5290,11 @@ private class DeceleratingIosFakeDriver(
         remainingDriftSteps = driftStepsPerSwipe
     }
 
+    override fun swipe(swipeDirection: SwipeDirection, durationMs: Long) {
+        super.swipe(swipeDirection, durationMs)
+        remainingDriftSteps = driftStepsPerSwipe
+    }
+
     override fun contentDescriptor(excludeKeyboardElements: Boolean): maestro.TreeNode {
         driftOneStep()
         return super.contentDescriptor(excludeKeyboardElements)
@@ -5223,5 +5331,42 @@ private class DeceleratingIosFakeDriver(
     private fun translateAll(element: FakeLayoutElement, dy: Int) {
         element.bounds = element.bounds?.translate(y = dy)
         element.children.forEach { translateAll(it, dy) }
+    }
+}
+
+/**
+ * Fake iOS driver on a static screen (MA-4135): [waitForAppToSettle] returns null even though
+ * nothing moves. Counts hierarchy observations so a test can assert a tap does not spin the
+ * stabilisation loop when there is nothing to stabilise.
+ */
+private class StaticNullSettleFakeDriver(
+    root: FakeLayoutElement,
+) : FakeDriver() {
+
+    var contentDescriptorCount = 0
+        private set
+
+    /** FakeDriver's event list is private; captured so the assertion can print the point. */
+    var lastTapPoint: Point? = null
+        private set
+
+    init {
+        setLayout(root)
+    }
+
+    override fun contentDescriptor(excludeKeyboardElements: Boolean): maestro.TreeNode {
+        contentDescriptorCount++
+        return super.contentDescriptor(excludeKeyboardElements)
+    }
+
+    override fun waitForAppToSettle(
+        initialHierarchy: maestro.ViewHierarchy?,
+        appId: String?,
+        timeoutMs: Int?,
+    ): maestro.ViewHierarchy? = null
+
+    override fun tap(point: Point) {
+        lastTapPoint = point
+        super.tap(point)
     }
 }


### PR DESCRIPTION
> **Merge recommendation:** targeted patch to unblock the customer (Wahed) now — their iOS flows are being killed by the 15-min watchdog today. The `recentScroll` heuristic is a stop-gap; the per-tap settle behaviour will be reworked properly in maestro core, which supersedes this. Suggest merging as the immediate fix.

## Problem
[MA-4124](https://linear.app/mobile-dev/issue/MA-4124) (`e7b67140b`) made iOS `tapOnElement` re-stabilise the element whenever `waitForAppToSettle` returns `null`. But on iOS that's the steady state for *every* settled screen, so every tap now ran the stabilisation loop — up to a 3s deadline + 2 extra hierarchy fetches. Long flows (Wahed onboarding) blew past the 15-min watchdog. iOS-only.

## Fix
Only a preceding scroll leaves momentum that outlives the static check, so gate stabilisation on a `recentScroll` hint: set by scroll/swipe gestures, and run `refreshElementUntilStable` only when `waitForAppToSettle == null && recentScroll`; otherwise trust the pre-wait hierarchy (pre-MA-4124 behaviour). `performTap` clears the hint, so it only affects the immediately-following tap.

## Verified on-device
Repro of Wahed `onboardNewUser` (iPhone-16 / iOS-18.2, real staging), matched by tap index:

| Metric | Regression | This PR |
|---|---|---|
| Elapsed to tap #47 | 817s | **622s (−24%)** |
| Taps entering the stabilisation loop | 53 | **4** |
| Taps hitting the full 3s deadline | 22 | **3** |

19m16s baseline → ~14.5 min, under the watchdog.

## Tradeoffs (inherent to the heuristic; resolved by the core rework)
A tap after *non-scroll* motion (e.g. a sliding modal) is no longer re-stabilised — restores long-standing pre-MA-4124 behaviour. A `scroll → assert → tap` sequence may still stabilise unnecessarily (safe, just slower).

## Tests
Case 145 (MA-4124 preserved), 146 (no-scroll skip), 147 (intervening tap clears hint), 148 (bare-swipe path). `IntegrationTest`: 165 pass.
