### PR TITLE
Text matches should match against 'error' property

### DIFF
--- a/maestro-client/src/main/java/maestro/Filters.kt
+++ b/maestro-client/src/main/java/maestro/Filters.kt
@@ -90,7 +90,20 @@ object Filters {
                 } ?: false
             }.toSet()
 
-            textMatches.union(hintTextMatches).union(accessibilityTextMatches).toList()
+            // Android (only) surfaces AccessibilityNodeInfo.getError() as the `error` attribute. It carries user-visible text.
+            val errorMatches = nodes.filter {
+                it.attributes["error"]?.let { value ->
+                    val strippedValue = value.replace('\n', ' ')
+
+                    value.isNotEmpty() // 'error' is written for every node, often empty
+                            && (regex.matches(value)
+                            || regex.pattern == value
+                            || regex.matches(strippedValue)
+                            || regex.pattern == strippedValue)
+                } ?: false
+            }
+
+            textMatches.union(hintTextMatches).union(accessibilityTextMatches).union(errorMatches).toList()
         }
     }
 

--- a/maestro-client/src/test/java/maestro/FiltersTest.kt
+++ b/maestro-client/src/test/java/maestro/FiltersTest.kt
@@ -79,6 +79,72 @@ class FiltersTest {
         assertThat(result).isEmpty()
     }
 
+    @Test
+    fun `textMatches matches the error attribute`() {
+        // Regression for #3515: a Compose field whose only content is its error semantics.
+        val node = errorNode(error = "This is an error!")
+
+        val result = Filters.textMatches(Regex("This is an error!"))(listOf(node))
+
+        assertThat(result).containsExactly(node)
+    }
+
+    @Test
+    fun `textMatches matches the error attribute by regex`() {
+        val node = errorNode(error = "This is an error!")
+
+        val result = Filters.textMatches(Regex("This is an.*"))(listOf(node))
+
+        assertThat(result).containsExactly(node)
+    }
+
+    @Test
+    fun `textMatches ignores a blank error attribute`() {
+        // The Android hierarchy dump writes `error` for every node, empty when there is no error, so
+        // an empty selector must not match on it. Only `error` is set here: the other text sources
+        // already match an empty regex when present-but-empty, which would mask the guard.
+        val node = TreeNode(attributes = mutableMapOf("error" to ""))
+
+        val result = Filters.textMatches(Regex(""))(listOf(node))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `textMatches still matches text, hintText and accessibilityText`() {
+        val textNode = TreeNode(attributes = mutableMapOf("text" to "Hello"))
+        val hintNode = TreeNode(attributes = mutableMapOf("hintText" to "Hello"))
+        val accessibilityNode = TreeNode(attributes = mutableMapOf("accessibilityText" to "Hello"))
+        val errorNode = errorNode(error = "Hello")
+
+        val result = Filters.textMatches(Regex("Hello"))(
+            listOf(textNode, hintNode, accessibilityNode, errorNode)
+        )
+
+        assertThat(result).containsExactly(textNode, hintNode, accessibilityNode, errorNode)
+    }
+
+    @Test
+    fun `textMatches does not match a node without the error`() {
+        val node = errorNode(error = "This is an error!")
+
+        val result = Filters.textMatches(Regex("Some other text"))(listOf(node))
+
+        assertThat(result).isEmpty()
+    }
+
+    private fun errorNode(error: String): TreeNode {
+        // Mirrors the Android hierarchy dump: the other text sources are present but empty.
+        return TreeNode(
+            attributes = mutableMapOf(
+                "text" to "",
+                "accessibilityText" to "",
+                "hintText" to "",
+                "error" to error,
+            )
+        )
+    }
+
     private fun sampleNodes(): List<TreeNode> {
         return listOf(
             node(bounds(0, 0)),

--- a/maestro-client/src/test/java/maestro/FiltersTest.kt
+++ b/maestro-client/src/test/java/maestro/FiltersTest.kt
@@ -41,6 +41,72 @@ class FiltersTest {
         assertThat(result).isEmpty()
     }
 
+    @Test
+    fun `textMatches matches the error attribute`() {
+        // Regression for #3515: a Compose field whose only content is its error semantics.
+        val node = errorNode(error = "This is an error!")
+
+        val result = Filters.textMatches(Regex("This is an error!"))(listOf(node))
+
+        assertThat(result).containsExactly(node)
+    }
+
+    @Test
+    fun `textMatches matches the error attribute by regex`() {
+        val node = errorNode(error = "This is an error!")
+
+        val result = Filters.textMatches(Regex("This is an.*"))(listOf(node))
+
+        assertThat(result).containsExactly(node)
+    }
+
+    @Test
+    fun `textMatches ignores a blank error attribute`() {
+        // The Android hierarchy dump writes `error` for every node, empty when there is no error, so
+        // an empty selector must not match on it. Only `error` is set here: the other text sources
+        // already match an empty regex when present-but-empty, which would mask the guard.
+        val node = TreeNode(attributes = mutableMapOf("error" to ""))
+
+        val result = Filters.textMatches(Regex(""))(listOf(node))
+
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `textMatches still matches text, hintText and accessibilityText`() {
+        val textNode = TreeNode(attributes = mutableMapOf("text" to "Hello"))
+        val hintNode = TreeNode(attributes = mutableMapOf("hintText" to "Hello"))
+        val accessibilityNode = TreeNode(attributes = mutableMapOf("accessibilityText" to "Hello"))
+        val errorNode = errorNode(error = "Hello")
+
+        val result = Filters.textMatches(Regex("Hello"))(
+            listOf(textNode, hintNode, accessibilityNode, errorNode)
+        )
+
+        assertThat(result).containsExactly(textNode, hintNode, accessibilityNode, errorNode)
+    }
+
+    @Test
+    fun `textMatches does not match a node without the error`() {
+        val node = errorNode(error = "This is an error!")
+
+        val result = Filters.textMatches(Regex("Some other text"))(listOf(node))
+
+        assertThat(result).isEmpty()
+    }
+
+    private fun errorNode(error: String): TreeNode {
+        // Mirrors the Android hierarchy dump: the other text sources are present but empty.
+        return TreeNode(
+            attributes = mutableMapOf(
+                "text" to "",
+                "accessibilityText" to "",
+                "hintText" to "",
+                "error" to error,
+            )
+        )
+    }
+
     private fun sampleNodes(): List<TreeNode> {
         return listOf(
             node(bounds(0, 0)),

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -1793,6 +1793,11 @@ class Orchestra(
             attributes["text"]
         } else if (!attributes["hintText"].isNullOrEmpty()) {
             attributes["hintText"]
+        } else if (!attributes["accessibilityText"].isNullOrEmpty()) {
+            attributes["accessibilityText"]
+        } else if (!attributes["error"].isNullOrEmpty()) {
+            // Android-only: EditText.setError() / Compose `error` semantics. See Filters.textMatches.
+            attributes["error"]
         } else {
             attributes["accessibilityText"]
         }


### PR DESCRIPTION
## Proposed changes

Plumbs the error property from the Android device hierarchy through the filters, to allow text matches against errors.

## Testing

Tested using the application shared in #3515. No e2e test, as our demo_app is Flutter, and doesn't have a mechanism for setting the error property.

## Issues fixed

Fixes #3515 