### PR TITLE
fix(web): disable chrome sandbox when running headless

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -125,6 +125,7 @@ class CdpWebDriver(
 
                 if (isHeadless) {
                     addArguments("--headless=new")
+                    addArguments("--no-sandbox")
                     if(screenSize != null){
                         addArguments("--window-size=" + screenSize.replace('x',','))
                     }


### PR DESCRIPTION
## Proposed changes

Pass `--no-sandbox` to the Chrome driver when starting it in headless mode.

## Testing

Tested in scenarios in which the released version would fail (running web tests headless on Linux hosts, e.g. CI) to verify the issue was solved. On Debian 12 (Node 24 container), `libgbm1` and `libxkbcommon0` are also required (not having them installed will present the same opaque error as launching Chrome without the `--no-sandbox` flag).

Also tested on `e2e/demo_app/.maestro/web_flows` (`textarea` flow failed, existing failure).

## Issues fixed

This addresses https://github.com/mobile-dev-inc/Maestro/issues/2576. However, this is a rather inelegant solution compared to using the config file as proposed in https://github.com/mobile-dev-inc/Maestro/issues/2576#issuecomment-3378454460.