### PR TITLE
Skip driver host port availability check when USE_XCODE_TEST_RUNNER is set

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -534,7 +534,11 @@ class TestCommand : Callable<Int> {
     private fun selectPort(effectiveShards: Int): Int {
         val userPort = driverHostPort ?: parent?.driverHostPort
         if (userPort != null) {
-            if (!isPortAvailable(userPort)) {
+            // With USE_XCODE_TEST_RUNNER the driver is managed externally and is
+            // expected to already be listening on this port, so an occupied port
+            // is the healthy state rather than a conflict.
+            val externallyManagedDriver = !System.getenv("USE_XCODE_TEST_RUNNER").isNullOrEmpty()
+            if (!externallyManagedDriver && !isPortAvailable(userPort)) {
                 throw CliError("Requested driver host port $userPort is not available")
             }
             return userPort


### PR DESCRIPTION
When USE_XCODE_TEST_RUNNER is set, the XCTest runner is managed externally and is expected to already be listening on the driver host port (LocalXCTestInstaller waits for it instead of launching it). Since 2.6.0, selectPort rejects an occupied --driver-host-port, which makes the externally-managed-runner workflow impossible: the port being in use is exactly the healthy state in that mode. This skips the availability check when the env var is set and changes nothing for default runs.

Related: #1816