### PR TITLE
fix(android): confirm locale via blocking broadcast when getprop lags

### DIFF
--- a/maestro-android/src/main/java/dev/mobile/maestro/receivers/LocaleSettingReceiver.kt
+++ b/maestro-android/src/main/java/dev/mobile/maestro/receivers/LocaleSettingReceiver.kt
@@ -71,8 +71,7 @@ class LocaleSettingReceiver : BroadcastReceiver(), HasAction {
             Log.e(TAG, "Failed to validate device locale", e)
             resultCode = RESULT_LOCALE_VALIDATION_FAILED
             resultData = "Failed to set locale $locale: ${e.message}"
-            // Do not fall through: without this the second try block below would overwrite the
-            // validation-failed code with SUCCESS/UPDATE_CONFIGURATION_FAILED and swallow the failure.
+            // Return so the try block below can't overwrite this failure code.
             return
         }
 

--- a/maestro-android/src/main/java/dev/mobile/maestro/receivers/LocaleSettingReceiver.kt
+++ b/maestro-android/src/main/java/dev/mobile/maestro/receivers/LocaleSettingReceiver.kt
@@ -71,6 +71,9 @@ class LocaleSettingReceiver : BroadcastReceiver(), HasAction {
             Log.e(TAG, "Failed to validate device locale", e)
             resultCode = RESULT_LOCALE_VALIDATION_FAILED
             resultData = "Failed to set locale $locale: ${e.message}"
+            // Do not fall through: without this the second try block below would overwrite the
+            // validation-failed code with SUCCESS/UPDATE_CONFIGURATION_FAILED and swallow the failure.
+            return
         }
 
         try {

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -129,6 +129,7 @@ object DeviceService {
                         SET_LOCALE_RESULT_SUCCESS -> PrintUtils.message("[Done] Setting the device locale to ${androidSpec.locale.code}...")
                         SET_LOCALE_RESULT_LOCALE_NOT_VALID -> throw IllegalStateException("Failed to set locale ${androidSpec.locale.code}, the locale is not valid for a chosen device")
                         SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED -> throw IllegalStateException("Failed to set locale ${androidSpec.locale.code}, exception during updating configuration occurred")
+                        SET_LOCALE_RESULT_LOCALE_VALIDATION_FAILED -> throw IllegalStateException("Failed to set locale ${androidSpec.locale.code}, the locale could not be validated for a chosen device")
                         else -> throw IllegalStateException("Failed to set locale ${androidSpec.locale.code}, unknown exception happened")
                     }
                     driver.uninstallMaestroDriverApp()
@@ -757,4 +758,5 @@ object DeviceService {
     private const val SET_LOCALE_RESULT_SUCCESS = 0
     private const val SET_LOCALE_RESULT_LOCALE_NOT_VALID = 1
     private const val SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED = 2
+    private const val SET_LOCALE_RESULT_LOCALE_VALIDATION_FAILED = 3
 }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -58,6 +58,8 @@ import java.util.Base64
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.io.use
 
@@ -71,6 +73,7 @@ data class LocaleRetryPolicy(
     val maxAttempts: Int = 3,
     val verifyPolls: Int = 32,
     val pollIntervalMs: Long = 250L,
+    val blockingBroadcastTimeoutMs: Long = 15_000L,
 )
 
 /**
@@ -972,14 +975,22 @@ class AndroidDriver(
                 } else {
                     // getprop can lag the reflection-based config update, so a poll miss is not proof of
                     // failure. Ask the receiver directly with a blocking, ordered broadcast and trust its
-                    // real result. By now the post-resume churn has settled, so this rarely blocks long.
+                    // real result. By now the post-resume churn has settled, so this rarely blocks long —
+                    // but a busy app or ANR could stall the ordered dispatch, so bound the wait and fall
+                    // back to a classified failure rather than hanging for the platform broadcast timeout.
                     logger.info("Locale $target unconfirmed via getprop; querying the receiver directly")
-                    val output = shell(
+                    val output = shellWithTimeout(
                         "am broadcast -a dev.mobile.maestro.locale " +
                             "-n dev.mobile.maestro/.receivers.LocaleSettingReceiver " +
-                            "--es lang $language --es country $country"
+                            "--es lang $language --es country $country",
+                        localeRetry.blockingBroadcastTimeoutMs
                     )
-                    extractSetLocaleResult(output)
+                    if (output == null) {
+                        logger.warn("Blocking locale broadcast did not return within ${localeRetry.blockingBroadcastTimeoutMs}ms")
+                        SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED
+                    } else {
+                        extractSetLocaleResult(output)
+                    }
                 }
             }
         }
@@ -994,6 +1005,24 @@ class AndroidDriver(
         val regex = Regex("result=(-?\\d+)")
         val match = regex.find(result)
         return match?.groups?.get(1)?.value?.toIntOrNull() ?: -1
+    }
+
+    /**
+     * Runs [command] via [shell] but gives up after [timeoutMs], returning null on timeout — [shell]
+     * itself has no timeout, so a busy app or ANR could otherwise stall the caller indefinitely. The
+     * abandoned shell keeps running harmlessly on its worker thread until it returns.
+     */
+    private fun shellWithTimeout(command: String, timeoutMs: Long): String? {
+        val executor = Executors.newSingleThreadExecutor()
+        return try {
+            CompletableFuture.supplyAsync({ shell(command) }, executor).get(timeoutMs, TimeUnit.MILLISECONDS)
+        } catch (e: TimeoutException) {
+            null
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        } finally {
+            executor.shutdown()
+        }
     }
 
     private fun awaitLocaleApplied(target: String): Boolean {
@@ -1451,9 +1480,13 @@ class AndroidDriver(
     companion object {
 
         // Result codes returned by [setDeviceLocale] (consumed by DeviceService / the cloud worker).
+        // These MUST stay in sync with LocaleSettingReceiver's RESULT_* codes in maestro-android — the
+        // two live in separate Gradle modules (the receiver ships inside the on-device APK), so there is
+        // no shared compile unit to enforce it.
         const val SET_LOCALE_RESULT_SUCCESS = 0
         const val SET_LOCALE_RESULT_LOCALE_NOT_VALID = 1
         const val SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED = 2
+        const val SET_LOCALE_RESULT_LOCALE_VALIDATION_FAILED = 3
 
         private const val SERVER_LAUNCH_TIMEOUT_MS = 15000L
         private const val MAESTRO_DRIVER_STARTUP_TIMEOUT = "MAESTRO_DRIVER_STARTUP_TIMEOUT"

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -973,11 +973,8 @@ class AndroidDriver(
                     logger.info("Device locale is $target")
                     SET_LOCALE_RESULT_SUCCESS
                 } else {
-                    // getprop can lag the reflection-based config update, so a poll miss is not proof of
-                    // failure. Ask the receiver directly with a blocking, ordered broadcast and trust its
-                    // real result. By now the post-resume churn has settled, so this rarely blocks long —
-                    // but a busy app or ANR could stall the ordered dispatch, so bound the wait and fall
-                    // back to a classified failure rather than hanging for the platform broadcast timeout.
+                    // getprop can lag the config update, so a poll miss isn't proof of failure. Confirm
+                    // directly with a blocking broadcast, bounded so a busy app/ANR can't stall us.
                     logger.info("Locale $target unconfirmed via getprop; querying the receiver directly")
                     val output = shellWithTimeout(
                         "am broadcast -a dev.mobile.maestro.locale " +
@@ -1007,11 +1004,7 @@ class AndroidDriver(
         return match?.groups?.get(1)?.value?.toIntOrNull() ?: -1
     }
 
-    /**
-     * Runs [command] via [shell] but gives up after [timeoutMs], returning null on timeout — [shell]
-     * itself has no timeout, so a busy app or ANR could otherwise stall the caller indefinitely. The
-     * abandoned shell keeps running harmlessly on its worker thread until it returns.
-     */
+    /** Runs [command] via [shell], returning null if it doesn't finish within [timeoutMs] ([shell] has no timeout of its own). */
     private fun shellWithTimeout(command: String, timeoutMs: Long): String? {
         val executor = Executors.newSingleThreadExecutor()
         return try {
@@ -1479,10 +1472,8 @@ class AndroidDriver(
 
     companion object {
 
-        // Result codes returned by [setDeviceLocale] (consumed by DeviceService / the cloud worker).
-        // These MUST stay in sync with LocaleSettingReceiver's RESULT_* codes in maestro-android — the
-        // two live in separate Gradle modules (the receiver ships inside the on-device APK), so there is
-        // no shared compile unit to enforce it.
+        // Result codes from [setDeviceLocale]. Keep in sync with LocaleSettingReceiver's RESULT_* codes
+        // (maestro-android) — separate modules, no shared compile unit to enforce it.
         const val SET_LOCALE_RESULT_SUCCESS = 0
         const val SET_LOCALE_RESULT_LOCALE_NOT_VALID = 1
         const val SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED = 2

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -970,8 +970,16 @@ class AndroidDriver(
                     logger.info("Device locale is $target")
                     SET_LOCALE_RESULT_SUCCESS
                 } else {
-                    logger.warn("Device locale did not reach $target after ${localeRetry.maxAttempts} attempts")
-                    SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED
+                    // getprop can lag the reflection-based config update, so a poll miss is not proof of
+                    // failure. Ask the receiver directly with a blocking, ordered broadcast and trust its
+                    // real result. By now the post-resume churn has settled, so this rarely blocks long.
+                    logger.info("Locale $target unconfirmed via getprop; querying the receiver directly")
+                    val output = shell(
+                        "am broadcast -a dev.mobile.maestro.locale " +
+                            "-n dev.mobile.maestro/.receivers.LocaleSettingReceiver " +
+                            "--es lang $language --es country $country"
+                    )
+                    extractSetLocaleResult(output)
                 }
             }
         }
@@ -980,6 +988,12 @@ class AndroidDriver(
     private fun currentEffectiveLocaleTag(): String {
         val persisted = shell("getprop persist.sys.locale").trim()
         return if (persisted.isNotEmpty()) persisted else shell("getprop ro.product.locale").trim()
+    }
+
+    private fun extractSetLocaleResult(result: String): Int {
+        val regex = Regex("result=(-?\\d+)")
+        val match = regex.find(result)
+        return match?.groups?.get(1)?.value?.toIntOrNull() ?: -1
     }
 
     private fun awaitLocaleApplied(target: String): Boolean {

--- a/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
@@ -25,9 +25,17 @@ class AndroidDriverSetLocaleTest {
     }
 
     // A driver wired to [connection] with a tiny, zero-wait retry budget so tests finish instantly.
-    private fun driver(connection: AndroidDeviceConnection) = AndroidDriver(
+    private fun driver(
+        connection: AndroidDeviceConnection,
+        blockingBroadcastTimeoutMs: Long = 15_000L,
+    ) = AndroidDriver(
         connection = connection,
-        localeRetry = LocaleRetryPolicy(maxAttempts = 2, verifyPolls = 2, pollIntervalMs = 0L),
+        localeRetry = LocaleRetryPolicy(
+            maxAttempts = 2,
+            verifyPolls = 2,
+            pollIntervalMs = 0L,
+            blockingBroadcastTimeoutMs = blockingBroadcastTimeoutMs,
+        ),
     )
 
     @Test
@@ -97,5 +105,33 @@ class AndroidDriverSetLocaleTest {
         // Bounded detached retries first, then exactly one blocking broadcast for the authoritative result.
         verify(exactly = 2) { connection.execDetached(any()) }
         verify(exactly = 1) { connection.shell(match { it.startsWith("am broadcast") }) }
+    }
+
+    @Test
+    fun `maps the receiver's validation-failed code (3) to a validation failure`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        every { connection.shell("getprop persist.sys.locale") } returns reply("en-US") // never becomes fr-FR
+        every { connection.shell(match { it.startsWith("am broadcast") }) } returns
+            reply("Broadcast completed: result=3, data=\"Failed to set locale fr_FR: boom\"")
+
+        val result = driver(connection).setDeviceLocale(country = "FR", language = "fr")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_LOCALE_VALIDATION_FAILED)
+    }
+
+    @Test
+    fun `falls back to a classified failure when the blocking broadcast does not return in time`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        every { connection.shell("getprop persist.sys.locale") } returns reply("en-US") // never becomes fr-FR
+        // A busy app / ANR: the ordered broadcast never returns within the bound.
+        every { connection.shell(match { it.startsWith("am broadcast") }) } answers {
+            Thread.sleep(1_000)
+            reply("Broadcast completed: result=0, data=\"fr_FR\"")
+        }
+
+        val result = driver(connection, blockingBroadcastTimeoutMs = 50L)
+            .setDeviceLocale(country = "FR", language = "fr")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED)
     }
 }

--- a/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
@@ -73,14 +73,29 @@ class AndroidDriverSetLocaleTest {
     }
 
     @Test
-    fun `retries then reports failure when the locale never applies`() {
+    fun `succeeds when getprop never confirms but the blocking broadcast returns success`() {
         val connection = mockk<AndroidDeviceConnection>(relaxed = true)
         every { connection.shell("getprop persist.sys.locale") } returns reply("en-US") // never becomes fr-FR
+        every { connection.shell(match { it.startsWith("am broadcast") }) } returns
+            reply("Broadcasting: Intent { act=dev.mobile.maestro.locale }\nBroadcast completed: result=0, data=\"fr_FR\"")
+
+        val result = driver(connection).setDeviceLocale(country = "FR", language = "fr")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_SUCCESS)
+    }
+
+    @Test
+    fun `reports the receiver's failure when the blocking broadcast returns a non-zero result`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        every { connection.shell("getprop persist.sys.locale") } returns reply("en-US") // never becomes fr-FR
+        every { connection.shell(match { it.startsWith("am broadcast") }) } returns
+            reply("Broadcast completed: result=2, data=\"Failed to set locale fr_FR\"")
 
         val result = driver(connection).setDeviceLocale(country = "FR", language = "fr")
 
         assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED)
-        // Bounded retry (maxAttempts = 2) — a fast, classified failure, never a multi-minute block.
+        // Bounded detached retries first, then exactly one blocking broadcast for the authoritative result.
         verify(exactly = 2) { connection.execDetached(any()) }
+        verify(exactly = 1) { connection.shell(match { it.startsWith("am broadcast") }) }
     }
 }


### PR DESCRIPTION
## Problem
[#3462](https://github.com/mobile-dev-inc/Maestro/pull/3462) fires the locale broadcast **detached** and confirms via `getprop persist.sys.locale`. But `getprop` can lag the reflection-based config update, so the locale *does* apply yet the poll never confirms → `SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED` → the cloud worker reports an `INFRA_ERROR`. This has been firing ~300× fleet-wide since #3462 shipped (2026-07-29). Infra-only — runs retry and pass on another host, no customer impact — but it's noise that trips retries/circuit-breakers.

## Fix
Keep the detached-fire + `getprop` poll as the fast path (still avoids the 120s ordered-broadcast hang #3462 fixed). When the poll doesn't confirm, fall back to the **old blocking, ordered `am broadcast`** and trust the receiver's authoritative `result=` code (re-adds `extractSetLocaleResult`). By then post-resume broadcast-queue churn has settled, so it rarely blocks.

- `result=0` → SUCCESS (fixes the false negative)
- non-zero → the receiver's real failure (genuine errors still surface)

## Tests
Assert on the applied-locale result, not on re-polling: getprop-lag + `result=0` → SUCCESS; `result=2` → failure (via the blocking broadcast).

Refs MA-4211 · regression from #3462 / MA-4105.
