### PR TITLE
fix(android): isolate unavailable devices during discovery

### DIFF
--- a/maestro-client/src/main/java/maestro/android/AdbServerDeviceDiscovery.kt
+++ b/maestro-client/src/main/java/maestro/android/AdbServerDeviceDiscovery.kt
@@ -1,0 +1,122 @@
+/*
+ *
+ *  Copyright (c) 2022 mobile.dev inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package maestro.android
+
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+
+internal data class AdbServerDevice(
+    val serial: String,
+    val state: String,
+) {
+    val isOnline: Boolean
+        get() = state == "device"
+}
+
+/**
+ * Reads the adb server's device snapshot without constructing a dadb connection for every entry.
+ *
+ * dadb's list implementation constructs devices before exposing their transport state. A single
+ * `unauthorized` or `offline` entry can therefore throw while being constructed and hide every
+ * healthy device in the same snapshot. Keeping enumeration and connection creation separate lets
+ * callers filter on `device` and isolate a race affecting one device from the rest of the list.
+ */
+internal object AdbServerDeviceDiscovery {
+
+    private const val HOST_DEVICES_COMMAND = "host:devices"
+    private const val IO_TIMEOUT_MS = 5_000
+
+    fun list(host: String, port: Int): List<AdbServerDevice> =
+        Socket().use { socket ->
+            socket.soTimeout = IO_TIMEOUT_MS
+            socket.connect(InetSocketAddress(host, port), IO_TIMEOUT_MS)
+            query(
+                input = DataInputStream(socket.getInputStream()),
+                output = DataOutputStream(socket.getOutputStream()),
+            )
+        }
+
+    internal fun query(
+        input: DataInputStream,
+        output: DataOutputStream,
+    ): List<AdbServerDevice> {
+        writeRequest(output, HOST_DEVICES_COMMAND)
+
+        return when (val status = readString(input, 4)) {
+            "OKAY" -> parse(readLengthPrefixedString(input))
+            "FAIL" -> throw IOException("ADB device enumeration failed: ${readLengthPrefixedString(input)}")
+            else -> throw IOException("Unexpected ADB device enumeration response: $status")
+        }
+    }
+
+    internal fun parse(response: String): List<AdbServerDevice> =
+        response.lineSequence()
+            .mapNotNull { line ->
+                val separator = line.indexOf('\t')
+                if (separator <= 0) {
+                    null
+                } else {
+                    val serial = line.substring(0, separator)
+                    val state = line.substring(separator + 1).trim()
+                    if (state.isEmpty()) null else AdbServerDevice(serial, state)
+                }
+            }
+            .toList()
+
+    internal fun <T> connectOnlineDevices(
+        devices: List<AdbServerDevice>,
+        connect: (String) -> T,
+        onFailure: (AdbServerDevice, Throwable) -> Unit = { _, _ -> },
+    ): List<T> =
+        devices.asSequence()
+            .filter { it.isOnline }
+            .mapNotNull { device ->
+                runCatching { connect(device.serial) }
+                    .onFailure { onFailure(device, it) }
+                    .getOrNull()
+            }
+            .toList()
+
+    private fun writeRequest(output: DataOutputStream, command: String) {
+        val commandBytes = command.toByteArray(StandardCharsets.UTF_8)
+        val lengthBytes = String.format("%04x", commandBytes.size)
+            .toByteArray(StandardCharsets.US_ASCII)
+        output.write(lengthBytes)
+        output.write(commandBytes)
+        output.flush()
+    }
+
+    private fun readLengthPrefixedString(input: DataInputStream): String {
+        val encodedLength = readString(input, 4)
+        val length = encodedLength.toIntOrNull(16)
+            ?: throw IOException("Invalid ADB response length: $encodedLength")
+        return readString(input, length)
+    }
+
+    private fun readString(input: DataInputStream, length: Int): String {
+        val bytes = ByteArray(length)
+        input.readFully(bytes)
+        return String(bytes, StandardCharsets.UTF_8)
+    }
+}

