### PR TITLE
fix(orchestra): parse absent disableAnimations as unset instead of false

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/WorkspaceConfig.kt
@@ -12,10 +12,7 @@ data class WorkspaceConfig(
     val baselineBranch: String? = null,
     val notifications: MaestroNotificationConfiguration? = null,
     @Deprecated("not supported now by default on cloud") val disableRetries: Boolean = false,
-    val platform: PlatformConfiguration? = PlatformConfiguration(
-        android = PlatformConfiguration.AndroidConfiguration(disableAnimations = false),
-        ios = PlatformConfiguration.IOSConfiguration(disableAnimations = false)
-    ),
+    val platform: PlatformConfiguration? = null,
     val testOutputDir: String? = null,
 ) {
 
@@ -42,11 +39,27 @@ data class WorkspaceConfig(
         val ios: IOSConfiguration? = null
     ) {
         data class AndroidConfiguration(
-            val disableAnimations: Boolean = false,
+            /**
+             * Unset by default. On executors that manage device animation state (e.g. Maestro
+             * Cloud), explicit `true` disables animations everywhere such executors manage them,
+             * explicit `false` makes the executor leave the device's animation state alone, and
+             * unset applies the executor default (animations disabled on Maestro Cloud for
+             * deterministic screenshots). Local CLI runs do not modify the device's animation
+             * settings.
+             */
+            val disableAnimations: Boolean? = null,
         )
 
         data class IOSConfiguration(
-            val disableAnimations: Boolean = false,
+            /**
+             * Unset by default. On executors that manage device animation state (e.g. Maestro
+             * Cloud), explicit `true` disables animations everywhere such executors manage them,
+             * explicit `false` makes the executor leave the device's animation state alone, and
+             * unset applies the executor default (animations disabled on Maestro Cloud for
+             * deterministic screenshots). Local CLI runs do not modify the device's animation
+             * settings.
+             */
+            val disableAnimations: Boolean? = null,
             val snapshotKeyHonorModalViews: Boolean? = null,
         )
     }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceExecutionPlannerTest.kt
@@ -211,6 +211,7 @@ internal class WorkspaceExecutionPlannerTest {
             path("/workspaces/007_empty_config/flowA.yaml"),
             path("/workspaces/007_empty_config/flowB.yaml"),
         )
+        assertThat(plan.workspaceConfig.platform).isNull()
     }
 
     @Test
@@ -376,6 +377,36 @@ internal class WorkspaceExecutionPlannerTest {
         )
     }
 
