### PR TITLE
fix(android): don't fail devtools WebView inspection on React/Vue/Angular circular DOMs

### DIFF
--- a/e2e/demo_app/.maestro/webView_chromeDevTools_deepDom.yaml
+++ b/e2e/demo_app/.maestro/webView_chromeDevTools_deepDom.yaml
@@ -11,3 +11,6 @@ tags:
 - tapOn: Webview Deep DOM Test
 - assertVisible:
     id: "deep-dom-marker"
+# Clobbered form id: only matches if the capture reads the id attribute, not the clobbered property.
+- assertVisible:
+    id: "clobbered-form-id"

--- a/e2e/demo_app/lib/webview_deep_dom_test_screen.dart
+++ b/e2e/demo_app/lib/webview_deep_dom_test_screen.dart
@@ -5,12 +5,12 @@ import 'package:webview_flutter_android/webview_flutter_android.dart';
 
 const _nestingDepth = 700;
 
-// This page exercises both WebView-hierarchy hazards in a single snapshot:
-//   1. Deep DOM — the marker sits under $_nestingDepth nested <div>s.
-//   2. Circular DOM — a form control named "id" clobbers form.id so a live <input> leaks into the
-//      snapshot, and a self-referential property on it (as frameworks attach to DOM nodes) makes it
-//      circular. A naive JSON.stringify throws "Converting circular structure to JSON".
-// The marker is only found if the capture serializes the circular node AND parses the deep tree.
+// This page exercises three WebView-hierarchy hazards in one snapshot:
+//   1. Deep DOM: the marker sits under $_nestingDepth nested <div>s.
+//   2. Circular DOM: a control named "id" clobbers form.id into a live <input> with a self-referential
+//      property, so a naive JSON.stringify throws "Converting circular structure to JSON".
+//   3. Clobbered id: the form's real id="clobbered-form-id" is only recovered by reading the attribute.
+//      aria-hidden keeps it out of the accessibility tree, so the devtools snapshot is its only source.
 String _buildDeepHtml() {
   final open = StringBuffer();
   final close = StringBuffer();
@@ -24,7 +24,7 @@ String _buildDeepHtml() {
   <head><meta name="viewport" content="width=device-width,initial-scale=1"></head>
   <body>
     <h1>WebView Deep DOM Test</h1>
-    <form>
+    <form id="clobbered-form-id" aria-hidden="true">
       <input name="id" value="clobber">
     </form>
     $open<div id="deep-dom-marker" aria-hidden="true">deep marker</div>$close

--- a/e2e/demo_app/lib/webview_deep_dom_test_screen.dart
+++ b/e2e/demo_app/lib/webview_deep_dom_test_screen.dart
@@ -5,6 +5,12 @@ import 'package:webview_flutter_android/webview_flutter_android.dart';
 
 const _nestingDepth = 700;
 
+// This page exercises both WebView-hierarchy hazards in a single snapshot:
+//   1. Deep DOM — the marker sits under $_nestingDepth nested <div>s.
+//   2. Circular DOM — a form control named "id" clobbers form.id so a live <input> leaks into the
+//      snapshot, and a self-referential property on it (as frameworks attach to DOM nodes) makes it
+//      circular. A naive JSON.stringify throws "Converting circular structure to JSON".
+// The marker is only found if the capture serializes the circular node AND parses the deep tree.
 String _buildDeepHtml() {
   final open = StringBuffer();
   final close = StringBuffer();
@@ -18,7 +24,14 @@ String _buildDeepHtml() {
   <head><meta name="viewport" content="width=device-width,initial-scale=1"></head>
   <body>
     <h1>WebView Deep DOM Test</h1>
+    <form>
+      <input name="id" value="clobber">
+    </form>
     $open<div id="deep-dom-marker" aria-hidden="true">deep marker</div>$close
+    <script>
+      var input = document.querySelector('input[name="id"]');
+      input.__reactFiber\$demo = { stateNode: input };
+    </script>
   </body>
 </html>
 ''';

--- a/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
+++ b/maestro-client/src/main/java/maestro/android/chromedevtools/DadbChromeDevToolsClient.kt
@@ -38,9 +38,13 @@ private data class RuntimeResponse<T>(
     val result: RemoteObject<T>
 )
 
+// `value` is absent when the in-page expression threw: CDP returns an error object (subtype "error",
+// a `description` carrying the JS stack). Nullable so that frame parses instead of raising a parse error.
 private data class RemoteObject<T>(
     val type: String,
-    val value: T,
+    val value: T? = null,
+    val subtype: String? = null,
+    val description: String? = null,
 )
 
 data class WebViewInfo(
@@ -101,7 +105,7 @@ class DadbChromeDevToolsClient internal constructor(
     )
 
     private val json = jacksonObjectMapper().configure(FAIL_ON_UNKNOWN_PROPERTIES, false).apply {
-        // Deep external DOMs (MA-4202) exceed Jackson's default 1000-level nesting cap; raise it (see
+        // Deep external DOMs exceed Jackson's default 1000-level nesting cap; raise it (see
         // the constant) so the trusted maestro-web.js snapshot decodes instead of being rejected.
         factory.setStreamReadConstraints(
             StreamReadConstraints.builder().maxNestingDepth(WEBVIEW_SNAPSHOT_MAX_NESTING_DEPTH).build()
@@ -138,7 +142,14 @@ class DadbChromeDevToolsClient internal constructor(
             .mapNotNull { info ->
                 degradeTo(null, "Failed to retrieve WebView hierarchy from chrome devtools: ${info.socketName} ${info.webSocketDebuggerUrl}") {
                     // Stringify in-page: returnByValue over a deep object graph trips V8's depth cap; a string does not.
-                    val snapshotJson = evaluateScript<RuntimeResponse<String>>(info.socketName, info.webSocketDebuggerUrl, "$script; maestro.viewportX = ${info.screenX}; maestro.viewportY = ${info.screenY}; maestro.viewportWidth = ${info.width}; maestro.viewportHeight = ${info.height}; JSON.stringify(window.maestro.getContentDescription());").result.value
+                    // cycleSafeReplacer drops DOM nodes / cycles so a page whose elements carry framework back-references serializes instead of throwing.
+                    val evaluated = evaluateScript<RuntimeResponse<String>>(info.socketName, info.webSocketDebuggerUrl, "$script; maestro.viewportX = ${info.screenX}; maestro.viewportY = ${info.screenY}; maestro.viewportWidth = ${info.width}; maestro.viewportHeight = ${info.height}; JSON.stringify(window.maestro.getContentDescription(), window.maestro.cycleSafeReplacer());").result
+                    // No string value means the evaluation itself threw: the page's content defeated serialization,
+                    // so classify it as a content failure, not a retryable parse error.
+                    val snapshotJson = evaluated.value
+                        ?: throw MaestroException.WebViewInspectionFailure(
+                            WEBVIEW_SNAPSHOT_SERIALIZATION_FAILED + (evaluated.description?.let { " ($it)" } ?: "")
+                        )
                     decodeSnapshot(snapshotJson)
                 }
             }
@@ -312,7 +323,7 @@ class DadbChromeDevToolsClient internal constructor(
     }
 
     private fun getWebViewSocketNames(): Set<String> {
-        // Discovery rides the same wedgeable dadb transport as the webview streams (MA-4111), so
+        // Discovery rides the same wedgeable dadb transport as the webview streams, so
         // it gets the same worker handoff and deadline: without one, a wedged transport parks the
         // capture in an un-abortable shell read before any webview socket is even opened.
         val response = boundedAdbCall(adbIoExecutor, stepTimeoutMillis, "WebView socket discovery") {
@@ -333,6 +344,11 @@ class DadbChromeDevToolsClient internal constructor(
         private const val WEBVIEW_TOO_COMPLEX_MESSAGE =
             "WebView content could not be inspected: its DOM is too large or too deeply nested for " +
                 "Maestro to read. This is a property of the page's own content, not test infrastructure."
+
+        // The in-page JSON.stringify threw (e.g. a circular structure from framework-attached DOM properties).
+        private const val WEBVIEW_SNAPSHOT_SERIALIZATION_FAILED =
+            "WebView content could not be serialized for inspection: the page's DOM defeated in-page " +
+                "serialization. This is a property of the page's own content, not test infrastructure."
 
         // One bound for every devtools step: the per-webview websocket wait and the
         // `cat /proc/net/unix` discovery shell call. Both answer in milliseconds on a healthy device.

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -79,6 +79,13 @@
 
     const isDocumentLoading = () => document.readyState !== 'complete'
 
+    // Read the identifier from the attribute, not the property: a form control named "id"/"name"/etc.
+    // clobbers node.id/node.name into a live element, which hides the real id and leaks a DOM node.
+    const attr = (node, name) => {
+        const value = node.getAttribute?.(name)
+        return typeof value === 'string' && value !== '' ? value : null
+    }
+
     const traverse = (node, includeChildren = true, iframeOffsetX = 0, iframeOffsetY = 0) => {
       if (!node || isInvalidTag(node)) return null
 
@@ -125,11 +132,11 @@
         return null;
       }
 
-      if (!!node.attributes['flt-semantics-identifier'] || !!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
-        const title = typeof node.title === 'string' ? node.title : null
-        // Prefer flt-semantics-identifier: on Flutter web node.id is an
-        // unstable internal handle, not the developer-set identifier.
-        attributes['resource-id'] = node.attributes['flt-semantics-identifier']?.value || node.id || node.ariaLabel || node.name || title || node.htmlFor || node.attributes['data-testid']?.value
+      // Prefer flt-semantics-identifier: on Flutter web node.id is an
+      // unstable internal handle, not the developer-set identifier.
+      const resourceId = node.attributes['flt-semantics-identifier']?.value || attr(node, 'id') || attr(node, 'aria-label') || attr(node, 'name') || attr(node, 'title') || attr(node, 'for') || node.attributes['data-testid']?.value
+      if (resourceId) {
+        attributes['resource-id'] = resourceId
       }
 
       if (node.tagName.toLowerCase() === 'body') {

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -161,6 +161,21 @@
         return traverse(document.body)
     }
 
+    // Replacer for JSON.stringify of the snapshot. A live DOM node can leak in and, on some frameworks,
+    // carry back-references (node -> ... -> node), so stringify throws "Converting circular structure to
+    // JSON" and the whole capture fails. Drop DOM nodes and break cycles so serialization always completes.
+    maestro.cycleSafeReplacer = () => {
+        const seen = new WeakSet();
+        return (key, value) => {
+            if (typeof Node !== 'undefined' && value instanceof Node) return undefined;
+            if (value !== null && typeof value === 'object') {
+                if (seen.has(value)) return undefined;
+                seen.add(value);
+            }
+            return value;
+        };
+    }
+
     maestro.queryCss = (selector) => {
         // Returns a list of matching elements for the given CSS selector.
         // Does not include children of discovered elements.

--- a/maestro-client/src/main/resources/maestro-web.js
+++ b/maestro-client/src/main/resources/maestro-web.js
@@ -79,11 +79,14 @@
 
     const isDocumentLoading = () => document.readyState !== 'complete'
 
-    // Read the identifier from the attribute, not the property: a form control named "id"/"name"/etc.
-    // clobbers node.id/node.name into a live element, which hides the real id and leaks a DOM node.
-    const attr = (node, name) => {
-        const value = node.getAttribute?.(name)
-        return typeof value === 'string' && value !== '' ? value : null
+    // Read an identifier as a string. node.id/node.name/etc. normally reflect the attribute, but a form
+    // control named "id"/"name"/etc. clobbers the property into a live element. When the property is not a
+    // string, fall back to the attribute so we keep the real value and never leak a DOM node.
+    const identifier = (node, prop, attrName) => {
+        const value = node[prop]
+        if (typeof value === 'string') return value || null
+        const attribute = node.getAttribute?.(attrName)
+        return typeof attribute === 'string' && attribute !== '' ? attribute : null
     }
 
     const traverse = (node, includeChildren = true, iframeOffsetX = 0, iframeOffsetY = 0) => {
@@ -132,11 +135,10 @@
         return null;
       }
 
-      // Prefer flt-semantics-identifier: on Flutter web node.id is an
-      // unstable internal handle, not the developer-set identifier.
-      const resourceId = node.attributes['flt-semantics-identifier']?.value || attr(node, 'id') || attr(node, 'aria-label') || attr(node, 'name') || attr(node, 'title') || attr(node, 'for') || node.attributes['data-testid']?.value
-      if (resourceId) {
-        attributes['resource-id'] = resourceId
+      if (!!node.attributes['flt-semantics-identifier'] || !!node.id || !!node.ariaLabel || !!node.name || !!node.title || !!node.htmlFor || !!node.attributes['data-testid']) {
+        // Prefer flt-semantics-identifier: on Flutter web node.id is an
+        // unstable internal handle, not the developer-set identifier.
+        attributes['resource-id'] = node.attributes['flt-semantics-identifier']?.value || identifier(node, 'id', 'id') || identifier(node, 'ariaLabel', 'aria-label') || identifier(node, 'name', 'name') || identifier(node, 'title', 'title') || identifier(node, 'htmlFor', 'for') || node.attributes['data-testid']?.value
       }
 
       if (node.tagName.toLowerCase() === 'body') {

--- a/maestro-client/src/test/java/maestro/android/chromedevtools/DadbChromeDevToolsClientTest.kt
+++ b/maestro-client/src/test/java/maestro/android/chromedevtools/DadbChromeDevToolsClientTest.kt
@@ -277,6 +277,25 @@ class DadbChromeDevToolsClientTest {
     }
 
     @Test
+    fun `a WebView whose DOM defeats in-page JSON serialization is a test-side failure, not infra`() {
+        val errorFrame =
+            """{"id":1,"result":{"result":{"type":"object","subtype":"error","className":"TypeError","description":"TypeError: Converting circular structure to JSON\n    --> starting at object with constructor 'HTMLInputElement'\n    |     property '__reactFiber${'$'}rf8jxem5jd' -> object with constructor 'oH'\n    --- property 'stateNode' closes the circle","objectId":"1.1.1"},"exceptionDetails":{"exceptionId":1,"text":"Uncaught"}}}"""
+        val streams = ArrayDeque<() -> AdbStream>(listOf(
+            { CannedHttpStream(httpResponse(webViewListing("/devtools/page/1"))) },
+            { WebSocketServerStream(errorFrame) },
+        ))
+        val dadb = FakeDadb(
+            onShell = { socketListing("webview_devtools_remote_111") },
+            onOpen = { streams.removeFirst()() },
+        )
+
+        clientOver(dadb).use { client ->
+            val thrown = assertThrows<MaestroException> { client.getWebViewTreeNodes() }
+            assertThat(thrown.message).contains("could not be serialized")
+        }
+    }
+
+    @Test
     fun `a WebView response too large for Jackson's read constraints is a test-side failure, not infra`() {
         // A read-constraint trip parsing the CDP response — here a 1001-digit number tripping
         // maxNumberLength, the same StreamConstraintsException class a >20MB DOM string trips on the
@@ -394,7 +413,7 @@ class DadbChromeDevToolsClientTest {
     @Test
     fun `a WebView DOM deeper than Jackson's default nesting cap is captured, not dropped`() {
         // 600 nodes (1200 JSON levels) is past Jackson's default 1000; the trusted snapshot must still
-        // decode rather than drop the whole WebView (MA-4202).
+        // decode rather than drop the whole WebView.
         val nodes = captureSnapshot(nestedSnapshotJson(600))
 
         assertThat(nodes).hasSize(1)

--- a/maestro-client/src/test/java/maestro/drivers/FlutterWebSemanticsIdentifierTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/FlutterWebSemanticsIdentifierTest.kt
@@ -71,6 +71,14 @@ class FlutterWebSemanticsIdentifierTest {
         assertThat(resourceId).isNull()
     }
 
+    @Test
+    fun `a clobbered id property falls back to the id attribute`() {
+        // A form control named "id" clobbers form.id into a live <input>, so node.id is an element rather
+        // than a string. resource-id must recover the developer-set id from the attribute instead.
+        val resourceId = resolveClobberedResourceId(attributeName = "id", attributeValue = "clobbered-form-id")
+        assertThat(resourceId).isEqualTo("clobbered-form-id")
+    }
+
     // --- harness -------------------------------------------------------------
 
     private val webScript: String by lazy {
@@ -104,6 +112,66 @@ class FlutterWebSemanticsIdentifierTest {
             return if (value.isNull) null else value.asString()
         }
     }
+
+    /**
+     * Builds an element whose reflected property [attributeName] is clobbered to a live element (as DOM
+     * clobbering does), while getAttribute still returns the real [attributeValue], and returns the
+     * resolved resource-id.
+     */
+    private fun resolveClobberedResourceId(attributeName: String, attributeValue: String): String? {
+        Context.newBuilder("js").build().use { context ->
+            context.eval("js", clobberedDomScript(attributeName, attributeValue))
+            context.eval("js", webScript)
+
+            val value = context.eval(
+                "js",
+                "maestro.getContentDescription().children[0].attributes['resource-id'] ?? null",
+            )
+            return if (value.isNull) null else value.asString()
+        }
+    }
+
+    private fun clobberedDomScript(attributeName: String, attributeValue: String): String = """
+        globalThis.Node = { TEXT_NODE: 3 };
+        globalThis.window = globalThis;
+        globalThis.innerWidth = 1024;
+        globalThis.innerHeight = 768;
+
+        // A live element leaking in via DOM clobbering: the reflected property is an element, not a string.
+        const clobber = { tagName: 'input', nodeType: 1 };
+
+        const element = {
+          tagName: 'form',
+          id: clobber,
+          attributes: {},
+          getAttribute(name) { return name === '$attributeName' ? '$attributeValue' : null; },
+          childNodes: [],
+          children: [],
+          selected: false,
+          parentElement: null,
+          getBoundingClientRect() { return { x: 0, y: 0, width: 100, height: 20 }; },
+        };
+
+        const body = {
+          tagName: 'body',
+          id: '',
+          attributes: {},
+          childNodes: [],
+          children: [element],
+          selected: false,
+          parentElement: null,
+          getBoundingClientRect() { return { x: 0, y: 0, width: 1024, height: 768 }; },
+        };
+        element.parentElement = body;
+
+        globalThis.document = {
+          body: body,
+          readyState: 'complete',
+          querySelectorAll() { return []; },
+        };
+
+        globalThis.maestro = {};
+    """.trimIndent()
 
     private fun domScript(
         tagName: String,


### PR DESCRIPTION
## What

`androidWebViewHierarchy: devtools` could fail to inspect a WebView, aborting the step with:

`Failed after 4 attempts: Failed to parse DOM snapshot … Converting circular structure to JSON`

## Why

The WebView hierarchy is serialized in-page with `JSON.stringify`. React/Vue/Angular attach circular back-references to DOM nodes (e.g. `__reactFiber$…`, `__vueParentComponent`, `__ngContext__`). When such a node reaches the snapshot, `JSON.stringify` throws and the whole capture fails — surfacing as a retried infra error rather than something actionable.

## Fix

- Serialize with a cycle-safe replacer that drops live DOM nodes and breaks cycles, so the snapshot always completes. Normal and deep-DOM pages are unaffected (byte-identical output).
- If an in-page serialization error still occurs, classify it as a WebView-content (test) error instead of retrying it as infra.

## Tests

- Unit: an in-page serialization error is classified as a content failure, not infra.
- E2E (`webView_chromeDevTools_deepDom`): the demo screen now also contains a circular DOM node, so one flow covers both deep and circular DOMs. Fails without the fix, passes with it.