### PR TITLE
fix(orchestra): interpolate appId for driver waits

### DIFF
--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -250,6 +250,7 @@ class Maestro(
             retryIfNoChange = retryIfNoChange,
             longPress = longPress,
             initialHierarchy = hierarchyBeforeTap,
+            appId = appId,
             tapRepeat = tapRepeat,
             waitToSettleTimeoutMs = waitToSettleTimeoutMs
         )
@@ -270,6 +271,7 @@ class Maestro(
                     retryIfNoChange = false,
                     waitUntilVisible = false,
                     longPress = longPress,
+                    appId = appId,
                     tapRepeat = tapRepeat
                 )
             }
@@ -381,6 +383,7 @@ class Maestro(
         retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
+        appId: String? = null,
         tapRepeat: TapRepeat? = null,
         waitToSettleTimeoutMs: Int? = null
     ) {
@@ -389,9 +392,27 @@ class Maestro(
         val capabilities = runInterruptible(Dispatchers.IO) { driver.capabilities() }
 
         if (Capability.FAST_HIERARCHY in capabilities) {
-            hierarchyBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs)
+            hierarchyBasedTap(
+                x = x,
+                y = y,
+                retryIfNoChange = retryIfNoChange,
+                longPress = longPress,
+                initialHierarchy = initialHierarchy,
+                appId = appId,
+                tapRepeat = tapRepeat,
+                waitToSettleTimeoutMs = waitToSettleTimeoutMs,
+            )
         } else {
-            screenshotBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs)
+            screenshotBasedTap(
+                x = x,
+                y = y,
+                retryIfNoChange = retryIfNoChange,
+                longPress = longPress,
+                initialHierarchy = initialHierarchy,
+                appId = appId,
+                tapRepeat = tapRepeat,
+                waitToSettleTimeoutMs = waitToSettleTimeoutMs,
+            )
         }
     }
 
