### PR TITLE
Add support for evaluating variables for assertScreenshot threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ maestro-orchestra/src/test/resources/media/assets/*
 
 # Local files
 local/
+
+# Ignore iOS intermediate build directory
+/driver-iPhoneSimulator/

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -490,7 +490,7 @@ data class ExtractTextWithAICommand(
 
 data class AssertScreenshotCommand(
     val path: String,
-    val thresholdPercentage: Double,
+    val thresholdPercentage: String,
     val cropOn: ElementSelector? = null,
     override val optional: Boolean = false,
     override val label: String? = null,
@@ -505,6 +505,7 @@ data class AssertScreenshotCommand(
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
             path = path.evaluateScripts(jsEngine),
+            thresholdPercentage = thresholdPercentage.evaluateScripts(jsEngine),
             cropOn = cropOn?.evaluateScripts(jsEngine)
         )
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -601,6 +601,14 @@ class Orchestra(
     }
 
     private suspend fun assertScreenshotCommand(command: AssertScreenshotCommand): Boolean {
+        val thresholdPercentage = command.thresholdPercentage.toDoubleOrNull()
+            ?: throw MaestroException.AssertionFailure(
+                message = "Invalid thresholdPercentage for assertScreenshot: \"${command.thresholdPercentage}\". Expected a number.",
+                hierarchyRoot = maestro.viewHierarchy().root,
+                debugMessage = "The assertScreenshot thresholdPercentage must resolve to a number (e.g. 95). " +
+                    "If you are using a variable, make sure it evaluates to a numeric value."
+            )
+
         val path = normalizeScreenshotPath(command.path)
 
         val candidates = buildList {
@@ -657,7 +665,7 @@ class Orchestra(
         val diffFileName = "${baseName}_diff.png"
         val diffFile = expectedFile.parentFile?.resolve(diffFileName) ?: File(diffFileName)
 
-        when (val result = ScreenshotMatch.compare(expectedImage, actualImage, command.thresholdPercentage, diffFile)) {
+        when (val result = ScreenshotMatch.compare(expectedImage, actualImage, thresholdPercentage, diffFile)) {
             is ScreenshotMatch.Result.Match -> return false // Screenshots are non-interactive
             is ScreenshotMatch.Result.SizeMismatch -> throw MaestroException.AssertionFailure(
                 message = "Screenshot size mismatch: ${command.description()} - expected ${result.expectedWidth}x${result.expectedHeight}, actual ${result.actualWidth}x${result.actualHeight}. Screenshots must have the same dimensions to compare.",

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertScreenshot.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlAssertScreenshot.kt
@@ -3,11 +3,11 @@ package maestro.orchestra.yaml
 import com.fasterxml.jackson.annotation.JsonCreator
 import maestro.orchestra.ElementSelector
 
-private const val DEFAULT_DIFF_THRESHOLD = 95.0
+private const val DEFAULT_DIFF_THRESHOLD = "95"
 
 data class YamlAssertScreenshot(
     val path: String,
-    val thresholdPercentage: Double = DEFAULT_DIFF_THRESHOLD,
+    val thresholdPercentage: String = DEFAULT_DIFF_THRESHOLD,
     val cropOn: YamlElementSelectorUnion? = null,
     val label: String? = null,
     val optional: Boolean = false,

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -11,6 +11,7 @@ import maestro.orchestra.AddMediaCommand
 import maestro.orchestra.AirplaneValue
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.AssertScreenshotCommand
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearKeychainCommand
 import maestro.orchestra.ClearStateCommand
@@ -848,6 +849,17 @@ internal class YamlCommandReaderTest {
         assertThat(error).hasMessageThat().contains("Unknown orientation: \${orientation}")
     }
 
+
+    @Test
+    fun `assertScreenshot thresholdPercentage accepts env variable, literal, and default`(
+        @YamlFile("034_assertScreenshot_threshold_env.yaml") commands: List<Command>
+    ) {
+        val screenshotCommands = commands.filterIsInstance<AssertScreenshotCommand>()
+
+        assertThat(screenshotCommands.map { it.thresholdPercentage })
+            .containsExactly($$"${THRESHOLD_PERCENTAGE}", "90", "95")
+            .inOrder()
+    }
 
     @Test
     fun `findUnknownWorkspaceConfigKeys returns empty for valid keys`() {

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/034_assertScreenshot_threshold_env.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/034_assertScreenshot_threshold_env.yaml
@@ -1,0 +1,11 @@
+appId: com.example.app
+env:
+  THRESHOLD_PERCENTAGE: 80
+---
+- assertScreenshot:
+    path: ./screenshot.png
+    thresholdPercentage: ${THRESHOLD_PERCENTAGE}
+- assertScreenshot:
+    path: ./screenshot.png
+    thresholdPercentage: 90
+- assertScreenshot: ./screenshot.png


### PR DESCRIPTION
## Proposed changes

```
      - assertScreenshot:
          path: '${FILE}_baseline'
          thresholdPercentage: ${THRESHOLD_PERCENTAGE}
```

## Testing

New unit tests. This doesn't seem to need e2e, given what's already covered.

## Issues fixed

Fixes #3337 