### PR TITLE
[DO NOT MERGE] 2.x oracle trace emitter (fidelity harness build branch)

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/MaestroCommandRunner.kt
@@ -34,6 +34,7 @@ import maestro.orchestra.Orchestra
 import maestro.orchestra.debug.CommandDebugMetadata
 import maestro.orchestra.debug.CommandStatus
 import maestro.orchestra.debug.FlowDebugOutput
+import maestro.orchestra.debug.StepTraceEmitter
 
 import maestro.orchestra.yaml.YamlCommandReader
 import maestro.utils.CliInsights
@@ -100,8 +101,16 @@ object MaestroCommandRunner {
 
         var commandSequenceNumber = 0
 
+        // 2x-oracle differential trace, env-gated. Written under the flow's artifact dir as
+        // steps.jsonl at the same schema the 3.x/device-core side writes. Orchestra emits per
+        // finished command; we own open/close.
+        val stepTrace = if (System.getenv("MAESTRO_STEP_TRACE") == "1" && artifactsDir != null) {
+            StepTraceEmitter(artifactsDir.resolve("steps.jsonl").toFile(), backendId = "2x").also { it.openFor() }
+        } else null
+
         val orchestra = Orchestra(
             maestro = maestro,
+            stepTraceEmitter = stepTrace,
             artifactsDir = artifactsDir,
             // --analyze feeds the AI from the bundle: capture a per-step screenshot
             // for every command so the analysis has the full visual trail.
@@ -189,7 +198,11 @@ object MaestroCommandRunner {
             apiKey = apiKey,    
         )
 
-        return orchestra.runFlow(commands)
+        return try {
+            orchestra.runFlow(commands)
+        } finally {
+            stepTrace?.close()
+        }
     }
 
     private fun toCommandStates(

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -16,6 +16,7 @@ import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.TestSuiteStatusView.TestSuiteViewModel
 import maestro.orchestra.Orchestra
 import maestro.orchestra.debug.FlowDebugOutput
+import maestro.orchestra.debug.StepTraceEmitter
 import maestro.orchestra.util.Env.withEnv
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
 import maestro.orchestra.yaml.YamlCommandReader
@@ -183,12 +184,19 @@ class TestSuiteInteractor(
         // Per-flow folder ArtifactsGenerator writes the bundle into (see BundleLayout).
         val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName, shardIndex)
 
+        // 2x-oracle differential trace, env-gated: steps.jsonl under this flow's artifact dir, at
+        // the same schema the 3.x/device-core side writes.
+        val stepTrace = if (System.getenv("MAESTRO_STEP_TRACE") == "1") {
+            StepTraceEmitter(flowDir.resolve("steps.jsonl").toFile(), backendId = "2x").also { it.openFor() }
+        } else null
+
         var debugOutput = FlowDebugOutput()
         val flowStartTime = System.currentTimeMillis()
         val flowTimeMillis = measureTimeMillis {
             try {
                 val orchestra = Orchestra(
                     maestro = maestro,
+                    stepTraceEmitter = stepTrace,
                     artifactsDir = flowDir,
                     captureFullArtifacts = captureFullArtifacts,
                     listeners = listOf(CliConsoleListener(shardPrefix)),
@@ -214,6 +222,7 @@ class TestSuiteInteractor(
                 errorMessage = ErrorViewUtils.exceptionToMessage(e)
             }
         }
+        stepTrace?.close()
         val flowDuration = flowTimeMillis.milliseconds
         // FIXME(bartekpacia): Save AI output as well
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -51,6 +51,9 @@ import maestro.orchestra.debug.ArtifactCollector
 import maestro.orchestra.debug.CommandOutcome
 import maestro.orchestra.debug.FlowDebugOutput
 import maestro.orchestra.debug.OrchestraListener
+import maestro.orchestra.debug.StepTraceEmitter
+import maestro.orchestra.devicecore.ChosenElement
+import maestro.orchestra.devicecore.Verdict
 import maestro.orchestra.filter.FilterWithDescription
 import maestro.orchestra.filter.TraitFilters
 import maestro.orchestra.geo.Traveller
@@ -130,6 +133,11 @@ class DefaultFlowController : FlowController {
  */
 class Orchestra(
     private val maestro: Maestro,
+    // 2x-oracle differential trace (never-merge branch): when non-null, Orchestra emits one
+    // PASS/FAIL/ERROR record per finished command (see [dispatchFinished]) at the same
+    // [StepTraceEmitter] schema the 3.x/device-core side writes. Behavior-neutral: null by
+    // default, so every existing caller is unaffected.
+    private val stepTraceEmitter: StepTraceEmitter? = null,
     private val artifactsDir: Path? = null,
     private val captureFullArtifacts: Boolean = false,
     private val listeners: List<OrchestraListener> = emptyList(),
@@ -165,6 +173,11 @@ class Orchestra(
     private lateinit var jsEngine: JsEngine
 
     private var copiedText: String? = null
+
+    // The element the current command resolved/acted on (legacy tap/assertVisible result),
+    // captured for the step trace. Reset per command in [executeCommand]; only tap/assert leaves
+    // populate it.
+    private var lastChosenElement: ChosenElement? = null
 
     private var timeMsOfLastInteraction = System.currentTimeMillis()
 
@@ -383,6 +396,9 @@ class Orchestra(
      */
     private suspend fun executeCommand(maestroCommand: MaestroCommand, config: MaestroConfig?): Boolean {
         val command = maestroCommand.asCommand()
+
+        // dispatchFinished reads it for the trace.
+        lastChosenElement = null
 
         flowController.waitIfPaused()
 
@@ -988,6 +1004,61 @@ class Orchestra(
         dispatch("onCommandFinished") {
             it.onCommandFinished(command, outcome, startedAt, finishedAt)
         }
+        emitStepTrace(command, outcome, sequenceNumber)
+    }
+
+    /**
+     * Emits the per-command differential-trace record at the same schema the 3.x/device-core side
+     * writes: [Verdict.PASS] on a clean finish (Completed/Warned), [Verdict.FAIL] on a thrown
+     * [MaestroException] (assert/tap failure), [Verdict.ERROR] on any other throwable. Skipped
+     * commands emit nothing. [lastChosenElement] carries the legacy tap/assertVisible result for
+     * tap/assert leaves; it's null for every other command.
+     *
+     * `main` has no `MaestroException.NotImplemented` type (it runs the legacy engine, where every
+     * verb is implemented), so unlike the device-core side there is no dedicated NotImplemented ->
+     * ERROR branch here — that case cannot arise on this branch. The emitted field set
+     * (stepIndex/backendId/command/verdict/chosenElement?/error?) is identical either way.
+     */
+    private fun emitStepTrace(command: MaestroCommand, outcome: CommandOutcome, sequenceNumber: Int) {
+        val emitter = stepTraceEmitter ?: return
+        val (verdict, error) = when (outcome) {
+            is CommandOutcome.Completed -> Verdict.PASS to null
+            is CommandOutcome.Warned -> Verdict.PASS to null
+            is CommandOutcome.Skipped -> return
+            is CommandOutcome.Failed -> {
+                val err = outcome.error
+                if (err is MaestroException) {
+                    Verdict.FAIL to StepTraceEmitter.StepError(err::class.simpleName ?: "MaestroException", err.message)
+                } else {
+                    Verdict.ERROR to StepTraceEmitter.StepError(err::class.simpleName ?: "Throwable", err.message)
+                }
+            }
+        }
+        emitter.emit(
+            stepIndex = sequenceNumber,
+            commandType = command.asCommand()?.let { it::class.simpleName } ?: "null",
+            selectorText = command.elementSelector()?.textRegex,
+            selectorId = command.elementSelector()?.idRegex,
+            verdict = verdict,
+            chosen = lastChosenElement,
+            error = error,
+        )
+    }
+
+    /** Maps a resolved legacy [UiElement] to the trace's flattened [ChosenElement] shape. */
+    private fun UiElement.toChosenElement(): ChosenElement {
+        val center = bounds.center()
+        return ChosenElement(
+            x = bounds.x,
+            y = bounds.y,
+            width = bounds.width,
+            height = bounds.height,
+            centerX = center.x,
+            centerY = center.y,
+            text = treeNode.attributes["text"],
+            resourceId = treeNode.attributes["resource-id"],
+            index = null,
+        )
     }
 
     /** Dispatches [block] to every listener in isolation — a thrower is logged, the rest still fire. */
@@ -1053,11 +1124,12 @@ class Orchestra(
 
         condition.visible?.let {
             try {
-                findElement(
+                val result = findElement(
                     selector = it,
                     timeoutMs = adjustedToLatestInteraction(timeoutMs ?: optionalLookupTimeoutMs),
                     optional = commandOptional,
                 )
+                lastChosenElement = result.element.toChosenElement()
             } catch (_: MaestroException.ElementNotFound) {
                 return false
             }
@@ -1329,7 +1401,7 @@ class Orchestra(
         config: MaestroConfig?,
     ): Boolean {
         val result = findElement(command.selector, optional = command.optional)
-
+        lastChosenElement = result.element.toChosenElement()
 
         // Handle element-relative tap if specified
         val relativePoint = command.relativePoint

--- a/maestro-orchestra/src/main/java/maestro/orchestra/debug/StepTraceEmitter.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/debug/StepTraceEmitter.kt
@@ -1,0 +1,80 @@
+package maestro.orchestra.debug
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import maestro.orchestra.devicecore.ChosenElement
+import maestro.orchestra.devicecore.Verdict
+import org.slf4j.LoggerFactory
+import java.io.BufferedWriter
+import java.io.File
+
+/**
+ * Writes one JSONL record per executed step at the frozen differential-gate schema (Spec C consumes
+ * it unchanged). Reads only data the step already produced — never touches the device. device-core
+ * has no decline path, so the WIP's declined/declinedReason fields are dropped; NON_NULL keeps the
+ * record shape identical to the legacy schema for every step.
+ */
+class StepTraceEmitter(
+    private val traceFile: File,
+    private val backendId: String = "devicecore",
+) {
+    private val mapper = jacksonObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    private var writer: BufferedWriter? = null
+
+    fun openFor() {
+        try {
+            traceFile.parentFile?.mkdirs()
+            writer = traceFile.bufferedWriter()
+        } catch (e: Exception) {
+            logger.warn("Failed to open step trace file at $traceFile", e)
+            writer = null
+        }
+    }
+
+    fun close() {
+        try { writer?.flush(); writer?.close() }
+        catch (e: Exception) { logger.warn("Failed to close step trace file at $traceFile", e) }
+        finally { writer = null }
+    }
+
+    fun emit(
+        stepIndex: Int,
+        commandType: String,
+        selectorText: String?,
+        selectorId: String?,
+        verdict: Verdict,
+        chosen: ChosenElement?,
+        error: StepError? = null,
+    ) {
+        val w = writer ?: return
+        val record = StepTraceRecord(
+            stepIndex = stepIndex,
+            backendId = backendId,
+            command = CommandDescriptor(commandType, selectorText, selectorId),
+            verdict = verdict.name,
+            chosenElement = chosen,
+            error = error,
+        )
+        try { w.write(mapper.writeValueAsString(record)); w.newLine(); w.flush() }
+        catch (e: Exception) { logger.warn("Failed to write step trace record for step $stepIndex", e) }
+    }
+
+    data class StepError(val type: String, val message: String?)
+
+    private data class StepTraceRecord(
+        val stepIndex: Int,
+        val backendId: String,
+        val command: CommandDescriptor,
+        val verdict: String,
+        val chosenElement: ChosenElement?,
+        val error: StepError?,
+    )
+
+    private data class CommandDescriptor(
+        val type: String,
+        val selectorText: String?,
+        val selectorId: String?,
+    )
+
+    companion object { private val logger = LoggerFactory.getLogger(StepTraceEmitter::class.java) }
+}

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreTrace.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceCoreTrace.kt
@@ -1,0 +1,28 @@
+package maestro.orchestra.devicecore
+
+/**
+ * The per-step verdict recorded on the differential trace: a step passed, failed its own
+ * assertion/action, or errored out (infra/unimplemented). Distinct from device-core's own
+ * [dev.mobile.devicecore.prototype.api.Outcome] — this is Maestro's coarse pass/fail/error, the
+ * thing the differential gate compares between backends.
+ */
+enum class Verdict { PASS, FAIL, ERROR }
+
+/**
+ * The element a step actually acted on / resolved, flattened for the trace. Geometry is in device
+ * coordinates; [centerX]/[centerY] are the tap injection point (for a tap) or the bounds center
+ * (for an assert). [text]/[resourceId]/[index] echo the selector that named it. Every field is
+ * optional-safe: device-core does not always carry bounds or a matched channel, so absent geometry
+ * reads 0 and an unnamed channel reads null.
+ */
+data class ChosenElement(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val centerX: Int,
+    val centerY: Int,
+    val text: String?,
+    val resourceId: String?,
+    val index: Int?,
+)

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OracleTraceEmissionTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OracleTraceEmissionTest.kt
@@ -1,0 +1,63 @@
+package maestro.orchestra.debug
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import maestro.DeviceInfo
+import maestro.Maestro
+import maestro.TreeNode
+import maestro.ViewHierarchy
+import maestro.device.Platform
+import maestro.orchestra.EvalScriptCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.Orchestra
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Task 2.1 parity check: on `main`'s legacy engine, a clean step must emit the same field set the
+ * 3.x/device-core side writes — stepIndex/backendId/command/verdict, with chosenElement and error
+ * both omitted (NON_NULL) when there's nothing to report. Proves the 2x oracle's `steps.jsonl` is
+ * byte-identical in shape to the 3.x trace for the passing case, before any backend-specific
+ * behavior (element resolution, failures) is layered on.
+ */
+class OracleTraceEmissionTest {
+
+    private fun mockMaestro(): Maestro = mockk(relaxed = true) {
+        coEvery { viewHierarchy(any()) } returns ViewHierarchy(TreeNode(attributes = mutableMapOf()))
+        coEvery { cachedDeviceInfo } returns DeviceInfo(
+            platform = Platform.ANDROID,
+            widthPixels = 100,
+            heightPixels = 200,
+            widthGrid = 100,
+            heightGrid = 200,
+        )
+    }
+
+    @Test
+    fun `a clean step emits stepIndex, backendId, command, verdict and no error`(@TempDir dir: File) {
+        val traceFile = File(dir, "steps.jsonl")
+        val emitter = StepTraceEmitter(traceFile, backendId = "2x").also { it.openFor() }
+        val orchestra = Orchestra(maestro = mockMaestro(), stepTraceEmitter = emitter)
+
+        runBlocking {
+            orchestra.runFlow(listOf(MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))))
+        }
+        emitter.close()
+
+        val line = traceFile.readLines().single()
+        val node = jacksonObjectMapper().readTree(line)
+
+        assertThat(node.fieldNames().asSequence().toList())
+            .containsExactly("stepIndex", "backendId", "command", "verdict")
+        assertThat(node.get("stepIndex").asInt()).isEqualTo(0)
+        assertThat(node.get("backendId").asText()).isEqualTo("2x")
+        assertThat(node.get("command").get("type").asText()).isEqualTo("EvalScriptCommand")
+        assertThat(node.get("verdict").asText()).isEqualTo("PASS")
+        assertThat(node.has("error")).isFalse()
+        assertThat(node.has("chosenElement")).isFalse()
+    }
+}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE.** This branch is never merged to `main`. It exists only to build the 2.x oracle binary for the fidelity harness ([#3528](https://github.com/mobile-dev-inc/Maestro/pull/3528)), and gets rebuilt off `main` as needed. Kept as a draft for visibility only.

## What it does

Ports `StepTraceEmitter` + `DeviceCoreTrace` onto a thin, behavior-neutral branch off `main` and wires per-step trace emission into Orchestra and the CLI runners, gated on `MAESTRO_STEP_TRACE=1`. With the env var unset, `main` behaves exactly as before.

It emits a `steps.jsonl` with the **same field schema** as the 3.x device-core candidate, so the harness can diff the two runs step by step — this side is the oracle (`backendId="2x"`), the one that implements every verb.
