### PR TITLE
Fix: Duration consistency in console output

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -11,7 +11,6 @@ import maestro.cli.report.TestDebugReporter
 import maestro.cli.report.TestSuiteReporter
 import maestro.cli.util.FileUtils.toCwdRelativeOrAbsoluteString
 import maestro.cli.util.PrintUtils
-import maestro.cli.util.TimeUtils
 import maestro.cli.view.ErrorViewUtils
 import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
@@ -25,7 +24,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.nio.file.Path
 import kotlin.system.measureTimeMillis
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 import maestro.cli.util.ScreenshotUtils
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
@@ -108,7 +107,7 @@ class TestSuiteInteractor(
 
         // Wall-clock elapsed rather than the sum of flow durations, so that the suite's reported
         // duration and its startTime describe the same window in the JUnit report.
-        val suiteDuration = ((System.currentTimeMillis() - suiteStartTime) / 1000).seconds
+        val suiteDuration = (System.currentTimeMillis() - suiteStartTime).milliseconds
 
         TestSuiteStatusView.showSuiteResult(
             TestSuiteViewModel(
@@ -215,7 +214,7 @@ class TestSuiteInteractor(
                 errorMessage = ErrorViewUtils.exceptionToMessage(e)
             }
         }
-        val flowDuration = TimeUtils.durationInSeconds(flowTimeMillis)
+        val flowDuration = flowTimeMillis.milliseconds
         // FIXME(bartekpacia): Save AI output as well
 
         TestSuiteStatusView.showFlowCompletion(

--- a/maestro-cli/src/main/java/maestro/cli/util/TimeUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/TimeUtils.kt
@@ -6,12 +6,12 @@ import kotlin.time.Duration.Companion.seconds
 
 object TimeUtils {
 
-    fun durationInSeconds(startTimeInMillis: Long?, endTimeInMillis: Long?): Duration {
-        if (startTimeInMillis == null || endTimeInMillis == null) return Duration.ZERO
-        return ((endTimeInMillis - startTimeInMillis) / 1000f).roundToLong().seconds
-    }
-
-    fun durationInSeconds(durationInMillis: Long): Duration {
-        return ((durationInMillis) / 1000f).roundToLong().seconds
-    }
+    /**
+     * Console output: whole seconds, except below a second where rounding would erase the
+     * value entirely, so millisecond precision is kept. Reports keep the millisecond-precision
+     * [Duration] they are given.
+     */
+    fun forDisplay(duration: Duration): Duration =
+        if (duration < 1.seconds) duration
+        else (duration.inWholeMilliseconds / 1000f).roundToLong().seconds
 }

--- a/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/TestSuiteStatusView.kt
@@ -3,6 +3,7 @@ package maestro.cli.view
 import maestro.cli.api.UploadStatus
 import maestro.cli.model.FlowStatus
 import maestro.cli.util.PrintUtils
+import maestro.cli.util.TimeUtils
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel.FlowResult
 import maestro.cli.view.TestSuiteStatusView.uploadUrl
 import org.jline.jansi.Ansi
@@ -19,7 +20,7 @@ object TestSuiteStatusView {
 
         printStatus(result.status, result.cancellationReason)
 
-        val durationString = result.duration?.let { " ($it)" }.orEmpty()
+        val durationString = result.duration?.let { " (${TimeUtils.forDisplay(it)})" }.orEmpty()
         print(" ${result.name}$durationString")
 
         if (result.status == FlowStatus.ERROR && result.error != null) {
@@ -60,7 +61,7 @@ object TestSuiteStatusView {
 
 
             if (passedFlows.isNotEmpty()) {
-                val durationMessage = suite.duration?.let { " in $it" } ?: ""
+                val durationMessage = suite.duration?.let { " in ${TimeUtils.forDisplay(it)}" } ?: ""
                 PrintUtils.success(
                     "${shardPrefix}${passedFlows.size}/${suite.flows.size} ${flowWord(passedFlows.size)} Passed$durationMessage",
                     bold = true,

--- a/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
@@ -476,8 +476,8 @@ class CloudInteractorTest {
           startTime = 0L,
           totalTime = 30L,
           flows = listOf(
-            createFlowResult("flow1", FlowStatus.SUCCESS, 0L, 50L),
-            createFlowResult("flow2", FlowStatus.SUCCESS, 0L, 50L)
+            createFlowResult("flow1", FlowStatus.SUCCESS, 0L, 2_400L),
+            createFlowResult("flow2", FlowStatus.SUCCESS, 0L, 3_600L)
           )
         )
         every { mockApiClient.uploadStatus(any(), any(), any()) } returns uploadStatus
@@ -498,14 +498,14 @@ class CloudInteractorTest {
 
         val output = outputStream.toString()
         val cleanOutput = output.replace(Regex("\\u001B\\[[;\\d]*m"), "")
-        assertThat(cleanOutput).contains("[Passed] flow1 (50ms)")
-        assertThat(cleanOutput).contains("[Passed] flow2 (50ms)")
+        assertThat(cleanOutput).contains("[Passed] flow1 (2s)")
+        assertThat(cleanOutput).contains("[Passed] flow2 (4s)")
         assertThat(cleanOutput).contains("2/2 Flows Passed")
         assertThat(cleanOutput).contains("Process will exit with code 0 (SUCCESS)")
         assertThat(cleanOutput).contains("http://example.com")
 
-        val flow1Occurrences = cleanOutput.split("[Passed] flow1 (50ms)").size - 1
-        val flow2Occurrences = cleanOutput.split("[Passed] flow2 (50ms)").size - 1
+        val flow1Occurrences = cleanOutput.split("[Passed] flow1 (2s)").size - 1
+        val flow2Occurrences = cleanOutput.split("[Passed] flow2 (4s)").size - 1
         assertThat(flow1Occurrences).isEqualTo(1)
         assertThat(flow2Occurrences).isEqualTo(1)
     }

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/TimeUtilsTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/TimeUtilsTest.kt
@@ -1,0 +1,41 @@
+package maestro.cli.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class TimeUtilsTest {
+
+    @Test
+    fun `forDisplay keeps millisecond precision below a second`() {
+        assertThat(TimeUtils.forDisplay(45.milliseconds)).isEqualTo(45.milliseconds)
+        assertThat(TimeUtils.forDisplay(400.milliseconds)).isEqualTo(400.milliseconds)
+        assertThat(TimeUtils.forDisplay(999.milliseconds)).isEqualTo(999.milliseconds)
+        assertThat(TimeUtils.forDisplay(Duration.ZERO)).isEqualTo(Duration.ZERO)
+    }
+
+    @Test
+    fun `forDisplay rounds down from a second upwards`() {
+        assertThat(TimeUtils.forDisplay(1_000.milliseconds)).isEqualTo(1.seconds)
+        assertThat(TimeUtils.forDisplay(1_499.milliseconds)).isEqualTo(1.seconds)
+    }
+
+    @Test
+    fun `forDisplay rounds up from the half second`() {
+        assertThat(TimeUtils.forDisplay(1_500.milliseconds)).isEqualTo(2.seconds)
+        assertThat(TimeUtils.forDisplay(1_600.milliseconds)).isEqualTo(2.seconds)
+    }
+
+    @Test
+    fun `forDisplay keeps whole seconds unchanged`() {
+        assertThat(TimeUtils.forDisplay(2.seconds)).isEqualTo(2.seconds)
+    }
+
+    @Test
+    fun `forDisplay rounds durations spanning minutes`() {
+        assertThat(TimeUtils.forDisplay(90_400.milliseconds)).isEqualTo(90.seconds)
+        assertThat(TimeUtils.forDisplay(1_915_947.milliseconds)).isEqualTo(1_916.seconds)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Right now, `maestro test` durations are printed as whole seconds, whilst `maestro cloud` durations are fractional.

This updates all console displays durations as whole seconds for values over 1s.

## Testing

Additional unit tests + tested locally.

## Issues fixed
