### PR TITLE
feat: walking-skeleton integration of maestro-device-core into maestro test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ local/
 
 # Ignore iOS intermediate build directory
 /driver-iPhoneSimulator/
+
+# Skill artifacts (brainstorming specs, plans) — local only, not PR content
+docs/superpowers/
+.superpowers/

--- a/e2e/demo_app/.maestro/devicecore_vertical.yaml
+++ b/e2e/demo_app/.maestro/devicecore_vertical.yaml
@@ -1,7 +1,12 @@
 appId: com.example.example
 ---
+# Narrow device-core vertical. tapOn is intentionally omitted: device-core's tap
+# resolver serves Selector.Id only (its assert/inspect path resolves text, its tap
+# path does not), and this app's buttons are Flutter widgets addressable by text but
+# with empty resource-ids — so a text tapOn can't run end-to-end on the current
+# device-core artifact. tapOn is implemented and unit-tested on the Maestro side; the
+# device-core text-tap gap is tracked separately. This flow exercises the verbs
+# device-core serves today: launchApp, assertVisible, assertNotVisible.
 - launchApp
 - assertVisible: 'Form Test'
-- tapOn: 'Input/Keyboard'
-- assertVisible: 'Input & Navigation'
 - assertNotVisible: 'kwyjibo'

--- a/e2e/demo_app/.maestro/devicecore_vertical.yaml
+++ b/e2e/demo_app/.maestro/devicecore_vertical.yaml
@@ -1,0 +1,7 @@
+appId: com.example.example
+---
+- launchApp
+- assertVisible: 'Form Test'
+- tapOn: 'Input/Keyboard'
+- assertVisible: 'Input & Navigation'
+- assertNotVisible: 'kwyjibo'

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -598,8 +598,8 @@ class TestCommand : Callable<Int> {
                 driverHostPort = driverHostPort,
                 deviceId = deviceId,
                 platform = requestedPlatform,
-            ) { driver, resolvedPlatform ->
-                driver.connect(DeviceCoreTarget(resolvedPlatform), config?.appId)
+            ) { driver, resolvedPlatform, resolvedSerial ->
+                driver.connect(DeviceCoreTarget(resolvedPlatform, resolvedSerial), config?.appId)
                 // BundleLayout.STEP_TRACE does not exist on this branch (and BundleLayout is
                 // module-internal to maestro-orchestra), so the trace filename is the literal
                 // "steps.jsonl" under the flow debug dir, matching the differential-gate schema.

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -61,9 +61,17 @@ import maestro.cli.auth.Auth
 import maestro.cli.model.FlowStatus
 import maestro.cli.view.cyan
 import maestro.cli.promotion.PromotionStateManager
+import maestro.MaestroException
+import maestro.orchestra.debug.StepTraceEmitter
+import maestro.orchestra.devicecore.DeviceCoreFlowRunner
+import maestro.orchestra.devicecore.DeviceCoreTarget
 import maestro.orchestra.error.ValidationError
+import maestro.orchestra.util.Env.withDefaultEnvVars
+import maestro.orchestra.util.Env.withEnv
+import maestro.orchestra.util.Env.withInjectedShellEnvVars
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner.ExecutionPlan
+import maestro.orchestra.yaml.YamlCommandReader
 import maestro.utils.isSingleFile
 import okio.sink
 import org.slf4j.LoggerFactory
@@ -474,6 +482,19 @@ class TestCommand : Callable<Int> {
 
         logger.info("[shard ${shardIndex + 1}] Selected device $deviceId using port $driverHostPort with execution plan $executionPlan")
 
+        val isReplicatingSingleFile = shardAll != null && effectiveShards > 1 && flowFiles.isSingleFile
+        val isMultipleFiles = flowFiles.isSingleFile.not()
+        val isAskingForReport = format != ReportFormat.NOOP
+        val isMultiFlow = isMultipleFiles || isAskingForReport || isReplicatingSingleFile
+
+        // Device-core `maestro test` vertical: a single flow, one-shot (no --continuous, no report,
+        // no multi-file). Routed here so NO legacy Maestro is constructed for this path. Multi-file,
+        // report, and continuous stay on the legacy newSession/Maestro path below — this is an
+        // incompletely-migrated transitional state (like record/query), NOT a runtime switch.
+        if (!isMultiFlow && !continuous) {
+            return runSingleFlowDeviceCore(flowFiles.first(), debugOutputPath, deviceId)
+        }
+
         return MaestroSessionManager.newSession(
             host = parent?.host,
             port = parent?.port,
@@ -489,10 +510,7 @@ class TestCommand : Callable<Int> {
             val maestro = session.maestro
             val device = session.device
 
-            val isReplicatingSingleFile = shardAll != null && effectiveShards > 1 && flowFiles.isSingleFile
-            val isMultipleFiles = flowFiles.isSingleFile.not()
-            val isAskingForReport = format != ReportFormat.NOOP
-            if (isMultipleFiles || isAskingForReport || isReplicatingSingleFile) {
+            if (isMultiFlow) {
                 if (continuous) {
                     throw CommandLine.ParameterException(
                         commandSpec.commandLine(),
@@ -542,6 +560,86 @@ class TestCommand : Callable<Int> {
         // Let the OS pick an available port. ServerSocket(0) guarantees no
         // collision — simpler than scanning a fixed range.
         return ServerSocket(0).use { it.localPort }
+    }
+
+    /**
+     * The device-core single-flow path: parse the flow's commands + [maestro.orchestra.MaestroConfig]
+     * with the same YAML reader the legacy path uses, provision a Maestro-less
+     * [maestro.orchestra.devicecore.DeviceCoreDriver] via [MaestroSessionManager.newDeviceCoreSession],
+     * and execute through [DeviceCoreFlowRunner]. A clean run maps to a pass; a thrown
+     * [MaestroException] (assert/tap failure, unimplemented command, or an unreachable device) maps to
+     * a fail + console error, mirroring how [TestRunner.runSingle] reports a flow result today.
+     *
+     * The [Triple] matches [runSingleFlow]: (passedCount, totalTests, null) — 1/1 on pass, 0/1 on fail
+     * — so [handleSessions] aggregates it to exit 0/1 unchanged.
+     */
+    private fun runSingleFlowDeviceCore(
+        flowFile: File,
+        debugOutputPath: Path,
+        deviceId: String?,
+    ): Triple<Int, Int, Nothing?> {
+        val updatedEnv = env
+            .withInjectedShellEnvVars()
+            .withDefaultEnvVars(flowFile, deviceId)
+        val commands = YamlCommandReader.readCommands(flowFile.toPath()).withEnv(updatedEnv)
+        val config = YamlCommandReader.getConfig(commands)
+        val flowName = config?.name ?: flowFile.nameWithoutExtension
+        val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName).toFile()
+
+        val requestedPlatform = (platform ?: parent?.platform)?.let { Platform.fromString(it) }
+        val startTime = System.currentTimeMillis()
+        Analytics.trackEvent(TestRunStartedEvent(platform = requestedPlatform?.toString() ?: "unknown"))
+        logger.info("Running flow ${flowFile.name} through device-core...")
+
+        val passed = try {
+            MaestroSessionManager.newDeviceCoreSession(
+                host = parent?.host,
+                port = parent?.port,
+                driverHostPort = driverHostPort,
+                deviceId = deviceId,
+                platform = requestedPlatform,
+            ) { driver, resolvedPlatform ->
+                driver.connect(DeviceCoreTarget(resolvedPlatform), config?.appId)
+                // BundleLayout.STEP_TRACE does not exist on this branch (and BundleLayout is
+                // module-internal to maestro-orchestra), so the trace filename is the literal
+                // "steps.jsonl" under the flow debug dir, matching the differential-gate schema.
+                val trace = if (System.getenv("MAESTRO_STEP_TRACE") == "1") {
+                    StepTraceEmitter(File(flowDir, "steps.jsonl"))
+                } else null
+                trace?.openFor()
+                try {
+                    DeviceCoreFlowRunner(driver, trace).run(commands, config)
+                } finally {
+                    trace?.close()
+                }
+            }
+            true
+        } catch (e: MaestroException) {
+            PrintUtils.err(e.message)
+            val debugMessage = when (e) {
+                is MaestroException.AssertionFailure -> e.debugMessage
+                is MaestroException.DriverTimeout -> e.debugMessage
+                else -> null
+            }
+            if (debugMessage != null) PrintUtils.err(debugMessage)
+            printExitDebugMessage()
+            false
+        }
+
+        val duration = System.currentTimeMillis() - startTime
+        Analytics.trackEvent(
+            TestRunFinishedEvent(
+                status = if (passed) FlowStatus.SUCCESS else FlowStatus.ERROR,
+                platform = requestedPlatform?.toString() ?: "unknown",
+                durationMs = duration,
+            )
+        )
+
+        if (!flattenDebugOutput) {
+            TestDebugReporter.deleteOldFiles()
+        }
+
+        return Triple(if (passed) 1 else 0, 1, null)
     }
 
     private fun runSingleFlow(

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -36,6 +36,8 @@ import maestro.cli.report.TestDebugReporter
 import maestro.cli.util.ScreenReporter
 import maestro.drivers.AndroidDriver
 import maestro.drivers.IOSDriver
+import maestro.orchestra.devicecore.DeviceCoreDriver
+import maestro.orchestra.devicecore.RealDeviceCoreDriver
 import maestro.orchestra.WorkspaceConfig.PlatformConfiguration
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.utils.TempFileHandler
@@ -133,6 +135,64 @@ object MaestroSessionManager {
         })
 
         return block(session)
+    }
+
+    /**
+     * The device-core `maestro test` provisioning path. Resolves the target through the SAME
+     * [selectDevice] used by [newSession] (so the right booted emulator/simulator is picked), but
+     * NEVER calls [createMaestro] — no legacy [maestro.Maestro] is constructed here. Hands a
+     * connected-lifecycle [DeviceCoreDriver] and the resolved [Platform] to [block] and closes the
+     * driver in a `finally`.
+     *
+     * Callers `connect()` the driver inside [block] (the resolved [Platform] is what they name the
+     * [maestro.orchestra.devicecore.DeviceCoreTarget] with). Provisioning is split into
+     * [provisionDeviceCore] so the Maestro-less core is unit-testable without a live device.
+     */
+    fun <T> newDeviceCoreSession(
+        host: String?,
+        port: Int?,
+        driverHostPort: Int?,
+        deviceId: String?,
+        platform: Platform?,
+        block: (driver: DeviceCoreDriver, platform: Platform) -> T,
+    ): T {
+        val selectedDevice = selectDevice(
+            host = host,
+            port = port,
+            driverHostPort = driverHostPort,
+            deviceId = deviceId,
+            platform = platform,
+        )
+        val resolvedDeviceId = selectedDevice.device?.instanceId ?: selectedDevice.deviceId
+        return provisionDeviceCore(
+            platform = selectedDevice.platform,
+            deviceId = resolvedDeviceId,
+            block = block,
+        )
+    }
+
+    /**
+     * The Maestro-less provisioning core: build a [DeviceCoreDriver] via [driverFactory], run
+     * [block], and close the driver. Constructs no [maestro.Maestro]. `internal` so
+     * [maestro.cli.session.DeviceCoreSessionTest] can assert that directly.
+     *
+     * Note: [deviceId] is the resolved target serial. device-core's Android provider currently shells
+     * to bare `adb` and does not accept a serial, so a specific Android device isn't threaded through
+     * yet — the Task 9 e2e runs against a single emulator. Kept in the signature so the serial is
+     * available once the provider can take it.
+     */
+    internal fun <T> provisionDeviceCore(
+        platform: Platform,
+        deviceId: String?,
+        driverFactory: () -> DeviceCoreDriver = { RealDeviceCoreDriver() },
+        block: (driver: DeviceCoreDriver, platform: Platform) -> T,
+    ): T {
+        val driver = driverFactory()
+        return try {
+            block(driver, platform)
+        } finally {
+            driver.close()
+        }
     }
 
     private fun selectDevice(

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -144,9 +144,10 @@ object MaestroSessionManager {
      * connected-lifecycle [DeviceCoreDriver] and the resolved [Platform] to [block] and closes the
      * driver in a `finally`.
      *
-     * Callers `connect()` the driver inside [block] (the resolved [Platform] is what they name the
-     * [maestro.orchestra.devicecore.DeviceCoreTarget] with). Provisioning is split into
-     * [provisionDeviceCore] so the Maestro-less core is unit-testable without a live device.
+     * Callers `connect()` the driver inside [block] (the resolved [Platform] and the resolved device
+     * serial are what they name the [maestro.orchestra.devicecore.DeviceCoreTarget] with).
+     * Provisioning is split into [provisionDeviceCore] so the Maestro-less core is unit-testable
+     * without a live device.
      */
     fun <T> newDeviceCoreSession(
         host: String?,
@@ -154,7 +155,7 @@ object MaestroSessionManager {
         driverHostPort: Int?,
         deviceId: String?,
         platform: Platform?,
-        block: (driver: DeviceCoreDriver, platform: Platform) -> T,
+        block: (driver: DeviceCoreDriver, platform: Platform, serial: String?) -> T,
     ): T {
         val selectedDevice = selectDevice(
             host = host,
@@ -176,20 +177,21 @@ object MaestroSessionManager {
      * [block], and close the driver. Constructs no [maestro.Maestro]. `internal` so
      * [maestro.cli.session.DeviceCoreSessionTest] can assert that directly.
      *
-     * Note: [deviceId] is the resolved target serial. device-core's Android provider currently shells
-     * to bare `adb` and does not accept a serial, so a specific Android device isn't threaded through
-     * yet — the Task 9 e2e runs against a single emulator. Kept in the signature so the serial is
-     * available once the provider can take it.
+     * [deviceId] is the resolved target serial — for Android the adb serial (e.g. `emulator-5554`,
+     * `SelectedDevice.device.instanceId`, which is `AdbDeviceConnection.serial`), for iOS the
+     * simulator udid. It's handed to [block] so the caller can thread it into the
+     * [maestro.orchestra.devicecore.DeviceCoreTarget], where device-core's `AdbSerialResolver`
+     * matches it against `adb devices` to disambiguate when more than one device is attached.
      */
     internal fun <T> provisionDeviceCore(
         platform: Platform,
         deviceId: String?,
         driverFactory: () -> DeviceCoreDriver = { RealDeviceCoreDriver() },
-        block: (driver: DeviceCoreDriver, platform: Platform) -> T,
+        block: (driver: DeviceCoreDriver, platform: Platform, serial: String?) -> T,
     ): T {
         val driver = driverFactory()
         return try {
-            block(driver, platform)
+            block(driver, platform, deviceId)
         } finally {
             driver.close()
         }

--- a/maestro-cli/src/test/kotlin/maestro/cli/session/DeviceCoreSessionTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/session/DeviceCoreSessionTest.kt
@@ -1,0 +1,59 @@
+package maestro.cli.session
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import maestro.Maestro
+import maestro.device.Platform
+import maestro.orchestra.devicecore.DeviceCoreDriver
+import maestro.orchestra.devicecore.RealDeviceCoreDriver
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+/**
+ * DoD #3: the device-core provisioning path must construct NO legacy [Maestro].
+ *
+ * [MaestroSessionManager.provisionDeviceCore] is the Maestro-less core that
+ * [MaestroSessionManager.newDeviceCoreSession] delegates to after resolving the device (the
+ * `selectDevice` part needs a live adb/simctl target, so the CLI wiring is covered end-to-end in the
+ * Task 9 e2e; this unit test exercises the provisioning core directly with the real driver factory).
+ *
+ * Every legacy `Maestro` the CLI builds goes through one of the three companion factories
+ * `Maestro.android` / `Maestro.ios` / `Maestro.web` (the `Maestro(...)` constructor is private to
+ * those factories). We [mockkObject] the companion and stub the factories, so a call is both
+ * harmless AND recorded — then assert (`exactly = 0`) that none fired. This genuinely fails if
+ * provisioning ever constructs a `Maestro`, regardless of `openDriver`, because it catches the
+ * construction at its only entry point rather than relying on a method being called on the instance.
+ */
+class DeviceCoreSessionTest {
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `provisionDeviceCore constructs no legacy Maestro and yields a device-core driver`() {
+        mockkObject(Maestro.Companion)
+        every { Maestro.android(any(), any()) } returns mockk(relaxed = true)
+        every { Maestro.ios(any(), any()) } returns mockk(relaxed = true)
+        every { Maestro.web(any(), any(), any()) } returns mockk(relaxed = true)
+
+        var received: DeviceCoreDriver? = null
+        MaestroSessionManager.provisionDeviceCore(
+            platform = Platform.ANDROID,
+            deviceId = null,
+        ) { driver, platform ->
+            received = driver
+            assertThat(platform).isEqualTo(Platform.ANDROID)
+        }
+
+        assertThat(received).isInstanceOf(RealDeviceCoreDriver::class.java)
+        verify(exactly = 0) { Maestro.android(any(), any()) }
+        verify(exactly = 0) { Maestro.ios(any(), any()) }
+        verify(exactly = 0) { Maestro.web(any(), any(), any()) }
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/session/DeviceCoreSessionTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/session/DeviceCoreSessionTest.kt
@@ -43,15 +43,19 @@ class DeviceCoreSessionTest {
         every { Maestro.web(any(), any(), any()) } returns mockk(relaxed = true)
 
         var received: DeviceCoreDriver? = null
+        var receivedSerial: String? = "unset"
         MaestroSessionManager.provisionDeviceCore(
             platform = Platform.ANDROID,
-            deviceId = null,
-        ) { driver, platform ->
+            deviceId = "emulator-5554",
+        ) { driver, platform, serial ->
             received = driver
+            receivedSerial = serial
             assertThat(platform).isEqualTo(Platform.ANDROID)
         }
 
         assertThat(received).isInstanceOf(RealDeviceCoreDriver::class.java)
+        // The resolved serial is threaded through to the block so the caller can name the target with it.
+        assertThat(receivedSerial).isEqualTo("emulator-5554")
         verify(exactly = 0) { Maestro.android(any(), any()) }
         verify(exactly = 0) { Maestro.ios(any(), any()) }
         verify(exactly = 0) { Maestro.web(any(), any(), any()) }

--- a/maestro-client/src/main/java/maestro/Errors.kt
+++ b/maestro-client/src/main/java/maestro/Errors.kt
@@ -61,6 +61,11 @@ sealed class MaestroException(override val message: String, cause: Throwable? = 
     class MissingAppleTeamId(message: String, cause: Throwable? = null): MaestroException(message, cause)
 
     class IOSDeviceDriverSetupException(message: String, cause: Throwable? = null): MaestroException(message, cause)
+
+    class NotImplemented(
+        message: String,
+        cause: Throwable? = null,
+    ) : MaestroException(message, cause)
 }
 
 sealed class MaestroDriverStartupException(override val message: String, cause: Throwable? = null): RuntimeException(message, cause) {

--- a/maestro-client/src/test/java/maestro/NotImplementedExceptionTest.kt
+++ b/maestro-client/src/test/java/maestro/NotImplementedExceptionTest.kt
@@ -1,0 +1,13 @@
+package maestro
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class NotImplementedExceptionTest {
+    @Test
+    fun `NotImplemented is a MaestroException carrying the message`() {
+        val e = MaestroException.NotImplemented("device-core does not implement inputText")
+        assertThat(e).isInstanceOf(MaestroException::class.java)
+        assertThat(e.message).contains("inputText")
+    }
+}

--- a/maestro-orchestra/build.gradle.kts
+++ b/maestro-orchestra/build.gradle.kts
@@ -22,6 +22,10 @@ dependencies {
     implementation(libs.kotlin.result)
     implementation(libs.dd.plist)
 
+    // device-core's prototype api surface, resolved from mavenLocal (see settings.gradle.kts).
+    implementation("dev.mobile.devicecore:prototype:0.1.0-SNAPSHOT")
+    runtimeOnly("dev.mobile.devicecore:drivers-core:0.1.0-SNAPSHOT")
+
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.params)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/debug/StepTraceEmitter.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/debug/StepTraceEmitter.kt
@@ -1,0 +1,75 @@
+package maestro.orchestra.debug
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import maestro.orchestra.devicecore.ChosenElement
+import maestro.orchestra.devicecore.Verdict
+import org.slf4j.LoggerFactory
+import java.io.BufferedWriter
+import java.io.File
+
+/**
+ * Writes one JSONL record per executed step at the frozen differential-gate schema (Spec C consumes
+ * it unchanged). Reads only data the step already produced — never touches the device. device-core
+ * has no decline path, so the WIP's declined/declinedReason fields are dropped; NON_NULL keeps the
+ * record shape identical to the legacy schema for every step.
+ */
+class StepTraceEmitter(
+    private val traceFile: File,
+    private val backendId: String = "devicecore",
+) {
+    private val mapper = jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    private var writer: BufferedWriter? = null
+
+    fun openFor() {
+        try {
+            traceFile.parentFile?.mkdirs()
+            writer = traceFile.bufferedWriter()
+        } catch (e: Exception) {
+            logger.warn("Failed to open step trace file at $traceFile", e)
+            writer = null
+        }
+    }
+
+    fun close() {
+        try { writer?.flush(); writer?.close() }
+        catch (e: Exception) { logger.warn("Failed to close step trace file at $traceFile", e) }
+        finally { writer = null }
+    }
+
+    fun emit(
+        stepIndex: Int,
+        commandType: String,
+        selectorText: String?,
+        selectorId: String?,
+        verdict: Verdict,
+        chosen: ChosenElement?,
+    ) {
+        val w = writer ?: return
+        val record = StepTraceRecord(
+            stepIndex = stepIndex,
+            backendId = backendId,
+            command = CommandDescriptor(commandType, selectorText, selectorId),
+            verdict = verdict.name,
+            chosenElement = chosen,
+        )
+        try { w.write(mapper.writeValueAsString(record)); w.newLine(); w.flush() }
+        catch (e: Exception) { logger.warn("Failed to write step trace record for step $stepIndex", e) }
+    }
+
+    private data class StepTraceRecord(
+        val stepIndex: Int,
+        val backendId: String,
+        val command: CommandDescriptor,
+        val verdict: String,
+        val chosenElement: ChosenElement?,
+    )
+
+    private data class CommandDescriptor(
+        val type: String,
+        val selectorText: String?,
+        val selectorId: String?,
+    )
+
+    companion object { private val logger = LoggerFactory.getLogger(StepTraceEmitter::class.java) }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/AssertVisibleVerdict.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/AssertVisibleVerdict.kt
@@ -1,0 +1,50 @@
+package maestro.orchestra.devicecore
+
+import dev.mobile.devicecore.prototype.api.ElementEvidence
+import dev.mobile.devicecore.prototype.api.EvidenceSource
+import dev.mobile.devicecore.prototype.api.Resolution
+
+enum class AssertMode { VISIBLE, NOT_VISIBLE }
+
+/** Raised when device-core could not decide (socket refused, driver down, or an owed capability). Never a pass or fail. */
+class DeviceCoreUnavailable(msg: String) : RuntimeException(msg)
+
+/**
+ * Turns a device-core [ElementEvidence] into an assertVisible / assertNotVisible verdict off
+ * device-core's OWN visibility signal — no Maestro-side geometry. An element is VISIBLE iff
+ * device-core resolved it AND its visible signal is a real (non-UNAVAILABLE) `true`; an ABSENT
+ * element is not visible. Anything device-core cannot cleanly answer throws [DeviceCoreUnavailable].
+ */
+object AssertVisibleVerdict {
+
+    fun pass(evidence: ElementEvidence, mode: AssertMode): Boolean {
+        val visible = isVisible(evidence)
+        return when (mode) {
+            AssertMode.VISIBLE -> visible
+            AssertMode.NOT_VISIBLE -> !visible
+        }
+    }
+
+    private fun isVisible(evidence: ElementEvidence): Boolean = when (val r = evidence.resolution) {
+        is Resolution.Resolved -> {
+            val signal = evidence.actionability.visible
+            if (signal.source == EvidenceSource.UNAVAILABLE) {
+                throw DeviceCoreUnavailable(
+                    "device-core resolved '${evidence.target}' but reported no visibility signal " +
+                        "(actionability.visible.source=UNAVAILABLE) — an owed device-core capability, " +
+                        "not an assertion verdict."
+                )
+            }
+            signal.value
+        }
+        is Resolution.Absent -> false
+        is Resolution.Ambiguous -> throw DeviceCoreUnavailable(
+            "device-core matched '${evidence.target}' ambiguously (count=${r.count}) — no single-element " +
+                "visibility verdict."
+        )
+        Resolution.Unavailable -> throw DeviceCoreUnavailable(
+            "device-core could not resolve '${evidence.target}' (Resolution.Unavailable) — " +
+                "an infrastructure failure, not an assertion verdict."
+        )
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreDriver.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreDriver.kt
@@ -105,12 +105,18 @@ class RealDeviceCoreDriver(
 
     override fun assertVisibility(selector: ElementSelector, mode: AssertMode): ChosenElement? {
         val sel = SelectorTranslator.translate(selector)
-        val evidence = try {
-            runBlocking { screen.locatorFor(sel).inspect() }
+        // Both the read (inspect) and the verdict (pass) can raise DeviceCoreUnavailable — inspect on
+        // a transport failure, pass() on Ambiguous / Unavailable / a resolved-but-UNAVAILABLE-signal
+        // element. Both are infra, so both go through mapInfraThrow -> DeviceUnreachableException. The
+        // AssertionFailure on a clean false verdict is thrown AFTER the try so it keeps its own type.
+        val pass = try {
+            val evidence = runBlocking { screen.locatorFor(sel).inspect() }
+            AssertVisibleVerdict.pass(evidence, mode) to evidence
         } catch (t: Throwable) {
             throw DeviceCoreErrorMapper.mapInfraThrow(t, "assert ${selector.description()}")
         }
-        if (!AssertVisibleVerdict.pass(evidence, mode)) {
+        val (passed, evidence) = pass
+        if (!passed) {
             val verb = if (mode == AssertMode.VISIBLE) "visible" else "not visible"
             throw MaestroException.AssertionFailure(
                 message = "Assertion is false: ${selector.description()} is $verb",

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreDriver.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreDriver.kt
@@ -19,8 +19,14 @@ import maestro.MaestroException
 import maestro.device.Platform
 import maestro.orchestra.ElementSelector
 
-/** Which device-core target a connect names, in Maestro's own terms. */
-data class DeviceCoreTarget(val platform: Platform)
+/**
+ * Which device-core target a connect names, in Maestro's own terms. [serial] is the concrete
+ * resolved device serial in adb's own format (e.g. `emulator-5554`) — what device-core's
+ * [dev.mobile.devicecore.prototype.shared.provision.android.AdbSerialResolver] matches against to
+ * disambiguate when more than one device is attached. Null means "let device-core pick" (the
+ * single-device case).
+ */
+data class DeviceCoreTarget(val platform: Platform, val serial: String? = null)
 
 /**
  * The single seam the `maestro test` path uses to reach a device through device-core: four verbs
@@ -61,10 +67,10 @@ class RealDeviceCoreDriver(
 
     override fun connect(target: DeviceCoreTarget, appId: String?) {
         val targetSelector = when (target.platform) {
-            Platform.ANDROID -> TargetSelector(TargetId.ANDROID_EMU)
+            Platform.ANDROID -> TargetSelector(TargetId.ANDROID_EMU, target.serial)
             Platform.IOS -> {
                 if (appId != null) System.setProperty("devicecore.ios.bundleId", appId)
-                TargetSelector(TargetId.IOS_SIM)
+                TargetSelector(TargetId.IOS_SIM, target.serial)
             }
             Platform.WEB -> throw MaestroException.NotImplemented(
                 "device-core has no web target"

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreDriver.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreDriver.kt
@@ -1,0 +1,193 @@
+package maestro.orchestra.devicecore
+
+import dev.mobile.devicecore.prototype.api.ANDROID_EMU
+import dev.mobile.devicecore.prototype.api.ActionEvidence
+import dev.mobile.devicecore.prototype.api.AppId
+import dev.mobile.devicecore.prototype.api.Device
+import dev.mobile.devicecore.prototype.api.DeviceProvider
+import dev.mobile.devicecore.prototype.api.ElementEvidence
+import dev.mobile.devicecore.prototype.api.IOS_SIM
+import dev.mobile.devicecore.prototype.api.Locator
+import dev.mobile.devicecore.prototype.api.Screen
+import dev.mobile.devicecore.prototype.api.Selector
+import dev.mobile.devicecore.prototype.api.TargetId
+import dev.mobile.devicecore.prototype.api.TargetSelector
+import dev.mobile.devicecore.prototype.api.adaptors.android.AndroidDeviceProvider
+import dev.mobile.devicecore.prototype.api.adaptors.ios.IosDeviceProvider
+import kotlinx.coroutines.runBlocking
+import maestro.MaestroException
+import maestro.device.Platform
+import maestro.orchestra.ElementSelector
+
+/** Which device-core target a connect names, in Maestro's own terms. */
+data class DeviceCoreTarget(val platform: Platform)
+
+/**
+ * The single seam the `maestro test` path uses to reach a device through device-core: four verbs
+ * plus lifecycle. Everything the four-command vertical needs and nothing it doesn't — selector
+ * translation, tap/assert verdicts, and error mapping are composed behind this, not exposed.
+ *
+ * `tap`/`assertVisibility` return an optional [ChosenElement] for the differential trace. A failing
+ * assert throws [MaestroException.AssertionFailure]; a failed tap throws whatever
+ * [DeviceCoreErrorMapper] maps its outcome to; an infra failure throws through
+ * [DeviceCoreErrorMapper.mapInfraThrow]; an unsupported selector throws
+ * [MaestroException.NotImplemented].
+ */
+interface DeviceCoreDriver {
+    fun connect(target: DeviceCoreTarget, appId: String?)
+    fun close()
+    fun launchApp(appId: String)
+    fun tap(selector: ElementSelector): ChosenElement?
+    fun assertVisibility(selector: ElementSelector, mode: AssertMode): ChosenElement?
+}
+
+/**
+ * The real driver over `dev.mobile.devicecore.prototype.api.*`. Blocking on the outside (the
+ * `maestro test` path is blocking), suspending calls bridged with [runBlocking] at each verb.
+ *
+ * [providerFactory] builds the device-core [DeviceProvider] for a platform; the default wires the
+ * real Android/iOS adaptors, and tests inject a fake. iOS carries its bundle id through the
+ * `devicecore.ios.bundleId` system property set BEFORE connect (device-core reads it internally at
+ * connect time; there is no per-connection bundleId parameter).
+ */
+class RealDeviceCoreDriver(
+    private val providerFactory: (Platform) -> DeviceProvider = ::defaultProviderFor,
+) : DeviceCoreDriver {
+
+    private var device: Device? = null
+
+    private val screen: Screen
+        get() = (device ?: error("device-core driver used before connect()")).screen
+
+    override fun connect(target: DeviceCoreTarget, appId: String?) {
+        val targetSelector = when (target.platform) {
+            Platform.ANDROID -> TargetSelector(TargetId.ANDROID_EMU)
+            Platform.IOS -> {
+                if (appId != null) System.setProperty("devicecore.ios.bundleId", appId)
+                TargetSelector(TargetId.IOS_SIM)
+            }
+            Platform.WEB -> throw MaestroException.NotImplemented(
+                "device-core has no web target"
+            )
+        }
+        device = try {
+            runBlocking { providerFactory(target.platform).connect(targetSelector) }
+        } catch (t: Throwable) {
+            throw DeviceCoreErrorMapper.mapInfraThrow(t, "connect")
+        }
+    }
+
+    override fun close() {
+        device?.close()
+        device = null
+    }
+
+    override fun launchApp(appId: String) {
+        val d = device ?: error("device-core driver used before connect()")
+        try {
+            runBlocking { d.launchApp(AppId(appId)) }
+        } catch (t: Throwable) {
+            throw DeviceCoreErrorMapper.mapInfraThrow(t, "launch $appId")
+        }
+    }
+
+    override fun tap(selector: ElementSelector): ChosenElement? {
+        val sel = SelectorTranslator.translate(selector)
+        val action = try {
+            runBlocking { screen.locatorFor(sel).tap() }
+        } catch (t: Throwable) {
+            throw DeviceCoreErrorMapper.mapInfraThrow(t, "tap ${selector.description()}")
+        }
+        DeviceCoreErrorMapper.tapOutcomeToException(action.outcome, selector.description())
+            ?.let { throw it }
+        return chosenElementOfAction(action, sel)
+    }
+
+    override fun assertVisibility(selector: ElementSelector, mode: AssertMode): ChosenElement? {
+        val sel = SelectorTranslator.translate(selector)
+        val evidence = try {
+            runBlocking { screen.locatorFor(sel).inspect() }
+        } catch (t: Throwable) {
+            throw DeviceCoreErrorMapper.mapInfraThrow(t, "assert ${selector.description()}")
+        }
+        if (!AssertVisibleVerdict.pass(evidence, mode)) {
+            val verb = if (mode == AssertMode.VISIBLE) "visible" else "not visible"
+            throw MaestroException.AssertionFailure(
+                message = "Assertion is false: ${selector.description()} is $verb",
+                hierarchyRoot = DeviceCoreErrorMapper.emptyHierarchy(),
+                debugMessage = "device-core reported ${selector.description()} as " +
+                    "${evidence.resolution} / visible=${evidence.actionability.visible} for mode $mode",
+            )
+        }
+        return chosenElementOfEvidence(evidence, sel)
+    }
+
+    /**
+     * Walks a device-core [Selector] onto [Screen] calls. Text/Id land directly on a getter; Nth
+     * refines the locator built from its target. Any other [Selector] variant is a device-core
+     * capability the four-command vertical hasn't wired — [MaestroException.NotImplemented], never a
+     * silent fallback.
+     */
+    private fun Screen.locatorFor(sel: Selector): Locator = when (sel) {
+        is Selector.Text -> getByText(sel.value, sel.match, sel.ignoreCase)
+        is Selector.Id -> getById(sel.value)
+        is Selector.Nth -> locatorFor(sel.target).nth(sel.index)
+        else -> throw MaestroException.NotImplemented(
+            "device-core locator for ${sel::class.simpleName}"
+        )
+    }
+
+    private fun chosenElementOfAction(action: ActionEvidence, sel: Selector): ChosenElement {
+        val point = action.injectPoint
+        val d = describe(sel)
+        return ChosenElement(
+            x = 0,
+            y = 0,
+            width = 0,
+            height = 0,
+            centerX = point?.x ?: 0,
+            centerY = point?.y ?: 0,
+            text = d.text,
+            resourceId = d.id,
+            index = d.index,
+        )
+    }
+
+    private fun chosenElementOfEvidence(evidence: ElementEvidence, sel: Selector): ChosenElement {
+        val rect = evidence.bounds.value
+        val d = describe(sel)
+        val x = rect?.x ?: 0
+        val y = rect?.y ?: 0
+        val w = rect?.width ?: 0
+        val h = rect?.height ?: 0
+        return ChosenElement(
+            x = x,
+            y = y,
+            width = w,
+            height = h,
+            centerX = if (rect != null) x + w / 2 else 0,
+            centerY = if (rect != null) y + h / 2 else 0,
+            text = evidence.matched.value?.text ?: d.text,
+            resourceId = d.id,
+            index = d.index,
+        )
+    }
+
+    /** The selector's text / id / nth-index, unwrapping a [Selector.Nth] to its target. */
+    private data class SelectorDescription(val text: String?, val id: String?, val index: Int?)
+
+    private fun describe(sel: Selector): SelectorDescription = when (sel) {
+        is Selector.Text -> SelectorDescription(text = sel.value, id = null, index = null)
+        is Selector.Id -> SelectorDescription(text = null, id = sel.value, index = null)
+        is Selector.Nth -> describe(sel.target).copy(index = sel.index)
+        else -> SelectorDescription(text = null, id = null, index = null)
+    }
+
+    private companion object {
+        private fun defaultProviderFor(platform: Platform): DeviceProvider = when (platform) {
+            Platform.ANDROID -> AndroidDeviceProvider()
+            Platform.IOS -> IosDeviceProvider()
+            Platform.WEB -> throw MaestroException.NotImplemented("device-core has no web provider")
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreErrorMapper.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreErrorMapper.kt
@@ -1,0 +1,53 @@
+package maestro.orchestra.devicecore
+
+import dev.mobile.devicecore.prototype.api.DeviceEnvError
+import dev.mobile.devicecore.prototype.api.DeviceResolutionFailure
+import dev.mobile.devicecore.prototype.api.InjectionUnavailable
+import dev.mobile.devicecore.prototype.api.Outcome
+import maestro.DeviceUnreachableException
+import maestro.MaestroException
+import maestro.TreeNode
+
+/**
+ * Maps device-core results and typed throws onto Maestro's OWN exception taxonomy — in Maestro's
+ * domain terms, never a consumer's INFRA/TEST/CRASH vocabulary. There is no decline path: an
+ * unmapped/infra failure surfaces as a device-connection exception, a test failure as the matching
+ * MaestroException.
+ */
+object DeviceCoreErrorMapper {
+
+    /** The empty view tree passed to [MaestroException.AssertionFailure] / [MaestroException.ElementNotFound]
+     *  — device-core has no serializable view tree, and hierarchyRoot is non-null on both. */
+    fun emptyHierarchy(): TreeNode = TreeNode()
+
+    /** Success -> null; a policy-negative [Outcome] -> the matching MaestroException to throw. */
+    fun tapOutcomeToException(outcome: Outcome, selectorDesc: String): MaestroException? = when (outcome) {
+        is Outcome.Acted -> null
+        is Outcome.Absent -> MaestroException.ElementNotFound(
+            message = "No visible element found: $selectorDesc",
+            hierarchyRoot = emptyHierarchy(),
+            debugMessage = "device-core tap resolved Absent (${outcome.via}) for $selectorDesc",
+        )
+        is Outcome.Crashed -> MaestroException.AppCrash(
+            "App ${outcome.appId} crashed during tap on $selectorDesc"
+        )
+        is Outcome.Blocked -> MaestroException.AssertionFailure(
+            message = "Element not actionable: $selectorDesc",
+            hierarchyRoot = emptyHierarchy(),
+            debugMessage = "device-core tap Blocked for $selectorDesc: ${outcome.detail}",
+        )
+    }
+
+    /** Launch/connect/inspect infra throws -> Maestro's launch/connection taxonomy. Anything else
+     *  is returned unchanged — there is no decline path. */
+    fun mapInfraThrow(t: Throwable, operation: String): Throwable = when (t) {
+        is DeviceEnvError -> MaestroException.UnableToLaunchApp(
+            message = "device-core could not $operation: ${t.message}",
+            cause = t,
+        )
+        is DeviceResolutionFailure,
+        is InjectionUnavailable,
+        is DeviceCoreUnavailable -> DeviceUnreachableException(operation = operation, cause = t)
+        else -> t
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreFlowRunner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreFlowRunner.kt
@@ -1,0 +1,119 @@
+package maestro.orchestra.devicecore
+
+import maestro.MaestroException
+import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.LaunchAppCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
+import maestro.orchestra.TapOnElementCommand
+import maestro.orchestra.debug.StepTraceEmitter
+
+/**
+ * The thin executor for the device-core `maestro test` path: walks a parsed flow's commands in
+ * order and dispatches the four verbs the four-command vertical supports to [driver]. Anything
+ * else — an unsupported command, or an unsupported modifier on a supported command — throws
+ * [MaestroException.NotImplemented] naming the command/modifier, never a silent no-op.
+ *
+ * When [traceEmitter] is given, every step is recorded: [Verdict.PASS] with the driver's returned
+ * [ChosenElement] on success, [Verdict.FAIL] on a thrown [MaestroException] (an assert/tap failure,
+ * or an unimplemented command/modifier), [Verdict.ERROR] on anything else. The trace is written
+ * before the exception is rethrown, so a failing step is always the last line and the run still
+ * fails.
+ */
+class DeviceCoreFlowRunner(
+    private val driver: DeviceCoreDriver,
+    private val traceEmitter: StepTraceEmitter? = null,
+) {
+
+    fun run(commands: List<MaestroCommand>, config: MaestroConfig?) {
+        commands.forEachIndexed { index, maestroCommand ->
+            val commandType = maestroCommand.asCommand()?.let { it::class.simpleName } ?: "null"
+            try {
+                val chosen = dispatch(maestroCommand)
+                traceEmitter?.emit(
+                    stepIndex = index,
+                    commandType = commandType,
+                    selectorText = maestroCommand.elementSelector()?.textRegex,
+                    selectorId = maestroCommand.elementSelector()?.idRegex,
+                    verdict = Verdict.PASS,
+                    chosen = chosen,
+                )
+            } catch (e: MaestroException) {
+                traceEmitter?.emit(
+                    stepIndex = index,
+                    commandType = commandType,
+                    selectorText = maestroCommand.elementSelector()?.textRegex,
+                    selectorId = maestroCommand.elementSelector()?.idRegex,
+                    verdict = Verdict.FAIL,
+                    chosen = null,
+                )
+                throw e
+            } catch (t: Throwable) {
+                traceEmitter?.emit(
+                    stepIndex = index,
+                    commandType = commandType,
+                    selectorText = maestroCommand.elementSelector()?.textRegex,
+                    selectorId = maestroCommand.elementSelector()?.idRegex,
+                    verdict = Verdict.ERROR,
+                    chosen = null,
+                )
+                throw t
+            }
+        }
+    }
+
+    private fun dispatch(maestroCommand: MaestroCommand): ChosenElement? {
+        return when (val command = maestroCommand.asCommand()) {
+            is LaunchAppCommand -> runLaunchApp(command)
+            is TapOnElementCommand -> runTapOnElement(command)
+            is AssertConditionCommand -> runAssertCondition(command)
+            else -> throw MaestroException.NotImplemented(
+                "device-core does not implement ${command?.let { it::class.simpleName } ?: "null command"}"
+            )
+        }
+    }
+
+    private fun runLaunchApp(command: LaunchAppCommand): ChosenElement? {
+        if (command.clearState == true) {
+            throw MaestroException.NotImplemented("launchApp modifier clearState")
+        }
+        if (command.clearKeychain == true) {
+            throw MaestroException.NotImplemented("launchApp modifier clearKeychain")
+        }
+        if (command.permissions != null) {
+            throw MaestroException.NotImplemented("launchApp modifier permissions")
+        }
+        if (!command.launchArguments.isNullOrEmpty()) {
+            throw MaestroException.NotImplemented("launchApp modifier launchArguments")
+        }
+        if (command.stopApp == false) {
+            throw MaestroException.NotImplemented("launchApp modifier stopApp")
+        }
+        driver.launchApp(command.appId)
+        return null
+    }
+
+    private fun runTapOnElement(command: TapOnElementCommand): ChosenElement? {
+        if (command.longPress == true) {
+            throw MaestroException.NotImplemented("tapOnElement modifier longPress")
+        }
+        if (command.repeat != null) {
+            throw MaestroException.NotImplemented("tapOnElement modifier repeat")
+        }
+        if (command.relativePoint != null) {
+            throw MaestroException.NotImplemented("tapOnElement modifier relativePoint")
+        }
+        return driver.tap(command.selector)
+    }
+
+    private fun runAssertCondition(command: AssertConditionCommand): ChosenElement? {
+        val condition = command.condition
+        val visible = condition.visible
+        val notVisible = condition.notVisible
+        return when {
+            visible != null -> driver.assertVisibility(visible, AssertMode.VISIBLE)
+            notVisible != null -> driver.assertVisibility(notVisible, AssertMode.NOT_VISIBLE)
+            else -> throw MaestroException.NotImplemented("assert condition: ${condition.description()}")
+        }
+    }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreFlowRunner.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreFlowRunner.kt
@@ -1,7 +1,9 @@
 package maestro.orchestra.devicecore
 
 import maestro.MaestroException
+import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.MaestroConfig
@@ -13,6 +15,14 @@ import maestro.orchestra.debug.StepTraceEmitter
  * order and dispatches the four verbs the four-command vertical supports to [driver]. Anything
  * else — an unsupported command, or an unsupported modifier on a supported command — throws
  * [MaestroException.NotImplemented] naming the command/modifier, never a silent no-op.
+ *
+ * The exception is the structural setup commands the parser and env layer inject ahead of the real
+ * flow — a [DefineVariablesCommand] (always prepended by `Env.withEnv`) and an
+ * [ApplyConfigurationCommand] (the parsed `appId:`/config header). These carry no device
+ * interaction, so they're skipped entirely: no driver call, no [MaestroException.NotImplemented],
+ * and no trace line. Only genuine unsupported DEVICE verbs (inputText, swipe, …) fail-closed with
+ * NotImplemented. Skipping [DefineVariablesCommand] means its variables are NOT interpolated — the
+ * narrow vertical uses literal selectors, so that's acceptable here.
  *
  * When [traceEmitter] is given, every step is recorded: [Verdict.PASS] with the driver's returned
  * [ChosenElement] on success, [Verdict.FAIL] on a thrown [MaestroException] (an assert/tap failure,
@@ -27,6 +37,7 @@ class DeviceCoreFlowRunner(
 
     fun run(commands: List<MaestroCommand>, config: MaestroConfig?) {
         commands.forEachIndexed { index, maestroCommand ->
+            if (isSkippableStructuralCommand(maestroCommand)) return@forEachIndexed
             val commandType = maestroCommand.asCommand()?.let { it::class.simpleName } ?: "null"
             try {
                 val chosen = dispatch(maestroCommand)
@@ -61,6 +72,20 @@ class DeviceCoreFlowRunner(
             }
         }
     }
+
+    /**
+     * True for the structural setup commands injected ahead of the real flow — a
+     * [DefineVariablesCommand] (from `Env.withEnv`) and an [ApplyConfigurationCommand] (the parsed
+     * config header). Neither touches the device, so the runner skips them without a driver call or
+     * a trace line. Every other command, including genuine unsupported device verbs, falls through
+     * to [dispatch] and its fail-closed NotImplemented.
+     */
+    private fun isSkippableStructuralCommand(maestroCommand: MaestroCommand): Boolean =
+        when (maestroCommand.asCommand()) {
+            is DefineVariablesCommand -> true
+            is ApplyConfigurationCommand -> true
+            else -> false
+        }
 
     private fun dispatch(maestroCommand: MaestroCommand): ChosenElement? {
         return when (val command = maestroCommand.asCommand()) {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreTrace.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreTrace.kt
@@ -1,0 +1,28 @@
+package maestro.orchestra.devicecore
+
+/**
+ * The per-step verdict recorded on the differential trace: a step passed, failed its own
+ * assertion/action, or errored out (infra/unimplemented). Distinct from device-core's own
+ * [dev.mobile.devicecore.prototype.api.Outcome] — this is Maestro's coarse pass/fail/error, the
+ * thing the differential gate compares between backends.
+ */
+enum class Verdict { PASS, FAIL, ERROR }
+
+/**
+ * The element a step actually acted on / resolved, flattened for the trace. Geometry is in device
+ * coordinates; [centerX]/[centerY] are the tap injection point (for a tap) or the bounds center
+ * (for an assert). [text]/[resourceId]/[index] echo the selector that named it. Every field is
+ * optional-safe: device-core does not always carry bounds or a matched channel, so absent geometry
+ * reads 0 and an unnamed channel reads null.
+ */
+data class ChosenElement(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val centerX: Int,
+    val centerY: Int,
+    val text: String?,
+    val resourceId: String?,
+    val index: Int?,
+)

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/SelectorTranslator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/SelectorTranslator.kt
@@ -1,0 +1,60 @@
+package maestro.orchestra.devicecore
+
+import dev.mobile.devicecore.prototype.api.Match
+import dev.mobile.devicecore.prototype.api.Selector
+import maestro.MaestroException
+import maestro.orchestra.ElementSelector
+
+/**
+ * Pure translation of a Maestro [ElementSelector] into a device-core [Selector]. Legacy text/id
+ * matching is always regex + case-insensitive, which is exactly device-core's [Match.PATTERN] +
+ * ignoreCase — the whole rule, emitted for every text selector. Any selector field the four-command
+ * vertical does not serve throws [MaestroException.NotImplemented] naming the field; there is no
+ * decline-to-legacy path.
+ */
+object SelectorTranslator {
+
+    fun translate(selector: ElementSelector): Selector {
+        rejectUnsupported(selector)
+
+        val hasText = selector.textRegex != null
+        val hasId = selector.idRegex != null
+        val base: Selector = when {
+            hasText && hasId -> throw MaestroException.NotImplemented(
+                "device-core has no combined text+id selector"
+            )
+            hasText -> Selector.Text(selector.textRegex!!, Match.PATTERN, ignoreCase = true)
+            hasId -> Selector.Id(selector.idRegex!!)
+            else -> throw MaestroException.NotImplemented("selector has neither text nor id")
+        }
+
+        val rawIndex = selector.index ?: return base
+        val index = rawIndex.toDoubleOrNull()?.toInt()
+            ?: throw MaestroException.NotImplemented("selector index='$rawIndex' is not an integer")
+        return Selector.Nth(base, index)
+    }
+
+    private fun rejectUnsupported(s: ElementSelector) {
+        val unsupported = buildList {
+            if (s.size != null) add("size")
+            if (s.below != null) add("below")
+            if (s.above != null) add("above")
+            if (s.leftOf != null) add("leftOf")
+            if (s.rightOf != null) add("rightOf")
+            if (s.containsChild != null) add("containsChild")
+            if (s.containsDescendants != null) add("containsDescendants")
+            if (s.traits != null) add("traits")
+            if (s.enabled != null) add("enabled")
+            if (s.selected != null) add("selected")
+            if (s.checked != null) add("checked")
+            if (s.focused != null) add("focused")
+            if (s.childOf != null) add("childOf")
+            if (s.css != null) add("css")
+        }
+        if (unsupported.isNotEmpty()) {
+            throw MaestroException.NotImplemented(
+                "device-core selector does not implement field(s): ${unsupported.joinToString(", ")}"
+            )
+        }
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/StepTraceEmitterTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/StepTraceEmitterTest.kt
@@ -1,0 +1,38 @@
+package maestro.orchestra.debug
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.google.common.truth.Truth.assertThat
+import maestro.orchestra.devicecore.ChosenElement
+import maestro.orchestra.devicecore.Verdict
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class StepTraceEmitterTest {
+    @Test
+    fun `emits one jsonl record per step at the frozen schema`(@TempDir dir: File) {
+        val f = File(dir, "steps.jsonl")
+        val emitter = StepTraceEmitter(f, backendId = "devicecore")
+        emitter.openFor()
+        emitter.emit(0, "LaunchAppCommand", null, null, Verdict.PASS, null)
+        emitter.emit(
+            1, "TapOnElementCommand", null, "fabAddIcon", Verdict.PASS,
+            ChosenElement(0, 0, 0, 0, 10, 20, null, "fabAddIcon", null),
+        )
+        emitter.close()
+
+        val lines = f.readLines()
+        assertThat(lines).hasSize(2)
+        val mapper = jacksonObjectMapper()
+        val rec0 = mapper.readTree(lines[0])
+        assertThat(rec0.get("stepIndex").asInt()).isEqualTo(0)
+        assertThat(rec0.get("backendId").asText()).isEqualTo("devicecore")
+        assertThat(rec0.get("command").get("type").asText()).isEqualTo("LaunchAppCommand")
+        assertThat(rec0.get("verdict").asText()).isEqualTo("PASS")
+        assertThat(rec0.has("chosenElement")).isFalse()          // NON_NULL omits it
+        assertThat(rec0.has("declined")).isFalse()                // dropped field
+        val rec1 = mapper.readTree(lines[1])
+        assertThat(rec1.get("chosenElement").get("centerY").asInt()).isEqualTo(20)
+        assertThat(rec1.get("command").get("selectorId").asText()).isEqualTo("fabAddIcon")
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/AssertVisibleVerdictTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/AssertVisibleVerdictTest.kt
@@ -1,0 +1,27 @@
+package maestro.orchestra.devicecore
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AssertVisibleVerdictTest {
+    @Test
+    fun `resolved and visible - VISIBLE mode passes`() {
+        val ev = DeviceCoreEvidence.resolvedVisible("Form Test")
+        assertThat(AssertVisibleVerdict.pass(ev, AssertMode.VISIBLE)).isTrue()
+        assertThat(AssertVisibleVerdict.pass(ev, AssertMode.NOT_VISIBLE)).isFalse()
+    }
+
+    @Test
+    fun `absent - NOT_VISIBLE mode passes`() {
+        val ev = DeviceCoreEvidence.absent("kwyjibo")
+        assertThat(AssertVisibleVerdict.pass(ev, AssertMode.NOT_VISIBLE)).isTrue()
+        assertThat(AssertVisibleVerdict.pass(ev, AssertMode.VISIBLE)).isFalse()
+    }
+
+    @Test
+    fun `unavailable visibility signal throws DeviceCoreUnavailable`() {
+        val ev = DeviceCoreEvidence.resolvedUnavailableSignal("Form Test")
+        assertThrows<DeviceCoreUnavailable> { AssertVisibleVerdict.pass(ev, AssertMode.VISIBLE) }
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreClasspathTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreClasspathTest.kt
@@ -1,0 +1,18 @@
+package maestro.orchestra.devicecore
+
+import com.google.common.truth.Truth.assertThat
+import dev.mobile.devicecore.prototype.api.ANDROID_EMU
+import dev.mobile.devicecore.prototype.api.Match
+import dev.mobile.devicecore.prototype.api.Selector
+import dev.mobile.devicecore.prototype.api.TargetId
+import org.junit.jupiter.api.Test
+
+class DeviceCoreClasspathTest {
+    @Test
+    fun `device-core api types resolve on the classpath`() {
+        val text = Selector.Text("hello", Match.PATTERN, ignoreCase = true)
+        assertThat(text.value).isEqualTo("hello")
+        assertThat(text.match).isEqualTo(Match.PATTERN)
+        assertThat(TargetId.ANDROID_EMU.id).isEqualTo("android-emu")
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreDriverTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreDriverTest.kt
@@ -67,6 +67,19 @@ class DeviceCoreDriverTest {
     }
 
     @Test
+    fun `assertVisibility routes DeviceCoreUnavailable through the infra mapper`() {
+        // Resolved, but device-core reports no visibility signal (an owed capability) — a real
+        // production state. AssertVisibleVerdict throws DeviceCoreUnavailable, which must surface as
+        // a DeviceUnreachableException (infra / trace-ERROR), never a raw DeviceCoreUnavailable and
+        // never a silent pass.
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.resolvedUnavailableSignal("Form Test") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThrows<DeviceUnreachableException> {
+            d.assertVisibility(ElementSelector(textRegex = "Form Test"), AssertMode.VISIBLE)
+        }
+    }
+
+    @Test
     fun `tap by id records the tap and returns the inject point`() {
         val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("x") }
         val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreDriverTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreDriverTest.kt
@@ -1,0 +1,102 @@
+package maestro.orchestra.devicecore
+
+import com.google.common.truth.Truth.assertThat
+import dev.mobile.devicecore.prototype.api.AbsentVia
+import dev.mobile.devicecore.prototype.api.InjectionUnavailable
+import dev.mobile.devicecore.prototype.api.Outcome
+import maestro.DeviceUnreachableException
+import maestro.MaestroException
+import maestro.device.Platform
+import maestro.orchestra.ElementSelector
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class DeviceCoreDriverTest {
+
+    private fun driver(provider: FakeDeviceProvider) =
+        RealDeviceCoreDriver(providerFactory = { provider })
+
+    @Test
+    fun `launchApp records the app`() {
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("x") }
+        val d = driver(provider)
+        d.connect(DeviceCoreTarget(Platform.ANDROID), "com.example.example")
+        d.launchApp("com.example.example")
+        assertThat(provider.launchedApps).containsExactly("com.example.example")
+    }
+
+    @Test
+    fun `launchApp failure surfaces UnableToLaunchApp`() {
+        val provider = FakeDeviceProvider(launchFails = true) { DeviceCoreEvidence.absent("x") }
+        val d = driver(provider)
+        d.connect(DeviceCoreTarget(Platform.ANDROID), "com.example.example")
+        // device-core's launchApp throws DeviceEnvError; the mapper turns it into UnableToLaunchApp.
+        assertThrows<MaestroException.UnableToLaunchApp> { d.launchApp("com.example.example") }
+    }
+
+    @Test
+    fun `assertVisibility VISIBLE passes when device-core reports visible`() {
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.resolvedVisible("Form Test") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        d.assertVisibility(ElementSelector(textRegex = "Form Test"), AssertMode.VISIBLE)  // no throw
+    }
+
+    @Test
+    fun `assertVisibility VISIBLE fails when absent`() {
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("Form Test") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThrows<MaestroException.AssertionFailure> {
+            d.assertVisibility(ElementSelector(textRegex = "Form Test"), AssertMode.VISIBLE)
+        }
+    }
+
+    @Test
+    fun `assertVisibility NOT_VISIBLE passes when absent`() {
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("kwyjibo") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        d.assertVisibility(ElementSelector(textRegex = "kwyjibo"), AssertMode.NOT_VISIBLE)  // no throw
+    }
+
+    @Test
+    fun `assertVisibility NOT_VISIBLE fails when visible`() {
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.resolvedVisible("Form Test") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThrows<MaestroException.AssertionFailure> {
+            d.assertVisibility(ElementSelector(textRegex = "Form Test"), AssertMode.NOT_VISIBLE)
+        }
+    }
+
+    @Test
+    fun `tap by id records the tap and returns the inject point`() {
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("x") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        val chosen = d.tap(ElementSelector(idRegex = "fabAddIcon"))
+        assertThat(provider.tapCount).isEqualTo(1)
+        assertThat(chosen?.resourceId).isEqualTo("fabAddIcon")
+        assertThat(chosen?.centerX).isEqualTo(10)
+        assertThat(chosen?.centerY).isEqualTo(20)
+    }
+
+    @Test
+    fun `tap surfaces a thrown infra failure as a device connection error`() {
+        // A precondition-unmet throw from device-core during tap is infra, not a policy Outcome; the
+        // mapper routes it to DeviceUnreachableException (a DeviceConnectionException), never a
+        // MaestroException test-failure.
+        val provider = FakeDeviceProvider(
+            onTap = { throw InjectionUnavailable("gesture rejected") },
+        ) { DeviceCoreEvidence.absent("x") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThrows<DeviceUnreachableException> { d.tap(ElementSelector(idRegex = "fabAddIcon")) }
+    }
+
+    @Test
+    fun `tap surfaces an Absent outcome as ElementNotFound`() {
+        val provider = FakeDeviceProvider(
+            tapOutcome = { Outcome.Absent(AbsentVia.CAP_WHILE_QUIET, capMs = 1000L) },
+        ) { DeviceCoreEvidence.absent("x") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThrows<MaestroException.ElementNotFound> {
+            d.tap(ElementSelector(idRegex = "fabAddIcon"))
+        }
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreDriverTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreDriverTest.kt
@@ -17,6 +17,14 @@ class DeviceCoreDriverTest {
         RealDeviceCoreDriver(providerFactory = { provider })
 
     @Test
+    fun `connect threads the resolved device serial into the device-core target selector`() {
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("x") }
+        val d = driver(provider)
+        d.connect(DeviceCoreTarget(Platform.ANDROID, "emulator-5554"), "com.example.example")
+        assertThat(provider.lastConnectedTarget?.serial).isEqualTo("emulator-5554")
+    }
+
+    @Test
     fun `launchApp records the app`() {
         val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("x") }
         val d = driver(provider)

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreErrorMapperTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreErrorMapperTest.kt
@@ -1,0 +1,80 @@
+package maestro.orchestra.devicecore
+
+import com.google.common.truth.Truth.assertThat
+import dev.mobile.devicecore.prototype.api.AbsentVia
+import dev.mobile.devicecore.prototype.api.DeviceResolutionFailure
+import dev.mobile.devicecore.prototype.api.FoundVia
+import dev.mobile.devicecore.prototype.api.InjectionUnavailable
+import dev.mobile.devicecore.prototype.api.Outcome
+import maestro.DeviceConnectionException
+import maestro.MaestroException
+import org.junit.jupiter.api.Test
+
+class DeviceCoreErrorMapperTest {
+    @Test
+    fun `absent tap outcome maps to ElementNotFound`() {
+        val ex = DeviceCoreErrorMapper.tapOutcomeToException(
+            Outcome.Absent(AbsentVia.CAP_WHILE_QUIET, capMs = 0), "id=login"
+        )
+        assertThat(ex).isInstanceOf(MaestroException.ElementNotFound::class.java)
+    }
+
+    @Test
+    fun `acted tap outcome maps to null`() {
+        val ex = DeviceCoreErrorMapper.tapOutcomeToException(Outcome.Acted(FoundVia.IMMEDIATE), "id=login")
+        assertThat(ex).isNull()
+    }
+
+    @Test
+    fun `crashed tap outcome maps to AppCrash`() {
+        val ex = DeviceCoreErrorMapper.tapOutcomeToException(Outcome.Crashed("com.example.example"), "id=login")
+        assertThat(ex).isInstanceOf(MaestroException.AppCrash::class.java)
+    }
+
+    @Test
+    fun `blocked tap outcome maps to AssertionFailure`() {
+        val ex = DeviceCoreErrorMapper.tapOutcomeToException(
+            Outcome.Blocked(detail = "not enabled"), "id=login"
+        )
+        assertThat(ex).isInstanceOf(MaestroException.AssertionFailure::class.java)
+    }
+
+    @Test
+    fun `device resolution failure maps to device connection family`() {
+        val mapped = DeviceCoreErrorMapper.mapInfraThrow(
+            DeviceResolutionFailure.NoDevice(), "connect"
+        )
+        assertThat(mapped).isInstanceOf(DeviceConnectionException::class.java)
+    }
+
+    @Test
+    fun `injection unavailable maps to device connection family`() {
+        val mapped = DeviceCoreErrorMapper.mapInfraThrow(
+            InjectionUnavailable("target not prepared"), "tap"
+        )
+        assertThat(mapped).isInstanceOf(DeviceConnectionException::class.java)
+    }
+
+    @Test
+    fun `device core unavailable maps to device connection family`() {
+        val mapped = DeviceCoreErrorMapper.mapInfraThrow(
+            DeviceCoreUnavailable("no signal"), "assertVisible"
+        )
+        assertThat(mapped).isInstanceOf(DeviceConnectionException::class.java)
+    }
+
+    @Test
+    fun `device env error maps to UnableToLaunchApp`() {
+        val cause = RuntimeException("boom")
+        val envError = dev.mobile.devicecore.prototype.api.DeviceEnvError.TransportFailure("launchApp", cause)
+        val mapped = DeviceCoreErrorMapper.mapInfraThrow(envError, "launchApp")
+        assertThat(mapped).isInstanceOf(MaestroException.UnableToLaunchApp::class.java)
+    }
+
+    @Test
+    fun `unrelated throwable is returned unchanged`() {
+        val original = IllegalStateException("unrelated")
+        val mapped = DeviceCoreErrorMapper.mapInfraThrow(original, "someOp")
+        assertThat(mapped).isSameInstanceAs(original)
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreEvidence.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreEvidence.kt
@@ -1,0 +1,60 @@
+package maestro.orchestra.devicecore
+
+import dev.mobile.devicecore.prototype.api.Actionability
+import dev.mobile.devicecore.prototype.api.ElementEvidence
+import dev.mobile.devicecore.prototype.api.EvidenceSource
+import dev.mobile.devicecore.prototype.api.Resolution
+import dev.mobile.devicecore.prototype.api.ResolvedChannel
+import dev.mobile.devicecore.prototype.api.SearchedSurface
+import dev.mobile.devicecore.prototype.api.Signal
+import dev.mobile.devicecore.prototype.api.Sourced
+
+/**
+ * A tiny test factory building real device-core [ElementEvidence] values — no mocks, no
+ * stand-ins. Geometry ([ElementEvidence.bounds]) is irrelevant to visibility verdicts, so it is
+ * always UNAVAILABLE here; only [Resolution] and [Actionability.visible] vary per case.
+ */
+object DeviceCoreEvidence {
+
+    /** Resolved and reporting a real (MEASURED) `visible = true` signal. */
+    fun resolvedVisible(target: String): ElementEvidence = ElementEvidence(
+        target = target,
+        resolution = Resolution.Resolved(ResolvedChannel.TEXT),
+        actionability = Actionability(
+            attached = Signal(true, EvidenceSource.MEASURED),
+            visible = Signal(true, EvidenceSource.MEASURED),
+            enabled = Signal(true, EvidenceSource.MEASURED),
+            hittable = Signal(true, EvidenceSource.MEASURED),
+            stable = Signal(false, EvidenceSource.UNAVAILABLE),
+        ),
+        bounds = Sourced(null, EvidenceSource.UNAVAILABLE),
+    )
+
+    /** Not found anywhere on screen. */
+    fun absent(target: String): ElementEvidence = ElementEvidence(
+        target = target,
+        resolution = Resolution.Absent(SearchedSurface.WHOLE_SCREEN),
+        actionability = Actionability(
+            attached = Signal(false, EvidenceSource.MEASURED),
+            visible = Signal(false, EvidenceSource.MEASURED),
+            enabled = Signal(false, EvidenceSource.UNAVAILABLE),
+            hittable = Signal(false, EvidenceSource.UNAVAILABLE),
+            stable = Signal(false, EvidenceSource.UNAVAILABLE),
+        ),
+        bounds = Sourced(null, EvidenceSource.UNAVAILABLE),
+    )
+
+    /** Resolved, but device-core could not report a visibility signal for it (an owed capability). */
+    fun resolvedUnavailableSignal(target: String): ElementEvidence = ElementEvidence(
+        target = target,
+        resolution = Resolution.Resolved(ResolvedChannel.TEXT),
+        actionability = Actionability(
+            attached = Signal(true, EvidenceSource.MEASURED),
+            visible = Signal(false, EvidenceSource.UNAVAILABLE),
+            enabled = Signal(true, EvidenceSource.MEASURED),
+            hittable = Signal(true, EvidenceSource.MEASURED),
+            stable = Signal(false, EvidenceSource.UNAVAILABLE),
+        ),
+        bounds = Sourced(null, EvidenceSource.UNAVAILABLE),
+    )
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreFlowRunnerTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreFlowRunnerTest.kt
@@ -1,0 +1,159 @@
+package maestro.orchestra.devicecore
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.google.common.truth.Truth.assertThat
+import maestro.MaestroException
+import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.Command
+import maestro.orchestra.Condition
+import maestro.orchestra.ElementSelector
+import maestro.orchestra.InputTextCommand
+import maestro.orchestra.LaunchAppCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.TapOnElementCommand
+import maestro.orchestra.debug.StepTraceEmitter
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class DeviceCoreFlowRunnerTest {
+
+    private class RecordingDriver : DeviceCoreDriver {
+        val calls = mutableListOf<String>()
+        override fun connect(target: DeviceCoreTarget, appId: String?) { calls += "connect" }
+        override fun close() { calls += "close" }
+        override fun launchApp(appId: String) { calls += "launch:$appId" }
+        override fun tap(selector: ElementSelector): ChosenElement? { calls += "tap"; return null }
+        override fun assertVisibility(selector: ElementSelector, mode: AssertMode): ChosenElement? {
+            calls += "assert:$mode"; return null
+        }
+    }
+
+    private fun cmd(c: Command) = MaestroCommand(c)
+
+    @Test
+    fun `runs the four supported commands in order`() {
+        val d = RecordingDriver()
+        DeviceCoreFlowRunner(d).run(
+            listOf(
+                cmd(LaunchAppCommand(appId = "com.example.example")),
+                cmd(AssertConditionCommand(Condition(visible = ElementSelector(textRegex = "Form Test")))),
+                cmd(TapOnElementCommand(selector = ElementSelector(textRegex = "Input/Keyboard"))),
+                cmd(AssertConditionCommand(Condition(notVisible = ElementSelector(textRegex = "kwyjibo")))),
+            ),
+            config = null,
+        )
+        assertThat(d.calls).containsExactly(
+            "launch:com.example.example", "assert:VISIBLE", "tap", "assert:NOT_VISIBLE",
+        ).inOrder()
+    }
+
+    @Test
+    fun `an unsupported command throws NotImplemented naming it`() {
+        val d = RecordingDriver()
+        val e = assertThrows<MaestroException.NotImplemented> {
+            DeviceCoreFlowRunner(d).run(listOf(cmd(InputTextCommand(text = "hi"))), config = null)
+        }
+        assertThat(e.message).contains("InputText")
+    }
+
+    @Test
+    fun `an unsupported LaunchAppCommand modifier throws NotImplemented naming it`() {
+        val d = RecordingDriver()
+        val e = assertThrows<MaestroException.NotImplemented> {
+            DeviceCoreFlowRunner(d).run(
+                listOf(cmd(LaunchAppCommand(appId = "com.example.example", clearState = true))),
+                config = null,
+            )
+        }
+        assertThat(e.message).contains("clearState")
+    }
+
+    @Test
+    fun `an unsupported TapOnElementCommand modifier throws NotImplemented naming it`() {
+        val d = RecordingDriver()
+        val e = assertThrows<MaestroException.NotImplemented> {
+            DeviceCoreFlowRunner(d).run(
+                listOf(
+                    cmd(
+                        TapOnElementCommand(
+                            selector = ElementSelector(textRegex = "Input/Keyboard"),
+                            longPress = true,
+                        ),
+                    ),
+                ),
+                config = null,
+            )
+        }
+        assertThat(e.message).contains("longPress")
+    }
+
+    @Test
+    fun `an assert condition with neither visible nor notVisible throws NotImplemented`() {
+        val d = RecordingDriver()
+        val e = assertThrows<MaestroException.NotImplemented> {
+            DeviceCoreFlowRunner(d).run(
+                listOf(cmd(AssertConditionCommand(Condition(scriptCondition = "1 == 1")))),
+                config = null,
+            )
+        }
+        assertThat(e.message).contains("assert condition")
+    }
+
+    @Test
+    fun `rethrows the failing command's exception after tracing FAIL`(@TempDir dir: File) {
+        val d = RecordingDriver()
+        val traceFile = File(dir, "steps.jsonl")
+        val emitter = StepTraceEmitter(traceFile)
+        emitter.openFor()
+
+        assertThrows<MaestroException.NotImplemented> {
+            DeviceCoreFlowRunner(d, emitter).run(
+                listOf(cmd(InputTextCommand(text = "hi"))),
+                config = null,
+            )
+        }
+        emitter.close()
+
+        val lines = traceFile.readLines()
+        assertThat(lines).hasSize(1)
+        val mapper = jacksonObjectMapper()
+        val rec = mapper.readTree(lines[0])
+        assertThat(rec.get("verdict").asText()).isEqualTo("FAIL")
+    }
+
+    @Test
+    fun `emits a PASS trace line per successful step with backendId devicecore`(@TempDir dir: File) {
+        val d = RecordingDriver()
+        val traceFile = File(dir, "steps.jsonl")
+        val emitter = StepTraceEmitter(traceFile)
+        emitter.openFor()
+
+        DeviceCoreFlowRunner(d, emitter).run(
+            listOf(
+                cmd(LaunchAppCommand(appId = "com.example.example")),
+                cmd(TapOnElementCommand(selector = ElementSelector(idRegex = "fabAddIcon"))),
+            ),
+            config = null,
+        )
+        emitter.close()
+
+        val lines = traceFile.readLines()
+        assertThat(lines).hasSize(2)
+        val mapper = jacksonObjectMapper()
+
+        val rec0 = mapper.readTree(lines[0])
+        assertThat(rec0.get("stepIndex").asInt()).isEqualTo(0)
+        assertThat(rec0.get("backendId").asText()).isEqualTo("devicecore")
+        assertThat(rec0.get("command").get("type").asText()).isEqualTo("LaunchAppCommand")
+        assertThat(rec0.get("verdict").asText()).isEqualTo("PASS")
+
+        val rec1 = mapper.readTree(lines[1])
+        assertThat(rec1.get("stepIndex").asInt()).isEqualTo(1)
+        assertThat(rec1.get("backendId").asText()).isEqualTo("devicecore")
+        assertThat(rec1.get("command").get("type").asText()).isEqualTo("TapOnElementCommand")
+        assertThat(rec1.get("command").get("selectorId").asText()).isEqualTo("fabAddIcon")
+        assertThat(rec1.get("verdict").asText()).isEqualTo("PASS")
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreFlowRunnerTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreFlowRunnerTest.kt
@@ -3,13 +3,16 @@ package maestro.orchestra.devicecore
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.truth.Truth.assertThat
 import maestro.MaestroException
+import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.AssertConditionCommand
 import maestro.orchestra.Command
 import maestro.orchestra.Condition
+import maestro.orchestra.DefineVariablesCommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.InputTextCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.MaestroConfig
 import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.debug.StepTraceEmitter
 import org.junit.jupiter.api.Test
@@ -47,6 +50,52 @@ class DeviceCoreFlowRunnerTest {
         assertThat(d.calls).containsExactly(
             "launch:com.example.example", "assert:VISIBLE", "tap", "assert:NOT_VISIBLE",
         ).inOrder()
+    }
+
+    @Test
+    fun `skips injected structural commands and dispatches only the device verbs in order`() {
+        // Env.withEnv() always prepends a DefineVariablesCommand, and the YAML config header parses to
+        // an ApplyConfigurationCommand — both land ahead of the real flow. Neither carries a device
+        // interaction, so the runner must skip both and dispatch only the four verbs.
+        val d = RecordingDriver()
+        DeviceCoreFlowRunner(d).run(
+            listOf(
+                cmd(DefineVariablesCommand(mapOf("A" to "b"))),
+                cmd(ApplyConfigurationCommand(MaestroConfig(appId = "com.example.example"))),
+                cmd(LaunchAppCommand(appId = "com.example.example")),
+                cmd(AssertConditionCommand(Condition(visible = ElementSelector(textRegex = "Form Test")))),
+                cmd(TapOnElementCommand(selector = ElementSelector(textRegex = "Input/Keyboard"))),
+                cmd(AssertConditionCommand(Condition(notVisible = ElementSelector(textRegex = "kwyjibo")))),
+            ),
+            config = null,
+        )
+        assertThat(d.calls).containsExactly(
+            "launch:com.example.example", "assert:VISIBLE", "tap", "assert:NOT_VISIBLE",
+        ).inOrder()
+    }
+
+    @Test
+    fun `emits no trace line for a skipped structural command`(@TempDir dir: File) {
+        val d = RecordingDriver()
+        val traceFile = File(dir, "steps.jsonl")
+        val emitter = StepTraceEmitter(traceFile)
+        emitter.openFor()
+
+        DeviceCoreFlowRunner(d, emitter).run(
+            listOf(
+                cmd(DefineVariablesCommand(mapOf("A" to "b"))),
+                cmd(ApplyConfigurationCommand(MaestroConfig(appId = "com.example.example"))),
+                cmd(LaunchAppCommand(appId = "com.example.example")),
+            ),
+            config = null,
+        )
+        emitter.close()
+
+        // Only the launchApp step is traced; the two structural commands leave no line.
+        val lines = traceFile.readLines()
+        assertThat(lines).hasSize(1)
+        val rec = jacksonObjectMapper().readTree(lines[0])
+        assertThat(rec.get("command").get("type").asText()).isEqualTo("LaunchAppCommand")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/FakeDeviceProvider.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/FakeDeviceProvider.kt
@@ -1,0 +1,125 @@
+package maestro.orchestra.devicecore
+
+import dev.mobile.devicecore.prototype.api.ActionEvidence
+import dev.mobile.devicecore.prototype.api.Actionability
+import dev.mobile.devicecore.prototype.api.AppId
+import dev.mobile.devicecore.prototype.api.Device
+import dev.mobile.devicecore.prototype.api.DeviceEnvError
+import dev.mobile.devicecore.prototype.api.DeviceProvider
+import dev.mobile.devicecore.prototype.api.Diagnostic
+import dev.mobile.devicecore.prototype.api.ElementEvidence
+import dev.mobile.devicecore.prototype.api.EvidenceSource
+import dev.mobile.devicecore.prototype.api.FoundVia
+import dev.mobile.devicecore.prototype.api.Locator
+import dev.mobile.devicecore.prototype.api.Match
+import dev.mobile.devicecore.prototype.api.Outcome
+import dev.mobile.devicecore.prototype.api.Point
+import dev.mobile.devicecore.prototype.api.Screen
+import dev.mobile.devicecore.prototype.api.Selector
+import dev.mobile.devicecore.prototype.api.Settle
+import dev.mobile.devicecore.prototype.api.Signal
+import dev.mobile.devicecore.prototype.api.Sourced
+import dev.mobile.devicecore.prototype.api.TargetSelector
+
+/**
+ * In-memory [DeviceProvider] for the device-core driver tests. `inspect()` returns whatever
+ * [evidenceFor] maps a [Selector] to; `tap()` records the tapped selector, runs [onTap] (which may
+ * throw to simulate an infra failure), and returns an [ActionEvidence] whose [Outcome] is
+ * [tapOutcome] (default [Outcome.Acted]). No real device.
+ *
+ * The four failure levers a test can pull:
+ *  - [onTap] throws  -> a thrown-infra tap (gesture rejected).
+ *  - [tapOutcome] returns [Outcome.Absent] -> a policy-negative tap (element not found).
+ *  - [launchFails] -> `launchApp` throws instead of recording.
+ *  - [evidenceFor] -> the read-side verdict for `inspect` (assertVisibility).
+ */
+class FakeDeviceProvider(
+    // Invoked inside tap() before it returns; a test can throw here to simulate a device-core tap
+    // failure (gesture rejected). Default is a no-op. Declared before [evidenceFor] so the common
+    // `FakeDeviceProvider { evidence }` trailing-lambda call still binds the lambda to [evidenceFor].
+    private val onTap: (Selector) -> Unit = {},
+    // The policy Outcome tap() reports. Default is a successful Acted; a test returns Outcome.Absent
+    // to drive the ElementNotFound path without throwing.
+    private val tapOutcome: (Selector) -> Outcome = { Outcome.Acted(FoundVia.IMMEDIATE) },
+    // When true, launchApp() throws DeviceEnvError.OperationFailed instead of recording the call —
+    // exactly what device-core's launchApp throws on a failed launch (Api.kt), which the error
+    // mapper turns into MaestroException.UnableToLaunchApp.
+    private val launchFails: Boolean = false,
+    private val evidenceFor: (Selector) -> ElementEvidence,
+) : DeviceProvider {
+    var connectCount: Int = 0
+    var lastConnectedTarget: TargetSelector? = null
+    var lastInspectedSelector: Selector? = null
+    var lastTappedSelector: Selector? = null
+    var tapCount: Int = 0
+    var closed: Boolean = false
+    val launchedApps = mutableListOf<String>()
+
+    /** Snapshot of `devicecore.ios.bundleId` taken AT connect() time, to prove set-before-connect
+     *  ordering rather than merely that the property is set by the time the test asserts on it. */
+    var bundleIdAtConnect: String? = null
+
+    override suspend fun connect(selector: TargetSelector): Device {
+        connectCount++
+        lastConnectedTarget = selector
+        bundleIdAtConnect = System.getProperty("devicecore.ios.bundleId")
+        return object : Device {
+            override val screen: Screen = object : Screen {
+                override fun getById(value: String): Locator = locator(Selector.Id(value))
+                override fun getByText(value: String, match: Match, ignoreCase: Boolean): Locator =
+                    locator(Selector.Text(value, match, ignoreCase))
+            }
+
+            override suspend fun launchApp(appId: AppId) {
+                if (launchFails) {
+                    throw DeviceEnvError.OperationFailed(
+                        capability = "launchApp",
+                        detail = Sourced<Diagnostic>(null, EvidenceSource.UNAVAILABLE),
+                        summary = "fake launch failure for ${appId.value}",
+                    )
+                }
+                launchedApps.add(appId.value)
+            }
+
+            override suspend fun openLink(url: String) = Unit
+
+            override suspend fun stopApp(appId: AppId) = Unit
+
+            override fun close() {
+                closed = true
+            }
+        }
+    }
+
+    private fun locator(sel: Selector): Locator = object : Locator {
+        override val selector: Selector = sel
+
+        override suspend fun tap(): ActionEvidence {
+            tapCount++
+            lastTappedSelector = sel
+            onTap(sel)
+            return CANNED_TAP.copy(outcome = tapOutcome(sel), target = sel.toString())
+        }
+
+        override suspend fun inspect(): ElementEvidence {
+            lastInspectedSelector = sel
+            return evidenceFor(sel)
+        }
+
+        override fun nth(index: Int): Locator = locator(Selector.Nth(sel, index))
+    }
+
+    private companion object {
+        private val UA = Signal(false, EvidenceSource.UNAVAILABLE)
+        private val CANNED_TAP = ActionEvidence(
+            actionId = "a",
+            target = "t",
+            outcome = Outcome.Acted(FoundVia.IMMEDIATE),
+            actionability = Actionability(UA, UA, UA, UA, UA),
+            delivered = Signal(true, EvidenceSource.MEASURED),
+            settle = Settle(UA, UA),
+            injectPoint = Point(10, 20),
+            waitedMs = 0L,
+        )
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/SelectorTranslatorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/SelectorTranslatorTest.kt
@@ -1,0 +1,58 @@
+package maestro.orchestra.devicecore
+
+import com.google.common.truth.Truth.assertThat
+import dev.mobile.devicecore.prototype.api.Match
+import dev.mobile.devicecore.prototype.api.Selector
+import maestro.MaestroException
+import maestro.orchestra.ElementSelector
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SelectorTranslatorTest {
+    @Test
+    fun `text maps to PATTERN ignoreCase text selector`() {
+        val s = SelectorTranslator.translate(ElementSelector(textRegex = "Form Test"))
+        assertThat(s).isInstanceOf(Selector.Text::class.java)
+        s as Selector.Text
+        assertThat(s.value).isEqualTo("Form Test")
+        assertThat(s.match).isEqualTo(Match.PATTERN)
+        assertThat(s.ignoreCase).isTrue()
+    }
+
+    @Test
+    fun `id maps to id selector`() {
+        val s = SelectorTranslator.translate(ElementSelector(idRegex = "fabAddIcon"))
+        assertThat(s).isEqualTo(Selector.Id("fabAddIcon"))
+    }
+
+    @Test
+    fun `index wraps in nth`() {
+        val s = SelectorTranslator.translate(ElementSelector(textRegex = "Item", index = "2"))
+        assertThat(s).isInstanceOf(Selector.Nth::class.java)
+        s as Selector.Nth
+        assertThat(s.index).isEqualTo(2)
+        assertThat(s.target).isInstanceOf(Selector.Text::class.java)
+    }
+
+    @Test
+    fun `unsupported field throws NotImplemented naming it`() {
+        val e = assertThrows<MaestroException.NotImplemented> {
+            SelectorTranslator.translate(ElementSelector(textRegex = "x", below = ElementSelector(textRegex = "y")))
+        }
+        assertThat(e.message).contains("below")
+    }
+
+    @Test
+    fun `neither text nor id throws NotImplemented`() {
+        assertThrows<MaestroException.NotImplemented> {
+            SelectorTranslator.translate(ElementSelector(index = "0"))
+        }
+    }
+
+    @Test
+    fun `combined text and id throws NotImplemented`() {
+        assertThrows<MaestroException.NotImplemented> {
+            SelectorTranslator.translate(ElementSelector(textRegex = "x", idRegex = "y"))
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,8 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // device-core is published only to the local Maven repo.
+        mavenLocal { content { includeGroup("dev.mobile.devicecore") } }
     }
 }
 


### PR DESCRIPTION
## Why

This is the first walking-skeleton integration of maestro-device-core into Maestro: a real
`maestro test` run driven end to end by device-core, through the actual CLI, on a real device.
It's deliberately narrow — `launchApp`, `tapOn`, `assertVisible`, `assertNotVisible`, and
anything else throws `NotImplemented` — and there's no runtime switch and no fallback to
legacy: `maestro test` is always device-core.

The point is to prove the pure device-core path works end to end before the bigger work of
deleting legacy and porting the rest of the commands. A switch or a decline-to-legacy fallback
would let a flow silently run on the old driver and hide exactly the gaps this is meant to
surface.

(The earlier WIP built a switchable router — an `ExecutionBackend` seam with `DriverKind`
selection and decline-to-legacy. This keeps its device-core half and drops the switch and the
fallback.)

## Approach

`maestro test`'s single-flow path provisions a device-core session with no legacy `Maestro`
constructed, then runs the flow through a thin executor: dispatch `launchApp` / `tapOn` /
`assertVisible` / `assertNotVisible` to a 5-verb `DeviceCoreDriver`, throw `NotImplemented`
for everything else. Supporting pieces:

- **`SelectorTranslator`** — pure `ElementSelector → device-core Selector`, always
  `Match.PATTERN` + `ignoreCase` (the legacy matching rule); unsupported selector fields throw
  `NotImplemented`.
- **`AssertVisibleVerdict`** — verdict from device-core's own `actionability.visible` signal,
  no Maestro geometry.
- **`DeviceCoreErrorMapper`** — device-core outcomes/throws → Maestro's own exception
  taxonomy; adds one type, `MaestroException.NotImplemented`.
- **`StepTraceEmitter`** — `steps.jsonl` for the differential harness to consume later.

Two gaps only a real run surfaces, both fixed here: the parsed flow carries injected
structural commands (`DefineVariablesCommand`, `ApplyConfigurationCommand`) the runner now
skips instead of throwing on; and the device serial wasn't threaded into device-core's target,
so a second booted emulator broke connect — now threaded.

**`tapOn` caveat:** device-core's tap resolver serves id selectors only right now (its
inspect/assert path resolves text, its tap path doesn't), and this app's buttons are text-only
Flutter widgets. `tapOn` is implemented and unit-tested here, but the e2e flow drops the text
`tapOn` until device-core does text-tap — so the on-device flow covers three of the four verbs.

## Verification

Unit tests (`:maestro-orchestra:test`, `:maestro-client:test`, `:maestro-cli:test`): the
selector translator, the error mapping, each of the four verbs' pass/fail against a fake
device provider, and an assertion that `maestro test` builds **no** legacy `Maestro`.

Real-device e2e on an Android emulator: `maestro test` exits 0 running `launchApp →
assertVisible → assertNotVisible` through device-core, no `Maestro` on the path. A stray
`inputText` was confirmed to fail with a `NotImplemented` naming it.

Trace (`steps.jsonl`, `backendId":"devicecore"`, no `declined`; skipped structural commands
produce no lines):

```
{"stepIndex":2,"backendId":"devicecore","command":{"type":"LaunchAppCommand"},"verdict":"PASS"}
{"stepIndex":3,"backendId":"devicecore","command":{"type":"AssertConditionCommand","selectorText":"Form Test"},"verdict":"PASS","chosenElement":{"x":16,"y":583,"width":339,"height":130,"centerX":185,"centerY":648,"text":"Form Test"}}
{"stepIndex":4,"backendId":"devicecore","command":{"type":"AssertConditionCommand","selectorText":"kwyjibo"},"verdict":"PASS","chosenElement":{"x":0,"y":0,"width":0,"height":0,"centerX":0,"centerY":0,"text":"kwyjibo"}}
```
