### PR TITLE
ci: add E2E gate job as a single required status check

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -635,3 +635,37 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: e2e/cli/test-cli.ps1
+
+  # Single required status check for the branch ruleset. A workflow name ("Test E2E") is not a check
+  # context — only jobs are — so main's ruleset requires this one job instead of enumerating each
+  # platform. It passes only when every platform job succeeded.
+  #
+  # always() is deliberate: without it a failed/cancelled upstream job would SKIP this gate, and a
+  # skipped required check reports as passing — the merge would go through with E2E red. Running
+  # always() turns any non-success (failure, cancelled, or skipped — e.g. build failed so the
+  # platform jobs never ran) into a red gate. Scoped to pull_request because that is the only event
+  # that gates a merge; a single-platform workflow_dispatch would otherwise fail the gate on the two
+  # platforms it intentionally skipped.
+  e2e-gate:
+    name: E2E gate
+    runs-on: ubuntu-latest
+    needs: [test-web, test-android, test-ios]
+    if: always() && github.event_name == 'pull_request'
+    steps:
+      - name: Require all E2E platform jobs to succeed
+        run: |
+          web='${{ needs.test-web.result }}'
+          android='${{ needs.test-android.result }}'
+          ios='${{ needs.test-ios.result }}'
+          echo "test-web=$web  test-android=$android  test-ios=$ios"
+          failed=0
+          for result in "$web" "$android" "$ios"; do
+            if [ "$result" != "success" ]; then
+              failed=1
+            fi
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::E2E gate failed — one or more platform jobs did not succeed"
+            exit 1
+          fi
+          echo "All E2E platform jobs succeeded."


### PR DESCRIPTION
## Why

E2E tests don't gate merges today. `main`'s ruleset ("Passing before merge") requires exactly two checks — `MaestroDriverLib Unit Tests` and `Unit Test on Java 17` — both from `test.yaml`. None of the E2E jobs are required. That's how v2.9.0 (#3535) merged while E2E was still running: nothing was gating on it.

The obvious fix — "require the Test E2E workflow" — doesn't exist in GitHub. Required status checks match **check contexts**, and a check context is a job name, not a workflow name. `Test E2E` is the workflow's display name; it never posts a check by that name. So the only way to require E2E is to require its jobs.

## Approach

Rather than enumerate `Test on Android` / `Test on iOS` / `Test on Web` individually in the ruleset (three slow, conditional jobs, each a separate required context), add one aggregation job — `E2E gate` — that depends on all three and fails unless every one succeeded. The ruleset then requires a single stable check.

Two decisions worth calling out:

- `if: always()` is deliberate. Without it, a failed or cancelled upstream job would *skip* the gate, and a skipped required check reports as passing — the merge would go through with E2E red. `always()` turns any non-success (failure, cancelled, or skipped because e.g. `build` failed and the platform jobs never ran) into a red gate.
- Scoped to `pull_request`, since that's the only event that gates a merge. A single-platform `workflow_dispatch` would otherwise fail the gate on the two platforms it intentionally skips.

The ruleset change itself isn't in this PR — requiring `E2E gate` is a repo-settings change that needs admin, and I'll add it manually once this merges and the check has reported at least once (GitHub only lets you require a context it has seen).

## Verification

- `actionlint` on the full workflow: the new job adds zero findings (the warnings it reports are all on pre-existing lines).
- Unit-tested the gate's shell logic locally across result combinations: `success/success/success` → pass; any `failure`, `cancelled`, or `skipped` → fail.
- This PR's own CI run exercises the gate for real — the `E2E gate` job runs after the three platform jobs and should report green here.

https://claude.ai/code/session_015ByjyZtC9z4g8hNP6rABSJ