### PR TITLE
feat: capture host exception class chain in JsScriptError.causeClass

### DIFF
--- a/maestro-client/src/main/java/maestro/js/JsScriptError.kt
+++ b/maestro-client/src/main/java/maestro/js/JsScriptError.kt
@@ -11,6 +11,13 @@ import org.graalvm.polyglot.PolyglotException
 data class JsScriptError(
     val message: String,
     val causeMessage: String?,
+    /**
+     * Class names of the originating host exception's cause chain (e.g.
+     * "java.net.SocketTimeoutException"), joined with " < ". Null for pure guest
+     * errors. Messages alone often omit the exception class, so downstream error
+     * classification needs this to tell transport failures from script failures.
+     */
+    val causeClass: String? = null,
     val sourceClass: String,
     val stackFrames: List<String>,
     val isHostException: Boolean,
@@ -34,6 +41,14 @@ class JsEvaluationException(val error: JsScriptError) : RuntimeException(error.m
 fun PolyglotException.toJsScriptError(): JsScriptError = JsScriptError(
     message = this.message ?: "(no message)",
     causeMessage = this.cause?.message,
+    causeClass = runCatching {
+        // asHostException() throws unless isHostException; cause is usually null for
+        // host exceptions, which is why the message-only fields can't carry the class.
+        val origin: Throwable? = if (this.isHostException) this.asHostException() else this.cause
+        origin?.let { root ->
+            generateSequence(root) { it.cause }.take(5).joinToString(" < ") { it.javaClass.name }
+        }
+    }.getOrNull(),
     sourceClass = this::class.java.name,
     stackFrames = runCatching {
         this.polyglotStackTrace.map { frame ->

--- a/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/GraalJsEngineTest.kt
@@ -256,6 +256,23 @@ class GraalJsEngineTest : JsEngineTest() {
         // All stack frames are Strings — none are live polyglot StackFrame objects
         err.stackFrames.forEach { assertThat(it).isInstanceOf(String::class.java) }
         assertThat(err.isGuestException).isTrue()
+        // Pure guest errors have no host exception behind them
+        assertThat(err.causeClass).isNull()
+    }
+
+    @Test
+    fun `JsScriptError captures host exception class in causeClass`() {
+        // Port 1 on localhost is closed, so the http binding's OkHttp call throws a real
+        // java.net exception through the polyglot boundary as a host exception. Its message
+        // ("Connection refused" / "Connect timed out") does not name the exception class;
+        // causeClass is what lets downstream classifiers identify transport failures.
+        val ex = assertThrows<JsEvaluationException> {
+            engine.evaluateScript("http.get('http://127.0.0.1:1')")
+        }
+        val err = ex.error
+        assertThat(err.isHostException).isTrue()
+        assertThat(err.causeClass).contains("Exception")
+        assertThat(err.causeClass).contains("java.")
     }
 
     @Test


### PR DESCRIPTION
## What

Add `causeClass: String? = null` to `JsScriptError`, populated from the originating host exception's cause chain (e.g. `java.net.SocketTimeoutException`), joined with " < ".

## Why

The JS `http` binding propagates OkHttp/java.net exceptions across the polyglot boundary as host exceptions. Their messages ("Connect timed out", "Connection refused") do not name the exception class, and `PolyglotException.cause` is null on the host-exception path, so downstream consumers that classify errors by exception class cannot tell a transport failure from a script failure. In Maestro Cloud this causes infrastructure blips to be billed to customers as test failures.

## How

`toJsScriptError()` reads the origin via `asHostException()` (falling back to `.cause` for guest exceptions), walks the cause chain bounded at 5 frames, and joins the class names. Resolved while the engine is still open, consistent with the existing detached-error design. Guest errors stay null.

## Test

`GraalJsEngineTest`: a real host exception via `engine.evaluateScript("http.get('http://127.0.0.1:1')")`, asserting `isHostException` and that `causeClass` contains "java." and "Exception"; plus a null assertion on the guest-error path. Deterministic: the connection is refused in milliseconds, or fails as `SocketTimeoutException` at the client's 10s cap, and the JDK default proxy selector excludes 127.*. No positional constructors exist (both call sites use named args), so inserting the field mid-class is source-compatible.

Consumed by the Maestro Cloud worker classifier (copilot branch `ma-4149-js-classifier`).
