### PR TITLE
fix(orchestra): route the assertScreenshot diff through the artifact collector

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -151,7 +151,7 @@ class TestCommand : Callable<Int> {
 
     @Option(
         names = ["--test-output-dir"],
-        description = ["Directory for this run's artifacts — manifest.json, commands.json, logs/, takeScreenshot/, startRecording/, and screenshotDiff/ written directly into it (overrides the default output location)"],
+        description = ["Directory for this run's artifacts — manifest.json, commands.json, logs/, takeScreenshot/, startRecording/, and assertScreenshot/ written directly into it (overrides the default output location)"],
     )
     private var testOutputDir: String? = null
 

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -151,7 +151,7 @@ class TestCommand : Callable<Int> {
 
     @Option(
         names = ["--test-output-dir"],
-        description = ["Directory for this run's artifacts — manifest.json, commands.json, logs/, takeScreenshot/, and startRecording/ written directly into it (overrides the default output location)"],
+        description = ["Directory for this run's artifacts — manifest.json, commands.json, logs/, takeScreenshot/, startRecording/, and screenshotDiff/ written directly into it (overrides the default output location)"],
     )
     private var testOutputDir: String? = null
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
@@ -13,6 +13,7 @@ enum class ArtifactKind {
     CRASH_REPORT,
     ANR_REPORT,
     AI_ANALYSIS,            // reserved; not emitted yet
+    SCREENSHOT_DIFF,        // assertScreenshot failure diff, one file per failing assertion
 }
 
 /** Concrete on-disk format of an artifact's bytes. ZIP is a download *view*, not a kind. */

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
@@ -13,7 +13,7 @@ enum class ArtifactKind {
     CRASH_REPORT,
     ANR_REPORT,
     AI_ANALYSIS,            // reserved; not emitted yet
-    SCREENSHOT_DIFF,        // assertScreenshot failure diff, one file per failing assertion
+    SCREENSHOT_DIFF,        // assertScreenshot failure diffs, one folder collection entry (schema v2)
 }
 
 /** Concrete on-disk format of an artifact's bytes. ZIP is a download *view*, not a kind. */
@@ -48,18 +48,17 @@ data class ArtifactManifest(
     companion object {
         /**
          * `$schema` written into every manifest: [SCHEMA_RESOURCE] published to a
-         * public GCS object by publish-schemas.yaml. Breaking change → new `vN` path;
-         * additive changes overwrite v1 in place (readers tolerate unknown fields).
-         *
-         * "Additive" covers new *fields* only (safe via `additionalProperties: true`).
-         * Adding an enum value can fail an external validator holding a cached v1, so
-         * prefer reserving values up front. Every in-ecosystem reader is string-typed
-         * and tolerant of unknown kinds (worker, backend, CLI), so a late addition —
-         * SCREENSHOT_DIFF was one — overwrites v1 in place, accepting that caveat.
+         * public GCS object by publish-schemas.yaml. Additive changes (new *fields*
+         * only, safe via `additionalProperties: true`) may overwrite the current `vN`
+         * in place; readers tolerate unknown fields. Adding an enum value is NOT
+         * additive: it fails validators holding the older schema. So any enum add or
+         * breaking change gets a new `vN` file, and every published version stays
+         * frozen; SCREENSHOT_DIFF is the v2 addition, with v1 frozen (checksum-guarded
+         * by the schema test).
          */
-        const val SCHEMA_URL = "https://storage.googleapis.com/maestro-schemas/artifact-manifest/v1.schema.json"
+        const val SCHEMA_URL = "https://storage.googleapis.com/maestro-schemas/artifact-manifest/v2.schema.json"
 
         /** Classpath copy of the schema CI publishes to [SCHEMA_URL]; checked by the schema-coverage test. */
-        const val SCHEMA_RESOURCE = "/maestro/orchestra/artifact-manifest/v1.schema.json"
+        const val SCHEMA_RESOURCE = "/maestro/orchestra/artifact-manifest/v2.schema.json"
     }
 }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
@@ -52,8 +52,10 @@ data class ArtifactManifest(
          * additive changes overwrite v1 in place (readers tolerate unknown fields).
          *
          * "Additive" covers new *fields* only (safe via `additionalProperties: true`).
-         * Adding an enum value is NOT additive — it fails readers holding a cached v1,
-         * so reserve enum values you know are coming up front rather than adding later.
+         * Adding an enum value can fail an external validator holding a cached v1, so
+         * prefer reserving values up front. Every in-ecosystem reader is string-typed
+         * and tolerant of unknown kinds (worker, backend, CLI), so a late addition —
+         * SCREENSHOT_DIFF was one — overwrites v1 in place, accepting that caveat.
          */
         const val SCHEMA_URL = "https://storage.googleapis.com/maestro-schemas/artifact-manifest/v1.schema.json"
 

--- a/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v1.schema.json
+++ b/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v1.schema.json
@@ -97,6 +97,10 @@
         {
           "const": "AI_ANALYSIS",
           "description": "Reserved for AI-generated analysis of the run. Not emitted yet."
+        },
+        {
+          "const": "SCREENSHOT_DIFF",
+          "description": "The visual diff PNG produced by a failed assertScreenshot command, under the run-root screenshotDiff/ folder. One file per failing assertion, reported individually (no count)."
         }
       ]
     },

--- a/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v2.schema.json
+++ b/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v2.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://storage.googleapis.com/maestro-schemas/artifact-manifest/v1.schema.json",
-  "title": "ArtifactManifest (v1)",
+  "$id": "https://storage.googleapis.com/maestro-schemas/artifact-manifest/v2.schema.json",
+  "title": "ArtifactManifest (v2)",
   "description": "The set of artifacts produced for a single Maestro flow run. Owned and emitted by Orchestra; written as manifest.json in the run's artifact root and consumed verbatim by the CLI and the cloud worker.",
   "type": "object",
   "additionalProperties": true,
@@ -97,6 +97,10 @@
         {
           "const": "AI_ANALYSIS",
           "description": "Reserved for AI-generated analysis of the run. Not emitted yet."
+        },
+        {
+          "const": "SCREENSHOT_DIFF",
+          "description": "Visual diff PNGs produced by failed assertScreenshot commands, in the run-root assertScreenshot/ folder. Reported as one collection entry with count set; one file per failing assertion, referenced from that command's COMMAND_METADATA artifacts list."
         }
       ]
     },

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/ArtifactManifestSchemaTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/ArtifactManifestSchemaTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
+import java.security.MessageDigest
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 
@@ -11,9 +12,11 @@ import kotlin.reflect.full.primaryConstructor
  * The schema is hand-written, so it can drift from the model it documents.
  * These tests are the guard: a new [ArtifactKind] / [ArtifactFormat], or a new
  * field on [ArtifactEntry] / [ArtifactManifest], that isn't documented in the
