### PR TITLE
Chore - Tidy up maps vs evaluateScripts

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -27,7 +27,7 @@ import maestro.SwipeDirection
 import maestro.TapRepeat
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
-import maestro.orchestra.util.Env.evaluateValueScripts
+import maestro.orchestra.util.Env.evaluateScriptsIncludingKeys
 import com.fasterxml.jackson.annotation.JsonIgnore
 import maestro.MaestroException
 import java.nio.file.Path
@@ -565,8 +565,8 @@ data class LaunchAppCommand(
     override fun evaluateScripts(jsEngine: JsEngine): LaunchAppCommand {
         return copy(
             appId = appId.evaluateScripts(jsEngine),
-            permissions = permissions?.evaluateValueScripts(jsEngine, "permissions"),
-            launchArguments = launchArguments?.evaluateScripts(jsEngine, "launchArguments"),
+            permissions = permissions?.evaluateScripts(jsEngine, "permissions"),
+            launchArguments = launchArguments?.evaluateScriptsIncludingKeys(jsEngine, "launchArguments"),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -585,7 +585,7 @@ data class SetPermissionsCommand(
     override fun evaluateScripts(jsEngine: JsEngine): SetPermissionsCommand {
         return copy(
             appId = appId.evaluateScripts(jsEngine),
-            permissions = permissions.evaluateValueScripts(jsEngine, "permissions"),
+            permissions = permissions.evaluateScripts(jsEngine, "permissions"),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -998,7 +998,7 @@ data class DefineVariablesCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): DefineVariablesCommand {
         return copy(
-            env = env.evaluateValueScripts(jsEngine, "env"),
+            env = env.evaluateScripts(jsEngine, "env"),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -1025,7 +1025,7 @@ data class RunScriptCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            env = env.evaluateValueScripts(jsEngine, "env"),
+            env = env.evaluateScripts(jsEngine, "env"),
             condition = condition?.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -27,6 +27,7 @@ import maestro.SwipeDirection
 import maestro.TapRepeat
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
+import maestro.orchestra.util.Env.evaluateValueScripts
 import com.fasterxml.jackson.annotation.JsonIgnore
 import maestro.MaestroException
 import java.nio.file.Path
@@ -564,13 +565,8 @@ data class LaunchAppCommand(
     override fun evaluateScripts(jsEngine: JsEngine): LaunchAppCommand {
         return copy(
             appId = appId.evaluateScripts(jsEngine),
-            permissions = permissions?.entries?.associate {
-                it.key.evaluateScripts(jsEngine) to it.value.evaluateScripts(jsEngine)
-            },
-            launchArguments = launchArguments?.entries?.associate {
-                val value = it.value
-                it.key.evaluateScripts(jsEngine) to if (value is String) value.evaluateScripts(jsEngine) else it.value
-            },
+            permissions = permissions?.evaluateScripts(jsEngine, "permissions"),
+            launchArguments = launchArguments?.evaluateScripts(jsEngine, "launchArguments"),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -589,9 +585,7 @@ data class SetPermissionsCommand(
     override fun evaluateScripts(jsEngine: JsEngine): SetPermissionsCommand {
         return copy(
             appId = appId.evaluateScripts(jsEngine),
-            permissions = permissions.entries.associate {
-                it.key.evaluateScripts(jsEngine) to it.value.evaluateScripts(jsEngine)
-            },
+            permissions = permissions.evaluateScripts(jsEngine, "permissions"),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -1004,9 +998,7 @@ data class DefineVariablesCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): DefineVariablesCommand {
         return copy(
-            env = env.mapValues { (_, value) ->
-                value.evaluateScripts(jsEngine)
-            },
+            env = env.evaluateValueScripts(jsEngine, "env"),
             label = label?.evaluateScripts(jsEngine)
         )
     }
@@ -1033,9 +1025,7 @@ data class RunScriptCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            env = env.mapValues { (_, value) ->
-                value.evaluateScripts(jsEngine)
-            },
+            env = env.evaluateValueScripts(jsEngine, "env"),
             condition = condition?.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )
@@ -1164,7 +1154,7 @@ data class AddMediaCommand(
 
     override fun evaluateScripts(jsEngine: JsEngine): Command {
         return copy(
-            mediaPaths = mediaPaths.map { it.evaluateScripts(jsEngine) },
+            mediaPaths = mediaPaths.evaluateScripts(jsEngine),
             label = label?.evaluateScripts(jsEngine)
         )
     }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -565,7 +565,7 @@ data class LaunchAppCommand(
     override fun evaluateScripts(jsEngine: JsEngine): LaunchAppCommand {
         return copy(
             appId = appId.evaluateScripts(jsEngine),
-            permissions = permissions?.evaluateScripts(jsEngine, "permissions"),
+            permissions = permissions?.evaluateValueScripts(jsEngine, "permissions"),
             launchArguments = launchArguments?.evaluateScripts(jsEngine, "launchArguments"),
             label = label?.evaluateScripts(jsEngine)
         )
@@ -585,7 +585,7 @@ data class SetPermissionsCommand(
     override fun evaluateScripts(jsEngine: JsEngine): SetPermissionsCommand {
         return copy(
             appId = appId.evaluateScripts(jsEngine),
-            permissions = permissions.evaluateScripts(jsEngine, "permissions"),
+            permissions = permissions.evaluateValueScripts(jsEngine, "permissions"),
             label = label?.evaluateScripts(jsEngine)
         )
     }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -2,6 +2,7 @@ package maestro.orchestra
 
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
+import maestro.orchestra.util.Env.evaluateValueScripts
 
 // Note: The appId config is only a yaml concept for now. It'll be a larger migration to get to a point
 // where appId is part of MaestroConfig (and factored out of MaestroCommands - eg: LaunchAppCommand).
@@ -19,7 +20,7 @@ data class MaestroConfig(
         return copy(
             appId = appId?.evaluateScripts(jsEngine),
             name = name?.evaluateScripts(jsEngine),
-            properties = properties.mapValues { (_, v) -> v.evaluateScripts(jsEngine) },
+            properties = properties.evaluateValueScripts(jsEngine, "config properties"),
             onFlowComplete = onFlowComplete?.evaluateScripts(jsEngine),
             onFlowStart = onFlowStart?.evaluateScripts(jsEngine),
         )

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/MaestroConfig.kt
@@ -2,7 +2,6 @@ package maestro.orchestra
 
 import maestro.js.JsEngine
 import maestro.orchestra.util.Env.evaluateScripts
-import maestro.orchestra.util.Env.evaluateValueScripts
 
 // Note: The appId config is only a yaml concept for now. It'll be a larger migration to get to a point
 // where appId is part of MaestroConfig (and factored out of MaestroCommands - eg: LaunchAppCommand).
@@ -20,7 +19,7 @@ data class MaestroConfig(
         return copy(
             appId = appId?.evaluateScripts(jsEngine),
             name = name?.evaluateScripts(jsEngine),
-            properties = properties.evaluateValueScripts(jsEngine, "config properties"),
+            properties = properties.evaluateScripts(jsEngine, "config properties"),
             onFlowComplete = onFlowComplete?.evaluateScripts(jsEngine),
             onFlowStart = onFlowStart?.evaluateScripts(jsEngine),
         )

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -28,20 +28,6 @@ object Env {
     fun List<String>.evaluateScripts(jsEngine: JsEngine): List<String> =
         map { it.evaluateScripts(jsEngine) }
 
-    /**
-     * Interpolates both the keys and the values of a string-keyed map. Values that aren't
-     * strings (e.g. the booleans and numbers allowed in `launchArguments`) pass through
-     * untouched.
-     *
-     * Because keys are interpolated, two literal keys can collapse into one — `${P}: allow`
-     * alongside `location: deny` with `P=location`. YAML rejects literal duplicates, so this
-     * is only reachable through interpolation, and silently keeping the last value would hide
-     * the mistake; [DuplicateKeyError] is raised instead.
-     *
-     * [description] names the map in error messages, e.g. "permissions".
-     *
-     * Use [evaluateValueScripts] where the key is a declaration site rather than user data.
-     */
     fun <V> Map<String, V>.evaluateScripts(jsEngine: JsEngine, description: String): Map<String, V> {
         if (isEmpty()) return this
         requireNoNullValues(description)
@@ -49,21 +35,13 @@ object Env {
         val result = LinkedHashMap<String, V>(size)
         forEach { (key, value) ->
             val evaluatedKey = key.evaluateScripts(jsEngine)
-            if (result.containsKey(evaluatedKey)) throw DuplicateKeyError(description, evaluatedKey)
+            if (result.containsKey(evaluatedKey)) throw DuplicateKeyError(description, evaluatedKey) //No duplicate keys in YAML
             result[evaluatedKey] = value.evaluateValueScript(jsEngine)
         }
         return result
     }
 
-    /**
-     * Interpolates the values of a string-keyed map, leaving the keys verbatim. Values that
-     * aren't strings pass through untouched.
-     *
-     * This is the right choice where the key names something being defined rather than
-     * carrying user data — an `env` block declares variable names, so interpolating them
-     * would produce a variable nothing can reference. See [evaluateScripts] for the
-     * both-sides variant.
-     */
+    /** Interpolates values only, leaving keys verbatim. See [evaluateScripts] for both. */
     fun <V> Map<String, V>.evaluateValueScripts(jsEngine: JsEngine, description: String): Map<String, V> {
         if (isEmpty()) return this
         requireNoNullValues(description)
@@ -80,10 +58,8 @@ object Env {
     }
 
     /**
-     * Jackson's KotlinModule lets nulls into maps declared with non-null value types (generic
-     * erasure), so a YAML entry like `KEY:` with no value lands here as null and would later
-     * crash interpolation with an opaque Kotlin null-intrinsics error. Callers use this to
-     * fail fast, naming every offending key so the user knows exactly what to fix.
+     * Jackson's KotlinModule lets nulls into maps declared with non-null value types, so a
+     * valueless YAML key (`KEY:`) arrives as null and would crash interpolation.
      */
     private fun Map<String, *>.nullValuedKeys(): Set<String> = filterValues { it == null }.keys
 
@@ -105,9 +81,6 @@ object Env {
             "or remove the key."
     )
 
-    /**
-     * Raised when a map reaching interpolation carries null values — see [nullValuedKeys].
-     */
     class MissingValueError(val description: String, val keys: Set<String>) : IllegalArgumentException(
         if (keys.size == 1) {
             "$description entry \"${keys.first()}\" has no value. "
@@ -116,9 +89,6 @@ object Env {
         } + "Set an explicit value (e.g. `${keys.first()}: \"\"` for an empty string) or remove the key."
     )
 
-    /**
-     * Raised when interpolating a map's keys collapses two of them into one — see [evaluateScripts].
-     */
     class DuplicateKeyError(val description: String, val key: String) : IllegalArgumentException(
         "$description has more than one entry for \"$key\" after interpolation. " +
             "Two keys resolved to the same name; rename or remove one."

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -25,14 +25,71 @@ object Env {
             }
     }
 
+    fun List<String>.evaluateScripts(jsEngine: JsEngine): List<String> =
+        map { it.evaluateScripts(jsEngine) }
+
+    /**
+     * Interpolates both the keys and the values of a string-keyed map. Values that aren't
+     * strings (e.g. the booleans and numbers allowed in `launchArguments`) pass through
+     * untouched.
+     *
+     * Because keys are interpolated, two literal keys can collapse into one — `${P}: allow`
+     * alongside `location: deny` with `P=location`. YAML rejects literal duplicates, so this
+     * is only reachable through interpolation, and silently keeping the last value would hide
+     * the mistake; [DuplicateKeyError] is raised instead.
+     *
+     * [description] names the map in error messages, e.g. "permissions".
+     *
+     * Use [evaluateValueScripts] where the key is a declaration site rather than user data.
+     */
+    fun <V> Map<String, V>.evaluateScripts(jsEngine: JsEngine, description: String): Map<String, V> {
+        if (isEmpty()) return this
+        requireNoNullValues(description)
+
+        val result = LinkedHashMap<String, V>(size)
+        forEach { (key, value) ->
+            val evaluatedKey = key.evaluateScripts(jsEngine)
+            if (result.containsKey(evaluatedKey)) throw DuplicateKeyError(description, evaluatedKey)
+            result[evaluatedKey] = value.evaluateValueScript(jsEngine)
+        }
+        return result
+    }
+
+    /**
+     * Interpolates the values of a string-keyed map, leaving the keys verbatim. Values that
+     * aren't strings pass through untouched.
+     *
+     * This is the right choice where the key names something being defined rather than
+     * carrying user data — an `env` block declares variable names, so interpolating them
+     * would produce a variable nothing can reference. See [evaluateScripts] for the
+     * both-sides variant.
+     */
+    fun <V> Map<String, V>.evaluateValueScripts(jsEngine: JsEngine, description: String): Map<String, V> {
+        if (isEmpty()) return this
+        requireNoNullValues(description)
+        return mapValues { (_, value) -> value.evaluateValueScript(jsEngine) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <V> V.evaluateValueScript(jsEngine: JsEngine): V =
+        if (this is String) evaluateScripts(jsEngine) as V else this
+
+    private fun Map<String, *>.requireNoNullValues(description: String) {
+        val nullKeys = nullValuedKeys()
+        if (nullKeys.isNotEmpty()) throw MissingValueError(description, nullKeys)
+    }
+
+    /**
+     * Jackson's KotlinModule lets nulls into maps declared with non-null value types (generic
+     * erasure), so a YAML entry like `KEY:` with no value lands here as null and would later
+     * crash interpolation with an opaque Kotlin null-intrinsics error. Callers use this to
+     * fail fast, naming every offending key so the user knows exactly what to fix.
+     */
+    private fun Map<String, *>.nullValuedKeys(): Set<String> = filterValues { it == null }.keys
+
     fun List<MaestroCommand>.withEnv(env: Map<String, String>): List<MaestroCommand> {
         if (env.isEmpty()) return this
-        // Jackson's KotlinModule allows null values into Map<String, String> (generic erasure),
-        // so a YAML entry like `KEY:` with no value lands here as null and later crashes
-        // DefineVariablesCommand.evaluateScripts with an opaque Kotlin null-intrinsics error.
-        // Fail fast with the offending keys so the user knows exactly what to fix.
-        @Suppress("UNCHECKED_CAST")
-        val nullKeys = (env as Map<String, String?>).filterValues { it == null }.keys
+        val nullKeys = env.nullValuedKeys()
         if (nullKeys.isNotEmpty()) throw EnvVariableMissingValueError(nullKeys)
         return listOf(MaestroCommand(DefineVariablesCommand(env))) + this
     }
@@ -46,6 +103,25 @@ object Env {
         "Environment variable(s) ${keys.joinToString(", ")} have no value. " +
             "Set an explicit value (e.g. `${keys.first()}: \"\"` for an empty string) " +
             "or remove the key."
+    )
+
+    /**
+     * Raised when a map reaching interpolation carries null values — see [nullValuedKeys].
+     */
+    class MissingValueError(val description: String, val keys: Set<String>) : IllegalArgumentException(
+        if (keys.size == 1) {
+            "$description entry \"${keys.first()}\" has no value. "
+        } else {
+            "$description entries ${keys.joinToString(", ") { "\"$it\"" }} have no value. "
+        } + "Set an explicit value (e.g. `${keys.first()}: \"\"` for an empty string) or remove the key."
+    )
+
+    /**
+     * Raised when interpolating a map's keys collapses two of them into one — see [evaluateScripts].
+     */
+    class DuplicateKeyError(val description: String, val key: String) : IllegalArgumentException(
+        "$description has more than one entry for \"$key\" after interpolation. " +
+            "Two keys resolved to the same name; rename or remove one."
     )
 
     /**

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -31,25 +31,25 @@ object Env {
     fun <V> Map<String, V>.evaluateScripts(jsEngine: JsEngine, description: String): Map<String, V> {
         if (isEmpty()) return this
         requireNoNullValues(description)
+        return mapValues { (_, value) -> value.evaluateIfString(jsEngine) }
+    }
+
+    /** Only for maps whose keys are an open namespace, not names from a fixed vocabulary. */
+    fun <V> Map<String, V>.evaluateScriptsIncludingKeys(jsEngine: JsEngine, description: String): Map<String, V> {
+        if (isEmpty()) return this
+        requireNoNullValues(description)
 
         val result = LinkedHashMap<String, V>(size)
         forEach { (key, value) ->
             val evaluatedKey = key.evaluateScripts(jsEngine)
             if (result.containsKey(evaluatedKey)) throw DuplicateKeyError(description, evaluatedKey) //No duplicate keys in YAML
-            result[evaluatedKey] = value.evaluateValueScript(jsEngine)
+            result[evaluatedKey] = value.evaluateIfString(jsEngine)
         }
         return result
     }
 
-    /** Interpolates values only, leaving keys verbatim. See [evaluateScripts] for both. */
-    fun <V> Map<String, V>.evaluateValueScripts(jsEngine: JsEngine, description: String): Map<String, V> {
-        if (isEmpty()) return this
-        requireNoNullValues(description)
-        return mapValues { (_, value) -> value.evaluateValueScript(jsEngine) }
-    }
-
     @Suppress("UNCHECKED_CAST")
-    private fun <V> V.evaluateValueScript(jsEngine: JsEngine): V =
+    private fun <V> V.evaluateIfString(jsEngine: JsEngine): V =
         if (this is String) evaluateScripts(jsEngine) as V else this
 
     private fun Map<String, *>.requireNoNullValues(description: String) {

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/CommandsTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/CommandsTest.kt
@@ -12,46 +12,49 @@ class CommandsTest {
 
     // https://github.com/mobile-dev-inc/Maestro/issues/2416
     @Test
-    fun `LaunchAppCommand evaluateScripts interpolates permission values`() {
+    fun `LaunchAppCommand evaluateScripts interpolates permission values but not names`() {
         GraalJsEngine(platform = "android").use { jsEngine ->
             jsEngine.putEnv("PERMISSION_VALUE", "allow")
-
-            val evaluated = LaunchAppCommand(
-                appId = "com.example.app",
-                permissions = mapOf("location" to "\${PERMISSION_VALUE}"),
-            ).evaluateScripts(jsEngine)
-
-            assertEquals(mapOf("location" to "allow"), evaluated.permissions)
-        }
-    }
-
-    // https://github.com/mobile-dev-inc/Maestro/issues/2416
-    @Test
-    fun `LaunchAppCommand evaluateScripts interpolates permission keys and leaves literals untouched`() {
-        GraalJsEngine(platform = "android").use { jsEngine ->
             jsEngine.putEnv("PERMISSION_NAME", "location")
 
             val evaluated = LaunchAppCommand(
                 appId = "com.example.app",
-                permissions = mapOf("\${PERMISSION_NAME}" to "allow", "camera" to "deny"),
+                permissions = mapOf("location" to "\${PERMISSION_VALUE}", "\${PERMISSION_NAME}" to "deny"),
             ).evaluateScripts(jsEngine)
 
-            assertEquals(mapOf("location" to "allow", "camera" to "deny"), evaluated.permissions)
+            assertEquals(mapOf("location" to "allow", "\${PERMISSION_NAME}" to "deny"), evaluated.permissions)
+        }
+    }
+
+    // https://github.com/mobile-dev-inc/Maestro/issues/3452
+    @Test
+    fun `LaunchAppCommand evaluateScripts interpolates launchArgument names and values`() {
+        GraalJsEngine(platform = "android").use { jsEngine ->
+            jsEngine.putEnv("ARG_NAME", "isCartScreen")
+            jsEngine.putEnv("USER_NAME", "ada")
+
+            val evaluated = LaunchAppCommand(
+                appId = "com.example.app",
+                launchArguments = mapOf("\${ARG_NAME}" to true, "user" to "\${USER_NAME}"),
+            ).evaluateScripts(jsEngine)
+
+            assertEquals(mapOf("isCartScreen" to true, "user" to "ada"), evaluated.launchArguments)
         }
     }
 
     // https://github.com/mobile-dev-inc/Maestro/issues/2416
     @Test
-    fun `SetPermissionsCommand evaluateScripts interpolates permission values`() {
+    fun `SetPermissionsCommand evaluateScripts interpolates permission values but not names`() {
         GraalJsEngine(platform = "android").use { jsEngine ->
             jsEngine.putEnv("PERMISSION_VALUE", "allow")
+            jsEngine.putEnv("PERMISSION_NAME", "location")
 
             val evaluated = SetPermissionsCommand(
                 appId = "com.example.app",
-                permissions = mapOf("location" to "\${PERMISSION_VALUE}"),
+                permissions = mapOf("location" to "\${PERMISSION_VALUE}", "\${PERMISSION_NAME}" to "deny"),
             ).evaluateScripts(jsEngine)
 
-            assertEquals(mapOf("location" to "allow"), evaluated.permissions)
+            assertEquals(mapOf("location" to "allow", "\${PERMISSION_NAME}" to "deny"), evaluated.permissions)
         }
     }
 

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
@@ -3,18 +3,27 @@ package maestro.orchestra.util
 import com.google.common.truth.Truth.assertThat
 import java.io.File
 import kotlin.random.Random
+import maestro.js.GraalJsEngine
+import maestro.js.JsEngine
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
+import maestro.orchestra.util.Env.evaluateScripts
+import maestro.orchestra.util.Env.evaluateValueScripts
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class EnvTest {
 
     private val emptyEnv = emptyMap<String, String>()
+
+    /** A JS engine with [vars] already bound, so `${NAME}` interpolates in the tests below. */
+    private fun jsEngine(vararg vars: Pair<String, String>): JsEngine =
+        GraalJsEngine().apply { vars.forEach { (key, value) -> putEnv(key, value) } }
 
     @Test
     fun `withDefaultEnvVars should add file name without extension`() {
@@ -173,5 +182,120 @@ class EnvTest {
         }
         assertThat(error.message).contains("AUTOMATED_EMAIL")
         assertThat(error.message).contains("REGION")
+    }
+
+    @Test
+    fun `List evaluateScripts interpolates every element`() {
+        val paths = listOf("./\${DIR}/a.png", "./static/b.png")
+
+        val evaluated = paths.evaluateScripts(jsEngine("DIR" to "media"))
+
+        assertThat(evaluated).containsExactly("./media/a.png", "./static/b.png").inOrder()
+    }
+
+    @Test
+    fun `Map evaluateScripts interpolates keys and values`() {
+        val permissions = mapOf("\${PERMISSION}" to "\${STATE}", "location" to "deny")
+
+        val evaluated = permissions.evaluateScripts(
+            jsEngine("PERMISSION" to "camera", "STATE" to "allow"),
+            "permissions",
+        )
+
+        assertThat(evaluated).containsExactly("camera", "allow", "location", "deny")
+    }
+
+    @Test
+    fun `Map evaluateScripts preserves insertion order`() {
+        val map = mapOf("c" to "3", "a" to "1", "b" to "2")
+
+        val evaluated = map.evaluateScripts(jsEngine(), "permissions")
+
+        assertThat(evaluated.keys).containsExactly("c", "a", "b").inOrder()
+    }
+
+    @Test
+    fun `Map evaluateScripts leaves non-string values untouched`() {
+        // launchArguments allows booleans and numbers alongside strings
+        val launchArguments = mapOf<String, Any>(
+            "\${FLAG_NAME}" to true,
+            "retries" to 3,
+            "user" to "\${USER_NAME}",
+        )
+
+        val evaluated = launchArguments.evaluateScripts(
+            jsEngine("FLAG_NAME" to "isCartScreen", "USER_NAME" to "ada"),
+            "launchArguments",
+        )
+
+        assertThat(evaluated).containsExactly("isCartScreen", true, "retries", 3, "user", "ada")
+    }
+
+    @Test
+    fun `Map evaluateScripts rejects keys that collide after interpolation`() {
+        // YAML rejects literal duplicates, so interpolation is the only way to reach this.
+        // Silently keeping the last value would hide the mistake.
+        val permissions = mapOf("\${PERMISSION}" to "allow", "location" to "deny")
+
+        val error = assertThrows<Env.DuplicateKeyError> {
+            permissions.evaluateScripts(jsEngine("PERMISSION" to "location"), "permissions")
+        }
+        assertThat(error.key).isEqualTo("location")
+        assertThat(error.message).contains("permissions")
+        assertThat(error.message).contains("location")
+    }
+
+    @Test
+    fun `Map evaluateScripts fails with a helpful message when a value is null`() {
+        // YAML `camera:` (no value) deserializes to null inside Map<String, String>
+        // due to Kotlin generic type erasure; simulate that here with an unchecked cast.
+        @Suppress("UNCHECKED_CAST")
+        val permissions = mapOf(
+            "camera" to null,
+            "location" to "deny",
+            "notifications" to null,
+        ) as Map<String, String>
+
+        val error = assertThrows<Env.MissingValueError> {
+            permissions.evaluateScripts(jsEngine(), "permissions")
+        }
+        assertThat(error.keys).containsExactly("camera", "notifications")
+        assertThat(error.message).contains("permissions")
+        assertThat(error.message).contains("camera")
+        assertThat(error.message).contains("notifications")
+        assertThat(error.message).doesNotContain("location")
+    }
+
+    @Test
+    fun `Map evaluateValueScripts interpolates values and leaves keys verbatim`() {
+        // env blocks declare variable names, so an interpolated key would define
+        // something nothing can reference
+        val env = mapOf("\${NOT_A_SCRIPT}" to "\${GREETING} world")
+
+        val evaluated = env.evaluateValueScripts(
+            jsEngine("NOT_A_SCRIPT" to "nope", "GREETING" to "hello"),
+            "env",
+        )
+
+        assertThat(evaluated).containsExactly("\${NOT_A_SCRIPT}", "hello world")
+    }
+
+    @Test
+    fun `Map evaluateValueScripts fails with a helpful message when a value is null`() {
+        @Suppress("UNCHECKED_CAST")
+        val env = mapOf("AUTOMATED_EMAIL" to null) as Map<String, String>
+
+        val error = assertThrows<Env.MissingValueError> {
+            env.evaluateValueScripts(jsEngine(), "env")
+        }
+        assertThat(error.keys).containsExactly("AUTOMATED_EMAIL")
+        assertThat(error.message).contains("env")
+        assertThat(error.message).contains("AUTOMATED_EMAIL")
+    }
+
+    @Test
+    fun `Map evaluateScripts leaves an empty map alone`() {
+        assertThat(emptyEnv.evaluateScripts(jsEngine(), "permissions")).isEmpty()
+        assertThat(emptyEnv.evaluateValueScripts(jsEngine(), "env")).isEmpty()
     }
 }

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
@@ -21,7 +21,6 @@ class EnvTest {
 
     private val emptyEnv = emptyMap<String, String>()
 
-    /** A JS engine with [vars] already bound, so `${NAME}` interpolates in the tests below. */
     private fun jsEngine(vararg vars: Pair<String, String>): JsEngine =
         GraalJsEngine().apply { vars.forEach { (key, value) -> putEnv(key, value) } }
 
@@ -195,28 +194,27 @@ class EnvTest {
 
     @Test
     fun `Map evaluateScripts interpolates keys and values`() {
-        val permissions = mapOf("\${PERMISSION}" to "\${STATE}", "location" to "deny")
+        val launchArguments = mapOf("\${ARG_NAME}" to "\${ARG_VALUE}", "screen" to "cart")
 
-        val evaluated = permissions.evaluateScripts(
-            jsEngine("PERMISSION" to "camera", "STATE" to "allow"),
-            "permissions",
+        val evaluated = launchArguments.evaluateScripts(
+            jsEngine("ARG_NAME" to "user", "ARG_VALUE" to "ada"),
+            "launchArguments",
         )
 
-        assertThat(evaluated).containsExactly("camera", "allow", "location", "deny")
+        assertThat(evaluated).containsExactly("user", "ada", "screen", "cart")
     }
 
     @Test
     fun `Map evaluateScripts preserves insertion order`() {
         val map = mapOf("c" to "3", "a" to "1", "b" to "2")
 
-        val evaluated = map.evaluateScripts(jsEngine(), "permissions")
+        val evaluated = map.evaluateScripts(jsEngine(), "launchArguments")
 
         assertThat(evaluated.keys).containsExactly("c", "a", "b").inOrder()
     }
 
     @Test
     fun `Map evaluateScripts leaves non-string values untouched`() {
-        // launchArguments allows booleans and numbers alongside strings
         val launchArguments = mapOf<String, Any>(
             "\${FLAG_NAME}" to true,
             "retries" to 3,
@@ -233,37 +231,34 @@ class EnvTest {
 
     @Test
     fun `Map evaluateScripts rejects keys that collide after interpolation`() {
-        // YAML rejects literal duplicates, so interpolation is the only way to reach this.
-        // Silently keeping the last value would hide the mistake.
-        val permissions = mapOf("\${PERMISSION}" to "allow", "location" to "deny")
+        val launchArguments = mapOf("\${ARG_NAME}" to "1", "retries" to "2")
 
         val error = assertThrows<Env.DuplicateKeyError> {
-            permissions.evaluateScripts(jsEngine("PERMISSION" to "location"), "permissions")
+            launchArguments.evaluateScripts(jsEngine("ARG_NAME" to "retries"), "launchArguments")
         }
-        assertThat(error.key).isEqualTo("location")
-        assertThat(error.message).contains("permissions")
-        assertThat(error.message).contains("location")
+        assertThat(error.key).isEqualTo("retries")
+        assertThat(error.message).contains("launchArguments")
+        assertThat(error.message).contains("retries")
     }
 
     @Test
     fun `Map evaluateScripts fails with a helpful message when a value is null`() {
-        // YAML `camera:` (no value) deserializes to null inside Map<String, String>
-        // due to Kotlin generic type erasure; simulate that here with an unchecked cast.
+        // Jackson erasure lets `user:` with no value through as null; simulate with a cast.
         @Suppress("UNCHECKED_CAST")
-        val permissions = mapOf(
-            "camera" to null,
-            "location" to "deny",
-            "notifications" to null,
-        ) as Map<String, String>
+        val launchArguments = mapOf(
+            "user" to null,
+            "screen" to "cart",
+            "token" to null,
+        ) as Map<String, Any>
 
         val error = assertThrows<Env.MissingValueError> {
-            permissions.evaluateScripts(jsEngine(), "permissions")
+            launchArguments.evaluateScripts(jsEngine(), "launchArguments")
         }
-        assertThat(error.keys).containsExactly("camera", "notifications")
-        assertThat(error.message).contains("permissions")
-        assertThat(error.message).contains("camera")
-        assertThat(error.message).contains("notifications")
-        assertThat(error.message).doesNotContain("location")
+        assertThat(error.keys).containsExactly("user", "token")
+        assertThat(error.message).contains("launchArguments")
+        assertThat(error.message).contains("user")
+        assertThat(error.message).contains("token")
+        assertThat(error.message).doesNotContain("screen")
     }
 
     @Test
@@ -295,7 +290,7 @@ class EnvTest {
 
     @Test
     fun `Map evaluateScripts leaves an empty map alone`() {
-        assertThat(emptyEnv.evaluateScripts(jsEngine(), "permissions")).isEmpty()
+        assertThat(emptyEnv.evaluateScripts(jsEngine(), "launchArguments")).isEmpty()
         assertThat(emptyEnv.evaluateValueScripts(jsEngine(), "env")).isEmpty()
     }
 }

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/EnvTest.kt
@@ -10,7 +10,7 @@ import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
 import maestro.orchestra.util.Env.evaluateScripts
-import maestro.orchestra.util.Env.evaluateValueScripts
+import maestro.orchestra.util.Env.evaluateScriptsIncludingKeys
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.util.Env.withInjectedShellEnvVars
@@ -193,10 +193,10 @@ class EnvTest {
     }
 
     @Test
-    fun `Map evaluateScripts interpolates keys and values`() {
+    fun `Map evaluateScriptsIncludingKeys interpolates keys and values`() {
         val launchArguments = mapOf("\${ARG_NAME}" to "\${ARG_VALUE}", "screen" to "cart")
 
-        val evaluated = launchArguments.evaluateScripts(
+        val evaluated = launchArguments.evaluateScriptsIncludingKeys(
             jsEngine("ARG_NAME" to "user", "ARG_VALUE" to "ada"),
             "launchArguments",
         )
@@ -205,10 +205,10 @@ class EnvTest {
     }
 
     @Test
-    fun `Map evaluateScripts preserves insertion order`() {
+    fun `Map evaluateScriptsIncludingKeys preserves insertion order`() {
         val map = mapOf("c" to "3", "a" to "1", "b" to "2")
 
-        val evaluated = map.evaluateScripts(jsEngine(), "launchArguments")
+        val evaluated = map.evaluateScriptsIncludingKeys(jsEngine(), "launchArguments")
 
         assertThat(evaluated.keys).containsExactly("c", "a", "b").inOrder()
     }
@@ -221,7 +221,7 @@ class EnvTest {
             "user" to "\${USER_NAME}",
         )
 
-        val evaluated = launchArguments.evaluateScripts(
+        val evaluated = launchArguments.evaluateScriptsIncludingKeys(
             jsEngine("FLAG_NAME" to "isCartScreen", "USER_NAME" to "ada"),
             "launchArguments",
         )
@@ -230,11 +230,11 @@ class EnvTest {
     }
 
     @Test
-    fun `Map evaluateScripts rejects keys that collide after interpolation`() {
+    fun `Map evaluateScriptsIncludingKeys rejects keys that collide after interpolation`() {
         val launchArguments = mapOf("\${ARG_NAME}" to "1", "retries" to "2")
 
         val error = assertThrows<Env.DuplicateKeyError> {
-            launchArguments.evaluateScripts(jsEngine("ARG_NAME" to "retries"), "launchArguments")
+            launchArguments.evaluateScriptsIncludingKeys(jsEngine("ARG_NAME" to "retries"), "launchArguments")
         }
         assertThat(error.key).isEqualTo("retries")
         assertThat(error.message).contains("launchArguments")
@@ -242,7 +242,7 @@ class EnvTest {
     }
 
     @Test
-    fun `Map evaluateScripts fails with a helpful message when a value is null`() {
+    fun `Map evaluateScriptsIncludingKeys fails with a helpful message when a value is null`() {
         // Jackson erasure lets `user:` with no value through as null; simulate with a cast.
         @Suppress("UNCHECKED_CAST")
         val launchArguments = mapOf(
@@ -252,7 +252,7 @@ class EnvTest {
         ) as Map<String, Any>
 
         val error = assertThrows<Env.MissingValueError> {
-            launchArguments.evaluateScripts(jsEngine(), "launchArguments")
+            launchArguments.evaluateScriptsIncludingKeys(jsEngine(), "launchArguments")
         }
         assertThat(error.keys).containsExactly("user", "token")
         assertThat(error.message).contains("launchArguments")
@@ -262,12 +262,12 @@ class EnvTest {
     }
 
     @Test
-    fun `Map evaluateValueScripts interpolates values and leaves keys verbatim`() {
+    fun `Map evaluateScripts interpolates values and leaves keys verbatim`() {
         // env blocks declare variable names, so an interpolated key would define
         // something nothing can reference
         val env = mapOf("\${NOT_A_SCRIPT}" to "\${GREETING} world")
 
-        val evaluated = env.evaluateValueScripts(
+        val evaluated = env.evaluateScripts(
             jsEngine("NOT_A_SCRIPT" to "nope", "GREETING" to "hello"),
             "env",
         )
@@ -276,12 +276,12 @@ class EnvTest {
     }
 
     @Test
-    fun `Map evaluateValueScripts fails with a helpful message when a value is null`() {
+    fun `Map evaluateScripts fails with a helpful message when a value is null`() {
         @Suppress("UNCHECKED_CAST")
         val env = mapOf("AUTOMATED_EMAIL" to null) as Map<String, String>
 
         val error = assertThrows<Env.MissingValueError> {
-            env.evaluateValueScripts(jsEngine(), "env")
+            env.evaluateScripts(jsEngine(), "env")
         }
         assertThat(error.keys).containsExactly("AUTOMATED_EMAIL")
         assertThat(error.message).contains("env")
@@ -291,6 +291,6 @@ class EnvTest {
     @Test
     fun `Map evaluateScripts leaves an empty map alone`() {
         assertThat(emptyEnv.evaluateScripts(jsEngine(), "launchArguments")).isEmpty()
-        assertThat(emptyEnv.evaluateValueScripts(jsEngine(), "env")).isEmpty()
+        assertThat(emptyEnv.evaluateScripts(jsEngine(), "env")).isEmpty()
     }
 }


### PR DESCRIPTION
## Proposed changes

Adds utility functions for performing evaluateScripts on Lists and Maps, removing a bunch of duplicated logic.

Also reverts an accident in #3428 - the key names in permissions were never intended to be interpolated.

## Testing

Unit tested.

## Issues fixed

Fixes #3452 