### PR TITLE
fix(web): guard node.name when deriving resource-id — a form containing <input name="name"> breaks hierarchy retrieval

### DIFF
--- a/e2e/demo_app/.maestro/web_flows/form_named_control.yaml
+++ b/e2e/demo_app/.maestro/web_flows/form_named_control.yaml
@@ -1,0 +1,39 @@
+# Regression for the unguarded node.name resource-id derivation: a <form>
+# containing a control named exactly "name" makes form.name evaluate to that
+# INPUT ELEMENT (HTML named-control override), and an element-valued
+# resource-id makes the hierarchy unserializable — every command then fails
+# with "Could not retrieve hierarchy through maestro.getContentDescription()".
+# The page's __framework property stands in for the enumerable internals
+# (React __reactFiber$…, Vue, Angular) every real framework attaches to DOM
+# nodes, which is what makes the element circular on real pages.
+# See https://github.com/mobile-dev-inc/Maestro/issues/3213.
+#
+# Page source, decoded:
+# <!doctype html>
+# <html>
+#   <head><meta charset="utf-8"><title>form name test</title></head>
+#   <body>
+#     <p>Before form</p>
+#     <form>
+#       <label for="n">Your name</label>
+#       <input id="n" name="name" placeholder="Enter your name"
+#         oninput="document.getElementById('status').textContent='Typed'">
+#     </form>
+#     <div id="status">Not typed</div>
+#     <script>
+#       const i = document.getElementById("n");
+#       i.__framework = { stateNode: i };
+#     </script>
+#   </body>
+# </html>
+
+url: data:text/html;charset=utf-8,%3C%21doctype%20html%3E%3Chtml%3E%3Chead%3E%3Cmeta%20charset%3D%22utf-8%22%3E%3Ctitle%3Eform%20name%20test%3C%2Ftitle%3E%3C%2Fhead%3E%3Cbody%3E%3Cp%3EBefore%20form%3C%2Fp%3E%3Cform%3E%3Clabel%20for%3D%22n%22%3EYour%20name%3C%2Flabel%3E%3Cinput%20id%3D%22n%22%20name%3D%22name%22%20placeholder%3D%22Enter%20your%20name%22%20oninput%3D%22document.getElementById%28%27status%27%29.textContent%3D%27Typed%27%22%3E%3C%2Fform%3E%3Cdiv%20id%3D%22status%22%3ENot%20typed%3C%2Fdiv%3E%3Cscript%3Econst%20i%3Ddocument.getElementById%28%22n%22%29%3Bi.__framework%3D%7BstateNode%3Ai%7D%3B%3C%2Fscript%3E%3C%2Fbody%3E%3C%2Fhtml%3E
+tags:
+  - passing
+  - web
+---
+- launchApp
+- assertVisible: "Before form"
+- tapOn: "Enter your name"
+- inputText: "Ada"
+- assertVisible: "Typed"

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -125,11 +125,17 @@
         return null;
       }
 