+    @Test
+    internal fun `019 - Platform config keys left unset parse as null`() {
+        // when
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/019_platform_config_unset"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        // then - absent disableAnimations stays unset, explicit values survive
+        val platformConfiguration = plan.workspaceConfig.platform
+        assertThat(platformConfiguration?.android?.disableAnimations).isNull()
+        assertThat(platformConfiguration?.ios?.disableAnimations).isFalse()
+        assertThat(platformConfiguration?.ios?.snapshotKeyHonorModalViews).isNull()
+    }
+
+    @Test
+    internal fun `020 - Config without platform block leaves platform null`() {
+        // when
+        val plan = WorkspaceExecutionPlanner.plan(
+            input = paths("/workspaces/013_execution_order"),
+            includeTags = listOf(),
+            excludeTags = listOf(),
+            config = null,
+        )
+
+        // then
+        assertThat(plan.workspaceConfig.platform).isNull()
+    }
 
     private fun path(path: String): Path? {
         val clazz = WorkspaceExecutionPlannerTest::class.java

--- a/maestro-orchestra/src/test/resources/workspaces/019_platform_config_unset/config.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/019_platform_config_unset/config.yaml
@@ -1,0 +1,4 @@
+platform:
+  android: {}
+  ios:
+    disableAnimations: false

--- a/maestro-orchestra/src/test/resources/workspaces/019_platform_config_unset/flowA.yaml
+++ b/maestro-orchestra/src/test/resources/workspaces/019_platform_config_unset/flowA.yaml
@@ -1,0 +1,3 @@
+appId: com.example.app
+---
+- launchApp


### PR DESCRIPTION
## Problem

`WorkspaceConfig` today cannot represent "the user said nothing about animations":

- `PlatformConfiguration.AndroidConfiguration.disableAnimations` and `IOSConfiguration.disableAnimations` are `Boolean = false`, so a platform block that omits the key deserializes to an explicit `false`.
- The `platform` property's default constructs a non-null `PlatformConfiguration` with `disableAnimations = false` on both platforms, so even a config with no `platform` block at all materializes explicit `false` values.

After parsing, `disableAnimations: false` written by the user and no mention of animations at all are indistinguishable. Any executor that manages device animation state (Maestro Cloud disables animations by default for deterministic screenshots) cannot honor an explicit opt-out without also breaking the sensible default for everyone who never set the key, and vice versa.

## Fix

Make absence survive parsing as `null`:

- `disableAnimations` becomes `Boolean? = null` on both `AndroidConfiguration` and `IOSConfiguration`.
- `WorkspaceConfig.platform` defaults to `null` instead of a pre-populated `PlatformConfiguration`, so both absence paths (platform block present but key omitted, and no platform block at all) reach consumers as `null`.
- KDoc on the fields documents the contract: unset by default; executors that manage device animation state treat unset as animations-disabled for deterministic screenshots; local CLI runs do not modify the device's animation settings.

## Zero local behavior change

The CLI has no actuation machinery for `disableAnimations`: a repo-wide sweep finds no local consumer of the field. The only reader of `WorkspaceConfig.platform` is `MaestroSessionManager`, which accesses `platformConfiguration?.ios?.snapshotKeyHonorModalViews` through an already null-safe chain and never touches `disableAnimations`; a `null` platform yields the same `null` it got before from the key being absent inside the default instance.

The precedent here is `snapshotKeyHonorModalViews`, and it is stronger than mere pass-through: that field does actuate locally, with the null-check at the actuation point (`MaestroSessionManager` hands it to `LocalXCTestInstaller`, and `XCRunnerCLIUtils`/`LocalSimulatorUtils` set the env var only when the value is non-null). The codebase already treats `null` as "leave the platform default alone" at the point of use, which is exactly the contract this change gives `disableAnimations`.

## Tests

`WorkspaceExecutionPlannerTest` (real YAML parsing path):

- New fixture `019_platform_config_unset`: a platform block where Android omits the key and iOS sets `disableAnimations: false`. Asserts Android parses as `null`, iOS keeps explicit `false`, and untouched `snapshotKeyHonorModalViews` stays `null`.
- New test on an existing fixture without a `platform` block: `workspaceConfig.platform` is `null`.
- Extended the empty-config test: the constructor-default path also yields `platform == null`.
- Existing test 017 continues to prove explicit `true` round-trips.

`./gradlew :maestro-orchestra-models:test :maestro-orchestra:test` green; `:maestro-cli` and `:maestro-client` compile unchanged.

## Compatibility

`maestro-orchestra-models` publishes to Maven Central (`dev.mobile:maestro-orchestra-models`, currently 2.8.0). This change turns `getDisableAnimations()` from `()Z` into `()Ljava/lang/Boolean;`, and changes the constructor/`copy`/`componentN` signatures accordingly, so it is binary-incompatible for third-party consumers compiled against the old artifact. That is intentional: the nullable type is the point of the change, since only `Boolean?` can represent "unset".

There is also a user-visible consequence once a consumer picks this up: existing configs whose platform block omits `disableAnimations` (and configs with no `platform` block) will resolve as unset, which animation-managing executors treat as animations-disabled; today both materialize `false`.

## Design note

If the CLI ever grows local animation enforcement, it should adopt the executor-default contract documented on the fields (treat unset as animations-disabled where the executor manages animation state) rather than reintroducing a parse-time `false`.
