### PR TITLE
fix(cli): honor MAESTRO_CLI_NO_ANALYTICS in ErrorReporter

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
+++ b/maestro-cli/src/main/java/maestro/cli/analytics/Analytics.kt
@@ -17,7 +17,7 @@ import kotlin.String
 object Analytics : AutoCloseable {
     private const val POSTHOG_API_KEY: String = "phc_XKhdIS7opUZiS58vpOqbjzgRLFpi0I6HU2g00hR7CVg"
     private const val POSTHOG_HOST: String = "https://us.i.posthog.com"
-    private const val DISABLE_ANALYTICS_ENV_VAR = "MAESTRO_CLI_NO_ANALYTICS"
+    const val DISABLE_ANALYTICS_ENV_VAR = "MAESTRO_CLI_NO_ANALYTICS"
     private val JSON = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
     private val apiClient = ApiClient(EnvUtils.BASE_API_URL)
     private val posthog: PostHogInterface = PostHog.with(

--- a/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
@@ -1,5 +1,6 @@
 package maestro.cli.util
 
+import maestro.cli.analytics.Analytics
 import maestro.cli.api.ApiClient
 import picocli.CommandLine
 import java.security.MessageDigest
@@ -14,6 +15,9 @@ object ErrorReporter {
     }
 
     fun report(exception: Exception, parseResult: CommandLine.ParseResult) {
+        // Gated here rather than at the call site so any future caller of report() inherits the opt-out (#3488).
+        if (System.getenv(Analytics.DISABLE_ANALYTICS_ENV_VAR) != null) return
+
         val args = parseResult.expandedArgs()
         val scrubbedArgs = args.mapIndexed { idx, arg ->
             if (idx > 0 && args[idx - 1] in listOf("-e", "--env")) {

--- a/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
+++ b/maestro-cli/src/main/java/maestro/cli/util/ErrorReporter.kt
@@ -15,7 +15,6 @@ object ErrorReporter {
     }
 
     fun report(exception: Exception, parseResult: CommandLine.ParseResult) {
-        // Gated here rather than at the call site so any future caller of report() inherits the opt-out (#3488).
         if (System.getenv(Analytics.DISABLE_ANALYTICS_ENV_VAR) != null) return
 
         val args = parseResult.expandedArgs()

--- a/maestro-cli/src/test/kotlin/maestro/cli/util/ErrorReporterTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/util/ErrorReporterTest.kt
@@ -1,0 +1,48 @@
+package maestro.cli.util
+
+import com.google.common.truth.Truth.assertThat
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import picocli.CommandLine
+import picocli.CommandLine.Command
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
+import uk.org.webcompere.systemstubs.jupiter.SystemStub
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension
+
+@ExtendWith(SystemStubsExtension::class)
+class ErrorReporterTest {
+
+    @SystemStub
+    private val environmentVariables = EnvironmentVariables()
+
+    private lateinit var server: MockWebServer
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `no error report is sent when MAESTRO_CLI_NO_ANALYTICS is set`() {
+        environmentVariables.set("MAESTRO_CLI_NO_ANALYTICS", "1")
+        environmentVariables.set("MAESTRO_API_URL", server.url("/").toString().trimEnd('/'))
+
+        ErrorReporter.report(RuntimeException("boom"), parseResult())
+
+        assertThat(server.requestCount).isEqualTo(0)
+    }
+
+    @Command(name = "dummy")
+    private class DummyCommand
+
+    private fun parseResult(): CommandLine.ParseResult =
+        CommandLine(DummyCommand()).parseArgs()
+}


### PR DESCRIPTION
## Proposed changes

`MAESTRO_CLI_NO_ANALYTICS` currently disables PostHog analytics events but does **not** gate `ErrorReporter`, which sends exception details and the (only partially sanitized) command line to `POST /maestro/error` on `api.copilot.mobile.dev`. The startup banner —

> Anonymous analytics enabled. To opt out, set MAESTRO_CLI_NO_ANALYTICS environment variable to any value before running Maestro.

— implies the env var disables all telemetry, so this is a user-facing surprise (and a data-governance concern for enterprise users who audit the CLI expecting a full opt-out).

This change:

- Exposes `Analytics.DISABLE_ANALYTICS_ENV_VAR` publicly (was `private const`), so the canonical env var name lives in exactly one place.
- Adds an early `return` at the top of `ErrorReporter.report()` that skips the outbound POST when `MAESTRO_CLI_NO_ANALYTICS` is set, mirroring the check `Analytics.trackEvent()` already performs.

No new env var is introduced — the existing opt-out simply starts covering error reports as well, matching what the banner already promises.

## Testing

Added `ErrorReporterTest` (`maestro-cli/src/test/kotlin/maestro/cli/util/ErrorReporterTest.kt`) as a regression test for #3488:

- Uses `system-stubs` to set `MAESTRO_CLI_NO_ANALYTICS=1` and route `MAESTRO_API_URL` at a `MockWebServer` — same testing patterns already used by `EnvUtilsTest` (env-var stubbing) and `ApiClientUploadRetryTest` (`MockWebServer` for HTTP-layer assertions).
- Invokes `ErrorReporter.report(...)` with a synthetic exception.
- Asserts `server.requestCount == 0`, proving the guard short-circuits before the executor submits the outbound POST.

If this line ever regresses (e.g. someone deletes the early `return`), the test fails — locking the fix in.

Verified via this PR's CI (build + unit tests on the `maestro-cli` module and downstream suites).

I didn't add a "happy path" test (env var unset → request sent) — that would essentially retest `ErrorReporter`'s pre-existing behavior, whereas the regression risk this PR introduces is entirely on the guard side. Happy to add it if reviewers prefer symmetric coverage.

## Issues fixed

Fixes #3488