### PR TITLE
fix(android): detect native (SIGSEGV) crashes, not just JVM ones

### DIFF
--- a/maestro-client/src/main/java/maestro/android/LogcatExtensions.kt
+++ b/maestro-client/src/main/java/maestro/android/LogcatExtensions.kt
@@ -1,18 +1,10 @@
 /** Android logcat helpers for crash/ANR collection. */
 package maestro.android
 
-import java.util.Locale
-
-/** Recent crash-buffer logcat lines mentioning [packageId], or null if the command fails. */
-fun AndroidDeviceConnection.getAppCrashLogs(packageId: String): String? {
+/** Recent crash-buffer logcat lines (JVM + native crashes, all apps), or null if the command fails. */
+fun AndroidDeviceConnection.getCrashLogs(): String? {
     return runCatching {
-        shell(
-            String.format(
-                Locale.US,
-                "logcat -v time -b crash -e \"%s\" -t 20 -d",
-                packageId
-            )
-        ).output
+        shell("logcat -v time -b crash -t 2000 -d").output
     }.getOrNull()
 }
 

--- a/maestro-client/src/main/java/maestro/android/crashes/LogcatReader.kt
+++ b/maestro-client/src/main/java/maestro/android/crashes/LogcatReader.kt
@@ -23,6 +23,11 @@ object LogcatReader {
     private val PROCESS = Pattern.compile("Process:\\s") // Process: com.example.app.alpha, PID: 28715
     private val FILTERED_LINE =
         Pattern.compile("(?!.+\\)\\:)\\s.+") // matches line without metadata info (date, tag, process etc..)
+    private val PROCESS_PACKAGE = Pattern.compile("Process:\\s+([^,\\s]+)")
+
+    private val NATIVE_SIGNAL = Pattern.compile("signal \\d+ \\((SIG[A-Z]+)\\)")
+    private val TOMBSTONE_PROCESS = Pattern.compile(">>> (\\S+) <<<")
+    private const val NATIVE_CRASH_NAME = "Native crash"
 
     // ANR patterns - matches ActivityManager ANR output
     // Example: "12-10 21:31:57.981 E/ActivityManager(  539): ANR in br.com.quintoandar.inquilinos.forno"
@@ -36,48 +41,63 @@ object LogcatReader {
     private const val MAX_RAW_LOG_SIZE = 32 * 1024
 
     /**
-     * Parses logcat output that contains only FATAL EXCEPTION(s)
-     *
-     * @param data logcat output
-     * @return crash report
+     * Parses logcat crash-buffer output for both JVM (`FATAL EXCEPTION:`) crashes and
+     * native (tombstone / `Fatal signal N (SIG…)`) crashes.
      */
-    private fun findCrashes(data: BufferedReader): LogcatCrashReport {
+    fun findCrashes(data: String): LogcatCrashReport {
+        val lines = data.lines()
+        return LogcatCrashReport(findJvmCrashes(lines) + findNativeCrashes(lines))
+    }
+
+    private fun findJvmCrashes(lines: List<String>): List<LogcatCrashReport.Crash> {
         val crashes = mutableListOf<LogcatCrashReport.Crash>()
-        var isProcessLine: Boolean = false
-        data.forEachLine {
-            val header = FATAL.matcher(it).let { matcher ->
-                if (matcher.find()) matcher.group()
-                else null
-            }
+        var isProcessLine = false
+        for (line in lines) {
+            val header = FATAL.matcher(line).let { if (it.find()) it.group() else null }
 
             if (header != null) {
-                val date = DATE_TIME.matcher(it).let { matcher ->
-                    if (matcher.find()) parseTime(matcher.group())
-                    else null
-                }
+                val date = DATE_TIME.matcher(line).let { if (it.find()) parseTime(it.group()) else null }
                 if (date != null) crashes.add(LogcatCrashReport.Crash(date, header))
             } else if (crashes.isNotEmpty()) {
                 val crash = crashes.last()
-                crash.stackTrace += "$it\n"
+                crash.stackTrace += "$line\n"
 
                 if (isProcessLine) { // previous line contains "process"
                     isProcessLine = false
-                    val cause = FILTERED_LINE.matcher(it).let { matcher ->
-                        if (matcher.find()) matcher.group()
-                        else null
-                    }
+                    val cause = FILTERED_LINE.matcher(line).let { if (it.find()) it.group() else null }
                     if (cause != null) crash.cause = cause.trimStart()
                 } else if (crash.cause.isEmpty()) {
-                    isProcessLine = PROCESS.matcher(it).find()
+                    PROCESS_PACKAGE.matcher(line).let { matcher ->
+                        if (matcher.find()) {
+                            isProcessLine = true
+                            crash.packageId = matcher.group(1)
+                        }
+                    }
                 }
             }
         }
-
-        return LogcatCrashReport(crashes)
+        return crashes
     }
 
-    fun findCrashes(data: String): LogcatCrashReport =
-        findCrashes(data.byteInputStream().bufferedReader(Charsets.UTF_8))
+    private fun findNativeCrashes(lines: List<String>): List<LogcatCrashReport.Crash> {
+        val crashes = mutableListOf<LogcatCrashReport.Crash>()
+        var current: LogcatCrashReport.Crash? = null
+        for (line in lines) {
+            if (line.contains("Fatal signal")) {
+                val date = DATE_TIME.matcher(line).let { if (it.find()) parseTime(it.group()) else null } ?: continue
+                current = LogcatCrashReport.Crash(date, NATIVE_CRASH_NAME).also { crashes.add(it) }
+            }
+            val crash = current ?: continue
+            if (!line.contains("F/libc") && !line.contains("F/DEBUG")) {
+                current = null
+                continue
+            }
+            crash.stackTrace += "$line\n"
+            TOMBSTONE_PROCESS.matcher(line).let { if (it.find()) crash.packageId = it.group(1) }
+            if (crash.cause.isEmpty()) NATIVE_SIGNAL.matcher(line).let { if (it.find()) crash.cause = it.group() }
+        }
+        return crashes
+    }
 
     /**
      * Parses logcat output for ANR (Application Not Responding) events.
@@ -203,6 +223,16 @@ data class LogcatCrashReport(val crashes: List<Crash>) {
         return crashes.maxByOrNull { it.date }
     }
 
+    /**
+     * @return Last crash for [packageId] within [timeSpan] (null span = any time)
+     */
+    fun getLastCrash(packageId: String, timeSpan: TimeAgo? = DEFAULT_TIME_AGO): Crash? {
+        val startDate = timeSpan?.toDate()
+        return crashes
+            .filter { it.packageId == packageId && (startDate == null || it.date > startDate) }
+            .maxByOrNull { it.date }
+    }
+
     data class TimeAgo(val time: Long, val unit: TimeUnit) {
         fun toDate(): Date = Date(Date().time - unit.toMillis(time))
     }
@@ -213,6 +243,7 @@ data class LogcatCrashReport(val crashes: List<Crash>) {
     ) {
         var cause: String = ""
         var stackTrace: String = ""
+        var packageId: String? = null
     }
 
     companion object {

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -33,7 +33,7 @@ import maestro.android.chromedevtools.AndroidWebViewHierarchyClient
 import maestro.android.crashes.LogcatCrashReport
 import maestro.android.crashes.LogcatReader
 import maestro.android.getActivityManagerLogs
-import maestro.android.getAppCrashLogs
+import maestro.android.getCrashLogs
 import maestro.android.orThrow
 import maestro.android.orThrowOnFailure
 import maestro.device.CapturedDeviceArtifact
@@ -872,9 +872,10 @@ class AndroidDriver(
         val artifacts = mutableListOf<CapturedDeviceArtifact>()
 
         try {
-            val crash = connection.getAppCrashLogs(appId)
+            val crash = connection.getCrashLogs()
                 ?.let {
                     LogcatReader.findCrashes(it).getLastCrash(
+                        appId,
                         LogcatCrashReport.TimeAgo(System.currentTimeMillis() - sinceEpochMs, java.util.concurrent.TimeUnit.MILLISECONDS)
                     )
                 }

--- a/maestro-client/src/test/java/maestro/android/crashes/LogcatReaderTest.kt
+++ b/maestro-client/src/test/java/maestro/android/crashes/LogcatReaderTest.kt
@@ -358,7 +358,68 @@ class LogcatReaderTest {
         }
     }
 
+    @Nested
+    inner class NativeCrashes {
+
+        @Test
+        fun `detects native SIGSEGV crash with package and signal`() {
+            val result = LogcatReader.findCrashes(buildNativeCrash(recentTimestamp(), "com.bww.reactive.uat"))
+
+            assertThat(result.crashes).hasSize(1)
+            val crash = result.crashes[0]
+            assertThat(crash.packageId).isEqualTo("com.bww.reactive.uat")
+            assertThat(crash.cause).contains("SIGSEGV")
+            assertThat(crash.stackTrace).contains("libreactnative.so")
+        }
+
+        @Test
+        fun `does not detect a native crash in ordinary logcat`() {
+            val logcat = """
+                07-14 10:30:00.000 D/MyApp(12345): Normal log message
+                07-14 10:30:01.000 I/MyApp(12345): Another normal message
+            """.trimIndent()
+
+            assertThat(LogcatReader.findCrashes(logcat).crashes).isEmpty()
+        }
+    }
+
+    @Test
+    fun `extracts package id from a JVM crash`() {
+        val logcat = buildLogcatCrash(
+            timestamp = recentTimestamp(),
+            packageName = "com.example.app",
+            pid = "28715",
+            exceptionType = "java.lang.NullPointerException",
+            exceptionMessage = "boom"
+        )
+
+        assertThat(LogcatReader.findCrashes(logcat).crashes.single().packageId).isEqualTo("com.example.app")
+    }
+
+    @Test
+    fun `getLastCrash filters by package id`() {
+        val logcat = buildNativeCrash(recentTimestamp(), "com.bww.reactive.uat") + "\n" +
+            buildNativeCrash(recentTimestamp(), "com.other.app")
+
+        val report = LogcatReader.findCrashes(logcat)
+
+        assertThat(report.getLastCrash("com.bww.reactive.uat", timeSpan = null)?.packageId)
+            .isEqualTo("com.bww.reactive.uat")
+        assertThat(report.getLastCrash("com.nonexistent", timeSpan = null)).isNull()
+    }
+
     // Test helpers
+
+    private fun buildNativeCrash(timestamp: String, packageId: String): String {
+        return """
+            $timestamp F/libc    ( 4963): Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x744b453f90b400f0 in tid 5093 (mqt_v_js), pid 4963 (com.bww.reactiv)
+            $timestamp F/DEBUG   ( 5100): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+            $timestamp F/DEBUG   ( 5100): pid: 4963, tid: 5093, name: mqt_v_js  >>> $packageId <<<
+            $timestamp F/DEBUG   ( 5100): signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x744b453f90b400f0
+            $timestamp F/DEBUG   ( 5100): backtrace:
+            $timestamp F/DEBUG   ( 5100):       #00 pc 00000000004f4d44  libreactnative.so (facebook::react::ShadowTreeRegistry::enumerate)
+        """.trimIndent()
+    }
 
     private fun recentTimestamp(): String {
         val now = Calendar.getInstance()


### PR DESCRIPTION
Android crash detection only recognized JVM `FATAL EXCEPTION:` crashes, so a native crash (e.g. a React Native / Hermes SIGSEGV) was never classified as an app crash — the run degraded into a generic element-not-found failure with no crash report.

`LogcatReader` now also parses native tombstones (`Fatal signal N (SIG…)` / `>>> <pkg> <<<`), and each crash carries a `packageId` so it can be attributed to the app. The crash-buffer capture no longer drops native lines: it reads the whole `crash` buffer — dropping the package-only `-e` grep and the 20-line window that also truncated JVM headers — and filters by package in the parser.

Fixes MA-4120.
