### PR TITLE
Fixes CDP target selection for modern Chrome

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -246,7 +246,8 @@ jobs:
       - name: Set up Chrome
         uses: browser-actions/setup-chrome@v2
         with:
-          chrome-version: 142
+          # Kept at a pinned major rather than `stable`, so a Chrome release cannot fail unrelated PRs.
+          chrome-version: 151
 
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/CdpWebDriver.kt
@@ -1,6 +1,7 @@
 package maestro.drivers
 
 import CdpClient
+import CdpTarget
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import kotlinx.coroutines.runBlocking
 import maestro.Capability
@@ -152,11 +153,41 @@ class CdpWebDriver(
         return seleniumDriver ?: error("Driver is not open")
     }
 
+    /**
+     * Resolves the CDP target that Chrome is actually showing the flow.
+     *
+     * `/json` lists a good deal more than the page under test, in no dependable order: Chrome 151
+     * publishes its omnibox WebUI as `browser_ui` targets, and a profile with extensions adds
+     * `background_page` and `service_worker` ones. Addressing the wrong one is quietly wrong rather
+     * than loudly broken — `window.innerHeight` answers 1 instead of the viewport height, a
+     * hierarchy read returns a foreign DOM, and `Page.captureScreenshot` never answers at all.
+     *
+     * Selenium window handles *are* CDP target ids, so the window Selenium holds is the
+     * authoritative answer. The type and scheme filters only cover the case where it cannot be read.
+     */
+    internal fun selectTarget(targets: List<CdpTarget>, windowHandle: String?): CdpTarget? {
+        return targets.firstOrNull { it.id == windowHandle }
+            ?: targets.firstOrNull {
+                it.type == PAGE_TARGET_TYPE && BROWSER_INTERNAL_URL_SCHEMES.none(it.url::startsWith)
+            }
+            ?: targets.firstOrNull { it.type == PAGE_TARGET_TYPE }
+    }
+
+    private suspend fun currentTarget(): CdpTarget {
+        val targets = cdpClient.listTargets()
+        val windowHandle = runCatching { seleniumDriver?.windowHandle }.getOrNull()
+
+        return selectTarget(targets, windowHandle) ?: error(
+            "No CDP page target available. Open targets: " +
+                targets.joinToString { "${it.type}:${it.url}" }
+        )
+    }
+
     private fun executeJS(js: String): Any? {
         return runBlocking {
             repeat(JS_EXECUTION_MAX_ATTEMPTS) { attempt ->
                 try {
-                    val target = cdpClient.listTargets().first()
+                    val target = currentTarget()
 
                     cdpClient.evaluate("$maestroWebScript", target)
 
@@ -204,7 +235,7 @@ class CdpWebDriver(
         if (point.y >= 0 && point.y.toLong() <= windowHeight) return 0L
 
         val scrolledPixels =
-            executeJS("() => {const delta = ${point.y} - Math.floor(window.innerHeight / 2); window.scrollBy({ top: delta, left: 0, behavior: 'smooth' }); return delta}()") as Int
+            executeJS("(() => {const delta = ${point.y} - Math.floor(window.innerHeight / 2); window.scrollBy({ top: delta, left: 0, behavior: 'smooth' }); return delta})()") as Int
         sleep(3000L)
         return scrolledPixels.toLong()
     }
@@ -256,8 +287,9 @@ class CdpWebDriver(
         injectedArguments = injectedArguments + launchArguments
 
         runBlocking {
-            val target = cdpClient.listTargets().first()
-            cdpClient.openUrl(appId, target)
+            // Navigate the window Selenium holds, so the Selenium-driven commands (inputText,
+            // eraseText) and the CDP-driven ones stay pointed at the same page.
+            cdpClient.openUrl(appId, currentTarget())
         }
     }
 
@@ -380,8 +412,7 @@ class CdpWebDriver(
 
         try {
             runBlocking {
-                val target = cdpClient.listTargets().first()
-                cdpClient.clearDataForOrigin(origin, "all", target)
+                cdpClient.clearDataForOrigin(origin, "all", currentTarget())
             }
         } catch (e: Exception) {
             LOGGER.warn("Failed to clear browser data for $origin", e)
@@ -556,8 +587,7 @@ class CdpWebDriver(
 
     override fun takeScreenshot(out: Sink, compressed: Boolean) {
         runBlocking {
-            val target = cdpClient.listTargets().first()
-            val bytes = cdpClient.captureScreenshot(target)
+            val bytes = cdpClient.captureScreenshot(currentTarget())
 
             out.buffer().use { it.write(bytes) }
         }
@@ -820,6 +850,13 @@ class CdpWebDriver(
         private const val RETRY_FETCHING_CONTENT_DESCRIPTION = 10
         private const val JS_EXECUTION_MAX_ATTEMPTS = 5
         private const val JS_EXECUTION_RETRY_DELAY_MS = 200L
+
+        // The only /json target type that is a real tab; everything else is a browser surface,
+        // an extension worker or an iframe.
+        private const val PAGE_TARGET_TYPE = "page"
+
+        private val BROWSER_INTERNAL_URL_SCHEMES =
+            listOf("chrome://", "chrome-untrusted://", "chrome-extension://", "devtools://")
 
         private val LOGGER = LoggerFactory.getLogger(CdpWebDriver::class.java)
     }

--- a/maestro-client/src/test/java/maestro/drivers/CdpWebDriverTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/CdpWebDriverTest.kt
@@ -1,11 +1,63 @@
 package maestro.drivers
 
+import CdpTarget
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
 class CdpWebDriverTest {
 
     private fun makeDriver() = CdpWebDriver(isStudio = false, isHeadless = false, screenSize = null)
+
+    private fun target(id: String, type: String, url: String) =
+        CdpTarget(id = id, title = id, url = url, type = type, webSocketDebuggerUrl = "ws://$id")
+
+    @Test
+    fun `selectTarget prefers the window Selenium holds`() {
+        val targets = listOf(
+            target("popup", "browser_ui", "chrome://omnibox-popup.top-chrome/"),
+            target("other-tab", "page", "https://example.com/"),
+            target("under-test", "page", "https://www.saucedemo.com/"),
+        )
+
+        val selected = makeDriver().selectTarget(targets, windowHandle = "under-test")
+
+        assertThat(selected?.id).isEqualTo("under-test")
+    }
+
+    @Test
+    fun `selectTarget skips browser and extension targets when the handle is unknown`() {
+        // Chrome 151 lists its omnibox WebUI first, and a profile with extensions adds more ahead
+        // of the page. Evaluating against any of them reads the wrong DOM.
+        val targets = listOf(
+            target("worker", "service_worker", "chrome-extension://abc/service_worker.js"),
+            target("popup", "browser_ui", "chrome://omnibox-popup.top-chrome/"),
+            target("frame", "iframe", "chrome-untrusted://new-tab-page/one-google-bar"),
+            target("under-test", "page", "https://www.saucedemo.com/"),
+        )
+
+        val selected = makeDriver().selectTarget(targets, windowHandle = null)
+
+        assertThat(selected?.id).isEqualTo("under-test")
+    }
+
+    @Test
+    fun `selectTarget falls back to an internal page when that is all there is`() {
+        val targets = listOf(
+            target("popup", "browser_ui", "chrome://omnibox-popup.top-chrome/"),
+            target("newtab", "page", "chrome://newtab/"),
+        )
+
+        val selected = makeDriver().selectTarget(targets, windowHandle = null)
+
+        assertThat(selected?.id).isEqualTo("newtab")
+    }
+
+    @Test
+    fun `selectTarget returns null when no page target exists`() {
+        val targets = listOf(target("popup", "browser_ui", "chrome://omnibox-popup.top-chrome/"))
+
+        assertThat(makeDriver().selectTarget(targets, windowHandle = null)).isNull()
+    }
 
     @Test
     fun `parseDomAsTreeNodes handles bounds as String`() {

--- a/maestro-web/src/main/kotlin/maestro/web/cdp/CdpClient.kt
+++ b/maestro-web/src/main/kotlin/maestro/web/cdp/CdpClient.kt
@@ -8,6 +8,7 @@ import io.ktor.serialization.kotlinx.json.*
 import io.ktor.websocket.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -27,8 +28,13 @@ data class CdpTarget(
     val id: String,
     val title: String,
     val url: String,
+    val type: String = "",
     val webSocketDebuggerUrl: String? = null,
 )
+
+// A live page replies in milliseconds, but some targets never reply at all: Page.captureScreenshot
+// against a non-visible target simply goes quiet. Without a bound that stalls the whole run.
+private const val CDP_RESPONSE_TIMEOUT_MS = 30_000L
 
 /**
  * A simple client for Chrome DevTools Protocol (CDP).
@@ -204,15 +210,19 @@ class CdpClient(
     }
 
     private suspend fun DefaultClientWebSocketSession.waitForMessage(messageId: Int): String {
-        for (frame in incoming) {
-            if (frame is Frame.Text) {
-                val text = frame.readText()
-                if (text.contains("\"id\":$messageId")) {
-                    return text
+        val text = withTimeoutOrNull(CDP_RESPONSE_TIMEOUT_MS) {
+            for (frame in incoming) {
+                if (frame is Frame.Text) {
+                    val text = frame.readText()
+                    if (text.contains("\"id\":$messageId")) {
+                        return@withTimeoutOrNull text
+                    }
                 }
             }
+            null
         }
-        error("No message with id $messageId received")
+
+        return text ?: error("No message with id $messageId received within ${CDP_RESPONSE_TIMEOUT_MS}ms")
     }
 
     private suspend fun <R> DefaultClientWebSocketSession.use(block: suspend (DefaultClientWebSocketSession) -> R): R {


### PR DESCRIPTION
Proposed changes

Recent Chrome versions, such as Chrome 151, expose an increased number of Chrome DevTools Protocol (CDP) targets, including browser UI components, extension workers, and iframes, often listed before the actual web page under test. Previously, Maestro would simply select the first available target, which led to incorrect command execution (e.g., JavaScript evaluation, screenshots, URL navigation) on the wrong target.

This change introduces a more robust CDP target selection mechanism:
- **Prioritizes the active Selenium window:** Maestro now identifies the correct target by correlating it with the `windowHandle` reported by Selenium, ensuring that both Selenium-driven and CDP-driven commands operate on the same page.
- **Filters out irrelevant targets:** Non-"page" type targets (like `browser_ui`, `service_worker`) and browser-internal URLs (`chrome://`, `chrome-extension://`) are explicitly ignored to prevent misdirection.
- **Adds CDP response timeout:** A timeout prevents indefinite hangs when CDP commands are inadvertently sent to unresponsive targets that do not return a response, such as non-visible or internal browser pages.

These changes ensure reliable interaction with web pages, especially against newer Chrome browser versions, making web tests more stable and accurate.

Testing

New unit tests have been added in `CdpWebDriverTest.kt` to thoroughly verify the `selectTarget` logic, covering various scenarios for target identification and filtering.

Issues fixed

Fixes #3506