--- a/maestro-client/src/main/java/maestro/android/AndroidDeviceConnection.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidDeviceConnection.kt
@@ -396,8 +396,10 @@ class AndroidDeviceConnection private constructor(
 
         /** Discover a single device reachable through [host]. */
         fun discover(host: String, driverHostPort: Int = DEFAULT_DRIVER_HOST_PORT): AndroidDeviceConnection? {
-            val dadb = Dadb.discover(host) ?: return null
-            return wrap(dadb, Endpoint(host, DEFAULT_ADB_SERVER_PORT), driverHostPort)
+            val connections = list(host, driverHostPort)
+            val selected = connections.firstOrNull()
+            connections.drop(1).forEach { it.close() }
+            return selected
         }
 
         /** Find the device whose serial equals [deviceId] among those reachable through [host]. */
@@ -406,7 +408,25 @@ class AndroidDeviceConnection private constructor(
             host: String = "localhost",
             driverHostPort: Int = DEFAULT_DRIVER_HOST_PORT,
         ): AndroidDeviceConnection? {
-            val dadb = Dadb.list(host).find { it.toString() == deviceId } ?: return null
+            val devices = adbServerDevices(host, DEFAULT_ADB_SERVER_PORT)
+            val dadb = when {
+                devices == null || devices.isEmpty() ->
+                    Dadb.list(host).find { it.toString() == deviceId }
+
+                else -> AdbServerDeviceDiscovery.connectOnlineDevices(
+                    devices = devices.filter { it.serial == deviceId },
+                    connect = { serial ->
+                        AdbServer.createDadb(
+                            adbServerHost = host,
+                            adbServerPort = DEFAULT_ADB_SERVER_PORT,
+                            deviceQuery = "host:transport:$serial",
+                        )
+                    },
+                    onFailure = { device, error ->
+                        LOGGER.debug("Unable to connect to Android device ${device.serial}: ${error.message}")
+                    },
+                ).firstOrNull()
+            } ?: return null
             return wrap(dadb, Endpoint(host, DEFAULT_ADB_SERVER_PORT), driverHostPort)
         }
 
@@ -429,21 +449,95 @@ class AndroidDeviceConnection private constructor(
             host: String = "localhost",
             driverHostPort: Int = DEFAULT_DRIVER_HOST_PORT,
         ): AndroidDeviceConnection? {
-            val dadb = Dadb.list(host).lastOrNull { it.toString() !in connectedSerials } ?: return null
-            return wrap(dadb, Endpoint(host, DEFAULT_ADB_SERVER_PORT), driverHostPort)
+            val connections = list(host, driverHostPort)
+            var selected: AndroidDeviceConnection? = null
+            connections.forEach { connection ->
+                if (connection.serial !in connectedSerials) {
+                    selected?.close()
+                    selected = connection
+                } else {
+                    connection.close()
+                }
+            }
+            return selected
         }
 
         /** Enumerate every device reachable through [host]. Each connection must be closed by the caller. */
         fun list(host: String = "localhost", driverHostPort: Int = DEFAULT_DRIVER_HOST_PORT): List<AndroidDeviceConnection> =
-            Dadb.list(host).map { wrap(it, Endpoint(host, DEFAULT_ADB_SERVER_PORT), driverHostPort) }
+            listDadbs(
+                host = host,
+                adbServerPort = DEFAULT_ADB_SERVER_PORT,
+                scanDirectEmulatorPortsWhenEmpty = true,
+            ).map { wrap(it, Endpoint(host, DEFAULT_ADB_SERVER_PORT), driverHostPort) }
 
         /** Enumerate every device reachable through the adb server on [adbServerPort]. */
         fun listFromAdbServer(
             adbServerPort: Int,
             driverHostPort: Int = DEFAULT_DRIVER_HOST_PORT,
         ): List<AndroidDeviceConnection> =
-            AdbServer.listDadbs(adbServerPort = adbServerPort)
+            listDadbs(
+                host = "localhost",
+                adbServerPort = adbServerPort,
+                scanDirectEmulatorPortsWhenEmpty = false,
+            )
                 .map { wrap(it, Endpoint("localhost", adbServerPort), driverHostPort) }
+
+        private fun listDadbs(
+            host: String,
+            adbServerPort: Int,
+            scanDirectEmulatorPortsWhenEmpty: Boolean,
+        ): List<Dadb> {
+            val devices = adbServerDevices(host, adbServerPort)
+            if (devices == null) {
+                return if (scanDirectEmulatorPortsWhenEmpty) {
+                    Dadb.list(host)
+                } else {
+                    AdbServer.listDadbs(adbServerHost = host, adbServerPort = adbServerPort)
+                }
+            }
+
+            if (devices.isEmpty() && scanDirectEmulatorPortsWhenEmpty) {
+                // Preserve dadb's direct emulator-port discovery fallback when no adb-server devices
+                // exist. Do not use this fallback for a non-empty snapshot containing only offline or
+                // unauthorized devices, as that would re-enter dadb's all-or-nothing list path.
+                return Dadb.list(host)
+            }
+
+            return AdbServerDeviceDiscovery.connectOnlineDevices(
+                devices = devices,
+                connect = { serial ->
+                    AdbServer.createDadb(
+                        adbServerHost = host,
+                        adbServerPort = adbServerPort,
+                        deviceQuery = "host:transport:$serial",
+                    )
+                },
+                onFailure = { device, error ->
+                    LOGGER.debug("Skipping Android device ${device.serial} during enumeration: ${error.message}")
+                },
+            )
+        }
+
+        private fun adbServerDevices(host: String, adbServerPort: Int): List<AdbServerDevice>? {
+            runCatching {
+                AdbServerDeviceDiscovery.list(host, adbServerPort)
+            }.getOrNull()?.let { return it }
+
+            // Let dadb locate the adb executable and start the server when necessary. This call may
+            // itself fail if the newly-started snapshot contains an unauthorized device; the raw
+            // status-aware query below is deliberately retried regardless.
+            runCatching {
+                AdbServer.listDadbs(adbServerHost = host, adbServerPort = adbServerPort)
+            }.getOrNull()?.forEach { dadb ->
+                runCatching { dadb.close() }
+            }
+
+            return runCatching {
+                AdbServerDeviceDiscovery.list(host, adbServerPort)
+            }.onFailure {
+                LOGGER.debug("Unable to enumerate Android devices from $host:$adbServerPort: ${it.message}")
+            }.getOrNull()
+        }
 
         /** Wrap a freshly-created [dadb] (the sole birthplace is the factories above; never injected). */
         private fun wrap(dadb: Dadb, endpoint: Endpoint, driverHostPort: Int): AndroidDeviceConnection =

--- a/maestro-client/src/test/java/maestro/android/AdbServerDeviceDiscoveryTest.kt
+++ b/maestro-client/src/test/java/maestro/android/AdbServerDeviceDiscoveryTest.kt
@@ -1,0 +1,84 @@
+package maestro.android
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+
+class AdbServerDeviceDiscoveryTest {
+
+    @Test
+    fun `query preserves device states and writes the adb host request`() {
+        val payload = """
+            healthy-serial	device
+            unauthorized-serial	unauthorized
+            offline-serial	offline
+        """.trimIndent() + "\n"
+        val output = ByteArrayOutputStream()
+
+        val devices = AdbServerDeviceDiscovery.query(
+            input = DataInputStream(ByteArrayInputStream(okayResponse(payload))),
+            output = DataOutputStream(output),
+        )
+
+        assertThat(devices).containsExactly(
+            AdbServerDevice("healthy-serial", "device"),
+            AdbServerDevice("unauthorized-serial", "unauthorized"),
+            AdbServerDevice("offline-serial", "offline"),
+        ).inOrder()
+        assertThat(output.toString(StandardCharsets.UTF_8))
+            .isEqualTo("000chost:devices")
+    }
+
+    @Test
+    fun `connectOnlineDevices ignores unusable states and isolates one connection failure`() {
+        val attempted = mutableListOf<String>()
+        val devices = listOf(
+            AdbServerDevice("healthy-1", "device"),
+            AdbServerDevice("unauthorized", "unauthorized"),
+            AdbServerDevice("raced-offline", "device"),
+            AdbServerDevice("offline", "offline"),
+            AdbServerDevice("healthy-2", "device"),
+        )
+
+        val connected = AdbServerDeviceDiscovery.connectOnlineDevices(
+            devices = devices,
+            connect = { serial ->
+                attempted += serial
+                if (serial == "raced-offline") throw IOException("transport changed")
+                serial
+            },
+        )
+
+        assertThat(attempted).containsExactly("healthy-1", "raced-offline", "healthy-2").inOrder()
+        assertThat(connected).containsExactly("healthy-1", "healthy-2").inOrder()
+    }
+
+    @Test
+    fun `query exposes an adb server failure`() {
+        val message = "device unauthorized"
+
+        val error = assertThrows<IOException> {
+            AdbServerDeviceDiscovery.query(
+                input = DataInputStream(ByteArrayInputStream(failResponse(message))),
+                output = DataOutputStream(ByteArrayOutputStream()),
+            )
+        }
+
+        assertThat(error).hasMessageThat().contains(message)
+    }
+
+    private fun okayResponse(payload: String): ByteArray =
+        "OKAY${encoded(payload)}".toByteArray(StandardCharsets.UTF_8)
+
+    private fun failResponse(message: String): ByteArray =
+        "FAIL${encoded(message)}".toByteArray(StandardCharsets.UTF_8)
+
+    private fun encoded(value: String): String =
+        String.format("%04x", value.toByteArray(StandardCharsets.UTF_8).size) + value
+}


### PR DESCRIPTION
## Proposed changes

- Query the adb server for device states before constructing dadb connections.
- Skip `unauthorized` and `offline` transports so they cannot hide healthy Android devices.
- Isolate per-device connection races across list, ID lookup, discovery, emulator launch, and custom adb-server enumeration.
- Preserve direct emulator-port discovery when the adb server reports no devices.

## Testing

- `./gradlew :maestro-client:test -x :maestro-ios-driver:buildIosDriver`
- Added unit coverage for mixed device states, per-device connection failure isolation, and adb protocol errors.

This does not need an E2E flow because the regression is in host-side adb enumeration and is covered with deterministic protocol-level unit tests; it does not require app UI or device interaction.

## Issues fixed

Fixes Android device discovery returning an empty list when adb reports a mix of healthy and unavailable devices.