@@ -401,6 +422,7 @@ class Maestro(
         retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
+        appId: String? = null,
         tapRepeat: TapRepeat? = null,
         waitToSettleTimeoutMs: Int? = null
     ) {
@@ -426,7 +448,10 @@ class Maestro(
             } else {
                 runInterruptible(Dispatchers.IO) { driver.tap(Point(x, y)) }
             }
-            val hierarchyAfterTap = waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
+            val hierarchyAfterTap = waitForAppToSettle(
+                appId = appId,
+                waitToSettleTimeoutMs = waitToSettleTimeoutMs,
+            )
 
             if (hierarchyAfterTap == null || hierarchyBeforeTap != hierarchyAfterTap) {
                 LOGGER.info("Something has changed in the UI judging by view hierarchy. Proceed.")
@@ -441,6 +466,7 @@ class Maestro(
         retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
+        appId: String? = null,
         tapRepeat: TapRepeat? = null,
         waitToSettleTimeoutMs: Int? = null
     ) {
@@ -467,7 +493,10 @@ class Maestro(
             } else {
                 runInterruptible(Dispatchers.IO) { driver.tap(Point(x, y)) }
             }
-            val hierarchyAfterTap = waitForAppToSettle(waitToSettleTimeoutMs = waitToSettleTimeoutMs)
+            val hierarchyAfterTap = waitForAppToSettle(
+                appId = appId,
+                waitToSettleTimeoutMs = waitToSettleTimeoutMs,
+            )
 
             if (hierarchyBeforeTap != hierarchyAfterTap) {
                 LOGGER.info("Something have changed in the UI judging by view hierarchy. Proceed.")

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -206,15 +206,18 @@ class Orchestra(
 
         var flowSuccess = false
         var exception: Throwable? = null
+        var evaluatedConfig: MaestroConfig? = config
         try {
             executeDefineVariablesCommands(commands, config)
+            // Config values are consumed outside command evaluation, so resolve them after flow env is available.
+            evaluatedConfig = config?.evaluateScripts(jsEngine)
             // filter out DefineVariablesCommand to not execute it twice
             val filteredCommands = commands.filter { it.asCommand() !is DefineVariablesCommand }
 
-            val onStartSuccess = config?.onFlowStart?.commands?.let {
+            val onStartSuccess = evaluatedConfig?.onFlowStart?.commands?.let {
                 executeCommands(
                     commands = it,
-                    config = config,
+                    config = evaluatedConfig,
                     shouldReinitJsEngine = false,
                 )
             } ?: true
@@ -222,7 +225,7 @@ class Orchestra(
             if (onStartSuccess) {
                 flowSuccess = executeCommands(
                     commands = filteredCommands,
-                    config = config,
+                    config = evaluatedConfig,
                     shouldReinitJsEngine = false,
                 ).also {
                     // close existing screen recording, if left open.
@@ -235,11 +238,11 @@ class Orchestra(
             exception = e
         } finally {
             val onCompleteSuccess = if (currentCoroutineContext().isActive) {
-                config?.onFlowComplete?.commands?.let {
+                evaluatedConfig?.onFlowComplete?.commands?.let {
                     try {
                         executeCommands(
                             commands = it,
-                            config = config,
+                            config = evaluatedConfig,
                             shouldReinitJsEngine = false,
                         )
                     } catch (e: CancellationException) {
@@ -1852,4 +1855,3 @@ class Orchestra(
     val isPaused: Boolean
         get() = flowController.isPaused
 }
-

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3245,8 +3245,8 @@ class IntegrationTest {
                 ),
             ),
             MaestroCommand(
-                TapOnElementCommand(
-                    selector = ElementSelector(text = "Target"),
+                tapOnElement = TapOnElementCommand(
+                    selector = ElementSelector(textRegex = "Target"),
                 ),
             ),
         ).withEnv(mapOf("APP_ID" to "com.example.app"))

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -3237,6 +3237,40 @@ class IntegrationTest {
     }
 
     @Test
+    fun `templated appId is used when settling after a tap`() {
+        val commands = listOf(
+            MaestroCommand(
+                ApplyConfigurationCommand(
+                    MaestroConfig(appId = "\${APP_ID}"),
+                ),
+            ),
+            MaestroCommand(
+                TapOnElementCommand(
+                    selector = ElementSelector(text = "Target"),
+                ),
+            ),
+        ).withEnv(mapOf("APP_ID" to "com.example.app"))
+        val driver = CapturingSettleAppIdFakeDriver()
+        driver.setLayout(
+            FakeLayoutElement().apply {
+                element {
+                    text = "Target"
+                    bounds = Bounds(0, 0, 100, 100)
+                }
+            },
+        )
+        driver.open()
+
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        assertThat(driver.lastSettleAppId).isEqualTo("com.example.app")
+    }
+
+    @Test
     fun `Case 108 - fail the flow and skip commands in case of onStart hook failure`() {
         // Given
         val commands = readCommands("108_failed_start_hook")
@@ -5410,6 +5444,20 @@ class IntegrationTest {
         val flowPath = Paths.get(resource.toURI())
         return YamlCommandReader.readCommands(flowPath)
             .withEnv(withEnv().withDefaultEnvVars(flowPath.toFile(), deviceId, shardIndex))
+    }
+}
+
+private class CapturingSettleAppIdFakeDriver : FakeDriver() {
+    var lastSettleAppId: String? = null
+        private set
+
+    override fun waitForAppToSettle(
+        initialHierarchy: maestro.ViewHierarchy?,
+        appId: String?,
+        timeoutMs: Int?,
+    ): maestro.ViewHierarchy? {
+        lastSettleAppId = appId
+        return initialHierarchy
     }
 }
 


### PR DESCRIPTION
## Summary

- Resolve the flow-level `MaestroConfig` after `DefineVariablesCommand` runs.
- Pass the evaluated config to flow hooks and commands so driver consumers such as `waitForAppToSettle` receive the interpolated `appId`.
- Add an integration regression test covering a templated `appId` during tap settling.

Fixes #3479

## Testing

- `git diff --check`
- `./gradlew :maestro-test:test --tests maestro.test.IntegrationTest --tests 'maestro.test.IntegrationTest.templated appId is used when settling after a tap'` *(blocked locally: no Java Runtime is installed)*
