### PR TITLE
fix(web): prefer data-testid over non-unique class in createXPathFromElement

### DIFF
--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -201,7 +201,7 @@
     }
 
     // https://stackoverflow.com/a/5178132
-    maestro.createXPathFromElement = (domElement) => {
+    const attributeXPathFromElement = (domElement) => {
         var allNodes = document.getElementsByTagName('*');
         for (var segs = []; domElement && domElement.nodeType == 1; domElement = domElement.parentNode)
         {
@@ -239,6 +239,40 @@
         }
         return segs.length ? '/' + segs.join('/') : null;
     }
+
+    const xpathResolvesToElement = (xpath, element) => {
+        try {
+            const result = document.evaluate(xpath, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+            return result.snapshotLength === 1 && result.snapshotItem(0) === element;
+        } catch (e) {
+            return false;
+        }
+    };
+
+    const positionalXPathFromElement = (domElement) => {
+        for (var segs = []; domElement && domElement.nodeType == 1; domElement = domElement.parentNode) {
+            var i = 1;
+            for (var sib = domElement.previousSibling; sib; sib = sib.previousSibling) {
+                if (sib.localName == domElement.localName) i++;
+            }
+            segs.unshift(domElement.localName.toLowerCase() + '[' + i + ']');
+        }
+        return segs.length ? '/' + segs.join('/') : null;
+    };
+
+    maestro.createXPathFromElement = (domElement) => {
+        // Attribute-based expressions are readable and stable, but not
+        // guaranteed unique: generated class names are shared across sibling
+        // elements (CSS-in-JS), and ids or data-testids can be duplicated.
+        // Verify the candidate resolves to exactly this element, otherwise
+        // fall back to the fully positional path, which is unique by
+        // construction.
+        const candidate = attributeXPathFromElement(domElement);
+        if (candidate && xpathResolvesToElement(candidate, domElement)) {
+            return candidate;
+        }
+        return positionalXPathFromElement(domElement);
+    };
 
     // -------------- Cross-origin iframe viewport params --------------
 

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -205,7 +205,19 @@
         var allNodes = document.getElementsByTagName('*');
         for (var segs = []; domElement && domElement.nodeType == 1; domElement = domElement.parentNode)
         {
-            if (domElement.hasAttribute('id')) {
+            if (domElement.hasAttribute('data-testid')) {
+                    var tid = domElement.getAttribute('data-testid');
+                    var uniqueTidCount = 0;
+                    for (var n=0;n < allNodes.length;n++) {
+                        if (allNodes[n].getAttribute && allNodes[n].getAttribute('data-testid') == tid) uniqueTidCount++;
+                        if (uniqueTidCount > 1) break;
+                    }
+                    if (uniqueTidCount == 1) {
+                        return '//*[@data-testid="' + tid + '"]' + (segs.length ? '/' + segs.join('/') : '');
+                    } else {
+                        segs.unshift(domElement.localName.toLowerCase() + '[@data-testid="' + tid + '"]');
+                    }
+            } else if (domElement.hasAttribute('id')) {
                     var uniqueIdCount = 0;
                     for (var n=0;n < allNodes.length;n++) {
                         if (allNodes[n].hasAttribute('id') && allNodes[n].id == domElement.id) uniqueIdCount++;


### PR DESCRIPTION
## Proposed changes

On the web driver, `inputText` can type into the **wrong input**, not the one the preceding `tapOn` focused. This is not universal, which is why it has gone unnoticed: it only happens when the focused element's computed XPath is **non-unique**, i.e. the element has no unique `id` and shares its `class` with an earlier same-tag element. Hand-written pages almost never hit this (inputs there tend to have a unique `id`, a distinct `class`, or no `class` at all, in which case the positional fallback `input[2]` resolves correctly). But under CSS-in-JS frameworks (**React Native Web**, **Flutter web**, styled-components and friends) every input carries the *same generated class* and no `id`, so the condition holds on essentially every screen. There, any screen with two or more inputs breaks deterministically: typing into any input after the first lands in the **first** input. (Single-input screens still resolve correctly, since the first match *is* the focused element.)

**Root cause.** `inputText` / `eraseText` both route through `CdpWebDriver.withActiveElement`, which reads `document.activeElement`, computes an XPath for it via `createXPathFromElement` (`maestro-client/src/main/resources/maestro-web.js`), then re-resolves that XPath with Selenium `findElement(By.xpath(...))` and sends keys to the returned element.

`createXPathFromElement` builds the path with the fallback chain **`id` -> `class` -> positional sibling index** and never considers `data-testid`. CSS-in-JS frameworks assign the **same generated class to every element of a kind**, so for a screen with several `<input>`s the function emits something like `input[@class="css-1a2b3c"]`, which matches **all** of them, and `findElement(By.xpath)` returns the **first** match. The tap focuses the right element (browser `document.activeElement` is correct), but the subsequent Selenium lookup targets input #1.

**Fix.** Two parts. First, a `data-testid` branch **before** `id`/`class`: a unique `data-testid` returns `//*[@data-testid="..."]`. `data-testid` is already Maestro's primary locator attribute on web (it maps to `resource-id` in `getContentDescription`, and `tapOn: { id: ... }` matches against it), so preferring it for the reverse XPath is consistent with how elements are located in the first place. Second, the attribute-based expression is now only a candidate: `createXPathFromElement` verifies with `document.evaluate` that it resolves to exactly the source element, and falls back to the fully positional absolute path (unique by construction) when it does not. That makes the generated expression unique and correct in every case, including shared classes without a testid and duplicated ids or testids, while keeping the readable attribute forms whenever they are actually unique.

Scope: one function in the injected `maestro-web.js`.

## Testing

Verified the injected script with `node --check` (JS-only change, no compilation).

Reproduction: a React-Native-Web-style page where two inputs share a class:

```html
<input class="css-1a2b3c" data-testid="first" />
<input class="css-1a2b3c" data-testid="second" />
```

```yaml
- tapOn:
    id: "second"
- inputText: "hello"
```

Before this change the text goes into the **first** input; logging confirms the tap correctly focuses input #2 (`document.activeElement` is input #2) but the non-unique `input[@class="css-1a2b3c"]` XPath makes Selenium's `.focus()`/sendKeys hit input #1. After the change it goes into the focused input. (Falsifiability check: remove the shared `class` from the repro and the bug disappears even without this fix, because the positional fallback `input[2]` is unique. That is why plain-HTML pages never surfaced this.)

Uniqueness verified in Chromium by evaluating the generated expression for each case and asserting it resolves to the source element and nothing else:

| case | generated expression |
|---|---|
| unique `data-testid` | `//*[@data-testid="a2"]` |
| shared class, no other attrs | `/html[1]/body[1]/div[2]/input[2]` |
| duplicate `data-testid` | `/html[1]/body[1]/div[3]/span[2]` |
| unique `id` | `id("uniq")` |
| duplicate `id` | `/html[1]/body[1]/div[5]/i[2]` |

Happy to add a two-input web screen + flow under `e2e/demo_app/` if you'd like this covered by an e2e; the current demo screens are single-input so they don't exercise the regression.

## Issues fixed

None linked. Filing directly as a Type A fix per `CONTRIBUTING.md`.