### PR TITLE
fix(android): don't block on the locale broadcast

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -64,6 +64,16 @@ import kotlin.io.use
 private val logger = LoggerFactory.getLogger(Maestro::class.java)
 
 /**
+ * How hard [AndroidDriver.setDeviceLocale] retries the detached locale broadcast while confirming
+ * the change via `getprop`. Injectable so tests can shrink the poll budget.
+ */
+data class LocaleRetryPolicy(
+    val maxAttempts: Int = 3,
+    val verifyPolls: Int = 32,
+    val pollIntervalMs: Long = 250L,
+)
+
+/**
  * Drives a single Android device. All transport — gRPC and dadb — is owned by
  * [connection]; this driver neither creates nor sees a raw `Dadb` or gRPC channel.
  */
@@ -72,6 +82,7 @@ class AndroidDriver(
     private var emulatorName: String = "",
     private val reinstallDriver: Boolean = true,
     private val metricsProvider: Metrics = MetricsProvider.getInstance(),
+    private val localeRetry: LocaleRetryPolicy = LocaleRetryPolicy(),
 ) : Driver {
     private var open = false
     private val hostPort: Int get() = connection.driverHostPort
@@ -917,17 +928,49 @@ class AndroidDriver(
 
     fun setDeviceLocale(country: String, language: String): Int {
         return metrics.measured("operation", mapOf("command" to "setDeviceLocale", "country" to country, "language" to language)) {
-            shell("pm grant dev.mobile.maestro android.permission.CHANGE_CONFIGURATION")
-            val output =
-                shell("am broadcast -a dev.mobile.maestro.locale -n dev.mobile.maestro/.receivers.LocaleSettingReceiver --es lang $language --es country $country")
-            extractSetLocaleResult(output)
+            val target = "$language-$country"
+
+            if (currentEffectiveLocaleTag().equals(target, ignoreCase = true)) {
+                logger.info("Device locale already $target; skipping locale broadcast")
+                SET_LOCALE_RESULT_SUCCESS
+            } else {
+                shell("pm grant dev.mobile.maestro android.permission.CHANGE_CONFIGURATION")
+
+                var applied = false
+                var attempt = 0
+                while (!applied && attempt < localeRetry.maxAttempts) {
+                    attempt++
+                    // Detached fire: do NOT wait on am's ordered receiver result.
+                    connection.execDetached(
+                        "nohup am broadcast -a dev.mobile.maestro.locale " +
+                            "-n dev.mobile.maestro/.receivers.LocaleSettingReceiver " +
+                            "--es lang $language --es country $country >/dev/null 2>&1 &"
+                    )
+                    applied = awaitLocaleApplied(target)
+                }
+
+                if (applied) {
+                    logger.info("Device locale is $target")
+                    SET_LOCALE_RESULT_SUCCESS
+                } else {
+                    logger.warn("Device locale did not reach $target after ${localeRetry.maxAttempts} attempts")
+                    SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED
+                }
+            }
         }
     }
 
-    private fun extractSetLocaleResult(result: String): Int {
-        val regex = Regex("result=(-?\\d+)")
-        val match = regex.find(result)
-        return match?.groups?.get(1)?.value?.toIntOrNull() ?: -1
+    private fun currentEffectiveLocaleTag(): String {
+        val persisted = shell("getprop persist.sys.locale").trim()
+        return if (persisted.isNotEmpty()) persisted else shell("getprop ro.product.locale").trim()
+    }
+
+    private fun awaitLocaleApplied(target: String): Boolean {
+        repeat(localeRetry.verifyPolls) {
+            if (shell("getprop persist.sys.locale").trim().equals(target, ignoreCase = true)) return true
+            if (localeRetry.pollIntervalMs > 0) Thread.sleep(localeRetry.pollIntervalMs)
+        }
+        return false
     }
 
     private fun addMediaToDevice(mediaFile: File) {
@@ -1375,6 +1418,11 @@ class AndroidDriver(
     }.getOrDefault(SERVER_LAUNCH_TIMEOUT_MS)
 
     companion object {
+
+        // Result codes returned by [setDeviceLocale] (consumed by DeviceService / the cloud worker).
+        const val SET_LOCALE_RESULT_SUCCESS = 0
+        const val SET_LOCALE_RESULT_LOCALE_NOT_VALID = 1
+        const val SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED = 2
 
         private const val SERVER_LAUNCH_TIMEOUT_MS = 15000L
         private const val MAESTRO_DRIVER_STARTUP_TIMEOUT = "MAESTRO_DRIVER_STARTUP_TIMEOUT"

--- a/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
@@ -1,0 +1,86 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import dadb.AdbShellResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import maestro.android.AndroidDeviceConnection
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [AndroidDriver.setDeviceLocale] (MA-4105).
+ *
+ * We never touch a real device: a fake [AndroidDeviceConnection] stands in for adb, scripted to
+ * return chosen `getprop` values. We then check which commands the driver ran — in particular
+ * whether it fired the (detached) locale broadcast at all, and how it reported the outcome.
+ */
+class AndroidDriverSetLocaleTest {
+
+    // A fake adb reply. The driver's shell() calls AdbShellResponse.orThrow(), which reads exitCode
+    // (must be 0 for success) and returns output — so we stub exactly those two.
+    private fun reply(text: String): AdbShellResponse = mockk {
+        every { exitCode } returns 0
+        every { output } returns text
+    }
+
+    // A driver wired to [connection] with a tiny, zero-wait retry budget so tests finish instantly.
+    private fun driver(connection: AndroidDeviceConnection) = AndroidDriver(
+        connection = connection,
+        localeRetry = LocaleRetryPolicy(maxAttempts = 2, verifyPolls = 2, pollIntervalMs = 0L),
+    )
+
+    @Test
+    fun `skips the broadcast when the fresh golden already matches (en_US)`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        // Fresh golden: persist.sys.locale is EMPTY, so the effective locale comes from ro.product.locale.
+        every { connection.shell("getprop persist.sys.locale") } returns reply("")
+        every { connection.shell("getprop ro.product.locale") } returns reply("en-US")
+
+        val result = driver(connection).setDeviceLocale(country = "US", language = "en")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_SUCCESS)
+        // Fix #1: the en_US majority fires ZERO broadcasts, so it can't trigger the storm.
+        verify(exactly = 0) { connection.execDetached(any()) }
+    }
+
+    @Test
+    fun `skips the broadcast when persist_sys_locale already matches`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        every { connection.shell("getprop persist.sys.locale") } returns reply("en-US")
+
+        val result = driver(connection).setDeviceLocale(country = "US", language = "en")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_SUCCESS)
+        verify(exactly = 0) { connection.execDetached(any()) }
+        // ro.product.locale isn't even consulted once persist.sys.locale answers.
+        verify(exactly = 0) { connection.shell("getprop ro.product.locale") }
+    }
+
+    @Test
+    fun `fires a DETACHED broadcast and verifies the change via getprop`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        // First read = current locale (en-US); after the broadcast, getprop reports the new locale.
+        every { connection.shell("getprop persist.sys.locale") } returns reply("en-US") andThen reply("fr-FR")
+
+        val result = driver(connection).setDeviceLocale(country = "FR", language = "fr")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_SUCCESS)
+        // Fix #2: fired once, detached (non-blocking), with the correct locale extras.
+        verify(exactly = 1) {
+            connection.execDetached(match { it.contains("--es lang fr") && it.contains("--es country FR") })
+        }
+    }
+
+    @Test
+    fun `retries then reports failure when the locale never applies`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        every { connection.shell("getprop persist.sys.locale") } returns reply("en-US") // never becomes fr-FR
+
+        val result = driver(connection).setDeviceLocale(country = "FR", language = "fr")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED)
+        // Bounded retry (maxAttempts = 2) — a fast, classified failure, never a multi-minute block.
+        verify(exactly = 2) { connection.execDetached(any()) }
+    }
+}


### PR DESCRIPTION
`setDeviceLocale` used to fire an ordered `am broadcast` and then wait for its result. Right after a snapshot resume the device's own GMS activity floods its broadcast queue, so that wait could hang all the way to the 120s socket timeout and show up as an `INFRA_ERROR`.

Now it checks the current locale first and skips the broadcast when it already matches. If it does need to change, it fires the broadcast detached and confirms the change with getprop instead of waiting on the ordered result. A busy queue just means a quick retry, not a stuck job.

The ticket had two more ideas I did not do:

1. Baking a default locale into the device image at build time. 
**_Not needed._** 
The device is almost always already `en_US`, and the skip adapts to whatever the device really is, so baking would add a build step and an image rebuild for no real gain.

2. Settle gate, waiting for the queue to calm down before firing. 
**_Not needed either._** 
We already wait on just this one change instead of freezing the whole job, and reliably knowing when the queue is calm is messy. With the skip and the detached fire it barely helps.