### PR TITLE
refactor(orchestra): make WorkspaceValidator jsEngineFactory internal

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceValidator.kt
@@ -60,7 +60,17 @@ object WorkspaceValidator {
         envParameters: Map<String, String>,
         includeTags: List<String>,
         excludeTags: List<String>,
-        jsEngineFactory: () -> JsEngine = ::GraalJsEngine,
+    ): Result<WorkspaceValidationResult, WorkspaceValidationError> =
+        validate(workspace, appId, envParameters, includeTags, excludeTags, ::GraalJsEngine)
+
+    // Keeping it on an `internal` overload keeps the public validate() signature at 5 args, mirroring Orchestra's internal jsEngineFactory.
+    internal fun validate(
+        workspace: File,
+        appId: String,
+        envParameters: Map<String, String>,
+        includeTags: List<String>,
+        excludeTags: List<String>,
+        jsEngineFactory: () -> JsEngine,
     ): Result<WorkspaceValidationResult, WorkspaceValidationError> {
         return try {
             val allFlows = mutableListOf<ValidatedFlow>()


### PR DESCRIPTION
Follow-up to #3508. The `jsEngineFactory` param is a test seam, so it shouldn't sit on the public `validate()` signature where every caller sees it.

Public `validate()` goes back to 5 args; the factory moves to an `internal` overload it delegates to — same pattern as `Orchestra`'s `internal jsEngineFactory`. No behaviour or caller changes.