### PR TITLE
fix(cli): don't write device-transport-death stacktraces into JUnit failure messages

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
+++ b/maestro-cli/src/main/java/maestro/cli/view/ErrorViewUtils.kt
@@ -1,5 +1,6 @@
 package maestro.cli.view
 
+import maestro.DeviceConnectionException
 import maestro.MaestroException
 import maestro.orchestra.error.InvalidFlowFile
 import maestro.orchestra.error.NoInputException
@@ -15,6 +16,7 @@ object ErrorViewUtils {
             is InvalidFlowFile -> "Flow file is invalid: ${e.flowPath}"
             is InterruptedException -> "Interrupted"
             is MaestroException -> e.message
+            is DeviceConnectionException -> e.message
             else -> e.stackTraceToString()
         }
     }

--- a/maestro-cli/src/test/kotlin/maestro/cli/view/ErrorViewUtilsTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/view/ErrorViewUtilsTest.kt
@@ -1,0 +1,87 @@
+package maestro.cli.view
+
+import com.google.common.truth.Truth.assertThat
+import maestro.DeviceDiagnostics
+import maestro.DeviceUnreachableException
+import maestro.android.DeviceAuthException
+import maestro.android.DeviceServerDiedException
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+class ErrorViewUtilsTest {
+
+    @Test
+    fun `device unreachable (iOS path, no diagnostics) maps to its concise message`() {
+        val e = DeviceUnreachableException(
+            operation = "inputText",
+            cause = IOException("Failed to connect to /127.0.0.1:55555"),
+        )
+
+        val message = ErrorViewUtils.exceptionToMessage(e)
+
+        assertThat(message).isEqualTo("Device became unreachable during inputText")
+    }
+
+    @Test
+    fun `device unreachable (Android path, with diagnostics) maps to its concise message`() {
+        val e = DeviceUnreachableException(
+            operation = "shell",
+            cause = IOException("connection reset"),
+            diagnostics = someDiagnostics(),
+        )
+
+        val message = ErrorViewUtils.exceptionToMessage(e)
+
+        assertThat(message).isEqualTo(
+            "Device emulator-5554 is unreachable during 'shell' " +
+                "(120ms since last byte, connection age 4500ms): AdbException: connection reset"
+        )
+    }
+
+    @Test
+    fun `device server died maps to its concise message`() {
+        val e = DeviceServerDiedException(
+            diagnostics = someDiagnostics(),
+            cause = IOException("UNAVAILABLE"),
+        )
+
+        val message = ErrorViewUtils.exceptionToMessage(e)
+
+        assertThat(message).isEqualTo(
+            "Device server died during 'shell' on emulator-5554 " +
+                "(120ms since last byte, connection age 4500ms): AdbException: connection reset"
+        )
+    }
+
+    @Test
+    fun `device auth failure maps to its concise message`() {
+        val e = DeviceAuthException(
+            serial = "emulator-5554",
+            cause = IOException("unauthorized"),
+        )
+
+        val message = ErrorViewUtils.exceptionToMessage(e)
+
+        assertThat(message).isEqualTo(
+            "Device emulator-5554 is unauthorized; accept the ADB authorization prompt on the device"
+        )
+    }
+
+    @Test
+    fun `unexpected exceptions still map to a full stacktrace`() {
+        val e = RuntimeException("boom")
+
+        val message = ErrorViewUtils.exceptionToMessage(e)
+
+        assertThat(message).contains("java.lang.RuntimeException: boom")
+        assertThat(message).contains("\tat ")
+    }
+
+    private fun someDiagnostics() = DeviceDiagnostics(
+        operation = "shell",
+        rootCause = "AdbException: connection reset",
+        serial = "emulator-5554",
+        msSinceLastByte = 120,
+        connectionAgeMs = 4500,
+    )
+}

--- a/maestro-client/src/main/java/maestro/DeviceUnreachableException.kt
+++ b/maestro-client/src/main/java/maestro/DeviceUnreachableException.kt
@@ -29,8 +29,11 @@ data class DeviceDiagnostics(
  * deliberately never land here, so a `catch (DeviceConnectionException)` can't swallow them.
  *
  * Still an [IOException] for backward compatibility, but consumers should prefer the typed base.
+ *
+ * The [message] is a short human-facing summary that consumers surface verbatim — subclasses
+ * must not embed stacktraces or unbounded content in it.
  */
-abstract class DeviceConnectionException(message: String, cause: Throwable?) : IOException(message, cause)
+abstract class DeviceConnectionException(override val message: String, cause: Throwable?) : IOException(message, cause)
 
 /**
  * Thrown when a driver call fails because the underlying device transport has stopped responding


### PR DESCRIPTION
## Proposed changes

Since cli-2.7.0, a device-transport death mid-flow (e.g. the iOS XCTest runner's HTTP socket dying) writes a **full JVM stacktrace** — several kilobytes — into the JUnit report's `<failure message>`, where consumers expect a short human-facing summary.

**Why we believe this is a bug, not intended behavior:**

- `DeviceUnreachableException`'s own KDoc (introduced in #3212) says: *"this is an infrastructure failure, not a test failure, and consumers should treat it accordingly (**no test-error reporting**, no flow-level retry)"*.
- #3372 — which created the shared `DeviceConnectionException` hierarchy and made `Orchestra` rethrow it past `onCommandFailed` — states the intended consumer contract in its description: *"A dead device is **retryable INFRA** (… CLI → suppressed via `isShutDown()`) … never reported as a customer/test failure."*
- That suppression was only implemented in `TestRunner` (interactive/continuous mode). The non-interactive `maestro test` path (`TestSuiteInteractor`) got no handling, so the rethrown exception falls into the generic `catch (e: Exception)` → `ErrorViewUtils.exceptionToMessage()` → `else -> e.stackTraceToString()` — a catch-all meant for *unexpected* errors, not for a typed infra exception.
- Before 2.7.0 this path was unreachable for transport deaths: `Orchestra` routed them through `onCommandFailed` and returned `false`, so the JUnit failure message was a short fallback string, never a stacktrace.

Beyond sheer size, the trace embeds a per-run local port (`Failed to connect to /127.0.0.1:<port>`), so every occurrence produces a unique failure message — breaking any tooling that groups test failures by message.

**The fix:** map `DeviceConnectionException` to its concise typed message in `exceptionToMessage()`, mirroring the `MaestroException` branch above it (e.g. `Device became unreachable during inputText`). This covers all three subtypes (`DeviceUnreachableException`, `DeviceServerDiedException`, `DeviceAuthException`) on both platforms. `DeviceConnectionException.message` is now a non-null `String` override, and its KDoc documents that consumers surface the message verbatim, so future subclasses keep it short.

The `else -> stackTraceToString()` fallback is deliberately kept for genuinely unexpected exceptions (NPEs etc.), where `e.message` is often null and the trace is the only useful diagnostic. Nothing is lost for debugging: both call sites already log the full stacktrace to maestro.log via `logger.error`.

## Testing

- New unit tests (`ErrorViewUtilsTest`): each of the three `DeviceConnectionException` subtypes maps to its exact one-line message; a plain `RuntimeException` still maps to a full stacktrace (regression guard for the fallback).
- `./gradlew :maestro-cli:test :maestro-client:test` pass.
- No e2e test: this changes error-message formatting in reports only; no flow behavior changes.

## Issues fixed

None filed for this specific regression. Related context: #3212 (introduced the exception and its infra-failure contract), #3372 (introduced the propagation change whose consumer side this PR completes).
