### PR TITLE
fix(analytics): only attach user identity when logged in via `maestro login`

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
+++ b/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
@@ -7,6 +7,7 @@ import com.posthog.server.PostHogConfig
 import com.posthog.server.PostHogInterface
 import maestro.auth.ApiKey
 import maestro.cli.api.ApiClient
+import maestro.cli.util.CiUtils
 import maestro.cli.util.EnvUtils
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
@@ -43,6 +44,18 @@ object Analytics : AutoCloseable {
 
     val uuid: String
         get() = analyticsStateManager.getState().uuid
+
+    /**
+     * True only when a human has authenticated this machine via `maestro login` (cached auth
+     * token file) and we're not running on CI. An API key provided via MAESTRO_CLOUD_API_KEY
+     * (an automation/CI credential) deliberately does not count: those runs stay anonymous,
+     * with org attribution via the `$groups` property only.
+     *
+     * Gates every identified-analytics behavior: capturing under the user id instead of the
+     * machine uuid, attaching user properties to events, and the `$identify` merge on login.
+     */
+    private val isInteractiveLogin: Boolean
+        get() = ApiKey.getCachedAuthToken() != null && CiUtils.getCiProvider() == null
 
 
     /**
@@ -93,14 +106,33 @@ object Analytics : AutoCloseable {
             val user = apiClient.getUser(token)
             val org =  apiClient.getOrg(token)
 
+            // Compute before updateState overwrites cachedToken
+            val isFirstAuth = analyticsStateManager.getState().cachedToken == null
+
             // Update local state with user info
             val updatedAnalyticsState = analyticsStateManager.updateState(token, user, org)
-            val identifyProperties = UserProperties.fromAnalyticsState(updatedAnalyticsState).toMap()
 
-            // Send identification to PostHog
-            posthog.identify(analyticsStateManager.getState().uuid, identifyProperties)
+            if (isInteractiveLogin) {
+                val identifyProperties = UserProperties.fromAnalyticsState(updatedAnalyticsState).toMap()
+                // Real identity merge: an `$identify` event with `$anon_distinct_id` folds this
+                // machine's anonymous history (captured under the local uuid) into the person
+                // keyed by user.id — the same distinct_id the web app identifies with, so CLI
+                // and web activity resolve to one person. Note posthog.identify() alone cannot
+                // do this: without $anon_distinct_id, ingestion only $set's person properties
+                // and never marks the person identified.
+                // Never sent on CI (isInteractiveLogin): the CI "uuid" is a shared provider
+                // slug ("github", ...) and merging it would graft unrelated runs onto a person.
+                posthog.capture(
+                    user.id,
+                    "\$identify",
+                    mapOf(
+                        "\$anon_distinct_id" to uuid,
+                        "\$set" to identifyProperties,
+                    )
+                )
+            }
+
             // Track user authentication event
-            val isFirstAuth = analyticsStateManager.getState().cachedToken == null
             trackEvent(UserAuthenticatedEvent(
                 isFirstAuth = isFirstAuth,
                 authMethod = "oauth"
@@ -109,6 +141,14 @@ object Analytics : AutoCloseable {
             // Analytics failures should never break CLI functionality or show errors to users
             logger.trace("Failed to identify user: ${e.message}", e)
         }
+    }
+
+    /**
+     * Clear locally-persisted user/org identity. Call on logout so subsequent events
+     * fall back to the anonymous path instead of carrying a stale identity.
+     */
+    fun clearIdentity() {
+        analyticsStateManager.clearUserState()
     }
 
     /**
@@ -139,6 +179,10 @@ object Analytics : AutoCloseable {
                 // Include super properties in each event since PostHog Java client doesn't have register
                 val eventData = convertEventToEventData(event)
                 val userState = analyticsStateManager.getState()
+                val identified = isInteractiveLogin && userState.user_id != null
+
+                // Org attribution applies to both identified and anonymous events (e.g. CI
+                // runs authenticated with an org API key are attributed to the org, not a person)
                 val groupProperties = userState.orgId?.let { orgId ->
                    mapOf(
                        "\$groups" to mapOf(
@@ -146,15 +190,26 @@ object Analytics : AutoCloseable {
                        )
                    )
                 } ?: emptyMap()
+
+                val identityProperties = if (identified) {
+                    UserProperties.fromAnalyticsState(userState).toMap()
+                } else {
+                    // Anonymous event: no person profile is created and the event is billed at
+                    // the anonymous rate (person_mode 'propertyless' instead of 'full').
+                    mapOf("\$process_person_profile" to false)
+                }
+
                 val properties =
                     eventData.properties +
                     superProperties.toMap() +
-                    UserProperties.fromAnalyticsState(userState).toMap() +
+                    identityProperties +
                     groupProperties
 
-                // Send Event
+                // Identified events are captured under the stable user id (shared with the web
+                // app, whose $identify merge links it to this machine's uuid history); anonymous
+                // events stay under the machine uuid (or CI provider slug on CI).
                 posthog.capture(
-                    uuid,
+                    if (identified) userState.user_id!! else uuid,
                     eventData.eventName,
                     properties
                 )
@@ -210,21 +265,14 @@ object Analytics : AutoCloseable {
     * Ensures pending analytics events are sent before shutdown
     */
     override fun close() {
-        // First, flush any pending PostHog events before shutting down threads
-        flush()
-
-        // Now shutdown PostHog to cleanup resources
-        try {
-            posthog.close()
-        } catch (e: Exception) {
-            // Analytics failures should never break CLI functionality or show errors to users
-            logger.trace("Failed to close PostHog: ${e.message}", e)
-        }
-
-        // Now shutdown the executor
+        // Order matters here (verified empirically):
+        // 1. Drain the executor FIRST — a trackEvent task may still be running (e.g. the
+        //    lazy identify path makes two API calls before enqueueing its PostHog events).
+        //    Flushing before the task finishes means its events enqueue after the flush and
+        //    get silently dropped by posthog.close().
         try {
             executor.shutdown()
-            if (!executor.awaitTermination(2, TimeUnit.SECONDS)) {
+            if (!executor.awaitTermination(4, TimeUnit.SECONDS)) {
                 // Analytics failures should never break CLI functionality or show errors to users
                 logger.trace("Analytics executor did not shutdown gracefully, forcing shutdown")
                 executor.shutdownNow()
@@ -232,6 +280,25 @@ object Analytics : AutoCloseable {
         } catch (e: InterruptedException) {
             executor.shutdownNow()
             Thread.currentThread().interrupt()
+        }
+
+        // 2. Flush queued PostHog events. The client drops the tail of the queue when close()
+        //    follows a single flush() too closely (observed empirically, even with a delay
+        //    after one flush); a second flush after a short pause drains the tail reliably.
+        flush()
+        try {
+            Thread.sleep(500)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+        flush()
+
+        // 3. Shutdown PostHog to cleanup resources
+        try {
+            posthog.close()
+        } catch (e: Exception) {
+            // Analytics failures should never break CLI functionality or show errors to users
+            logger.trace("Failed to close PostHog: ${e.message}", e)
         }
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/analytics/AnalyticsStateManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/analytics/AnalyticsStateManager.kt
@@ -27,6 +27,9 @@ import kotlin.io.path.writeText
 data class AnalyticsState(
     val uuid: String,
     val enabled: Boolean,
+    // Bumped when the anonymous-id scheme changes; states below the current version get their
+    // uuid rotated on load. Defaults to 1 so files written by older CLIs read as pre-rotation.
+    val analyticsSchemaVersion: Int = 1,
     val cachedToken: String? = null,
     val lastUploadedForCLI: String? = null,
     @JsonFormat(shape = JsonFormat.Shape.STRING, timezone = "UTC") val lastUploadedTime: Instant?,
@@ -53,6 +56,12 @@ data class AnalyticsState(
 class AnalyticsStateManager(
     private val analyticsStatePath: Path
 ) {
+    companion object {
+        // v2: anonymous-by-default analytics — anonymous ids rotated so they carry no
+        // pre-existing person profile (see migrateIfNeeded)
+        private const val CURRENT_SCHEMA_VERSION = 2
+    }
+
     private val logger = LoggerFactory.getLogger(AnalyticsStateManager::class.java)
     
     private val JSON = jacksonObjectMapper().apply {
@@ -60,13 +69,16 @@ class AnalyticsStateManager(
         enable(SerializationFeature.INDENT_OUTPUT)
     }
 
+    // Written from the main thread (login/logout) and read from the analytics executor threads.
+    @Volatile
     private var _analyticsState: AnalyticsState? = null
 
     fun getState(): AnalyticsState {
-        if (_analyticsState == null) {
-            _analyticsState = loadState()
+        // Synchronized: the first call may load + migrate (rotating the uuid); two threads
+        // racing that check-then-act would each mint a different uuid.
+        return _analyticsState ?: synchronized(this) {
+            _analyticsState ?: loadState().also { _analyticsState = it }
         }
-        return _analyticsState!!
     }
 
     fun hasRunBefore(): Boolean {
@@ -102,6 +114,7 @@ class AnalyticsStateManager(
         val state = AnalyticsState(
           uuid = uuid ?: generateUUID(),
           enabled = granted,
+          analyticsSchemaVersion = CURRENT_SCHEMA_VERSION,
           lastUploadedTime = null
         )
         saveState(state)
@@ -119,9 +132,9 @@ class AnalyticsStateManager(
     }
 
     private fun loadState(): AnalyticsState {
-        return try {
+        val state = try {
             if (analyticsStatePath.exists()) {
-                JSON.readValue(analyticsStatePath.readText())
+                JSON.readValue<AnalyticsState>(analyticsStatePath.readText())
             } else {
                 createDefaultState()
             }
@@ -129,18 +142,68 @@ class AnalyticsStateManager(
             logger.warn("Failed to read analytics state: ${e.message}. Using default.")
             createDefaultState()
         }
+        return migrateIfNeeded(state)
+    }
+
+    /**
+     * Rotate the anonymous id once when adopting the anonymous-by-default analytics scheme.
+     *
+     * PostHog upgrades anonymous events ("$process_person_profile": false) to identified billing
+     * (person_mode 'force_upgrade') whenever the distinct_id already has a person profile — and
+     * every uuid that was active before this scheme has one, because all events used to be
+     * captured with full person processing. A fresh uuid has no person profile, and anonymous
+     * events never create one, so rotated ids stay on the anonymous rate permanently.
+     */
+    private fun migrateIfNeeded(state: AnalyticsState): AnalyticsState {
+        if (state.analyticsSchemaVersion >= CURRENT_SCHEMA_VERSION) return state
+        val migrated = state.copy(
+            uuid = generateUUID(),
+            analyticsSchemaVersion = CURRENT_SCHEMA_VERSION,
+        )
+        saveState(migrated)
+        return migrated
     }
 
     private fun createDefaultState(): AnalyticsState {
         return AnalyticsState(
           uuid = generateUUID(),
           enabled = false,
+          analyticsSchemaVersion = CURRENT_SCHEMA_VERSION,
           lastUploadedTime = null,
         )
     }
 
     private fun generateUUID(): String {
-        return CiUtils.getCiProvider() ?: UUID.randomUUID().toString()
+        // The "ci:" prefix keeps CI runs groupable by provider while using a distinct_id
+        // namespace that has no pre-existing person profile: the legacy bare slugs ("github",
+        // "circleci", ...) each have a person profile from years of full-mode events, which
+        // would force-upgrade anonymous events back to identified billing.
+        return CiUtils.getCiProvider()?.let { "ci:$it" } ?: UUID.randomUUID().toString()
+    }
+
+    /**
+     * Clear identifying user/org info from local state on logout, keeping uuid/enabled intact
+     * so anonymous tracking continues under the same distinct id.
+     */
+    fun clearUserState(): AnalyticsState {
+        val clearedState = getState().copy(
+            cachedToken = null,
+            user_id = null,
+            email = null,
+            name = null,
+            workOSOrgId = null,
+            orgId = null,
+            orgName = null,
+            orgPlan = null,
+            orgTrialExpiresOn = null,
+            orgStatus = null,
+            currentPlan = null,
+            isInTrial = null,
+            daysUntilTrialExpiry = null,
+            daysUntilGracePeriodExpiry = null,
+        )
+        saveState(clearedState)
+        return clearedState
     }
 }
 

--- a/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/LogoutCommand.kt
@@ -30,8 +30,10 @@ class LogoutCommand : Callable<Int> {
     override fun call(): Int {
         // Track logout event before deleting the token
         Analytics.trackEvent(UserLoggedOutEvent())
-        
+
         cachedAuthTokenFile.deleteIfExists()
+        // Clear persisted user/org identity so subsequent events are anonymous
+        Analytics.clearIdentity()
 
         message("Logged out.")
 

--- a/maestro-client/src/main/java/maestro/auth/ApiKey.kt
+++ b/maestro-client/src/main/java/maestro/auth/ApiKey.kt
@@ -20,7 +20,11 @@ class ApiKey {
             return System.getenv("MAESTRO_CLOUD_API_KEY")
         }
 
-        private fun getCachedAuthToken(): String? {
+        /**
+         * Token cached by `maestro login`, or null. Public so callers can distinguish a durable
+         * human login (this file) from an automation credential (MAESTRO_CLOUD_API_KEY env var).
+         */
+        fun getCachedAuthToken(): String? {
             if (!cachedAuthTokenFile.exists()) return null
             if (cachedAuthTokenFile.isDirectory()) return null
             val cachedAuthToken = cachedAuthTokenFile.readText()


### PR DESCRIPTION
Reworks CLI analytics attribution so identity is only attached when a user
has explicitly logged in via `maestro login`. Fixes three bugs:

- CI runs with an org API key attached user emails to identities shared by
  all users on the same CI provider
- `maestro logout` kept attaching cached identity to events after logout
- A shutdown race silently dropped the last events of a run

Logged-out and CI usage is now fully anonymous (no person profiles);
logged-in events use the account user id, consistent with other surfaces.
No new data collected; opt-out unchanged.