### PR TITLE
fix(ios): wait for the async crash .ips before collecting it

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -79,6 +79,9 @@ class IOSDriver(
     private var deviceLogStream: Process? = null
     private var deviceLogFile: java.io.File? = null
 
+    @Volatile
+    private var lastAppCrashDetectedMs: Long = 0
+
     override fun name(): String {
         return metrics.measured("name") {
             NAME
@@ -603,8 +606,9 @@ class IOSDriver(
         val simulatorId = iosDevice.deviceId ?: return emptyList()
         if (appId == null) return emptyList()
         return try {
-            val crashFile = IOSCrashFileFinder().findCrashFile(simulatorId, appId)
-                ?.takeIf { it.lastModified() >= sinceEpochMs } ?: return emptyList()
+            val timeoutMs = if (lastAppCrashDetectedMs >= sinceEpochMs) CRASH_REPORT_TIMEOUT_MS else 0
+            val crashFile = IOSCrashFileFinder()
+                .waitForCrashFile(simulatorId, appId, sinceEpochMs, timeoutMs) ?: return emptyList()
             val parsed = IPSParser.parse(crashFile.readText())
             val dest = File(outputDir, DeviceArtifactFiles.CRASH_REPORT)
             crashFile.copyTo(dest, overwrite = true)
@@ -626,6 +630,7 @@ class IOSDriver(
             LOGGER.error("Device unreachable while processing $callName command", unreachable)
             throw DeviceUnreachableException(unreachable.callName, unreachable)
         } catch (appCrashException: IOSDeviceErrors.AppCrash) {
+            lastAppCrashDetectedMs = System.currentTimeMillis()
             LOGGER.error("Detected app crash during $callName command", appCrashException)
             throw MaestroException.AppCrash(appCrashException.errorMessage)
         } catch (timeoutException: IOSDeviceErrors.OperationTimeout) {
@@ -675,6 +680,8 @@ class IOSDriver(
         private const val SCREEN_SETTLE_TIMEOUT_MS: Long = 3000
 
         private const val LOG_FLUSH_TIMEOUT_SECONDS: Long = 2
+
+        private const val CRASH_REPORT_TIMEOUT_MS: Long = 15_000
     }
 }
 

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/crash/IOSCrashFileFinder.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/crash/IOSCrashFileFinder.kt
@@ -20,6 +20,8 @@ class IOSCrashFileFinder(
     companion object {
         private val logger = LoggerFactory.getLogger(IOSCrashFileFinder::class.java)
 
+        private const val DEFAULT_POLL_INTERVAL_MS = 500L
+
         /**
          * Default directories to search for crash reports.
          * Includes both user-level and system-level DiagnosticReports directories
@@ -72,6 +74,30 @@ class IOSCrashFileFinder(
         logger.info("Crash detection: crashFile=$crashFileName, totalForBundle=${candidates.size}, bundleId=$bundleId")
 
         return result
+    }
+
+    /**
+     * Poll [findCrashFile] until a report newer than [sinceEpochMs] appears or [timeoutMs] elapses —
+     * iOS writes the .ips asynchronously, so a single lookup at flow end can miss it.
+     * [timeoutMs] <= 0 checks exactly once.
+     */
+    fun waitForCrashFile(
+        simulatorId: String,
+        bundleId: String,
+        sinceEpochMs: Long,
+        timeoutMs: Long,
+        pollIntervalMs: Long = DEFAULT_POLL_INTERVAL_MS,
+    ): File? {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (true) {
+            findCrashFile(simulatorId, bundleId)
+                ?.takeIf { it.lastModified() >= sinceEpochMs }
+                ?.let { return it }
+
+            val remaining = deadline - System.currentTimeMillis()
+            if (remaining <= 0) return null
+            Thread.sleep(minOf(pollIntervalMs, remaining))
+        }
     }
 
     /**

--- a/maestro-ios-driver/src/test/kotlin/xcuitest/crash/IOSCrashFileFinderTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/xcuitest/crash/IOSCrashFileFinderTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import kotlin.concurrent.thread
 
 class IOSCrashFileFinderTest {
 
@@ -176,6 +177,53 @@ class IOSCrashFileFinderTest {
             val result = finder.findCrashFile(testSimulatorId, testBundleId)
 
             assertThat(result).isEqualTo(validFile)
+        }
+    }
+
+    @Nested
+    inner class WaitForCrashFile {
+
+        @Test
+        fun `returns a crash report that appears after the crash`(@TempDir tempDir: File) {
+            val finder = IOSCrashFileFinder(listOf(tempDir))
+            val sinceEpochMs = System.currentTimeMillis()
+            val writer = thread {
+                Thread.sleep(200)
+                File(tempDir, "TestApp.ips").writeText(buildIpsFile(testSimulatorId, "TestApp", testBundleId))
+            }
+
+            val result = finder.waitForCrashFile(testSimulatorId, testBundleId, sinceEpochMs, timeoutMs = 5000, pollIntervalMs = 20)
+
+            writer.join()
+            assertThat(result).isNotNull()
+        }
+
+        @Test
+        fun `returns null when no crash report appears within the timeout`(@TempDir tempDir: File) {
+            val finder = IOSCrashFileFinder(listOf(tempDir))
+
+            val result = finder.waitForCrashFile(testSimulatorId, testBundleId, System.currentTimeMillis(), timeoutMs = 300, pollIntervalMs = 20)
+
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `ignores a stale report and waits for the fresh one`(@TempDir tempDir: File) {
+            val sinceEpochMs = System.currentTimeMillis()
+            File(tempDir, "Stale.ips").apply {
+                writeText(buildIpsFile(testSimulatorId, "TestApp", testBundleId))
+                setLastModified(sinceEpochMs - 60_000)
+            }
+            val finder = IOSCrashFileFinder(listOf(tempDir))
+            val writer = thread {
+                Thread.sleep(200)
+                File(tempDir, "Fresh.ips").writeText(buildIpsFile(testSimulatorId, "TestApp", testBundleId))
+            }
+
+            val result = finder.waitForCrashFile(testSimulatorId, testBundleId, sinceEpochMs, timeoutMs = 5000, pollIntervalMs = 20)
+
+            writer.join()
+            assertThat(result?.name).isEqualTo("Fresh.ips")
         }
     }
 


### PR DESCRIPTION
iOS writes the crash `.ips` to `DiagnosticReports` asynchronously — a few seconds after the crash. `collectCrashArtifacts` looked once at flow end and almost always missed it, so `crash-report.txt` was absent from run artifacts.

`IOSCrashFileFinder.waitForCrashFile` now polls until the report appears or a timeout elapses. `IOSDriver` only waits when a crash was actually detected during the flow; other flows check once.

Fixes MA-4126.
