### PR TITLE
fix(orchestra): close GraalJS engine after validating each flow

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
@@ -7,6 +7,7 @@ import maestro.orchestra.CompositeCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.WorkspaceConfig
 import maestro.js.GraalJsEngine
+import maestro.js.JsEngine
 import maestro.orchestra.error.InvalidFlowFile
 import maestro.orchestra.error.SyntaxError as OrchestraSyntaxError
 import maestro.orchestra.error.ValidationError
@@ -59,6 +60,7 @@ object WorkspaceValidator {
         envParameters: Map<String, String>,
         includeTags: List<String>,
         excludeTags: List<String>,
+        jsEngineFactory: () -> JsEngine = ::GraalJsEngine,
     ): Result<WorkspaceValidationResult, WorkspaceValidationError> {
         return try {
             val allFlows = mutableListOf<ValidatedFlow>()
@@ -103,12 +105,17 @@ object WorkspaceValidator {
                                 "${path.name}; flows now run on GraalJS, the default engine."
                         ))
                     }
-                    val jsEngine = GraalJsEngine().also { engine ->
+                    val jsEngine = jsEngineFactory().also { engine ->
                         envParameters.forEach { (key, value) -> engine.putEnv(key, value) }
                     }
-                    val config = applyConfigurationCommand
-                        ?.evaluateScripts(jsEngine)
-                        ?.config
+                    // Close the engine so its GraalVM context doesn't leak across flows.
+                    val config = try {
+                        applyConfigurationCommand
+                            ?.evaluateScripts(jsEngine)
+                            ?.config
+                    } finally {
+                        jsEngine.close()
+                    }
                     val flowName = config?.name ?: path.nameWithoutExtension
                     allFlows.add(ValidatedFlow(path.toString(), flowName, commands, config?.appId))
                 }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceValidatorTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceValidatorTest.kt
@@ -1,6 +1,8 @@
 package maestro.orchestra.workspace
 
 import com.google.common.truth.Truth.assertThat
+import maestro.js.GraalJsEngine
+import maestro.js.JsEngine
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -44,6 +46,38 @@ class WorkspaceValidatorTest {
 
     private fun flowWithName(name: String): String {
         return baseFlowContent.replace("appId:", "name: $name\nappId:")
+    }
+
+    /** Wraps a real engine so the test can observe whether validate() closed it. */
+    private class TrackingJsEngine(private val delegate: JsEngine) : JsEngine by delegate {
+        var closed = false
+            private set
+
+        override fun close() {
+            closed = true
+            delegate.close()
+        }
+    }
+
+    @Test
+    fun `validate closes every JS engine it creates`() {
+        val engines = mutableListOf<TrackingJsEngine>()
+
+        val result = WorkspaceValidator.validate(
+            workspace = makeWorkspaceZip(
+                "flow_a.yaml" to baseFlowContent,
+                "flow_b.yaml" to baseFlowContent,
+            ),
+            appId = "com.example.app",
+            envParameters = mapOf("APP_ID" to "com.example.app"),
+            includeTags = emptyList(),
+            excludeTags = emptyList(),
+            jsEngineFactory = { TrackingJsEngine(GraalJsEngine()).also(engines::add) },
+        )
+
+        assertThat(result.isOk).isTrue()
+        assertThat(engines).isNotEmpty()
+        assertThat(engines.filter { !it.closed }).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
### Problem
`WorkspaceValidator` creates a `GraalJsEngine` for every flow to evaluate its config scripts, but never closes it. Each engine owns its own GraalVM polyglot context, so validating many flows in a single long lived process leaks the contexts' compiled script state (Truffle shapes, function data, host interop `Method` caches). Memory grows without bound until the process runs out of heap.

This hits any process that validates workspaces repeatedly rather than exiting per run.

### Fix
Close each engine in a `finally` once its config scripts are evaluated, so the GraalVM context is released instead of accumulating.

### How it was found

I asked Claude to hunt for the leak by doing memory census of live pods and compare fresh vs long-running pods. What it did:

- Used `jmap -histo:live` 1 for memory census
- It took that census on a freshly-started pod and on one that had been up a long time.
- Spotted the linear-with-uptime growth. 
- Then worked with claude to reach exactly the root problem with code.

Live heap analysis of a long running process showed ~85% of the heap retained by GraalVM/GraalJS objects, scaling linearly with uptime: a fresh process held ~450k `java.lang.reflect.Method`, a 28h old one held ~9.5M, a 21x jump in lockstep across every GraalJS class. The only JS entry point on that path was `WorkspaceValidator`, whose per flow engines were never closed.

### Tests
Added `validate closes every JS engine it creates`, which injects a tracking engine factory and asserts every engine created during validation is closed. The new `jsEngineFactory` parameter defaults to `GraalJsEngine`, so callers are unaffected. Full `maestro-orchestra` suite passes (17/17 in `WorkspaceValidatorTest`).