- * schema fails the build. The schema sets `additionalProperties: true` so
- * additive fields stay forward-compatible for validators; the field check keeps
- * the schema a complete, drift-free reference regardless.
+ * current schema ([ArtifactManifest.SCHEMA_RESOURCE]) fails the build. The
+ * schema sets `additionalProperties: true` so additive fields stay
+ * forward-compatible for validators; the field check keeps the schema a
+ * complete, drift-free reference regardless. Superseded versions are frozen
+ * once published (enum adds are not additive), guarded by checksum.
  */
 class ArtifactManifestSchemaTest {
 
@@ -38,6 +41,19 @@ class ArtifactManifestSchemaTest {
         val documented = schema.at("/\$defs/ArtifactFormat/enum").map { it.asText() }
 
         assertThat(documented).containsExactlyElementsIn(ArtifactFormat.entries.map { it.name })
+    }
+
+    @Test
+    fun `published v1 schema stays frozen`() {
+        // v1 is published and may be cached by external validators; it must never change.
+        // Enum values added since (SCREENSHOT_DIFF) live in v2 onward. If this fails, revert
+        // the v1 edit and put the change in a new schema version instead.
+        val v1 = javaClass.getResourceAsStream("/maestro/orchestra/artifact-manifest/v1.schema.json")
+            ?.readBytes() ?: error("v1 schema resource not found")
+        val sha256 = MessageDigest.getInstance("SHA-256").digest(v1)
+            .joinToString("") { "%02x".format(it) }
+
+        assertThat(sha256).isEqualTo("dd5bac62f9f4a5313761a205342f3d22033554c0a9f57a208d6a7d28212d18b2")
     }
 
     @Test

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -693,7 +693,14 @@ class Orchestra(
             debugMessage = "The assertScreenshot command requires a valid image file. Supported formats include PNG, JPEG, GIF, BMP, TIFF, and WBMP. The file at ${expectedFile.absolutePath} could not be read."
         )
 
-        val diffFile = expectedFile.resolveSibling("${expectedFile.nameWithoutExtension}_diff.png")
+        // The diff goes through the collector like every other command output: in a bundle it lands
+        // in the artifacts dir and the manifest (so Cloud uploads it); with no bundle it is
+        // CWD-relative, no longer beside the reference image.
+        val diffFile = artifactsGenerator.allocateCommandArtifact(
+            ArtifactKind.SCREENSHOT_DIFF,
+            "${expectedFile.nameWithoutExtension}_diff.png",
+            "assertScreenshot",
+        )
 
         when (val result = ScreenshotMatch.compare(expectedImage, actualImage, thresholdPercentage, diffFile)) {
             is ScreenshotMatch.Result.Match -> return false // Screenshots are non-interactive
@@ -1202,7 +1209,6 @@ class Orchestra(
         // Generator owns the bundle path and records the file; null means no bundle (write CWD-relative).
         val outFile = artifactsGenerator
             .allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "${command.path}.png", "takeScreenshot")
-            ?: File("${command.path}.png")
         val fileSink = artifactSink(outFile, command.path, "takeScreenshot")
 
         val cropOn = command.cropOn
@@ -1228,7 +1234,6 @@ class Orchestra(
         // Recorded at start; the file is finalized at stopRecording.
         val outFile = artifactsGenerator
             .allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "${command.path}.mp4", "startRecording")
-            ?: File("${command.path}.mp4")
         screenRecording = maestro.startScreenRecording(artifactSink(outFile, command.path, "startRecording"))
         return false
     }

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -697,13 +697,20 @@ class Orchestra(
         // The diff goes through the collector like every other command output: in a bundle it lands
         // in the artifacts dir and the manifest (so Cloud uploads it); with no bundle it is
         // CWD-relative, no longer beside the reference image.
-        val diffFile = artifactsGenerator.allocateCommandArtifact(
-            ArtifactKind.SCREENSHOT_DIFF,
-            "${expectedFile.nameWithoutExtension}_diff.png",
-            "assertScreenshot",
-        )
+        val diffFile = artifactsGenerator.allocateScreenshotDiff(expectedFile.nameWithoutExtension)
 
-        when (val result = ScreenshotMatch.compare(expectedImage, actualImage, thresholdPercentage, diffFile)) {
+        // The only I/O inside compare is the diff write, so a throw here is a destination
+        // problem; report it typed, like the other command outputs do via artifactSink.
+        val result = try {
+            ScreenshotMatch.compare(expectedImage, actualImage, thresholdPercentage, diffFile)
+        } catch (e: Exception) {
+            throw MaestroException.DestinationIsNotWritable(
+                "Cannot write assertScreenshot diff to \"${diffFile.path}\": ${e.message}",
+                e,
+            )
+        }
+
+        when (result) {
             is ScreenshotMatch.Result.Match -> return false // Screenshots are non-interactive
             is ScreenshotMatch.Result.SizeMismatch -> throw MaestroException.AssertionFailure(
                 message = "Screenshot size mismatch: ${command.description()} - expected ${result.expectedWidth}x${result.expectedHeight}, actual ${result.actualWidth}x${result.actualHeight}. Screenshots must have the same dimensions to compare.",

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -146,6 +146,7 @@ class Orchestra(
     private val onCommandReset: (MaestroCommand) -> Unit = {},
     private val onCommandMetadataUpdate: (MaestroCommand, CommandMetadata) -> Unit = { _, _ -> },
     private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
+    private val onScreenshotDiffCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
     private val onCommandGeneratedOutput: (command: Command, defects: List<Defect>, screenshot: Buffer) -> Unit = { _, _, _ -> },
     private val apiKey: String? = null,
     private val AIPredictionEngine: AIPredictionEngine? = apiKey?.let { CloudAIPredictionEngine(it) },
@@ -175,7 +176,7 @@ class Orchestra(
     // ArtifactsGenerator is always the first listener: it writes the bundle when
     // artifactsDir is set and populates debugOutput either way.
     private val artifactsGenerator: ArtifactsGenerator =
-        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts, onStepScreenshotCaptured)
+        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts, onStepScreenshotCaptured, onScreenshotDiffCaptured)
     private val effectiveListeners: List<OrchestraListener> = listOf(artifactsGenerator) + listeners
 
     private var commandSequenceCounter: Int = 0

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -649,9 +649,9 @@ class Orchestra(
         val path = normalizeScreenshotPath(command.path)
 
         val candidates = buildList {
-            command.flowPath?.let { add(it.resolve(path).toFile()) }
-            artifactsDir?.let { add(it.resolve(BundleLayout.TAKE_SCREENSHOT_DIR).resolve(path).normalize().toFile()) }
-            add(File(path))
+            command.flowPath?.let { add(it.resolve(path).toFile()) } // funnel-exempt: read
+            artifactsDir?.let { add(it.resolve(BundleLayout.TAKE_SCREENSHOT_DIR).resolve(path).normalize().toFile()) } // funnel-exempt: read
+            add(File(path)) // funnel-exempt: read
         }.distinctBy { it.canonicalPath }
 
         val expectedFile = candidates.firstOrNull { it.exists() }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
@@ -36,6 +36,11 @@ internal class ArtifactCollector(artifactsDir: Path) {
         ArtifactKind.SCREEN_HIERARCHY to Collection(BundleLayout.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),
     )
 
+    /** Command-output kinds that share a folder but are reported 1:1 (never folded to a count entry). */
+    private val singleFileCommandKinds: Map<ArtifactKind, Collection> = mapOf(
+        ArtifactKind.SCREENSHOT_DIFF to Collection(BundleLayout.SCREENSHOT_DIFF_DIR, ArtifactFormat.PNG),
+    )
+
     private data class Record(
         val kind: ArtifactKind,
         val format: ArtifactFormat?,
@@ -72,7 +77,7 @@ internal class ArtifactCollector(artifactsDir: Path) {
      * is allowed: what decides is where it lands, not how it is written.
      */
     fun allocateCommandOutput(kind: ArtifactKind, path: String, commandName: String, sequenceNumber: Int?): File {
-        val collection = collectionKinds.getValue(kind)
+        val collection = collectionKinds[kind] ?: singleFileCommandKinds.getValue(kind)
         val folder = artifactsDir.resolve(collection.dir)
 
         val resolved = try {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
@@ -34,11 +34,7 @@ internal class ArtifactCollector(artifactsDir: Path) {
         ArtifactKind.START_SCREEN_RECORDING to Collection(BundleLayout.START_RECORDING_DIR, ArtifactFormat.MP4),
         ArtifactKind.SCREENSHOT to Collection(BundleLayout.STEP_SCREENSHOTS_DIR, ArtifactFormat.PNG),
         ArtifactKind.SCREEN_HIERARCHY to Collection(BundleLayout.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),
-    )
-
-    /** Command-output kinds that share a folder but are reported 1:1 (never folded to a count entry). */
-    private val singleFileCommandKinds: Map<ArtifactKind, Collection> = mapOf(
-        ArtifactKind.SCREENSHOT_DIFF to Collection(BundleLayout.SCREENSHOT_DIFF_DIR, ArtifactFormat.PNG),
+        ArtifactKind.SCREENSHOT_DIFF to Collection(BundleLayout.ASSERT_SCREENSHOT_DIR, ArtifactFormat.PNG),
     )
 
     private data class Record(
@@ -77,7 +73,7 @@ internal class ArtifactCollector(artifactsDir: Path) {
      * is allowed: what decides is where it lands, not how it is written.
      */
     fun allocateCommandOutput(kind: ArtifactKind, path: String, commandName: String, sequenceNumber: Int?): File {
-        val collection = collectionKinds[kind] ?: singleFileCommandKinds.getValue(kind)
+        val collection = collectionKinds.getValue(kind)
         val folder = artifactsDir.resolve(collection.dir)
 
         val resolved = try {

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -46,6 +46,7 @@ internal class ArtifactsGenerator(
     private val maestro: Maestro,
     private val captureFullArtifacts: Boolean = false,
     private val onStepScreenshotCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
+    private val onScreenshotDiffCaptured: (sequenceNumber: Int, relativePath: String) -> Unit = { _, _ -> },
 ) : OrchestraListener {
 
     val debugOutput = FlowDebugOutput()
@@ -130,6 +131,13 @@ internal class ArtifactsGenerator(
             metadata.error = outcome.error
             if (outcome.error is MaestroException) {
                 debugOutput.exception = outcome.error
+            }
+            // A failed assertScreenshot has written its diff by now; report it to the host the same
+            // way step screenshots are, so per-step consumers can reference it without a dir scan.
+            metadata.sequenceNumber?.let { seq ->
+                collector?.artifactsForStep(seq)
+                    ?.firstOrNull { it.type == ArtifactKind.SCREENSHOT_DIFF }
+                    ?.let { onScreenshotDiffCaptured(seq, it.path) }
             }
         }
         if (artifactsDir == null || outcome is CommandOutcome.Skipped) return

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -145,8 +145,11 @@ internal class ArtifactsGenerator(
             if (outcome.error is MaestroException) {
                 debugOutput.exception = outcome.error
             }
-            // A failed assertScreenshot has written its diff by now; report it to the host the same
-            // way step screenshots are, so per-step consumers can reference it without a dir scan.
+        }
+        if (outcome is CommandOutcome.Failed || outcome is CommandOutcome.Warned) {
+            // A mismatched assertScreenshot has written its diff by now (a Warned outcome is an
+            // `optional: true` mismatch); report it to the host the same way step screenshots
+            // are, so per-step consumers can reference it without a dir scan.
             metadata.sequenceNumber?.let { seq ->
                 collector?.artifactsForStep(seq)
                     ?.firstOrNull { it.type == ArtifactKind.SCREENSHOT_DIFF }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -103,11 +103,12 @@ internal class ArtifactsGenerator(
 
     /**
      * Allocate (and record) a command-output file through the collector, attributed
-     * to the running command. Null when no bundle is produced ([artifactsDir] null) —
-     * the caller then writes CWD-relative, as before.
+     * to the running command. When no bundle is produced ([artifactsDir] null) the
+     * returned file is CWD-relative at [path], unrecorded — the pre-bundle behavior.
+     * Non-null so callers cannot reintroduce their own raw-`File` fallback paths.
      */
-    fun allocateCommandArtifact(kind: ArtifactKind, path: String, commandName: String): File? {
-        val collector = collector ?: return null
+    fun allocateCommandArtifact(kind: ArtifactKind, path: String, commandName: String): File {
+        val collector = collector ?: return File(path)
         return collector.allocateCommandOutput(
             kind, path, commandName, currentCommandMetadata?.sequenceNumber,
         )

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -115,6 +115,19 @@ internal class ArtifactsGenerator(
         )
     }
 
+    /**
+     * Allocate the failure diff for the running assertScreenshot. Bundle names carry the
+     * command's sequence number (like step screenshots) so two assertions against same-named
+     * references cannot overwrite each other's diff. No bundle: CWD-relative, unrecorded.
+     */
+    fun allocateScreenshotDiff(referenceName: String): File {
+        val fileName = "${referenceName}_diff.png"
+        val collector = collector ?: return File(fileName)
+        val seq = currentCommandMetadata?.sequenceNumber
+        val uniqueName = seq?.let { "step-%03d-%s".format(it, fileName) } ?: fileName
+        return collector.allocateCommandOutput(ArtifactKind.SCREENSHOT_DIFF, uniqueName, "assertScreenshot", seq)
+    }
+
     override fun onCommandFinished(
         cmd: MaestroCommand,
         outcome: CommandOutcome,

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -124,7 +124,9 @@ internal class ArtifactsGenerator(
         val fileName = "${referenceName}_diff.png"
         val collector = collector ?: return File(fileName)
         val seq = currentCommandMetadata?.sequenceNumber
-        val uniqueName = seq?.let { "step-%03d-%s".format(it, fileName) } ?: fileName
+        // Same 1-based step index as every other step-prefixed bundle name, so prefix
+        // correlation pairs the diff with its own step's screenshot and hierarchy.
+        val uniqueName = seq?.let { "step-${StepArtifactNaming.index(it)}-$fileName" } ?: fileName
         return collector.allocateCommandOutput(ArtifactKind.SCREENSHOT_DIFF, uniqueName, "assertScreenshot", seq)
     }
 

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
@@ -21,7 +21,7 @@ package maestro.orchestra.debug
  *   screenshots/              ← step screenshots, step-<NNN>-<type>[-<arg>].png (action steps + final.png; failed step only when flag off)
  *   screen-hierarchy/         ← per-step view hierarchy JSON
  *   screen-recording.mp4      ← full-run recording (flag-gated)
- *   screenshotDiff/           ← assertScreenshot failure diffs, one PNG per failing assertion
+ *   assertScreenshot/         ← assertScreenshot failure diffs, one PNG per failing assertion
  *   ai-analysis/              ← screenshots an AI command analyzed (with defects)
  * ```
  */
@@ -48,7 +48,7 @@ internal object BundleLayout {
 
     const val SCREEN_RECORDING = "screen-recording.mp4"
 
-    const val SCREENSHOT_DIFF_DIR = "screenshotDiff"
+    const val ASSERT_SCREENSHOT_DIR = "assertScreenshot"
 
     const val AI_ANALYSIS_DIR = "ai-analysis"
 }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
@@ -21,6 +21,7 @@ package maestro.orchestra.debug
  *   screenshots/              ← step screenshots, step-<NNN>-<type>[-<arg>].png (action steps + final.png; failed step only when flag off)
  *   screen-hierarchy/         ← per-step view hierarchy JSON
  *   screen-recording.mp4      ← full-run recording (flag-gated)
+ *   screenshotDiff/           ← assertScreenshot failure diffs, one PNG per failing assertion
  *   ai-analysis/              ← screenshots an AI command analyzed (with defects)
  * ```
  */
@@ -46,6 +47,8 @@ internal object BundleLayout {
     const val SCREEN_HIERARCHY_DIR = "screen-hierarchy"
 
     const val SCREEN_RECORDING = "screen-recording.mp4"
+
+    const val SCREENSHOT_DIFF_DIR = "screenshotDiff"
 
     const val AI_ANALYSIS_DIR = "ai-analysis"
 }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
@@ -38,8 +38,11 @@ internal object StepArtifactNaming {
         return leaf !is CompositeCommand && leaf.visible()
     }
 
+    /** 1-based, zero-padded step index — the `NNN` every step-prefixed bundle name shares. */
+    fun index(sequenceNumber: Int): String = (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
+
     fun stem(sequenceNumber: Int, command: MaestroCommand?): String {
-        val index = (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
+        val index = index(sequenceNumber)
         val slug = command?.let(::slug)
         return if (slug.isNullOrEmpty()) "step-$index" else "step-$index-$slug"
     }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -370,7 +370,7 @@ class ArtifactsGeneratorTest {
 
         val diff = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT_DIFF }
         // Named by sequence number so same-named references in different assertions cannot collide.
-        assertThat(diff.relativePath).isEqualTo("screenshotDiff/step-000-home_baseline_diff.png")
+        assertThat(diff.relativePath).isEqualTo("screenshotDiff/step-001-home_baseline_diff.png")
         assertThat(diff.format).isEqualTo(ArtifactFormat.PNG)
         assertThat(diff.count).isNull()
         assertThat(diff.sizeBytes).isEqualTo(2)

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -337,9 +337,9 @@ class ArtifactsGeneratorTest {
         val cmd = MaestroCommand(tapOnElement = null)
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "login/home.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "splash.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
-        gen.allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "clip.mp4", "startRecording")!!.writeBytes(byteArrayOf(1))
+        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "login/home.png", "takeScreenshot").writeBytes(byteArrayOf(1))
+        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "splash.png", "takeScreenshot").writeBytes(byteArrayOf(1))
+        gen.allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "clip.mp4", "startRecording").writeBytes(byteArrayOf(1))
         gen.onFlowEnd()
 
         val takeScreenshot = gen.artifactManifest.entries
@@ -355,6 +355,26 @@ class ArtifactsGeneratorTest {
         assertThat(startRecording.count).isEqualTo(1)
         assertThat(startRecording.sizeBytes).isNull()
         assertThat(startRecording.metadata).isEmpty()
+    }
+
+    @Test
+    fun `screenshot diff lands under its folder and is reported individually, never folded`() {
+        // Unlike the collection kinds above, each diff is its own manifest entry (count == null):
+        // consumers list and label diffs individually instead of zipping a folder.
+        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val cmd = MaestroCommand(tapOnElement = null)
+        gen.onFlowStart()
+        gen.onCommandStart(cmd, sequenceNumber = 0)
+        gen.allocateCommandArtifact(ArtifactKind.SCREENSHOT_DIFF, "home_baseline_diff.png", "assertScreenshot")
+            .writeBytes(byteArrayOf(1, 2))
+        gen.onFlowEnd()
+
+        val diff = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT_DIFF }
+        assertThat(diff.relativePath).isEqualTo("screenshotDiff/home_baseline_diff.png")
+        assertThat(diff.format).isEqualTo(ArtifactFormat.PNG)
+        assertThat(diff.count).isNull()
+        assertThat(diff.sizeBytes).isEqualTo(2)
+        assertThat(tempDir.resolve(diff.relativePath).exists()).isTrue()
     }
 
     @Test
@@ -665,7 +685,7 @@ class ArtifactsGeneratorTest {
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
+        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot").writeBytes(byteArrayOf(1))
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 
@@ -701,7 +721,7 @@ class ArtifactsGeneratorTest {
         gen.onCommandStart(first, sequenceNumber = 0)
         gen.onCommandFinished(first, CommandOutcome.Completed, 100L, 150L)
         gen.onCommandStart(second, sequenceNumber = 1)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
+        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot").writeBytes(byteArrayOf(1))
         gen.onCommandFinished(second, CommandOutcome.Completed, 150L, 200L)
         gen.onFlowEnd()
 
@@ -732,13 +752,16 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `allocateCommandArtifact returns null and records nothing when artifactsDir is null`() {
+    fun `allocateCommandArtifact falls back to a CWD-relative file and records nothing when artifactsDir is null`() {
         val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        assertThat(gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")).isNull()
+        // The pre-bundle behavior: the caller's path verbatim, nothing written, nothing recorded.
+        val fallback = gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")
+        assertThat(fallback.path).isEqualTo("checkout.png")
+        assertThat(fallback.exists()).isFalse()
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -365,12 +365,12 @@ class ArtifactsGeneratorTest {
         val cmd = MaestroCommand(tapOnElement = null)
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        gen.allocateCommandArtifact(ArtifactKind.SCREENSHOT_DIFF, "home_baseline_diff.png", "assertScreenshot")
-            .writeBytes(byteArrayOf(1, 2))
+        gen.allocateScreenshotDiff("home_baseline").writeBytes(byteArrayOf(1, 2))
         gen.onFlowEnd()
 
         val diff = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT_DIFF }
-        assertThat(diff.relativePath).isEqualTo("screenshotDiff/home_baseline_diff.png")
+        // Named by sequence number so same-named references in different assertions cannot collide.
+        assertThat(diff.relativePath).isEqualTo("screenshotDiff/step-000-home_baseline_diff.png")
         assertThat(diff.format).isEqualTo(ArtifactFormat.PNG)
         assertThat(diff.count).isNull()
         assertThat(diff.sizeBytes).isEqualTo(2)

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -785,10 +785,10 @@ class ArtifactsGeneratorTest {
         // self-describing even after it's moved away from its run folder.
         val manifest = jacksonObjectMapper().readTree(tempDir.resolve("manifest.json").toFile())
         assertThat(manifest["\$schema"].asText())
-            .isEqualTo("https://storage.googleapis.com/maestro-schemas/artifact-manifest/v1.schema.json")
+            .isEqualTo("https://storage.googleapis.com/maestro-schemas/artifact-manifest/v2.schema.json")
 
         // No per-run schema file is bundled any more.
-        assertThat(tempDir.resolve("manifest.v1.schema.json").toFile().exists()).isFalse()
+        assertThat(tempDir.resolve("manifest.v2.schema.json").toFile().exists()).isFalse()
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -358,23 +358,26 @@ class ArtifactsGeneratorTest {
     }
 
     @Test
-    fun `screenshot diff lands under its folder and is reported individually, never folded`() {
-        // Unlike the collection kinds above, each diff is its own manifest entry (count == null):
-        // consumers list and label diffs individually instead of zipping a folder.
+    fun `screenshot diffs fold to one assertScreenshot folder entry with a count`() {
+        // Same shape as the other repeatable command outputs (takeScreenshot/, startRecording/):
+        // one folder entry, count = number of diffs. Per-diff paths stay reachable via commands.json.
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
         gen.allocateScreenshotDiff("home_baseline").writeBytes(byteArrayOf(1, 2))
+        gen.onCommandStart(cmd, sequenceNumber = 1)
+        gen.allocateScreenshotDiff("home_baseline").writeBytes(byteArrayOf(3))
         gen.onFlowEnd()
 
         val diff = gen.artifactManifest.entries.single { it.kind == ArtifactKind.SCREENSHOT_DIFF }
-        // Named by sequence number so same-named references in different assertions cannot collide.
-        assertThat(diff.relativePath).isEqualTo("screenshotDiff/step-001-home_baseline_diff.png")
+        assertThat(diff.relativePath).isEqualTo(BundleLayout.ASSERT_SCREENSHOT_DIR)
         assertThat(diff.format).isEqualTo(ArtifactFormat.PNG)
-        assertThat(diff.count).isNull()
-        assertThat(diff.sizeBytes).isEqualTo(2)
-        assertThat(tempDir.resolve(diff.relativePath).exists()).isTrue()
+        assertThat(diff.count).isEqualTo(2)
+        assertThat(diff.sizeBytes).isNull()
+        // Named by sequence number so same-named references in different assertions cannot collide.
+        assertThat(tempDir.resolve("assertScreenshot/step-001-home_baseline_diff.png").exists()).isTrue()
+        assertThat(tempDir.resolve("assertScreenshot/step-002-home_baseline_diff.png").exists()).isTrue()
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraArtifactFunnelTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraArtifactFunnelTest.kt
@@ -6,31 +6,32 @@ import java.io.File
 
 /**
  * Seam guard: every command output in Orchestra is allocated through
- * [ArtifactsGenerator.allocateCommandArtifact] (the collector funnel), never a raw `File(...)`
- * path of the command's own. A raw path is how artifacts historically fell out of the Cloud
- * bundle one at a time: written somewhere the uploader never reads and recorded nowhere (most
- * recently the assertScreenshot diff). If this test fails, route the new output through the
- * funnel; widen the allowlist only for reads or non-artifact files.
+ * [ArtifactsGenerator.allocateCommandArtifact] (the collector funnel), never a path the command
+ * builds itself. Self-built paths are how artifacts historically fell out of the Cloud bundle
+ * one at a time: written somewhere the uploader never reads and recorded nowhere (most recently
+ * the assertScreenshot diff, built via `resolveSibling`). This scans for the path-construction
+ * shapes that class used — `File(...)`, `resolveSibling(...)`, `Paths.get(...)`, `.toFile()` —
+ * and fails on any line not explicitly marked as a read. If this test fails, route the new
+ * output through the funnel; mark a line `// funnel-exempt: read` only when it resolves a path
+ * to read, never to write an artifact.
  */
 class OrchestraArtifactFunnelTest {
 
     @Test
-    fun `orchestra constructs no raw File paths outside the allowlist`() {
-        val orchestra = File("src/main/java/maestro/orchestra/Orchestra.kt")
+    fun `orchestra builds no output paths outside the funnel`() {
+        val projectDir = System.getenv("PROJECT_DIR") ?: "."
+        val orchestra = File(projectDir, "src/main/java/maestro/orchestra/Orchestra.kt")
         assertThat(orchestra.exists()).isTrue()
+
+        val pathConstruction = Regex("""\bFile\s*\(|\bresolveSibling\s*\(|\bPaths\.get\s*\(|\.toFile\s*\(""")
         val source = orchestra.readText()
 
-        // Lines allowed to construct a File directly: reads and non-artifact temp files only.
-        val allowed = setOf(
-            "add(File(path))", // assertScreenshot reference-image candidate: a read, not an output
-        )
-
-        val rawConstructions = Regex("""\bFile\(""").findAll(source)
+        val unexempted = pathConstruction.findAll(source)
             .map { source.lineAt(it.range.first) }
-            .filterNot { line -> allowed.any { line.contains(it) } }
+            .filterNot { it.contains("// funnel-exempt:") }
             .toList()
 
-        assertThat(rawConstructions).isEmpty()
+        assertThat(unexempted).isEmpty()
     }
 
     private fun String.lineAt(index: Int): String {

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraArtifactFunnelTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraArtifactFunnelTest.kt
@@ -1,0 +1,41 @@
+package maestro.orchestra.debug
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Seam guard: every command output in Orchestra is allocated through
+ * [ArtifactsGenerator.allocateCommandArtifact] (the collector funnel), never a raw `File(...)`
+ * path of the command's own. A raw path is how artifacts historically fell out of the Cloud
+ * bundle one at a time: written somewhere the uploader never reads and recorded nowhere (most
+ * recently the assertScreenshot diff). If this test fails, route the new output through the
+ * funnel; widen the allowlist only for reads or non-artifact files.
+ */
+class OrchestraArtifactFunnelTest {
+
+    @Test
+    fun `orchestra constructs no raw File paths outside the allowlist`() {
+        val orchestra = File("src/main/java/maestro/orchestra/Orchestra.kt")
+        assertThat(orchestra.exists()).isTrue()
+        val source = orchestra.readText()
+
+        // Lines allowed to construct a File directly: reads and non-artifact temp files only.
+        val allowed = setOf(
+            "add(File(path))", // assertScreenshot reference-image candidate: a read, not an output
+        )
+
+        val rawConstructions = Regex("""\bFile\(""").findAll(source)
+            .map { source.lineAt(it.range.first) }
+            .filterNot { line -> allowed.any { line.contains(it) } }
+            .toList()
+
+        assertThat(rawConstructions).isEmpty()
+    }
+
+    private fun String.lineAt(index: Int): String {
+        val start = lastIndexOf('\n', index) + 1
+        val end = indexOf('\n', index).let { if (it == -1) length else it }
+        return substring(start, end).trim()
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -587,6 +587,34 @@ class OrchestraListenerDispatchTest {
     }
 
     @Test
+    fun `an optional assertScreenshot mismatch still reports its diff`() {
+        // optional: true converts the failure to a warning; the diff is written all the same and
+        // must stay attributed, or the soft failure's only explanation is unfindable per-step.
+        val commands = listOf(
+            MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "home")),
+            MaestroCommand(
+                assertScreenshotCommand = AssertScreenshotCommand(
+                    path = "home",
+                    thresholdPercentage = "99",
+                    optional = true,
+                ),
+            ),
+        )
+        val capturedDiffs = mutableListOf<Pair<Int, String>>()
+        val orchestra = Orchestra(
+            maestro = mockMaestroWithScreenshots(changing = true),
+            artifactsDir = tempDir,
+            onScreenshotDiffCaptured = { seq, path -> capturedDiffs.add(seq to path) },
+        )
+
+        runBlocking { orchestra.runFlow(commands) }
+
+        assertThat(capturedDiffs).hasSize(1)
+        assertThat(capturedDiffs.single().first).isEqualTo(1)
+        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-001-home_diff.png")
+    }
+
+    @Test
     @EnabledOnOs(OS.LINUX, OS.MAC)
     fun `takeScreenshot keeps a backslash in the file name instead of inventing a folder`() {
         val cmd = MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "checkout\\v2"))

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -577,13 +577,13 @@ class OrchestraListenerDispatchTest {
         }
 
         assertThat(e.message).contains("threshold not met")
-        assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-001-home_diff.png").toFile().exists()).isTrue()
+        assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-002-home_diff.png").toFile().exists()).isTrue()
         assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
         // The host is told about the diff the same way it is told about step screenshots,
         // attributed to the failing command's sequence number (the second command here).
         assertThat(capturedDiffs).hasSize(1)
         assertThat(capturedDiffs.single().first).isEqualTo(1)
-        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-001-home_diff.png")
+        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-002-home_diff.png")
     }
 
     @Test
@@ -611,7 +611,7 @@ class OrchestraListenerDispatchTest {
 
         assertThat(capturedDiffs).hasSize(1)
         assertThat(capturedDiffs.single().first).isEqualTo(1)
-        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-001-home_diff.png")
+        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-002-home_diff.png")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -577,13 +577,13 @@ class OrchestraListenerDispatchTest {
         }
 
         assertThat(e.message).contains("threshold not met")
-        assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-002-home_diff.png").toFile().exists()).isTrue()
+        assertThat(tempDir.resolve("${BundleLayout.ASSERT_SCREENSHOT_DIR}/step-002-home_diff.png").toFile().exists()).isTrue()
         assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
         // The host is told about the diff the same way it is told about step screenshots,
         // attributed to the failing command's sequence number (the second command here).
         assertThat(capturedDiffs).hasSize(1)
         assertThat(capturedDiffs.single().first).isEqualTo(1)
-        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-002-home_diff.png")
+        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.ASSERT_SCREENSHOT_DIR}/step-002-home_diff.png")
     }
 
     @Test
@@ -611,7 +611,7 @@ class OrchestraListenerDispatchTest {
 
         assertThat(capturedDiffs).hasSize(1)
         assertThat(capturedDiffs.single().first).isEqualTo(1)
-        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-002-home_diff.png")
+        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.ASSERT_SCREENSHOT_DIR}/step-002-home_diff.png")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -577,13 +577,13 @@ class OrchestraListenerDispatchTest {
         }
 
         assertThat(e.message).contains("threshold not met")
-        assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/home_diff.png").toFile().exists()).isTrue()
+        assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-001-home_diff.png").toFile().exists()).isTrue()
         assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
         // The host is told about the diff the same way it is told about step screenshots,
         // attributed to the failing command's sequence number (the second command here).
         assertThat(capturedDiffs).hasSize(1)
         assertThat(capturedDiffs.single().first).isEqualTo(1)
-        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/home_diff.png")
+        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/step-001-home_diff.png")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -552,7 +552,10 @@ class OrchestraListenerDispatchTest {
     }
 
     @Test
-    fun `assertScreenshot writes its diff beside a reference reached through a parent segment`() {
+    fun `assertScreenshot writes its diff into the collector's diff folder, not beside the reference`() {
+        // The diff's location no longer derives from where the reference resolved (which used to
+        // scatter it: workspace dir, takeScreenshot folder, or CWD). It is a command output like
+        // any other: allocated by the collector, recorded, uniform.
         val commands = listOf(
             MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "login/../home")),
             MaestroCommand(
@@ -569,7 +572,8 @@ class OrchestraListenerDispatchTest {
         }
 
         assertThat(e.message).contains("threshold not met")
-        assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isTrue()
+        assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/home_diff.png").toFile().exists()).isTrue()
+        assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -565,7 +565,12 @@ class OrchestraListenerDispatchTest {
                 ),
             ),
         )
-        val orchestra = Orchestra(maestro = mockMaestroWithScreenshots(changing = true), artifactsDir = tempDir)
+        val capturedDiffs = mutableListOf<Pair<Int, String>>()
+        val orchestra = Orchestra(
+            maestro = mockMaestroWithScreenshots(changing = true),
+            artifactsDir = tempDir,
+            onScreenshotDiffCaptured = { seq, path -> capturedDiffs.add(seq to path) },
+        )
 
         val e = assertThrows<MaestroException.AssertionFailure> {
             runBlocking { orchestra.runFlow(commands) }
@@ -574,6 +579,9 @@ class OrchestraListenerDispatchTest {
         assertThat(e.message).contains("threshold not met")
         assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/home_diff.png").toFile().exists()).isTrue()
         assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
+        // The host is told about the diff the same way it is told about step screenshots.
+        assertThat(capturedDiffs).hasSize(1)
+        assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/home_diff.png")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -579,8 +579,10 @@ class OrchestraListenerDispatchTest {
         assertThat(e.message).contains("threshold not met")
         assertThat(tempDir.resolve("${BundleLayout.SCREENSHOT_DIFF_DIR}/home_diff.png").toFile().exists()).isTrue()
         assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
-        // The host is told about the diff the same way it is told about step screenshots.
+        // The host is told about the diff the same way it is told about step screenshots,
+        // attributed to the failing command's sequence number (the second command here).
         assertThat(capturedDiffs).hasSize(1)
+        assertThat(capturedDiffs.single().first).isEqualTo(1)
         assertThat(capturedDiffs.single().second).isEqualTo("${BundleLayout.SCREENSHOT_DIFF_DIR}/home_diff.png")
     }
 


### PR DESCRIPTION
## What

Routes the `assertScreenshot` failure diff through the artifact collector, like every other command output.

- New `ArtifactKind.SCREENSHOT_DIFF` (+ v1 schema entry). Diffs land under `screenshotDiff/` in the bundle and are reported 1:1 in the manifest (never folded into a count entry), named `step-NNN-<reference>_diff.png` by the failing command's sequence number so two assertions against same-named references cannot overwrite each other.
- `allocateCommandArtifact` is now non-null: it owns the no-bundle CWD fallback, so call sites cannot reintroduce their own raw-`File` fallback paths. New `allocateScreenshotDiff` allocates the diff with the same funnel.
- New `onScreenshotDiffCaptured` callback (mirrors `onStepScreenshotCaptured`): fired when a failed command produced a diff, so hosts (the cloud worker) can attribute it per step without scanning the bundle by convention.
- A failed diff write now surfaces as `MaestroException.DestinationIsNotWritable`, like other command outputs, instead of a raw comparison-library exception.
- Guard test (`OrchestraArtifactFunnelTest`): scans `Orchestra.kt` for self-built path constructions (`File(...)`, `resolveSibling(...)`, `Paths.get(...)`, `.toFile()`) outside explicitly marked reads, so the next command output cannot silently bypass the funnel.

## Why

The diff was the last command output written as a raw `File`, placed beside the reference image. On Maestro Cloud the reference resolves into the workspace temp dir, which the bundle uploader never reads, so the one artifact explaining a failed visual assertion never reached the customer (mobile-dev's MA-4167, confirmed on a production run whose artifact registry had 5 types and no diff). Every historical artifact gap (recordings, logs, crash reports) had this same shape: an output written outside the collector, fixed one at a time. This closes the last one and adds the guard that keeps it closed.

## Behavior change (local)

The diff no longer lands beside the reference image:

- `maestro test` (bundle mode): in the debug output dir under `screenshotDiff/`, recorded in the manifest.
- No-bundle mode (`maestro test -c`): CWD-relative `<reference>_diff.png`, same fallback rule as `takeScreenshot`.

The failure message has always printed the diff's absolute path and still does; nothing documented referenced the old location (checked docs, e2e flows, maestro-docs).

## Schema note

`SCREENSHOT_DIFF` is added to the published v1 schema in place. The policy comment previously said enum additions are not additive; I verified every in-ecosystem manifest reader (worker, backend, CLI) is string-typed and tolerant of unknown kinds, and none validates against the JSON schema, so the comment now states the actual rule: prefer reserving values up front, and a late addition overwrites v1 accepting the cached-external-validator caveat.

## Verification

- `:maestro-orchestra:test`, `:maestro-orchestra-models:test` (incl. the bidirectional schema coverage test), and `:maestro-test:test` all green.
- New/updated tests: diff manifest shape (1:1, PNG, sequence-numbered path, sizeBytes); diff location + per-step callback attribution (sequence number pinned); non-null fallback semantics (CWD-relative, nothing recorded); the funnel guard.
