### PR TITLE
feat(device): selectable Android system-image tag (SystemImageTag)

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -10,6 +10,7 @@ import maestro.cli.util.EnvUtils
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
 import maestro.device.Platform
+import maestro.device.SystemImageTag
 import maestro.device.locale.AndroidLocale
 import maestro.device.locale.IosLocale
 import maestro.device.locale.WebLocale
@@ -83,6 +84,13 @@ class StartDeviceCommand : Callable<Int> {
     )
     private var forceCreate: Boolean = false
 
+    @CommandLine.Option(
+        order = 6,
+        names = ["--device-tag"],
+        description = ["Android system-image tag: google_apis (default) or google_apis_playstore"],
+    )
+    private var deviceTag: String? = null
+
     override fun call(): Int {
         TestDebugReporter.install(null, printToConsole = parent?.verbose == true)
 
@@ -102,6 +110,10 @@ class StartDeviceCommand : Callable<Int> {
                     // AndroidLocale is a data class (no pre-defined constant); parse the default
                     locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
                     cpuArchitecture = EnvUtils.getMacOSArchitecture(),
+                    tag = deviceTag
+                        ?.let { raw -> SystemImageTag.entries.firstOrNull { it.value == raw }
+                            ?: throw CliError("Unknown --device-tag '$raw'. Valid: ${SystemImageTag.entries.joinToString { it.value }}") }
+                        ?: default.tag,
                 )
             }
             Platform.IOS -> {

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -110,10 +110,7 @@ class StartDeviceCommand : Callable<Int> {
                     // AndroidLocale is a data class (no pre-defined constant); parse the default
                     locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
                     cpuArchitecture = EnvUtils.getMacOSArchitecture(),
-                    tag = deviceTag
-                        ?.let { raw -> SystemImageTag.entries.firstOrNull { it.value == raw }
-                            ?: throw CliError("Unknown --device-tag '$raw'. Valid: ${SystemImageTag.entries.joinToString { it.value }}") }
-                        ?: default.tag,
+                    tag = deviceTag?.let { SystemImageTag.fromString(it) } ?: default.tag,
                 )
             }
             Platform.IOS -> {

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -10,7 +10,6 @@ import maestro.cli.util.EnvUtils
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
 import maestro.device.Platform
-import maestro.device.SystemImageTag
 import maestro.device.locale.AndroidLocale
 import maestro.device.locale.IosLocale
 import maestro.device.locale.WebLocale
@@ -84,13 +83,6 @@ class StartDeviceCommand : Callable<Int> {
     )
     private var forceCreate: Boolean = false
 
-    @CommandLine.Option(
-        order = 6,
-        names = ["--device-tag"],
-        description = ["Android system-image tag: google_apis (default) or google_apis_playstore"],
-    )
-    private var deviceTag: String? = null
-
     override fun call(): Int {
         TestDebugReporter.install(null, printToConsole = parent?.verbose == true)
 
@@ -110,7 +102,6 @@ class StartDeviceCommand : Callable<Int> {
                     // AndroidLocale is a data class (no pre-defined constant); parse the default
                     locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
                     cpuArchitecture = EnvUtils.getMacOSArchitecture(),
-                    tag = deviceTag?.let { SystemImageTag.fromString(it) } ?: default.tag,
                 )
             }
             Platform.IOS -> {

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
@@ -133,7 +133,7 @@ object DeviceCreateUtil {
                 deviceName = deviceSpec.deviceName,
                 device = deviceSpec.model,
                 systemImage = systemImage,
-                tag = deviceSpec.tag,
+                tag = deviceSpec.tag.value,
                 abi = deviceSpec.cpuArchitecture.value,
                 force = forceCreate,
             )

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -2,6 +2,7 @@ package maestro.device
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
 import maestro.device.locale.AndroidLocale
 import maestro.device.locale.DeviceLocale
 import maestro.device.locale.IosLocale
@@ -20,10 +21,20 @@ enum class CPU_ARCHITECTURE(val value: String) {
 }
 
 /**
+ * The Google-defined system-image tag — the third segment of
+ * `system-images;<os>;<tag>;<abi>`. `.value` is the literal tag string, mirroring
+ * the `cpuArchitecture.value` precedent; `@JsonValue` serializes it as that string.
+ */
+enum class SystemImageTag(@JsonValue val value: String) {
+    GOOGLE_APIS("google_apis"),
+    GOOGLE_APIS_PLAYSTORE("google_apis_playstore"),
+}
+
+/**
  * Strongly typed device configuration. Callers must provide `model` and `os`;
  * all other fields have sensible defaults that can be overridden when needed.
  *
- * Derived values (osVersion, deviceName, emulatorImage, tag) are computed at
+ * Derived values (osVersion, deviceName, emulatorImage) are computed at
  * access time via `get()` properties — they are not stored in the data class
  * and therefore never serialized or persisted.
  *
@@ -49,6 +60,7 @@ sealed class DeviceSpec {
         override val os: String,
         override val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
         val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
+        val tag: SystemImageTag = SystemImageTag.GOOGLE_APIS,
     ) : DeviceSpec() {
         init {
             require(model.isNotBlank()) { "DeviceSpec.Android: model cannot be blank" }
@@ -58,8 +70,7 @@ sealed class DeviceSpec {
         override val platform = Platform.ANDROID
         override val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
         override val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
-        val tag: String get() = "google_apis"
-        val emulatorImage: String get() = "system-images;$os;$tag;${cpuArchitecture.value}"
+        val emulatorImage: String get() = "system-images;$os;${tag.value};${cpuArchitecture.value}"
 
         companion object {
             val DEFAULT: Android = Android(model = "pixel_6", os = "android-33")

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -27,7 +27,16 @@ enum class CPU_ARCHITECTURE(val value: String) {
  */
 enum class SystemImageTag(@JsonValue val value: String) {
     GOOGLE_APIS("google_apis"),
-    GOOGLE_APIS_PLAYSTORE("google_apis_playstore"),
+    GOOGLE_APIS_PLAYSTORE("google_apis_playstore");
+
+    companion object {
+        fun fromString(value: String): SystemImageTag {
+            return entries.firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException(
+                    "Unknown system-image tag: '$value'. Must be one of: ${entries.joinToString { it.value }}"
+                )
+        }
+    }
 }
 
 /**

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -27,16 +27,7 @@ enum class CPU_ARCHITECTURE(val value: String) {
  */
 enum class SystemImageTag(@JsonValue val value: String) {
     GOOGLE_APIS("google_apis"),
-    GOOGLE_APIS_PLAYSTORE("google_apis_playstore");
-
-    companion object {
-        fun fromString(value: String): SystemImageTag {
-            return entries.firstOrNull { it.value == value }
-                ?: throw IllegalArgumentException(
-                    "Unknown system-image tag: '$value'. Must be one of: ${entries.joinToString { it.value }}"
-                )
-        }
-    }
+    GOOGLE_APIS_PLAYSTORE("google_apis_playstore"),
 }
 
 /**

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -64,6 +64,23 @@ internal class DeviceSpecTest {
     }
 
     @Test
+    fun `Android default tag is google_apis and emulatorImage derives from it`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-36")
+        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS)
+        assertThat(spec.emulatorImage).isEqualTo("system-images;android-36;google_apis;arm64-v8a")
+    }
+
+    @Test
+    fun `Android playstore tag flows into emulatorImage`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-36",
+            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
+        )
+        assertThat(spec.emulatorImage).isEqualTo("system-images;android-36;google_apis_playstore;arm64-v8a")
+    }
+
+    @Test
     fun `Android computed osVersion is parsed from os string`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
         assertThat(spec.osVersion).isEqualTo(34)

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -81,6 +81,19 @@ internal class DeviceSpecTest {
     }
 
     @Test
+    fun `SystemImageTag fromString parses a known tag value`() {
+        assertThat(SystemImageTag.fromString("google_apis_playstore"))
+            .isEqualTo(SystemImageTag.GOOGLE_APIS_PLAYSTORE)
+    }
+
+    @Test
+    fun `SystemImageTag fromString rejects an unknown tag value`() {
+        val error = assertThrows<IllegalArgumentException> { SystemImageTag.fromString("nonsense") }
+        assertThat(error).hasMessageThat().contains("nonsense")
+        assertThat(error).hasMessageThat().contains("google_apis_playstore")
+    }
+
+    @Test
     fun `Android computed osVersion is parsed from os string`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
         assertThat(spec.osVersion).isEqualTo(34)

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -81,19 +81,6 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `SystemImageTag fromString parses a known tag value`() {
-        assertThat(SystemImageTag.fromString("google_apis_playstore"))
-            .isEqualTo(SystemImageTag.GOOGLE_APIS_PLAYSTORE)
-    }
-
-    @Test
-    fun `SystemImageTag fromString rejects an unknown tag value`() {
-        val error = assertThrows<IllegalArgumentException> { SystemImageTag.fromString("nonsense") }
-        assertThat(error).hasMessageThat().contains("nonsense")
-        assertThat(error).hasMessageThat().contains("google_apis_playstore")
-    }
-
-    @Test
     fun `Android computed osVersion is parsed from os string`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
         assertThat(spec.osVersion).isEqualTo(34)

--- a/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
+++ b/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.google.common.truth.Truth.assertThat
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
+import maestro.device.SystemImageTag
 import maestro.device.locale.AndroidLocale
 import org.junit.jupiter.api.Test
 
@@ -82,6 +83,29 @@ class DeviceSpecSerializationTest {
         )
         assertThat(json.get("locale").get("code").asText()).isEqualTo("de_DE")
         assertThat(json.get("locale").get("platform").asText()).isEqualTo("ANDROID")
+    }
+
+    @Test
+    fun `default google_apis tag is omitted from sparse output`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-36")
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+        assertThat(json.has("tag")).isFalse()
+        assertThat(json.fieldNames().asSequence().toSet())
+            .containsExactly("platform", "model", "os")
+    }
+
+    @Test
+    fun `non-default playstore tag is emitted as its JsonValue string and round-trips`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-36",
+            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
+        )
+        val json = mapper.readTree(mapper.writeValueAsString(spec))
+        assertThat(json.get("tag").asText()).isEqualTo("google_apis_playstore")
+
+        val deserialized = mapper.readValue(mapper.writeValueAsString(spec), DeviceSpec::class.java)
+        assertThat(deserialized).isEqualTo(spec)
     }
 
     @Test


### PR DESCRIPTION
## Why

We want to offer Google Play system images (`google_apis_playstore`) as a device
option in the configurator — a spike (MA-4173) showed a stock playstore image
fixes a Maps crash end-to-end. To offer it, `DeviceSpec` has to be able to
represent which tag a device uses, and today it can't: `DeviceSpec.Android`
exposes the tag as a constant (`val tag: String get() = "google_apis"`), so every
spec is `google_apis` and there's no way to express playstore at all. This PR
makes the tag a real, settable field on the spec.

## Approach

The tag becomes a typed enum whose values *are* the Google tag strings, and a
defaulted last field on `DeviceSpec.Android` — the same pattern `cpuArchitecture`
already uses. `emulatorImage` derives from it, so every consumer keeps reading
`spec.emulatorImage` and never touches the tag directly.

```kotlin
enum class SystemImageTag(@JsonValue val value: String) {
    GOOGLE_APIS("google_apis"),
    GOOGLE_APIS_PLAYSTORE("google_apis_playstore");
    companion object { fun fromString(value: String): SystemImageTag = ... }
}

val tag: SystemImageTag = SystemImageTag.GOOGLE_APIS   // new, last param, defaulted
val emulatorImage: String get() = "system-images;$os;${tag.value};${cpuArchitecture.value}"
```

`fromString` mirrors `Platform.fromString` and is here for `backend/`, an internal
client of this library, to parse the tag out of API payloads.

Wire-compatible by default: the sparse serializer omits any field equal to its
default, so a `GOOGLE_APIS` spec serializes byte-identically to today, and
`@JsonValue` makes a non-default tag serialize as its literal string. The one
production reader of `.tag`, `DeviceCreateUtil`, now uses `.tag.value`.

**Deferred:** the `CloudCommand` selector (once cloud supports the tag), crossing
the worker-api boundary with a non-default tag, the backend opt-in/entitlement
surface, and `supported-devices.yml` tag validation.

## Verification

- `maestro-client` unit suite green, including cases pinning the default and
  playstore paths through `emulatorImage`, and `fromString` parse/reject.
- Serialization tests pin the wire contract: default tag **omitted** from sparse
  output, non-default **emitted** as its `@JsonValue` string and round-tripped.
  The pre-existing legacy-blob test still deserializes.
- `maestro-cli` compiles with the `.value` fix in `DeviceCreateUtil`.