-      if (!!node.attributes['flt-semantics-identifier'] || !!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
+      // node.name is not guaranteed to be a string: HTMLFormElement's named-control
+      // getter overrides the form's own IDL attributes, so a <form> containing a
+      // control named "name" makes node.name evaluate to that ELEMENT. Left
+      // unguarded, the element becomes the resource-id and the hierarchy can no
+      // longer be serialized over CDP (same reason node.title is guarded below).
+      const name = typeof node.name === 'string' ? node.name : null
+      if (!!node.attributes['flt-semantics-identifier'] || !!node.id || !!node.ariaLabel || !!name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
         const title = typeof node.title === 'string' ? node.title : null
         // Prefer flt-semantics-identifier: on Flutter web node.id is an
         // unstable internal handle, not the developer-set identifier.
-        attributes['resource-id'] = node.attributes['flt-semantics-identifier']?.value || node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
+        attributes['resource-id'] = node.attributes['flt-semantics-identifier']?.value || node.id || node.ariaLabel || name || title || node.htmlFor || node.attributes['data-testid']?.value
       }
 
       if (node.tagName.toLowerCase() === 'body') {

--- a/maestro-client/src/test/java/maestro/drivers/WebHierarchyFormNameShadowingTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/WebHierarchyFormNameShadowingTest.kt
@@ -1,0 +1,140 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import org.graalvm.polyglot.Context
+import org.junit.jupiter.api.Test
+
+/**
+ * Exercises the bundled maestro-web.js against the HTML named-control override:
+ * HTMLFormElement's named getter shadows the form's own IDL attributes, so a
+ * `<form>` containing `<input name="name">` makes `form.name` evaluate to that
+ * INPUT ELEMENT rather than a string.
+ *
+ * Left unguarded, that element becomes the form's resource-id and the
+ * hierarchy can no longer be serialized (the element's parentElement
+ * back-reference is circular — on real pages React/Vue fibers make it worse).
+ * In real runs every subsequent command then fails with
+ * "Could not retrieve hierarchy through maestro.getContentDescription()".
+ *
+ * Forms with a field literally named "name" are common (any "your name" form),
+ * so this is easy to hit. See
+ * https://github.com/mobile-dev-inc/Maestro/issues/3213.
+ */
+class WebHierarchyFormNameShadowingTest {
+
+    @Test
+    fun `a form whose name property is a child element does not poison the hierarchy`() {
+        Context.newBuilder("js").build().use { context ->
+            context.eval("js", domScript(nameShadowedByChildElement = true))
+            context.eval("js", webScript)
+
+            // Serializability is the property the CDP transport needs, and it is
+            // exactly what an element-valued resource-id destroys: the element's
+            // parentElement back-reference makes the tree circular.
+            val json = context.eval(
+                "js",
+                "JSON.stringify(maestro.getContentDescription())",
+            )
+            assertThat(json.isNull).isFalse()
+
+            // The form has no string-valued identifying property, so it must get
+            // no resource-id at all — never the element.
+            val resourceId = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id'] ?? null",
+            )
+            assertThat(resourceId.isNull).isTrue()
+        }
+    }
+
+    @Test
+    fun `a string-valued name is still used as the resource-id (unchanged)`() {
+        Context.newBuilder("js").build().use { context ->
+            context.eval("js", domScript(nameShadowedByChildElement = false))
+            context.eval("js", webScript)
+
+            val resourceId = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id'] ?? null",
+            )
+            assertThat(resourceId.asString()).isEqualTo("checkout-form")
+        }
+    }
+
+    // --- harness (same shape as FlutterWebSemanticsIdentifierTest) ----------
+
+    private val webScript: String by lazy {
+        requireNotNull(javaClass.classLoader.getResource("maestro-web.js")) {
+            "maestro-web.js was not found on the test classpath"
+        }.readText()
+    }
+
+    /**
+     * body > form > input, where the input's name attribute is "name". With
+     * [nameShadowedByChildElement] the form's `name` property IS the input
+     * object — exactly what a browser produces for that markup. Without it,
+     * the form's `name` stays an ordinary string.
+     */
+    private fun domScript(nameShadowedByChildElement: Boolean): String {
+        val formName = if (nameShadowedByChildElement) "input" else "'checkout-form'"
+        return """
+            globalThis.Node = { TEXT_NODE: 3 };
+            globalThis.window = globalThis;
+            globalThis.innerWidth = 1024;
+            globalThis.innerHeight = 768;
+
+            const input = {
+              tagName: 'input',
+              id: '',
+              name: 'name',
+              attributes: {},
+              childNodes: [],
+              children: [],
+              selected: false,
+              parentElement: null,
+              getBoundingClientRect() {
+                return { x: 0, y: 20, width: 100, height: 20 };
+              },
+            };
+
+            const form = {
+              tagName: 'form',
+              id: '',
+              attributes: {},
+              childNodes: [],
+              children: [input],
+              selected: false,
+              parentElement: null,
+              getBoundingClientRect() {
+                return { x: 0, y: 0, width: 200, height: 60 };
+              },
+            };
+            // Assigned after construction, the way the browser's named-control
+            // getter effectively behaves for <form><input name="name"></form>.
+            form.name = $formName;
+            input.parentElement = form;
+
+            const body = {
+              tagName: 'body',
+              id: '',
+              attributes: {},
+              childNodes: [],
+              children: [form],
+              selected: false,
+              parentElement: null,
+              getBoundingClientRect() {
+                return { x: 0, y: 0, width: 1024, height: 768 };
+              },
+            };
+            form.parentElement = body;
+
+            globalThis.document = {
+              body: body,
+              readyState: 'complete',
+              querySelectorAll() { return []; },
+            };
+
+            globalThis.maestro = {};
+        """.trimIndent()
+    }
+}


### PR DESCRIPTION
**Any web page with a `<form>` containing `<input name="name">` breaks every Maestro command** with:

```
Could not retrieve hierarchy through maestro.getContentDescription() (tried 10 times
```

Likely the undiagnosed cause of #3213 — that reporter's flow dies exactly when a form step containing `#field-name` mounts, and a second user reported the same error.

## Root cause

Per the HTML spec, `HTMLFormElement`'s named-control getter overrides the form's own IDL attributes — so on such a form, `node.name` evaluates to the **input element**, not a string. `maestro-web.js` used `node.name` unguarded when deriving `resource-id`, so the element landed in the hierarchy, which then cannot be serialized (the element is circular via `parentElement`, and via framework internals like React's `__reactFiber$…` own-properties on real pages). The empty response surfaces as `MismatchedInputException: No content to map due to end-of-input` on each of the 10 retries — and every subsequent command fails the same way while the form is mounted.

Forms with a field literally named `name` are everywhere (any "your name" input; common MUI and Clerk screens), so this is easy to hit and looks like flake until diagnosed.

## Fix

Guard `node.name` exactly the way `node.title` already is — that guard exists one property over, for the same reason.

## Tests

- New `WebHierarchyFormNameShadowingTest` (same GraalVM harness as `FlutterWebSemanticsIdentifierTest`): the poisoning test fails without the guard and passes with it; a control test pins that a string-valued `name` still resolves as before.
- New e2e web flow `web_flows/form_named_control.yaml`, in the same `data:`-URL pattern as `flutter_semantics_identifier.yaml`: fails on an unpatched build, passes with the guard.
- Full `maestro-client` suite: 258 tests, 0 failures. Complete `demo_app` web e2e lane: **12/12** on a CLI built from this branch.

## Standalone repro

https://github.com/edvedafi/maestro-form-name-repro — two pages identical except `name="username"` vs `name="name"`, plus a run script: control passes, bug fails, waiting/settling doesn't help (the state isn't transient), and a 2.6.0 binary with this one-line guard applied passes the bug page.
