### PR TITLE
Fix maestro cloud "similar device" hint

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -534,6 +534,7 @@ class ApiClient(
             deviceName = deviceConfigMap["deviceName"] as String,
             orientation = deviceConfigMap["orientation"] as String,
             osVersion = deviceConfigMap["osVersion"] as String,
+            deviceOs = deviceConfigMap["deviceOs"] as? String,
             displayInfo = deviceConfigMap["displayInfo"] as String,
             deviceLocale = deviceConfigMap["deviceLocale"] as? String
         )
@@ -875,6 +876,7 @@ data class DeviceConfiguration(
     val deviceName: String,
     val orientation: String,
     val osVersion: String,
+    val deviceOs: String? = null,
     val displayInfo: String,
     val deviceLocale: String?
 )

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -466,13 +466,14 @@ class CloudInteractor(
      *
      * `maestro cloud` and `maestro start-device` share the same `--device-*` value formats, so
      * whenever the user explicitly passed a flag to `cloud` we echo it back verbatim. When a flag
-     * was defaulted (not supplied) we fall back to the run's device configuration: for `--device-os`
-     * the response's [DeviceConfiguration.deviceOs] already holds the exact prefixed form
-     * (`android-34`, `iOS-18-2`) — unlike [DeviceConfiguration.osVersion], which is a lossy,
-     * unprefixed major (e.g. iOS `18` for an `18.2` run); for `--device-locale` the reported locale
-     * is already in the expected format; for `--device-model` the response has no reliable model
-     * token. When a fallback value is unavailable we leave a placeholder for the user to fill in
-     * rather than emit a subtly-wrong command.
+     * was defaulted (not supplied) we fall back to the run's device configuration, which reports
+     * each value in the same namespace `start-device` consumes: `--device-os` from
+     * [DeviceConfiguration.deviceOs], the exact prefixed form (`android-34`, `iOS-18-2`) — unlike
+     * [DeviceConfiguration.osVersion], which is a lossy, unprefixed major (e.g. iOS `18` for an
+     * `18.2` run); `--device-model` from [DeviceConfiguration.deviceName], the model slug
+     * (`pixel_6`, `iPhone-11`); and `--device-locale` from [DeviceConfiguration.deviceLocale].
+     * When a fallback value is unavailable we leave a placeholder for the user to fill in rather
+     * than emit a subtly-wrong command.
      */
     internal fun buildStartDeviceCommand(
         deviceConfiguration: DeviceConfiguration,
@@ -482,7 +483,7 @@ class CloudInteractor(
     ): String {
         val platformName = Platform.fromString(deviceConfiguration.platform).toString().lowercase()
         val osValue = deviceOs ?: deviceConfiguration.deviceOs ?: "<device_os>"
-        val modelValue = deviceModel ?: "<device_model>"
+        val modelValue = deviceModel ?: deviceConfiguration.deviceName
         val localeValue = deviceLocale ?: deviceConfiguration.deviceLocale ?: "<device_locale>"
 
         return "maestro start-device --platform=$platformName --device-model=$modelValue --device-os=$osValue --device-locale=$localeValue"

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -212,7 +212,7 @@ class CloudInteractor(
             val appId = response.appId
             val uploadUrl = uploadUrl(project, appId, response.uploadId, client.domain)
             val deviceMessage =
-                if (response.deviceConfiguration != null) printDeviceInfo(response.deviceConfiguration) else ""
+                if (response.deviceConfiguration != null) printDeviceInfo(response.deviceConfiguration, deviceModel, deviceOs, deviceLocale) else ""
 
             val uploadResponse = printMaestroCloudResponse(
                 async,
@@ -439,22 +439,64 @@ class CloudInteractor(
         }
     }
 
-    private fun printDeviceInfo(deviceConfiguration: DeviceConfiguration): String {
+    private fun printDeviceInfo(
+        deviceConfiguration: DeviceConfiguration,
+        deviceModel: String? = null,
+        deviceOs: String? = null,
+        deviceLocale: String? = null,
+    ): String {
         val platform = Platform.fromString(deviceConfiguration.platform)
         PrintUtils.info("\n")
 
-        val version = deviceConfiguration.osVersion
+        val startDeviceCommand = buildStartDeviceCommand(deviceConfiguration, deviceModel, deviceOs, deviceLocale)
+
         val lines = listOf(
             "Maestro cloud device specs:\n* @|magenta ${deviceConfiguration.displayInfo} - ${deviceConfiguration.deviceLocale}|@\n",
             "To change OS version use this option: @|magenta --device-os=<version>|@",
             "To change devices use this option: @|magenta --device-model=<device_model>|@",
             "To change device locale use this option: @|magenta --device-locale=<device_locale>|@",
-            "To create a similar device locally, run: @|magenta `maestro start-device --platform=${
-                platform.toString().lowercase()
-            } --device-model=<device_model> --device-os=$version --device-locale=${deviceConfiguration.deviceLocale}`|@"
+            "To create a similar device locally, run: @|magenta `$startDeviceCommand`|@"
         )
 
         return lines.joinToString("\n").render().box()
+    }
+
+    /**
+     * Builds the `maestro start-device ...` command suggested to reproduce a cloud run locally.
+     *
+     * `maestro cloud` and `maestro start-device` share the same `--device-*` value formats, so
+     * whenever the user explicitly passed a flag to `cloud` we echo it back verbatim. When a flag
+     * was defaulted (not supplied) we fall back to the run's device configuration: for `--device-os`
+     * that requires reconstructing the prefixed form (see [reconstructDeviceOs]); for `--device-locale`
+     * the reported locale is already in the expected format; for `--device-model` the response has no
+     * reliable model token, so we leave a placeholder for the user to fill in.
+     */
+    internal fun buildStartDeviceCommand(
+        deviceConfiguration: DeviceConfiguration,
+        deviceModel: String? = null,
+        deviceOs: String? = null,
+        deviceLocale: String? = null,
+    ): String {
+        val platformName = Platform.fromString(deviceConfiguration.platform).toString().lowercase()
+        val osValue = deviceOs ?: reconstructDeviceOs(platformName, deviceConfiguration.osVersion)
+        val modelValue = deviceModel ?: "<device_model>"
+        val localeValue = deviceLocale ?: deviceConfiguration.deviceLocale ?: "<device_locale>"
+
+        return "maestro start-device --platform=$platformName --device-model=$modelValue --device-os=$osValue --device-locale=$localeValue"
+    }
+
+    /**
+     * The per-run device configuration reports [osVersion] in an unprefixed form (e.g. Android
+     * `34`, iOS `18.2`), whereas `maestro start-device --device-os` expects the prefixed,
+     * dash-separated form (`android-34`, `iOS-18-2`). Reconstruct it here so the suggested
+     * command is runnable when the user did not explicitly pass `--device-os`.
+     */
+    internal fun reconstructDeviceOs(platform: String, osVersion: String): String {
+        return when (platform) {
+            "android" -> if (osVersion.startsWith("android-")) osVersion else "android-$osVersion"
+            "ios" -> if (osVersion.startsWith("iOS-")) osVersion else "iOS-${osVersion.replace('.', '-')}"
+            else -> osVersion
+        }
     }
 
 

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -467,9 +467,12 @@ class CloudInteractor(
      * `maestro cloud` and `maestro start-device` share the same `--device-*` value formats, so
      * whenever the user explicitly passed a flag to `cloud` we echo it back verbatim. When a flag
      * was defaulted (not supplied) we fall back to the run's device configuration: for `--device-os`
-     * that requires reconstructing the prefixed form (see [reconstructDeviceOs]); for `--device-locale`
-     * the reported locale is already in the expected format; for `--device-model` the response has no
-     * reliable model token, so we leave a placeholder for the user to fill in.
+     * the response's [DeviceConfiguration.deviceOs] already holds the exact prefixed form
+     * (`android-34`, `iOS-18-2`) — unlike [DeviceConfiguration.osVersion], which is a lossy,
+     * unprefixed major (e.g. iOS `18` for an `18.2` run); for `--device-locale` the reported locale
+     * is already in the expected format; for `--device-model` the response has no reliable model
+     * token. When a fallback value is unavailable we leave a placeholder for the user to fill in
+     * rather than emit a subtly-wrong command.
      */
     internal fun buildStartDeviceCommand(
         deviceConfiguration: DeviceConfiguration,
@@ -478,25 +481,11 @@ class CloudInteractor(
         deviceLocale: String? = null,
     ): String {
         val platformName = Platform.fromString(deviceConfiguration.platform).toString().lowercase()
-        val osValue = deviceOs ?: reconstructDeviceOs(platformName, deviceConfiguration.osVersion)
+        val osValue = deviceOs ?: deviceConfiguration.deviceOs ?: "<device_os>"
         val modelValue = deviceModel ?: "<device_model>"
         val localeValue = deviceLocale ?: deviceConfiguration.deviceLocale ?: "<device_locale>"
 
         return "maestro start-device --platform=$platformName --device-model=$modelValue --device-os=$osValue --device-locale=$localeValue"
-    }
-
-    /**
-     * The per-run device configuration reports [osVersion] in an unprefixed form (e.g. Android
-     * `34`, iOS `18.2`), whereas `maestro start-device --device-os` expects the prefixed,
-     * dash-separated form (`android-34`, `iOS-18-2`). Reconstruct it here so the suggested
-     * command is runnable when the user did not explicitly pass `--device-os`.
-     */
-    internal fun reconstructDeviceOs(platform: String, osVersion: String): String {
-        return when (platform) {
-            "android" -> if (osVersion.startsWith("android-")) osVersion else "android-$osVersion"
-            "ios" -> if (osVersion.startsWith("iOS-")) osVersion else "iOS-${osVersion.replace('.', '-')}"
-            else -> osVersion
-        }
     }
 
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
@@ -482,50 +482,12 @@ class CloudInteractorTest {
         assertThat(flow2Occurrences).isEqualTo(1)
     }
 
-    // ---- start-device hint: OS reconstruction ----
-
-    @Test
-    fun `reconstructDeviceOs prefixes a bare Android version`() {
-        assertThat(createCloudInteractor().reconstructDeviceOs("android", "34"))
-            .isEqualTo("android-34")
-    }
-
-    @Test
-    fun `reconstructDeviceOs leaves an already-prefixed Android version untouched`() {
-        assertThat(createCloudInteractor().reconstructDeviceOs("android", "android-34"))
-            .isEqualTo("android-34")
-    }
-
-    @Test
-    fun `reconstructDeviceOs prefixes a bare iOS version`() {
-        assertThat(createCloudInteractor().reconstructDeviceOs("ios", "18"))
-            .isEqualTo("iOS-18")
-    }
-
-    @Test
-    fun `reconstructDeviceOs converts a dotted iOS version to the dashed prefixed form`() {
-        assertThat(createCloudInteractor().reconstructDeviceOs("ios", "18.2"))
-            .isEqualTo("iOS-18-2")
-    }
-
-    @Test
-    fun `reconstructDeviceOs leaves an already-prefixed iOS version untouched`() {
-        assertThat(createCloudInteractor().reconstructDeviceOs("ios", "iOS-18-2"))
-            .isEqualTo("iOS-18-2")
-    }
-
-    @Test
-    fun `reconstructDeviceOs passes an unknown platform version through unchanged`() {
-        assertThat(createCloudInteractor().reconstructDeviceOs("web", "default"))
-            .isEqualTo("default")
-    }
-
     // ---- start-device hint: command construction ----
 
     @Test
     fun `buildStartDeviceCommand echoes the flags the user passed to cloud verbatim`() {
         val command = createCloudInteractor().buildStartDeviceCommand(
-            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US"),
+            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US", deviceOs = "android-34"),
             deviceModel = "pixel_7",
             deviceOs = "android-34",
             deviceLocale = "fr_FR",
@@ -537,22 +499,24 @@ class CloudInteractorTest {
     }
 
     @Test
-    fun `buildStartDeviceCommand reconstructs os and locale from the run config when flags were defaulted`() {
+    fun `buildStartDeviceCommand takes os and locale from the run config when flags were defaulted`() {
         val command = createCloudInteractor().buildStartDeviceCommand(
-            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US"),
+            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US", deviceOs = "android-34"),
         )
 
-        // os is reconstructed (bare "34" -> "android-34"), locale comes from the response,
-        // and model stays a placeholder because the response has no reliable model token.
+        // os and locale come from the response's exact fields, and model stays a placeholder
+        // because the response has no reliable model token.
         assertThat(command).isEqualTo(
             "maestro start-device --platform=android --device-model=<device_model> --device-os=android-34 --device-locale=en_US"
         )
     }
 
     @Test
-    fun `buildStartDeviceCommand reconstructs a dotted iOS version from the run config`() {
+    fun `buildStartDeviceCommand uses the run config's exact iOS device-os including the minor version`() {
+        // The response's deviceOs carries the full prefixed form (iOS-18-2), unlike osVersion which
+        // is the lossy major "18" — the hint must reproduce the exact simulator version.
         val command = createCloudInteractor().buildStartDeviceCommand(
-            deviceConfiguration = deviceConfiguration(platform = "IOS", osVersion = "18.2", deviceLocale = "en_US"),
+            deviceConfiguration = deviceConfiguration(platform = "IOS", osVersion = "18", deviceLocale = "en_US", deviceOs = "iOS-18-2"),
         )
 
         assertThat(command).isEqualTo(
@@ -561,9 +525,18 @@ class CloudInteractorTest {
     }
 
     @Test
+    fun `buildStartDeviceCommand falls back to an os placeholder when the run config has no deviceOs`() {
+        val command = createCloudInteractor().buildStartDeviceCommand(
+            deviceConfiguration = deviceConfiguration(platform = "IOS", osVersion = "18", deviceLocale = "en_US", deviceOs = null),
+        )
+
+        assertThat(command).contains("--device-os=<device_os>")
+    }
+
+    @Test
     fun `buildStartDeviceCommand falls back to a locale placeholder when the run config has none`() {
         val command = createCloudInteractor().buildStartDeviceCommand(
-            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = null),
+            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = null, deviceOs = "android-34"),
         )
 
         assertThat(command).contains("--device-locale=<device_locale>")
@@ -575,11 +548,13 @@ class CloudInteractorTest {
         platform: String,
         osVersion: String,
         deviceLocale: String?,
+        deviceOs: String? = null,
     ): DeviceConfiguration = DeviceConfiguration(
         platform = platform,
         deviceName = "Test Device",
         orientation = "portrait",
         osVersion = osVersion,
+        deviceOs = deviceOs,
         displayInfo = "Test Device",
         deviceLocale = deviceLocale,
     )

--- a/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
@@ -482,7 +482,107 @@ class CloudInteractorTest {
         assertThat(flow2Occurrences).isEqualTo(1)
     }
 
+    // ---- start-device hint: OS reconstruction ----
+
+    @Test
+    fun `reconstructDeviceOs prefixes a bare Android version`() {
+        assertThat(createCloudInteractor().reconstructDeviceOs("android", "34"))
+            .isEqualTo("android-34")
+    }
+
+    @Test
+    fun `reconstructDeviceOs leaves an already-prefixed Android version untouched`() {
+        assertThat(createCloudInteractor().reconstructDeviceOs("android", "android-34"))
+            .isEqualTo("android-34")
+    }
+
+    @Test
+    fun `reconstructDeviceOs prefixes a bare iOS version`() {
+        assertThat(createCloudInteractor().reconstructDeviceOs("ios", "18"))
+            .isEqualTo("iOS-18")
+    }
+
+    @Test
+    fun `reconstructDeviceOs converts a dotted iOS version to the dashed prefixed form`() {
+        assertThat(createCloudInteractor().reconstructDeviceOs("ios", "18.2"))
+            .isEqualTo("iOS-18-2")
+    }
+
+    @Test
+    fun `reconstructDeviceOs leaves an already-prefixed iOS version untouched`() {
+        assertThat(createCloudInteractor().reconstructDeviceOs("ios", "iOS-18-2"))
+            .isEqualTo("iOS-18-2")
+    }
+
+    @Test
+    fun `reconstructDeviceOs passes an unknown platform version through unchanged`() {
+        assertThat(createCloudInteractor().reconstructDeviceOs("web", "default"))
+            .isEqualTo("default")
+    }
+
+    // ---- start-device hint: command construction ----
+
+    @Test
+    fun `buildStartDeviceCommand echoes the flags the user passed to cloud verbatim`() {
+        val command = createCloudInteractor().buildStartDeviceCommand(
+            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US"),
+            deviceModel = "pixel_7",
+            deviceOs = "android-34",
+            deviceLocale = "fr_FR",
+        )
+
+        assertThat(command).isEqualTo(
+            "maestro start-device --platform=android --device-model=pixel_7 --device-os=android-34 --device-locale=fr_FR"
+        )
+    }
+
+    @Test
+    fun `buildStartDeviceCommand reconstructs os and locale from the run config when flags were defaulted`() {
+        val command = createCloudInteractor().buildStartDeviceCommand(
+            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US"),
+        )
+
+        // os is reconstructed (bare "34" -> "android-34"), locale comes from the response,
+        // and model stays a placeholder because the response has no reliable model token.
+        assertThat(command).isEqualTo(
+            "maestro start-device --platform=android --device-model=<device_model> --device-os=android-34 --device-locale=en_US"
+        )
+    }
+
+    @Test
+    fun `buildStartDeviceCommand reconstructs a dotted iOS version from the run config`() {
+        val command = createCloudInteractor().buildStartDeviceCommand(
+            deviceConfiguration = deviceConfiguration(platform = "IOS", osVersion = "18.2", deviceLocale = "en_US"),
+        )
+
+        assertThat(command).isEqualTo(
+            "maestro start-device --platform=ios --device-model=<device_model> --device-os=iOS-18-2 --device-locale=en_US"
+        )
+    }
+
+    @Test
+    fun `buildStartDeviceCommand falls back to a locale placeholder when the run config has none`() {
+        val command = createCloudInteractor().buildStartDeviceCommand(
+            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = null),
+        )
+
+        assertThat(command).contains("--device-locale=<device_locale>")
+    }
+
     // ---- Helpers ----
+
+    private fun deviceConfiguration(
+        platform: String,
+        osVersion: String,
+        deviceLocale: String?,
+    ): DeviceConfiguration = DeviceConfiguration(
+        platform = platform,
+        deviceName = "Test Device",
+        orientation = "portrait",
+        osVersion = osVersion,
+        displayInfo = "Test Device",
+        deviceLocale = deviceLocale,
+    )
 
     private fun createUploadStatus(completed: Boolean, status: UploadStatus.Status, flows: List<UploadStatus.FlowResult>, startTime: Long?, totalTime: Long?): UploadStatus {
         return UploadStatus(

--- a/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
@@ -499,15 +499,15 @@ class CloudInteractorTest {
     }
 
     @Test
-    fun `buildStartDeviceCommand takes os and locale from the run config when flags were defaulted`() {
+    fun `buildStartDeviceCommand takes model, os and locale from the run config when flags were defaulted`() {
         val command = createCloudInteractor().buildStartDeviceCommand(
-            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US", deviceOs = "android-34"),
+            deviceConfiguration = deviceConfiguration(platform = "Android", osVersion = "34", deviceLocale = "en_US", deviceOs = "android-34", deviceName = "pixel_7"),
         )
 
-        // os and locale come from the response's exact fields, and model stays a placeholder
-        // because the response has no reliable model token.
+        // model, os and locale all come from the response's exact fields — deviceName is the
+        // model slug that start-device consumes directly.
         assertThat(command).isEqualTo(
-            "maestro start-device --platform=android --device-model=<device_model> --device-os=android-34 --device-locale=en_US"
+            "maestro start-device --platform=android --device-model=pixel_7 --device-os=android-34 --device-locale=en_US"
         )
     }
 
@@ -516,11 +516,11 @@ class CloudInteractorTest {
         // The response's deviceOs carries the full prefixed form (iOS-18-2), unlike osVersion which
         // is the lossy major "18" — the hint must reproduce the exact simulator version.
         val command = createCloudInteractor().buildStartDeviceCommand(
-            deviceConfiguration = deviceConfiguration(platform = "IOS", osVersion = "18", deviceLocale = "en_US", deviceOs = "iOS-18-2"),
+            deviceConfiguration = deviceConfiguration(platform = "IOS", osVersion = "18", deviceLocale = "en_US", deviceOs = "iOS-18-2", deviceName = "iPhone-11"),
         )
 
         assertThat(command).isEqualTo(
-            "maestro start-device --platform=ios --device-model=<device_model> --device-os=iOS-18-2 --device-locale=en_US"
+            "maestro start-device --platform=ios --device-model=iPhone-11 --device-os=iOS-18-2 --device-locale=en_US"
         )
     }
 
@@ -549,9 +549,10 @@ class CloudInteractorTest {
         osVersion: String,
         deviceLocale: String?,
         deviceOs: String? = null,
+        deviceName: String = "pixel_6",
     ): DeviceConfiguration = DeviceConfiguration(
         platform = platform,
-        deviceName = "Test Device",
+        deviceName = deviceName,
         orientation = "portrait",
         osVersion = osVersion,
         deviceOs = deviceOs,


### PR DESCRIPTION
## Proposed changes

Spotted that for a cloud run in the CLI you get this:

```
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                           │
│   Maestro cloud device specs:                                                                                                                             │
│   * Maestro_ANDROID_pixel_6_android-34 - en_US                                                                                                            │
│                                                                                                                                                           │
│   To change OS version use this option: --device-os=<version>                                                                                             │
│   To change devices use this option: --device-model=<device_model>                                                                                        │
│   To change device locale use this option: --device-locale=<device_locale>                                                                                │
│   To create a similar device locally, run: `maestro start-device --platform=android --device-model=<device_model> --device-os=34 --device-locale=en_US`   │
│                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

`--device-os=34` is wrong, and in fixing that, I've also been optimistic about `--device-model`, reflecting back what the user input (since it's _very probably_ a useful local device identifier too).


## Testing

- Added unit tests.
- Works on my machine.

When specifying `--device-os android-34` you're given the OS back:

```
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                   │
│   Maestro cloud device specs:                                                                                                                                     │
│   * Maestro_ANDROID_pixel_6_android-34 - en_US                                                                                                                    │
│                                                                                                                                                                   │
│   To change OS version use this option: --device-os=<version>                                                                                                     │
│   To change devices use this option: --device-model=<device_model>                                                                                                │
│   To change device locale use this option: --device-locale=<device_locale>                                                                                        │
│   To create a similar device locally, run: `maestro start-device --platform=android --device-model=<device_model> --device-os=android-34 --device-locale=en_US`   │
│                                                                                                                                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

When not specifying `--device-os` it's reconstructed from defaults

```
╭───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                   │
│   Maestro cloud device specs:                                                                                                                                     │
│   * Maestro_ANDROID_pixel_6_android-33 - en_US                                                                                                                    │
│                                                                                                                                                                   │
│   To change OS version use this option: --device-os=<version>                                                                                                     │
│   To change devices use this option: --device-model=<device_model>                                                                                                │
│   To change device locale use this option: --device-locale=<device_locale>                                                                                        │
│   To create a similar device locally, run: `maestro start-device --platform=android --device-model=<device_model> --device-os=android-33 --device-locale=en_US`   │
│                                                                                                                                                                   │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

When specifying device and model, they're both echoed back:

```
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                            │
│   Maestro cloud device specs:                                                                                                                              │
│   * Maestro_ANDROID_pixel_9_android-36 - en_US                                                                                                             │
│                                                                                                                                                            │
│   To change OS version use this option: --device-os=<version>                                                                                              │
│   To change devices use this option: --device-model=<device_model>                                                                                         │
│   To change device locale use this option: --device-locale=<device_locale>                                                                                 │
│   To create a similar device locally, run: `maestro start-device --platform=android --device-model=pixel_9 --device-os=android-36 --device-locale=en_US`   │
│                                                                                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## Issues fixed

n/a