### PR TITLE
fix(android): wait out a late locale flip with a grace poll

### DIFF
--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -71,6 +71,7 @@ data class LocaleRetryPolicy(
     val maxAttempts: Int = 3,
     val verifyPolls: Int = 32,
     val pollIntervalMs: Long = 250L,
+    val graceVerifyPolls: Int = 120, // Waits out a late locale flip before giving up: 120 × 250ms = 30s, only on the slow path
 )
 
 /**
@@ -966,11 +967,14 @@ class AndroidDriver(
                     applied = awaitLocaleApplied(target)
                 }
 
+                // Re-firing won't cure a late-running receiver; only waiting does. Give the prop one last, longer window to flip before classifying this as a failure.
+                if (!applied) applied = awaitLocaleApplied(target, localeRetry.graceVerifyPolls)
+
                 if (applied) {
                     logger.info("Device locale is $target")
                     SET_LOCALE_RESULT_SUCCESS
                 } else {
-                    logger.warn("Device locale did not reach $target after ${localeRetry.maxAttempts} attempts")
+                    logger.warn("Device locale did not reach $target after ${localeRetry.maxAttempts} attempts + grace window")
                     SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED
                 }
             }
@@ -982,10 +986,11 @@ class AndroidDriver(
         return if (persisted.isNotEmpty()) persisted else shell("getprop ro.product.locale").trim()
     }
 
-    private fun awaitLocaleApplied(target: String): Boolean {
-        repeat(localeRetry.verifyPolls) {
+    private fun awaitLocaleApplied(target: String, polls: Int = localeRetry.verifyPolls): Boolean {
+        repeat(polls) { poll ->
             if (shell("getprop persist.sys.locale").trim().equals(target, ignoreCase = true)) return true
-            if (localeRetry.pollIntervalMs > 0) Thread.sleep(localeRetry.pollIntervalMs)
+            // Don't sleep after the final poll; its result is about to be returned.
+            if (poll < polls - 1 && localeRetry.pollIntervalMs > 0) Thread.sleep(localeRetry.pollIntervalMs)
         }
         return false
     }

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -71,7 +71,9 @@ data class LocaleRetryPolicy(
     val maxAttempts: Int = 3,
     val verifyPolls: Int = 32,
     val pollIntervalMs: Long = 250L,
-    val graceVerifyPolls: Int = 120, // Waits out a late locale flip before giving up: 120 × 250ms = 30s, only on the slow path
+    // Grace window on every unapplied path: 30 × 1000ms = 30s, polled coarsely to keep the getprop count low.
+    val graceVerifyPolls: Int = 30,
+    val graceIntervalMs: Long = 1000L,
 )
 
 /**
@@ -968,7 +970,7 @@ class AndroidDriver(
                 }
 
                 // Re-firing won't cure a late-running receiver; only waiting does. Give the prop one last, longer window to flip before classifying this as a failure.
-                if (!applied) applied = awaitLocaleApplied(target, localeRetry.graceVerifyPolls)
+                if (!applied) applied = awaitLocaleApplied(target, localeRetry.graceVerifyPolls, localeRetry.graceIntervalMs)
 
                 if (applied) {
                     logger.info("Device locale is $target")
@@ -986,11 +988,15 @@ class AndroidDriver(
         return if (persisted.isNotEmpty()) persisted else shell("getprop ro.product.locale").trim()
     }
 
-    private fun awaitLocaleApplied(target: String, polls: Int = localeRetry.verifyPolls): Boolean {
+    private fun awaitLocaleApplied(
+        target: String,
+        polls: Int = localeRetry.verifyPolls,
+        intervalMs: Long = localeRetry.pollIntervalMs,
+    ): Boolean {
         repeat(polls) { poll ->
             if (shell("getprop persist.sys.locale").trim().equals(target, ignoreCase = true)) return true
             // Don't sleep after the final poll; its result is about to be returned.
-            if (poll < polls - 1 && localeRetry.pollIntervalMs > 0) Thread.sleep(localeRetry.pollIntervalMs)
+            if (poll < polls - 1 && intervalMs > 0) Thread.sleep(intervalMs)
         }
         return false
     }

--- a/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
@@ -28,7 +28,7 @@ class AndroidDriverSetLocaleTest {
     // A driver wired to [connection] with a tiny, zero-wait retry budget so tests finish instantly.
     private fun driver(connection: AndroidDeviceConnection) = AndroidDriver(
         connection = connection,
-        localeRetry = LocaleRetryPolicy(maxAttempts = 2, verifyPolls = 2, pollIntervalMs = 0L, graceVerifyPolls = 4),
+        localeRetry = LocaleRetryPolicy(maxAttempts = 2, verifyPolls = 2, pollIntervalMs = 0L, graceVerifyPolls = 4, graceIntervalMs = 0L),
     )
 
     @Test

--- a/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AndroidDriverSetLocaleTest.kt
@@ -7,6 +7,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import maestro.android.AndroidDeviceConnection
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Unit tests for [AndroidDriver.setDeviceLocale] (MA-4105).
@@ -27,7 +28,7 @@ class AndroidDriverSetLocaleTest {
     // A driver wired to [connection] with a tiny, zero-wait retry budget so tests finish instantly.
     private fun driver(connection: AndroidDeviceConnection) = AndroidDriver(
         connection = connection,
-        localeRetry = LocaleRetryPolicy(maxAttempts = 2, verifyPolls = 2, pollIntervalMs = 0L),
+        localeRetry = LocaleRetryPolicy(maxAttempts = 2, verifyPolls = 2, pollIntervalMs = 0L, graceVerifyPolls = 4),
     )
 
     @Test
@@ -73,14 +74,31 @@ class AndroidDriverSetLocaleTest {
     }
 
     @Test
-    fun `retries then reports failure when the locale never applies`() {
+    fun `reports failure when the locale never applies, even through the grace window`() {
         val connection = mockk<AndroidDeviceConnection>(relaxed = true)
         every { connection.shell("getprop persist.sys.locale") } returns reply("en-US") // never becomes fr-FR
 
         val result = driver(connection).setDeviceLocale(country = "FR", language = "fr")
 
         assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_UPDATE_CONFIGURATION_FAILED)
-        // Bounded retry (maxAttempts = 2) — a fast, classified failure, never a multi-minute block.
+        // Bounded retry (maxAttempts = 2) + a grace poll — a fast, classified failure, never a multi-minute block.
+        verify(exactly = 2) { connection.execDetached(any()) }
+    }
+
+    @Test
+    fun `succeeds when the locale flips late, during the grace window`() {
+        val connection = mockk<AndroidDeviceConnection>(relaxed = true)
+        // getprop lags: it reads en-US through the initial check + both retry attempts
+        // (1 + maxAttempts*verifyPolls = 5 reads), then the prop finally flips during the grace poll.
+        val reads = AtomicInteger(0)
+        every { connection.shell("getprop persist.sys.locale") } answers {
+            if (reads.incrementAndGet() <= 5) reply("en-US") else reply("fr-FR")
+        }
+
+        val result = driver(connection).setDeviceLocale(country = "FR", language = "fr")
+
+        assertThat(result).isEqualTo(AndroidDriver.SET_LOCALE_RESULT_SUCCESS)
+        // The grace window catches the late flip without re-firing the broadcast.
         verify(exactly = 2) { connection.execDetached(any()) }
     }
 }


### PR DESCRIPTION
## Problem

`setDeviceLocale` fires the locale broadcast detached and confirms via `getprop persist.sys.locale` within a ~24s budget (3×32×250ms). Under post-resume GMS/broadcast-queue churn the receiver runs late: the prop flips *just after* the budget, so the driver returns `UPDATE_CONFIGURATION_FAILED` for a locale that did apply → INFRA_ERROR.

Fleet data (production, arm-m2m): last 14d dominated by **en-CA ~61%**, then it-IT / fr-FR / pt-BR / fi-FI / en-GB / zh-CN — all valid, non-default locales. Pure getprop lag; nothing throws.

## Fix
Re-firing the broadcast can not cure a late-running receiver; only waiting does. After the detached retries, poll `getprop` once more over a longer **grace window** (default 120×250ms = 30s, spent only on the slow non-default path) before classifying as failure.

- No blocking/ordered broadcast (keeps the post-resume hang fix intact)
- No result-code plumbing
- Also skips the wasted trailing sleep after the final poll