### PR TITLE
CI: Update to maintained version of the no-response action

### DIFF
--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'mobile-dev-inc/maestro'
     steps:
-      - uses: godofredoc/no-response@0ce2dc0e63e1c7d2b87752ceed091f6d32c9df09
+      - uses: tcely/no-response@5ca0a0d740b27fe2be2bbd39defd7a6b433e21f4 # v0.2.2
         with:
           token: ${{ github.token }}
           closeComment: >


### PR DESCRIPTION
The old version was node-12, this is bun, so no more node-20 warnings.

Behaviour is nearly identical. The only difference with our current setup is that a comment by the author in the first 15 mins won't automatically reopen issues - good!

