### PR TITLE
Add resilience to the iOS webview e2e test

### DIFF
--- a/e2e/workspaces/simple_web_view/webview.yaml
+++ b/e2e/workspaces/simple_web_view/webview.yaml
@@ -10,7 +10,7 @@ tags:
 
 - extendedWaitUntil:
     visible: Login
-    timeout: 30000
+    timeout: 90000
     label: Wait for Login page to load
 - assertVisible: Sign In
 - assertVisible: Forgot your password?

--- a/e2e/workspaces/simple_web_view/webview.yaml
+++ b/e2e/workspaces/simple_web_view/webview.yaml
@@ -6,11 +6,16 @@ tags:
 - launchApp:
     clearState: true
 
-- tapOn: Open Login Page
-
-- extendedWaitUntil:
-    visible: Login
-    timeout: 90000
-    label: Wait for Login page to load
+# The tap can be silently dropped on a loaded runner, leaving us on the launch
+# screen. Re-drive rather than wait; assertNotVisible confirms we navigated.
+- retry:
+    maxRetries: 2
+    commands:
+      - tapOn: Open Login Page
+      - assertNotVisible: Open Login Page
+      - extendedWaitUntil:
+          visible: Login
+          timeout: 90000
+          label: Wait for Login page to load
 - assertVisible: Sign In
 - assertVisible: Forgot your password?


### PR DESCRIPTION
## Proposed changes

Increase timeout on a test that keeps flaking. An iOS device under load might not be rendering the page and updating the hierarchy in a timely way.

## Testing

Is CI :)

## Issues fixed
