### PR TITLE
fix(cli): don't retry an upload whose outcome is unknown

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -218,6 +218,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.google.truth)
     testImplementation(libs.system.stubs.jupiter)
+    testImplementation(libs.square.mock.server)
 }
 
 tasks.named<Test>("test") {

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -384,8 +384,8 @@ class ApiClient(
 
         fun abortAmbiguousUpload(detail: String): Nothing = throw CliError(
             "$detail\n" +
-                "The upload may already have been accepted — retrying automatically would risk starting " +
-                "every flow a second time. Check whether it landed before uploading again:\n" +
+                "A network error occurred during upload, and will not be retried.\n" +
+                "Your upload may still have been accepted:\n" +
                 TestSuiteStatusView.projectUrl(projectId, domain)
         )
 

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -18,6 +18,7 @@ import maestro.cli.runner.resultview.AnsiResultView
 import maestro.cli.util.CiUtils
 import maestro.cli.util.EnvUtils
 import maestro.cli.util.PrintUtils
+import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.brightRed
 import maestro.cli.view.cyan
 import maestro.cli.view.green
@@ -38,8 +39,12 @@ import okio.ForwardingSink
 import okio.IOException
 import okio.buffer
 import java.io.File
+import java.net.ConnectException
+import java.net.UnknownHostException
 import java.nio.file.Path
 import java.util.Scanner
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLHandshakeException
 import kotlin.io.path.absolutePathString
 import kotlin.io.path.exists
 import kotlin.time.Duration.Companion.minutes
@@ -55,6 +60,15 @@ class ApiClient(
         protocols = listOf(Protocol.HTTP_1_1),
         interceptors = listOf(SystemInformationInterceptor()),
     )
+
+    // Uploads are the only call that legitimately runs for minutes, and a timeout there now aborts
+    // instead of retrying. No overall cap: a multi-GB binary can outlast any fixed budget, so the
+    // inherited per-operation timeouts do the work — writeTimeout catches a stalled upload,
+    // readTimeout a server that went quiet. Shares the connection pool.
+    private val uploadClient = client.newBuilder()
+        .readTimeout(UPLOAD_READ_TIMEOUT_MINUTES, TimeUnit.MINUTES)
+        .callTimeout(0, TimeUnit.MILLISECONDS)
+        .build()
 
     val domain: String
         get() {
@@ -327,7 +341,9 @@ class ApiClient(
             )
         }
 
-        val body = bodyBuilder.build()
+        // runMaestroTest is not idempotent: each POST creates a fresh upload and one run per flow.
+        val bodyFullySent = java.util.concurrent.atomic.AtomicBoolean(false)
+        val body = bodyBuilder.build().onFullyWritten { bodyFullySent.set(true) }
 
         fun retry(message: String, e: Throwable? = null): UploadResponse {
             if (completedRetries >= maxRetryCount) {
@@ -366,6 +382,13 @@ class ApiClient(
             )
         }
 
+        fun abortAmbiguousUpload(detail: String): Nothing = throw CliError(
+            "$detail\n" +
+                "The upload may already have been accepted — retrying automatically would risk starting " +
+                "every flow a second time. Check whether it landed before uploading again:\n" +
+                TestSuiteStatusView.projectUrl(projectId, domain)
+        )
+
         val url = "$baseUrl/v2/project/$projectId/runMaestroTest"
 
         val response = try {
@@ -375,9 +398,13 @@ class ApiClient(
                 .post(body)
                 .build()
 
-            client.newCall(request).execute()
+            uploadClient.newCall(request).execute()
         } catch (e: IOException) {
-            return retry("Upload failed due to socket exception", e)
+            // A timeout means "we don't know", not "it failed" — repeat only what the server cannot hold.
+            if (neverReachedServer(e) || !bodyFullySent.get()) {
+                return retry("Upload failed due to socket exception", e)
+            }
+            abortAmbiguousUpload("Upload timed out waiting for a response from Maestro Cloud (${e.message}).")
         }
 
         response.use {
@@ -442,8 +469,9 @@ class ApiClient(
                     }
                 }
 
+                // A gateway 502/504 means the proxy gave up waiting, not that the backend did.
                 if (response.code >= 500) {
-                    return retry("Upload failed with status code ${response.code}: $errorMessage")
+                    abortAmbiguousUpload("Upload failed with status code ${response.code}: $errorMessage")
                 } else {
                     throw CliError("Upload request failed (${response.code}): $errorMessage")
                 }
@@ -532,6 +560,26 @@ class ApiClient(
         if (Unit is T) return Ok(Unit)
         val parsed = JSON.readValue(response.body?.bytes(), T::class.java)
         return Ok(parsed)
+    }
+
+    /**
+     * Proves nothing was delivered. Needed on top of the body-sent flag: OkHttp retries connection
+     * failures, so a body written on one attempt latches the flag for a request that never landed.
+     */
+    private fun neverReachedServer(e: IOException): Boolean =
+        e is ConnectException || e is UnknownHostException || e is SSLHandshakeException
+
+    /** Runs [callback] once we finish writing — not proof of delivery. Must be idempotent. */
+    private fun RequestBody.onFullyWritten(callback: () -> Unit) = object : RequestBody() {
+
+        override fun contentLength() = this@onFullyWritten.contentLength()
+
+        override fun contentType() = this@onFullyWritten.contentType()
+
+        override fun writeTo(sink: BufferedSink) {
+            this@onFullyWritten.writeTo(sink)
+            callback()
+        }
     }
 
     private fun RequestBody.observable(
@@ -802,6 +850,7 @@ class ApiClient(
 
     companion object {
         private const val BASE_RETRY_DELAY_MS = 3000L
+        private const val UPLOAD_READ_TIMEOUT_MINUTES = 15L
         private val JSON = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -131,6 +131,15 @@ object TestSuiteStatusView {
         }
     }
 
+    /** Project overview, for when we have no upload id to point at. */
+    fun projectUrl(projectId: String, domain: String = ""): String {
+        return if (domain.contains("localhost")) {
+            "http://localhost:3000/project/$projectId/maestro-test"
+        } else {
+            "https://app.maestro.dev/project/$projectId/maestro-test"
+        }
+    }
+
     private fun flowWord(count: Int) = if (count == 1) "Flow" else "Flows"
 
     data class TestSuiteViewModel(

--- a/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
@@ -54,7 +54,7 @@ class ApiClientUploadRetryTest {
 
         val error = assertThrows<CliError> { upload() }
 
-        assertThat(error.message).contains("may already have been accepted")
+        assertThat(error.message).contains("may still have been accepted")
         assertThat(error.message).contains("/project/proj_test/maestro-test")
         assertThat(server.requestCount).isEqualTo(1)
     }

--- a/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
@@ -1,0 +1,124 @@
+package maestro.cli.api
+
+import com.google.common.truth.Truth.assertThat
+import maestro.cli.CliError
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+/**
+ * `runMaestroTest` creates a fresh upload and one run per flow on every POST, so the CLI may only
+ * repeat it when the request provably never landed (MA-4145).
+ */
+class ApiClientUploadRetryTest {
+
+    private lateinit var server: MockWebServer
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `losing the connection after the request was sent does not re-upload`() {
+        // Same "we don't know what it did" state as a read timeout, without the wait. Enqueued
+        // repeatedly so OkHttp's own retries fail fast instead of blocking on an empty queue.
+        // Reaching the abort message proves our retry loop never ran — it throws a different one.
+        repeat(4) { server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST)) }
+
+        val error = assertThrows<CliError> { upload() }
+
+        assertThat(error.message).contains("may already have been accepted")
+        assertThat(error.message).contains("/project/proj_test/maestro-test")
+    }
+
+    @Test
+    fun `gateway 502 does not re-upload`() {
+        // The proxy gave up waiting, not the backend — it may have finished creating every run.
+        server.enqueue(MockResponse().setResponseCode(502).setBody("Bad Gateway"))
+
+        val error = assertThrows<CliError> { upload() }
+
+        assertThat(error.message).contains("may already have been accepted")
+        assertThat(error.message).contains("/project/proj_test/maestro-test")
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `4xx still fails immediately without the ambiguity warning`() {
+        server.enqueue(MockResponse().setResponseCode(400).setBody("Bad workspace"))
+
+        val error = assertThrows<CliError> { upload() }
+
+        assertThat(error.message).contains("Bad workspace")
+        assertThat(error.message).doesNotContain("may already have been accepted")
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `failing before the request lands still retries`() {
+        // Dropped at connect, so the server never saw a request: repeating it is safe.
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+        server.enqueue(MockResponse().setResponseCode(200).setBody(UPLOAD_RESPONSE))
+
+        val response = upload(maxRetryCount = 1)
+
+        assertThat(response.uploadId).isEqualTo("mupload_test")
+    }
+
+    private fun upload(maxRetryCount: Int = 3): UploadResponse {
+        val workspaceZip = tempDir.resolve("workspace.zip").apply { writeText("not really a zip") }
+
+        return ApiClient(server.url("/").toString().trimEnd('/')).upload(
+            authToken = "token",
+            appFile = null,
+            appBinaryId = "app_binary_test",
+            workspaceZip = workspaceZip,
+            uploadName = null,
+            mappingFile = null,
+            repoOwner = null,
+            repoName = null,
+            branch = null,
+            commitSha = null,
+            pullRequestId = null,
+            disableNotifications = false,
+            projectId = "proj_test",
+            androidApiLevel = null,
+            maxRetryCount = maxRetryCount,
+        )
+    }
+
+    private companion object {
+        val UPLOAD_RESPONSE = """
+            {
+              "orgId": "org_test",
+              "uploadId": "mupload_test",
+              "appId": "app_test",
+              "appBinaryId": "app_binary_test",
+              "deviceConfiguration": {
+                "platform": "IOS",
+                "deviceName": "iPhone 15",
+                "orientation": "PORTRAIT",
+                "osVersion": "17",
+                "displayInfo": "iPhone 15",
+                "deviceLocale": "en_US"
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
@@ -66,7 +66,7 @@ class ApiClientUploadRetryTest {
         val error = assertThrows<CliError> { upload() }
 
         assertThat(error.message).contains("Bad workspace")
-        assertThat(error.message).doesNotContain("may already have been accepted")
+        assertThat(error.message).doesNotContain("may still have been accepted")
         assertThat(server.requestCount).isEqualTo(1)
     }
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientUploadRetryTest.kt
@@ -43,7 +43,7 @@ class ApiClientUploadRetryTest {
 
         val error = assertThrows<CliError> { upload() }
 
-        assertThat(error.message).contains("may already have been accepted")
+        assertThat(error.message).contains("may still have been accepted")
         assertThat(error.message).contains("/project/proj_test/maestro-test")
     }
 


### PR DESCRIPTION
`runMaestroTest` creates a fresh upload and one run per flow on every POST. The CLI retried any `IOException` or 5xx — but a read timeout or a gateway 502 means "we don't know", not "it failed", so we re-sent uploads the server had already accepted and multiplied the suite. A 357-flow upload became ~6,800 runs.

Now we retry only when the server cannot hold a complete request: no connection was established, or the body was never fully sent. Anything else stops and points the user at their project to check whether it landed.

Both conditions are needed — OkHttp retries connections internally, so a body written on one attempt latches the flag for a request that never arrived.

Also gives uploads a 15min read timeout and drops the 5min **call** timeout, which capped the entire transfer and put the backend's 4GB max upload size out of reach. Per-operation read/write timeouts still bound a stalled upload or a silent server.

This stops duplicates; it doesn't make retries safe. That needs an idempotency key the server can dedupe on, so an unknown outcome resolves automatically instead of by hand.

Tests: 4 cases in `ApiClientUploadRetryTest` (timeout after send, gateway 502, 4xx, pre-send failure still retries).