### PR TITLE
feat(cli): Allow --device-os to accept full Android system image path (PR 3/4)

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -22,6 +22,8 @@ import maestro.cli.view.TestSuiteStatusView
 import maestro.cli.view.brightRed
 import maestro.cli.view.cyan
 import maestro.cli.view.green
+import maestro.device.DeviceSpec
+import maestro.device.serialization.DeviceSpecModule
 import maestro.utils.HttpClient
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
@@ -264,7 +266,7 @@ class ApiClient(
         projectId: String,
         deviceModel: String? = null,
         deviceOs: String? = null,
-        androidSystemImage: String? = null,
+        deviceSpec: DeviceSpec? = null,
         androidApiLevel: Int?,
         iOSVersion: String? = null,
     ): UploadResponse {
@@ -288,7 +290,7 @@ class ApiClient(
         requestPart["projectId"] = projectId
         deviceModel?.let { requestPart["deviceModel"] = it }
         deviceOs?.let { requestPart["deviceOs"] = it }
-        androidSystemImage?.let { requestPart["androidSystemImage"] = it }
+        deviceSpec?.let { requestPart["deviceSpec"] = it }
         androidApiLevel?.let { requestPart["androidApiLevel"] = it }
         iOSVersion?.let { requestPart["iOSVersion"] = it }
         if (includeTags.isNotEmpty()) requestPart["includeTags"] = includeTags
@@ -379,7 +381,7 @@ class ApiClient(
                 projectId = projectId,
                 deviceModel = deviceModel,
                 deviceOs = deviceOs,
-                androidSystemImage = androidSystemImage,
+                deviceSpec = deviceSpec,
                 androidApiLevel = androidApiLevel,
                 iOSVersion = iOSVersion,
             )
@@ -456,7 +458,7 @@ class ApiClient(
                                 projectId = projectId,
                                 deviceModel = deviceModel,
                                 deviceOs = deviceOs,
-                                androidSystemImage = androidSystemImage,
+                                deviceSpec = deviceSpec,
                                 androidApiLevel = androidApiLevel,
                                 iOSVersion = iOSVersion,
                             )
@@ -856,7 +858,12 @@ class ApiClient(
     companion object {
         private const val BASE_RETRY_DELAY_MS = 3000L
         private const val UPLOAD_READ_TIMEOUT_MINUTES = 15L
-        private val JSON = jacksonObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        private val JSON = jacksonObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            // Without this, DeviceSpec.Android's systemImageOverride (@get:JsonIgnore, see
+            // DeviceSpec.kt) is invisible to Jackson's default bean introspection and the
+            // requestPart["deviceSpec"] send would silently drop the system-image override.
+            .registerModule(DeviceSpecModule())
     }
 }
 

--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -264,6 +264,7 @@ class ApiClient(
         projectId: String,
         deviceModel: String? = null,
         deviceOs: String? = null,
+        androidSystemImage: String? = null,
         androidApiLevel: Int?,
         iOSVersion: String? = null,
     ): UploadResponse {
@@ -287,6 +288,7 @@ class ApiClient(
         requestPart["projectId"] = projectId
         deviceModel?.let { requestPart["deviceModel"] = it }
         deviceOs?.let { requestPart["deviceOs"] = it }
+        androidSystemImage?.let { requestPart["androidSystemImage"] = it }
         androidApiLevel?.let { requestPart["androidApiLevel"] = it }
         iOSVersion?.let { requestPart["iOSVersion"] = it }
         if (includeTags.isNotEmpty()) requestPart["includeTags"] = includeTags
@@ -377,6 +379,7 @@ class ApiClient(
                 projectId = projectId,
                 deviceModel = deviceModel,
                 deviceOs = deviceOs,
+                androidSystemImage = androidSystemImage,
                 androidApiLevel = androidApiLevel,
                 iOSVersion = iOSVersion,
             )
@@ -453,6 +456,7 @@ class ApiClient(
                                 projectId = projectId,
                                 deviceModel = deviceModel,
                                 deviceOs = deviceOs,
+                                androidSystemImage = androidSystemImage,
                                 androidApiLevel = androidApiLevel,
                                 iOSVersion = iOSVersion,
                             )

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -98,6 +98,7 @@ class CloudInteractor(
         projectId: String? = null,
         deviceModel: String? = null,
         deviceOs: String? = null,
+        androidSystemImage: String? = null,
         androidApiLevel: Int? = null,
         iOSVersion: String? = null,
     ): Int {
@@ -195,6 +196,7 @@ class CloudInteractor(
                 deviceLocale = deviceLocale,
                 deviceModel = deviceModel,
                 deviceOs = deviceOs,
+                androidSystemImage = androidSystemImage,
                 androidApiLevel = androidApiLevel,
                 iOSVersion = iOSVersion,
             )

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -40,7 +40,9 @@ import maestro.orchestra.validation.AppValidationException
 import maestro.orchestra.validation.AppValidator
 import maestro.orchestra.validation.WorkspaceValidationException
 import maestro.orchestra.validation.WorkspaceValidator
+import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
+import maestro.device.locale.AndroidLocale
 import maestro.utils.TemporaryDirectory
 import okio.BufferedSink
 import okio.buffer
@@ -98,7 +100,6 @@ class CloudInteractor(
         projectId: String? = null,
         deviceModel: String? = null,
         deviceOs: String? = null,
-        androidSystemImage: String? = null,
         androidApiLevel: Int? = null,
         iOSVersion: String? = null,
     ): Int {
@@ -143,6 +144,7 @@ class CloudInteractor(
 
             // Validate app and resolve platform
             // When appBinaryId is provided, skip CLI-side validation — the server validates
+            var resolvedPlatform: Platform? = null
             if (appBinaryId == null) {
                 val appValidator = AppValidator(
                     appFileValidator = appFileValidator,
@@ -158,6 +160,7 @@ class CloudInteractor(
                 } catch (e: AppValidationException) {
                     throw CliError(e.message ?: "App validation failed")
                 }
+                resolvedPlatform = resolvedAppValidation.platform
 
                 // Validate workspace against appId before uploading to catch errors early
                 try {
@@ -171,6 +174,31 @@ class CloudInteractor(
                 } catch (e: WorkspaceValidationException) {
                     throw CliError(e.message ?: "Workspace validation failed")
                 }
+            }
+
+            // The --device-os shape is the only switch: a full 'system-images;<os>;<tag>;<abi>'
+            // path builds a typed DeviceSpec.Android and is sent instead of the loose fields
+            // below; a version-shaped or absent --device-os keeps today's loose-field send.
+            val fullImage = deviceOs?.takeIf { it.startsWith("system-images;") }
+            val androidDeviceSpec: DeviceSpec.Android? = fullImage?.let { image ->
+                // A full system-image path is Android by construction. If we validated the
+                // binary locally (appBinaryId == null) and it isn't Android, fail fast rather
+                // than sending an Android spec for an iOS/web app. The backend guards too.
+                if (appBinaryId == null && resolvedPlatform != Platform.ANDROID) {
+                    throw CliError(
+                        "--device-os is a full Android system image ($image) but the app is ${resolvedPlatform?.description}."
+                    )
+                }
+                val segments = image.split(";")
+                DeviceSpec.Android(
+                    model = deviceModel ?: DeviceSpec.Android.DEFAULT.model,
+                    os = segments[1],
+                    systemImageOverride = image,
+                    locale = deviceLocale?.let { AndroidLocale.fromString(it) }
+                        ?: DeviceSpec.Android.DEFAULT.locale,
+                    cpuArchitecture = CPU_ARCHITECTURE.entries.firstOrNull { it.value == segments[3] }
+                        ?: CPU_ARCHITECTURE.ARM64,
+                )
             }
 
             val response = client.upload(
@@ -193,12 +221,12 @@ class CloudInteractor(
                 progressListener = { totalBytes, bytesWritten ->
                     progressBar.set(bytesWritten.toFloat() / totalBytes.toFloat())
                 },
-                deviceLocale = deviceLocale,
-                deviceModel = deviceModel,
-                deviceOs = deviceOs,
-                androidSystemImage = androidSystemImage,
-                androidApiLevel = androidApiLevel,
-                iOSVersion = iOSVersion,
+                deviceLocale = if (androidDeviceSpec != null) null else deviceLocale,
+                deviceModel = if (androidDeviceSpec != null) null else deviceModel,
+                deviceOs = if (androidDeviceSpec != null) null else deviceOs,
+                deviceSpec = androidDeviceSpec,
+                androidApiLevel = if (androidDeviceSpec != null) null else androidApiLevel,
+                iOSVersion = if (androidDeviceSpec != null) null else iOSVersion,
             )
 
             // Track finish after upload completion

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -165,18 +165,12 @@ class CloudCommand : Callable<Int> {
     private var deviceModel: String? = null
 
     @Option(order = 21, names = ["--device-os"], description = [
-      "OS version to run your flow against.",
+      "OS version to run your flow against, or a full Android system image.",
       "  iOS: iOS-18-2, iOS-26-2, etc. maestro list-cloud-devices",
-      "  Android: android-33, android-34, etc. maestro list-cloud-devices"
+      "  Android: android-33, android-34, etc. maestro list-cloud-devices",
+      "  Android (full image): system-images;android-34;google_apis_playstore;arm64-v8a",
     ])
     private var deviceOs: String? = null
-
-    @Option(order = 22, names = ["--android-system-image"], description = [
-      "Full Android system image to run your flow against, e.g.",
-      "  system-images;android-34;google_apis_playstore;arm64-v8a",
-      "Overrides the image selected by --device-os. Android only.",
-    ])
-    private var androidSystemImage: String? = null
 
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
@@ -255,7 +249,6 @@ class CloudCommand : Callable<Int> {
             projectId = projectId,
             deviceModel = deviceModel,
             deviceOs = deviceOs,
-            androidSystemImage = androidSystemImage,
             androidApiLevel = androidApiLevel,
             iOSVersion = iOSVersion
         )

--- a/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/CloudCommand.kt
@@ -171,6 +171,13 @@ class CloudCommand : Callable<Int> {
     ])
     private var deviceOs: String? = null
 
+    @Option(order = 22, names = ["--android-system-image"], description = [
+      "Full Android system image to run your flow against, e.g.",
+      "  system-images;android-34;google_apis_playstore;arm64-v8a",
+      "Overrides the image selected by --device-os. Android only.",
+    ])
+    private var androidSystemImage: String? = null
+
     @Option(hidden = true, names = ["--fail-on-cancellation"], description = ["Fail the command if the upload is marked as cancelled"])
     private var failOnCancellation: Boolean = false
 
@@ -248,6 +255,7 @@ class CloudCommand : Callable<Int> {
             projectId = projectId,
             deviceModel = deviceModel,
             deviceOs = deviceOs,
+            androidSystemImage = androidSystemImage,
             androidApiLevel = androidApiLevel,
             iOSVersion = iOSVersion
         )

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -69,23 +69,13 @@ class StartDeviceCommand : Callable<Int> {
         order = 4,
         names = ["--device-os"],
         description = [
-            "OS version to use:",
+            "OS version to use, or a full Android system image:",
             "  iOS: iOS-18-2, iOS-26-2 etc. maestro list-devices",
-            "  Android: android-33, android-34, etc. maestro list-devices"
+            "  Android: android-33, android-34, etc. maestro list-devices",
+            "  Android (full image): system-images;android-34;google_apis_playstore;arm64-v8a",
         ],
     )
     private var deviceOs: String? = null
-
-    @CommandLine.Option(
-        order = 5,
-        names = ["--android-system-image"],
-        description = [
-            "Full Android system image to launch, e.g.",
-            "  system-images;android-34;google_apis_playstore;arm64-v8a",
-            "Overrides the image selected by --device-os. Android only.",
-        ],
-    )
-    private var androidSystemImage: String? = null
 
     @CommandLine.Option(
         order = 6,
@@ -97,11 +87,15 @@ class StartDeviceCommand : Callable<Int> {
     internal fun buildDeviceSpec(parsedPlatform: Platform): DeviceSpec = when (parsedPlatform) {
         Platform.ANDROID -> {
             val default = DeviceSpec.Android.DEFAULT
+            val isFullImage = deviceOs?.startsWith("system-images;") == true
             DeviceSpec.Android(
                 // osVersion is nullable; ?.let prevents interpolating "android-null"
                 model = deviceModel ?: default.model,
-                os = deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
-                systemImageOverride = androidSystemImage,
+                // A full-image --device-os supplies os via its 2nd segment; otherwise the
+                // prefixed version, then --os-version, then the default.
+                os = if (isFullImage) deviceOs!!.split(";")[1]
+                     else deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
+                systemImageOverride = if (isFullImage) deviceOs else null,
                 // AndroidLocale is a data class (no pre-defined constant); parse the default
                 locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
                 cpuArchitecture = EnvUtils.getMacOSArchitecture(),

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -78,10 +78,52 @@ class StartDeviceCommand : Callable<Int> {
 
     @CommandLine.Option(
         order = 5,
+        names = ["--android-system-image"],
+        description = [
+            "Full Android system image to launch, e.g.",
+            "  system-images;android-34;google_apis_playstore;arm64-v8a",
+            "Overrides the image selected by --device-os. Android only.",
+        ],
+    )
+    private var androidSystemImage: String? = null
+
+    @CommandLine.Option(
+        order = 6,
         names = ["--force-create"],
         description = ["Will override existing device if it already exists"],
     )
     private var forceCreate: Boolean = false
+
+    internal fun buildDeviceSpec(parsedPlatform: Platform): DeviceSpec = when (parsedPlatform) {
+        Platform.ANDROID -> {
+            val default = DeviceSpec.Android.DEFAULT
+            DeviceSpec.Android(
+                // osVersion is nullable; ?.let prevents interpolating "android-null"
+                model = deviceModel ?: default.model,
+                os = deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
+                systemImageOverride = androidSystemImage,
+                // AndroidLocale is a data class (no pre-defined constant); parse the default
+                locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
+                cpuArchitecture = EnvUtils.getMacOSArchitecture(),
+            )
+        }
+        Platform.IOS -> {
+            val default = DeviceSpec.Ios.DEFAULT
+            DeviceSpec.Ios(
+                model = deviceModel ?: default.model,
+                os = deviceOs ?: osVersion?.let { "iOS-$it" } ?: default.os,
+                locale = deviceLocale?.let { IosLocale.fromString(it) } ?: default.locale,
+            )
+        }
+        Platform.WEB -> {
+            val default = DeviceSpec.Web.DEFAULT
+            DeviceSpec.Web(
+                model = deviceModel ?: default.model,
+                os = deviceOs ?: osVersion ?: default.os,
+                locale = deviceLocale?.let { WebLocale.fromString(it) } ?: default.locale,
+            )
+        }
+    }
 
     override fun call(): Int {
         TestDebugReporter.install(null, printToConsole = parent?.verbose == true)
@@ -92,35 +134,7 @@ class StartDeviceCommand : Callable<Int> {
 
         // Get the device configuration
         val parsedPlatform = Platform.fromString(platform)
-        val deviceSpec: DeviceSpec = when (parsedPlatform) {
-            Platform.ANDROID -> {
-                val default = DeviceSpec.Android.DEFAULT
-                DeviceSpec.Android(
-                    // osVersion is nullable; ?.let prevents interpolating "android-null"
-                    model = deviceModel ?: default.model,
-                    os = deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
-                    // AndroidLocale is a data class (no pre-defined constant); parse the default
-                    locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
-                    cpuArchitecture = EnvUtils.getMacOSArchitecture(),
-                )
-            }
-            Platform.IOS -> {
-                val default = DeviceSpec.Ios.DEFAULT
-                DeviceSpec.Ios(
-                    model = deviceModel ?: default.model,
-                    os = deviceOs ?: osVersion?.let { "iOS-$it" } ?: default.os,
-                    locale = deviceLocale?.let { IosLocale.fromString(it) } ?: default.locale,
-                )
-            }
-            Platform.WEB -> {
-                val default = DeviceSpec.Web.DEFAULT
-                DeviceSpec.Web(
-                    model = deviceModel ?: default.model,
-                    os = deviceOs ?: osVersion ?: default.os,
-                    locale = deviceLocale?.let { WebLocale.fromString(it) } ?: default.locale,
-                )
-            }
-        }
+        val deviceSpec: DeviceSpec = buildDeviceSpec(parsedPlatform)
 
         // Get/Create the device
         val device = DeviceCreateUtil.getOrCreateDevice(

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
@@ -91,7 +91,7 @@ object DeviceCreateUtil {
     fun getOrCreateAndroidDevice(
         deviceSpec: DeviceSpec.Android, forceCreate: Boolean, shardIndex: Int? = null
     ): Device.AvailableForLaunch {
-        val systemImage = deviceSpec.emulatorImage
+        val systemImage = deviceSpec.systemImage
         // check connected device
         if (DeviceService.isDeviceConnected(deviceSpec.deviceName, Platform.ANDROID) != null && shardIndex == null && !forceCreate)
             throw CliError("A device with name ${deviceSpec.deviceName} is already connected")
@@ -133,8 +133,6 @@ object DeviceCreateUtil {
                 deviceName = deviceSpec.deviceName,
                 device = deviceSpec.model,
                 systemImage = systemImage,
-                tag = deviceSpec.tag.value,
-                abi = deviceSpec.cpuArchitecture.value,
                 force = forceCreate,
             )
         } catch (e: IllegalStateException) {

--- a/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientAndroidSystemImageTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientAndroidSystemImageTest.kt
@@ -1,0 +1,156 @@
+package maestro.cli.api
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.google.common.truth.Truth.assertThat
+import maestro.device.CPU_ARCHITECTURE
+import maestro.device.DeviceSpec
+import maestro.device.serialization.DeviceSpecModule
+import okhttp3.MultipartReader
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import okio.Buffer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+/**
+ * `ApiClient.upload` no longer has an `androidSystemImage` param — it takes a typed
+ * `deviceSpec: DeviceSpec?` instead, and it's a dumb pass-through: whatever the caller sends is
+ * what lands in the multipart `request` part. (The `--device-os` shape branching — deriving a
+ * `DeviceSpec.Android` from a full 'system-images;...' path and nulling the loose fields — is
+ * `CloudInteractor`'s job, covered by CloudInteractorTest.) This exercises the wire contract at
+ * the `ApiClient.upload` boundary: a `deviceSpec` is Jackson-serialized under the "deviceSpec"
+ * key, a loose `deviceOs` still goes under "deviceOs", and "androidSystemImage" never appears.
+ */
+class ApiClientAndroidSystemImageTest {
+
+    private lateinit var server: MockWebServer
+
+    // DeviceSpecModule must be registered for this test to parse the wire JSON at all: it's what
+    // makes systemImageOverride (@get:JsonIgnore on DeviceSpec.Android, see DeviceSpec.kt) visible
+    // under its "systemImage" wire name in the first place — the same module ApiClient itself
+    // must register on its own mapper for the real send to carry the override at all.
+    private val mapper = jacksonObjectMapper().registerModule(DeviceSpecModule())
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer().apply { start() }
+        server.enqueue(MockResponse().setResponseCode(200).setBody(UPLOAD_RESPONSE))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `a passed deviceSpec sends a deviceSpec part carrying the system-image override`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-36",
+            systemImageOverride = "system-images;android-36;google_apis_playstore;arm64-v8a",
+            cpuArchitecture = CPU_ARCHITECTURE.ARM64,
+        )
+
+        upload(deviceSpec = spec)
+
+        val requestPart = capturedRequestPart()
+        assertThat(requestPart).containsKey("deviceSpec")
+        assertThat(requestPart).doesNotContainKey("deviceOs")
+        assertThat(requestPart).doesNotContainKey("androidSystemImage")
+
+        @Suppress("UNCHECKED_CAST")
+        val specJson = requestPart["deviceSpec"] as Map<String, Any?>
+        val roundTripped = mapper.convertValue(specJson, DeviceSpec::class.java) as DeviceSpec.Android
+        assertThat(roundTripped).isEqualTo(spec)
+    }
+
+    @Test
+    fun `no deviceSpec keeps sending the loose deviceOs and never sends androidSystemImage`() {
+        upload(deviceOs = "android-34")
+
+        val requestPart = capturedRequestPart()
+        assertThat(requestPart).doesNotContainKey("deviceSpec")
+        assertThat(requestPart).doesNotContainKey("androidSystemImage")
+        assertThat(requestPart["deviceOs"]).isEqualTo("android-34")
+    }
+
+    @Test
+    fun `neither deviceOs nor deviceSpec sends neither key`() {
+        upload()
+
+        val requestPart = capturedRequestPart()
+        assertThat(requestPart).doesNotContainKey("deviceOs")
+        assertThat(requestPart).doesNotContainKey("deviceSpec")
+        assertThat(requestPart).doesNotContainKey("androidSystemImage")
+    }
+
+    private fun upload(deviceOs: String? = null, deviceSpec: DeviceSpec? = null) {
+        val workspaceZip = tempDir.resolve("workspace.zip").apply { writeText("not really a zip") }
+
+        ApiClient(server.url("/").toString().trimEnd('/')).upload(
+            authToken = "token",
+            appFile = null,
+            appBinaryId = "app_binary_test",
+            workspaceZip = workspaceZip,
+            uploadName = null,
+            mappingFile = null,
+            repoOwner = null,
+            repoName = null,
+            branch = null,
+            commitSha = null,
+            pullRequestId = null,
+            disableNotifications = false,
+            projectId = "proj_test",
+            androidApiLevel = null,
+            deviceOs = deviceOs,
+            deviceSpec = deviceSpec,
+        )
+    }
+
+    private fun capturedRequestPart(): Map<String, Any?> {
+        val recorded: RecordedRequest = server.takeRequest()
+        val contentType = recorded.getHeader("Content-Type")!!
+        val boundary = Regex("boundary=\"?([^\";]+)\"?").find(contentType)!!.groupValues[1]
+
+        val reader = MultipartReader(Buffer().apply { write(recorded.body.readByteArray()) }, boundary)
+        reader.use {
+            while (true) {
+                val part = it.nextPart() ?: break
+                val disposition = part.headers["Content-Disposition"] ?: ""
+                val body = part.body.readUtf8()
+                if (Regex("name=\"request\"").containsMatchIn(disposition)) {
+                    return mapper.readValue(body)
+                }
+            }
+        }
+        throw AssertionError("No 'request' part found in the multipart body")
+    }
+
+    private companion object {
+        val UPLOAD_RESPONSE = """
+            {
+              "orgId": "org_test",
+              "uploadId": "mupload_test",
+              "appId": "app_test",
+              "appBinaryId": "app_binary_test",
+              "deviceConfiguration": {
+                "platform": "ANDROID",
+                "deviceName": "pixel_6",
+                "orientation": "PORTRAIT",
+                "osVersion": "33",
+                "displayInfo": "pixel_6",
+                "deviceLocale": "en_US"
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
@@ -93,7 +93,7 @@ class CloudInteractorTest {
                 excludeTags = any(), disableNotifications = any(),
                 deviceLocale = any(), progressListener = any(),
                 projectId = any(), deviceModel = any(), deviceOs = any(),
-                androidApiLevel = any(), iOSVersion = any(),
+                androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
             )
         } returns UploadResponse(
             orgId = "org_1",
@@ -175,6 +175,7 @@ class CloudInteractorTest {
             deviceModel = any(),
             deviceOs = any(),
             androidApiLevel = any(),
+            androidSystemImage = any(),
             iOSVersion = any(),
         ) }
     }
@@ -252,7 +253,7 @@ class CloudInteractorTest {
             excludeTags = any(), disableNotifications = any(),
             deviceLocale = eq("fr_FR"), progressListener = any(),
             projectId = any(), deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), iOSVersion = any(),
+            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
         ) }
     }
 
@@ -279,7 +280,7 @@ class CloudInteractorTest {
             excludeTags = any(), disableNotifications = any(),
             deviceLocale = any(), progressListener = any(),
             projectId = any(), deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), iOSVersion = any(),
+            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
         ) }
     }
 
@@ -311,7 +312,7 @@ class CloudInteractorTest {
             excludeTags = any(), disableNotifications = any(),
             deviceLocale = any(), progressListener = any(),
             projectId = any(), deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), iOSVersion = any(),
+            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
         ) }
     }
 
@@ -339,7 +340,7 @@ class CloudInteractorTest {
             disableNotifications = any(), deviceLocale = any(),
             progressListener = any(), projectId = any(),
             deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), iOSVersion = any(),
+            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
         ) }
     }
 
@@ -359,6 +360,59 @@ class CloudInteractorTest {
         )
 
         assertThat(result).isEqualTo(0)
+    }
+
+    // ---- --android-system-image ----
+
+    @Test
+    fun `the requested android system image reaches the upload`() {
+        stubUploadResponse()
+
+        val result = createCloudInteractor().upload(
+            flowFile = androidFlowFile(), appFile = null, async = true,
+            projectId = "proj_1", appBinaryId = "app_binary_1",
+            androidSystemImage = "system-images;android-34;google_apis_playstore;arm64-v8a",
+        )
+
+        assertThat(result).isEqualTo(0)
+        verify {
+            mockApiClient.upload(
+                authToken = any(), appFile = any(), workspaceZip = any(),
+                uploadName = any(), mappingFile = any(), repoOwner = any(),
+                repoName = any(), branch = any(), commitSha = any(),
+                pullRequestId = any(), env = any(), appBinaryId = any(), includeTags = any(),
+                excludeTags = any(), disableNotifications = any(),
+                deviceLocale = any(), progressListener = any(),
+                projectId = any(), deviceModel = any(), deviceOs = any(),
+                androidApiLevel = any(),
+                androidSystemImage = "system-images;android-34;google_apis_playstore;arm64-v8a",
+                iOSVersion = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `no requested image leaves androidSystemImage null on the upload`() {
+        stubUploadResponse()
+
+        val result = createCloudInteractor().upload(
+            flowFile = androidFlowFile(), appFile = null, async = true,
+            projectId = "proj_1", appBinaryId = "app_binary_1",
+        )
+
+        assertThat(result).isEqualTo(0)
+        verify {
+            mockApiClient.upload(
+                authToken = any(), appFile = any(), workspaceZip = any(),
+                uploadName = any(), mappingFile = any(), repoOwner = any(),
+                repoName = any(), branch = any(), commitSha = any(),
+                pullRequestId = any(), env = any(), appBinaryId = any(), includeTags = any(),
+                excludeTags = any(), disableNotifications = any(),
+                deviceLocale = any(), progressListener = any(),
+                projectId = any(), deviceModel = any(), deviceOs = any(),
+                androidApiLevel = any(), androidSystemImage = isNull(), iOSVersion = any(),
+            )
+        }
     }
 
     @Test

--- a/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
@@ -10,6 +10,8 @@ import maestro.cli.api.UploadStatus
 import maestro.cli.auth.Auth
 import maestro.cli.model.FlowStatus
 import maestro.cli.report.ReportFormat
+import maestro.device.CPU_ARCHITECTURE
+import maestro.device.DeviceSpec
 import maestro.orchestra.validation.AppMetadataAnalyzer
 import maestro.orchestra.validation.WorkspaceValidator
 import org.junit.jupiter.api.BeforeEach
@@ -93,7 +95,7 @@ class CloudInteractorTest {
                 excludeTags = any(), disableNotifications = any(),
                 deviceLocale = any(), progressListener = any(),
                 projectId = any(), deviceModel = any(), deviceOs = any(),
-                androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
+                androidApiLevel = any(), deviceSpec = any<DeviceSpec.Android>(), iOSVersion = any(),
             )
         } returns UploadResponse(
             orgId = "org_1",
@@ -175,7 +177,7 @@ class CloudInteractorTest {
             deviceModel = any(),
             deviceOs = any(),
             androidApiLevel = any(),
-            androidSystemImage = any(),
+            deviceSpec = any<DeviceSpec.Android>(),
             iOSVersion = any(),
         ) }
     }
@@ -253,7 +255,7 @@ class CloudInteractorTest {
             excludeTags = any(), disableNotifications = any(),
             deviceLocale = eq("fr_FR"), progressListener = any(),
             projectId = any(), deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
+            androidApiLevel = any(), deviceSpec = any<DeviceSpec.Android>(), iOSVersion = any(),
         ) }
     }
 
@@ -280,7 +282,7 @@ class CloudInteractorTest {
             excludeTags = any(), disableNotifications = any(),
             deviceLocale = any(), progressListener = any(),
             projectId = any(), deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
+            androidApiLevel = any(), deviceSpec = any<DeviceSpec.Android>(), iOSVersion = any(),
         ) }
     }
 
@@ -312,7 +314,7 @@ class CloudInteractorTest {
             excludeTags = any(), disableNotifications = any(),
             deviceLocale = any(), progressListener = any(),
             projectId = any(), deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
+            androidApiLevel = any(), deviceSpec = any<DeviceSpec.Android>(), iOSVersion = any(),
         ) }
     }
 
@@ -340,7 +342,7 @@ class CloudInteractorTest {
             disableNotifications = any(), deviceLocale = any(),
             progressListener = any(), projectId = any(),
             deviceModel = any(), deviceOs = any(),
-            androidApiLevel = any(), androidSystemImage = any(), iOSVersion = any(),
+            androidApiLevel = any(), deviceSpec = any<DeviceSpec.Android>(), iOSVersion = any(),
         ) }
     }
 
@@ -362,19 +364,26 @@ class CloudInteractorTest {
         assertThat(result).isEqualTo(0)
     }
 
-    // ---- --android-system-image ----
+    // ---- --device-os (full Android system image) ----
 
     @Test
-    fun `the requested android system image reaches the upload`() {
+    fun `a full-path device-os builds a typed deviceSpec and nulls the loose device fields`() {
         stubUploadResponse()
 
         val result = createCloudInteractor().upload(
             flowFile = androidFlowFile(), appFile = null, async = true,
             projectId = "proj_1", appBinaryId = "app_binary_1",
-            androidSystemImage = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            deviceOs = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            deviceModel = "pixel_6",
         )
 
         assertThat(result).isEqualTo(0)
+        val expectedSpec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-34",
+            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            cpuArchitecture = CPU_ARCHITECTURE.ARM64,
+        )
         verify {
             mockApiClient.upload(
                 authToken = any(), appFile = any(), workspaceZip = any(),
@@ -382,17 +391,42 @@ class CloudInteractorTest {
                 repoName = any(), branch = any(), commitSha = any(),
                 pullRequestId = any(), env = any(), appBinaryId = any(), includeTags = any(),
                 excludeTags = any(), disableNotifications = any(),
-                deviceLocale = any(), progressListener = any(),
-                projectId = any(), deviceModel = any(), deviceOs = any(),
-                androidApiLevel = any(),
-                androidSystemImage = "system-images;android-34;google_apis_playstore;arm64-v8a",
-                iOSVersion = any(),
+                deviceLocale = isNull(), progressListener = any(),
+                projectId = any(), deviceModel = isNull(), deviceOs = isNull(),
+                androidApiLevel = isNull(),
+                deviceSpec = eq(expectedSpec),
+                iOSVersion = isNull(),
             )
         }
     }
 
     @Test
-    fun `no requested image leaves androidSystemImage null on the upload`() {
+    fun `a version-shaped device-os keeps sending the loose deviceOs and no deviceSpec`() {
+        stubUploadResponse()
+
+        val result = createCloudInteractor().upload(
+            flowFile = androidFlowFile(), appFile = null, async = true,
+            projectId = "proj_1", appBinaryId = "app_binary_1",
+            deviceOs = "android-34",
+        )
+
+        assertThat(result).isEqualTo(0)
+        verify {
+            mockApiClient.upload(
+                authToken = any(), appFile = any(), workspaceZip = any(),
+                uploadName = any(), mappingFile = any(), repoOwner = any(),
+                repoName = any(), branch = any(), commitSha = any(),
+                pullRequestId = any(), env = any(), appBinaryId = any(), includeTags = any(),
+                excludeTags = any(), disableNotifications = any(),
+                deviceLocale = any(), progressListener = any(),
+                projectId = any(), deviceModel = any(), deviceOs = eq("android-34"),
+                androidApiLevel = any(), deviceSpec = isNull<DeviceSpec.Android>(), iOSVersion = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `no requested device-os leaves deviceSpec null on the upload`() {
         stubUploadResponse()
 
         val result = createCloudInteractor().upload(
@@ -409,10 +443,24 @@ class CloudInteractorTest {
                 pullRequestId = any(), env = any(), appBinaryId = any(), includeTags = any(),
                 excludeTags = any(), disableNotifications = any(),
                 deviceLocale = any(), progressListener = any(),
-                projectId = any(), deviceModel = any(), deviceOs = any(),
-                androidApiLevel = any(), androidSystemImage = isNull(), iOSVersion = any(),
+                projectId = any(), deviceModel = any(), deviceOs = isNull(),
+                androidApiLevel = any(), deviceSpec = isNull<DeviceSpec.Android>(), iOSVersion = any(),
             )
         }
+    }
+
+    @Test
+    fun `a full-path device-os on a locally-validated non-Android app fails fast`() {
+        val error = assertThrows<CliError> {
+            createCloudInteractor().upload(
+                flowFile = iosFlowFile(), appFile = iosApp(), async = true,
+                projectId = "proj_1",
+                deviceOs = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            )
+        }
+
+        assertThat(error.message).contains("system-images;android-34;google_apis_playstore;arm64-v8a")
+        assertThat(error.message).contains("iOS")
     }
 
     @Test

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/CloudCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/CloudCommandTest.kt
@@ -7,8 +7,12 @@ import picocli.CommandLine
 class CloudCommandTest {
 
     @Test
-    fun `help output lists the new flag`() {
+    fun `help output documents the full-path device-os form and drops the dedicated flag`() {
+        // picocli wraps long option descriptions across lines, so assert on a fragment that
+        // survives wrapping rather than the whole "system-images;..." literal.
         val help = CommandLine(CloudCommand()).usageMessage
-        assertThat(help).contains("--android-system-image")
+        assertThat(help).doesNotContain("--android-system-image")
+        assertThat(help).contains("Android system image")
+        assertThat(help).contains("system-images;")
     }
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/CloudCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/CloudCommandTest.kt
@@ -1,0 +1,14 @@
+package maestro.cli.command
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import picocli.CommandLine
+
+class CloudCommandTest {
+
+    @Test
+    fun `help output lists the new flag`() {
+        val help = CommandLine(CloudCommand()).usageMessage
+        assertThat(help).contains("--android-system-image")
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
@@ -2,6 +2,7 @@ package maestro.cli.command
 
 import com.google.common.truth.Truth.assertThat
 import maestro.cli.util.EnvUtils
+import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
 import maestro.device.Platform
 import org.junit.jupiter.api.Test
@@ -26,31 +27,40 @@ class StartDeviceCommandTest {
     }
 
     @Test
-    fun `the flag reaches the constructed Android spec's systemImage`() {
+    fun `a full-path device-os reaches the constructed Android spec's systemImage`() {
+        val abi = EnvUtils.getMacOSArchitecture().value
         val spec = parse(
             "--platform", "android",
-            "--device-os", "android-34",
-            "--android-system-image", "system-images;android-34;google_apis_playstore;arm64-v8a",
+            "--device-os", "system-images;android-34;google_apis_playstore;$abi",
         ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
 
+        assertThat(spec.os).isEqualTo("android-34")
         assertThat(spec.systemImage)
-            .isEqualTo("system-images;android-34;google_apis_playstore;arm64-v8a")
+            .isEqualTo("system-images;android-34;google_apis_playstore;$abi")
     }
 
     @Test
-    fun `an os-mismatched image throws`() {
+    fun `a full-path device-os with an abi that doesn't match this host throws`() {
+        // cpuArchitecture always reflects the actual host (EnvUtils.getMacOSArchitecture()), so a
+        // full-path --device-os naming a different abi fails DeviceSpec.Android's own consistency
+        // check rather than silently launching the wrong image.
+        val mismatchedAbi = if (EnvUtils.getMacOSArchitecture() == CPU_ARCHITECTURE.ARM64) "x86_64" else "arm64-v8a"
+
         assertThrows<IllegalArgumentException> {
             parse(
                 "--platform", "android",
-                "--device-os", "android-33",
-                "--android-system-image", "system-images;android-34;google_apis;arm64-v8a",
+                "--device-os", "system-images;android-34;google_apis;$mismatchedAbi",
             ).buildDeviceSpec(Platform.ANDROID)
         }
     }
 
     @Test
-    fun `help output lists the new flag`() {
+    fun `help output documents the full-path device-os form and drops the dedicated flag`() {
+        // picocli wraps long option descriptions across lines, so assert on a fragment that
+        // survives wrapping rather than the whole "system-images;..." literal.
         val help = CommandLine(StartDeviceCommand()).usageMessage
-        assertThat(help).contains("--android-system-image")
+        assertThat(help).doesNotContain("--android-system-image")
+        assertThat(help).contains("Android system image")
+        assertThat(help).contains("system-images;")
     }
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
@@ -1,0 +1,56 @@
+package maestro.cli.command
+
+import com.google.common.truth.Truth.assertThat
+import maestro.cli.util.EnvUtils
+import maestro.device.DeviceSpec
+import maestro.device.Platform
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import picocli.CommandLine
+
+class StartDeviceCommandTest {
+
+    private fun parse(vararg args: String): StartDeviceCommand {
+        val command = StartDeviceCommand()
+        CommandLine(command).parseArgs(*args)
+        return command
+    }
+
+    @Test
+    fun `an unset flag leaves the Android spec on the default system image`() {
+        val spec = parse("--platform", "android").buildDeviceSpec(Platform.ANDROID)
+
+        assertThat(spec).isInstanceOf(DeviceSpec.Android::class.java)
+        assertThat((spec as DeviceSpec.Android).systemImage)
+            .isEqualTo("system-images;android-33;google_apis;${EnvUtils.getMacOSArchitecture().value}")
+    }
+
+    @Test
+    fun `the flag reaches the constructed Android spec's systemImage`() {
+        val spec = parse(
+            "--platform", "android",
+            "--device-os", "android-34",
+            "--android-system-image", "system-images;android-34;google_apis_playstore;arm64-v8a",
+        ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
+
+        assertThat(spec.systemImage)
+            .isEqualTo("system-images;android-34;google_apis_playstore;arm64-v8a")
+    }
+
+    @Test
+    fun `an os-mismatched image throws`() {
+        assertThrows<IllegalArgumentException> {
+            parse(
+                "--platform", "android",
+                "--device-os", "android-33",
+                "--android-system-image", "system-images;android-34;google_apis;arm64-v8a",
+            ).buildDeviceSpec(Platform.ANDROID)
+        }
+    }
+
+    @Test
+    fun `help output lists the new flag`() {
+        val help = CommandLine(StartDeviceCommand()).usageMessage
+        assertThat(help).contains("--android-system-image")
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/device/DeviceCreateUtilTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/device/DeviceCreateUtilTest.kt
@@ -7,6 +7,7 @@ import io.mockk.slot
 import io.mockk.unmockkObject
 import io.mockk.verify
 import maestro.cli.command.StartDeviceCommand
+import maestro.cli.util.EnvUtils
 import maestro.device.Device
 import maestro.device.DeviceService
 import maestro.device.DeviceSpec
@@ -51,10 +52,10 @@ class DeviceCreateUtilTest {
 
     @Test
     fun `a playstore request does not reuse the google_apis emulator of the same model and os`() {
+        val abi = EnvUtils.getMacOSArchitecture().value
         val spec = specFromCli(
             "--platform", "android",
-            "--device-os", "android-33",
-            "--android-system-image", "system-images;android-33;google_apis_playstore;arm64-v8a",
+            "--device-os", "system-images;android-33;google_apis_playstore;$abi",
         ) as DeviceSpec.Android
 
         val device = DeviceCreateUtil.getOrCreateAndroidDevice(spec, forceCreate = false)

--- a/maestro-cli/src/test/kotlin/maestro/cli/device/DeviceCreateUtilTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/device/DeviceCreateUtilTest.kt
@@ -1,0 +1,86 @@
+package maestro.cli.device
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import maestro.cli.command.StartDeviceCommand
+import maestro.device.Device
+import maestro.device.DeviceService
+import maestro.device.DeviceSpec
+import maestro.device.Platform
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import picocli.CommandLine
+
+class DeviceCreateUtilTest {
+
+    private val existingGoogleApisAvd = "Maestro_ANDROID_pixel_6_android-33"
+
+    @BeforeEach
+    fun setUp() {
+        mockkObject(DeviceService)
+        every { DeviceService.isDeviceConnected(any(), any()) } returns null
+        every { DeviceService.isAndroidSystemImageInstalled(any()) } returns true
+        every { DeviceService.createAndroidDevice(any(), any(), any(), any()) } returns "avd-just-created"
+        every { DeviceService.isDeviceAvailableToLaunch(any(), Platform.ANDROID) } answers {
+            val requestedName = firstArg<String>()
+            if (existingGoogleApisAvd.equals(requestedName, ignoreCase = true)) {
+                Device.AvailableForLaunch(
+                    modelId = existingGoogleApisAvd,
+                    description = existingGoogleApisAvd,
+                    platform = Platform.ANDROID,
+                    deviceType = Device.DeviceType.EMULATOR,
+                    deviceSpec = DeviceSpec.Android(model = "pixel_6", os = "android-33"),
+                )
+            } else null
+        }
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkObject(DeviceService)
+
+    private fun specFromCli(vararg args: String): DeviceSpec {
+        val command = StartDeviceCommand()
+        CommandLine(command).parseArgs(*args)
+        return command.buildDeviceSpec(Platform.ANDROID)
+    }
+
+    @Test
+    fun `a playstore request does not reuse the google_apis emulator of the same model and os`() {
+        val spec = specFromCli(
+            "--platform", "android",
+            "--device-os", "android-33",
+            "--android-system-image", "system-images;android-33;google_apis_playstore;arm64-v8a",
+        ) as DeviceSpec.Android
+
+        val device = DeviceCreateUtil.getOrCreateAndroidDevice(spec, forceCreate = false)
+
+        assertThat(device.modelId).isEqualTo("avd-just-created")
+        val createdName = slot<String>()
+        val createdImage = slot<String>()
+        verify {
+            DeviceService.createAndroidDevice(
+                deviceName = capture(createdName),
+                device = any(),
+                systemImage = capture(createdImage),
+                force = any(),
+            )
+        }
+        assertThat(createdName.captured).isNotEqualTo(existingGoogleApisAvd)
+        assertThat(createdImage.captured).contains("google_apis_playstore")
+    }
+
+    @Test
+    fun `an unflagged request still reuses the existing google_apis emulator`() {
+        val spec = specFromCli("--platform", "android", "--device-os", "android-33") as DeviceSpec.Android
+
+        val device = DeviceCreateUtil.getOrCreateAndroidDevice(spec, forceCreate = false)
+
+        assertThat(device.modelId).isEqualTo(existingGoogleApisAvd)
+        verify(exactly = 0) { DeviceService.createAndroidDevice(any(), any(), any(), any()) }
+    }
+}

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -537,15 +537,11 @@ object DeviceService {
      * @param deviceName Any device name
      * @param device Device type as specified by the Android SDK i.e. "pixel_6"
      * @param systemImage Full system package i.e "system-images;android-28;google_apis;x86_64"
-     * @param tag google apis or playstore tag i.e. google_apis or google_apis_playstore
-     * @param abi x86_64, x86, arm64 etc..
      */
     fun createAndroidDevice(
         deviceName: String,
         device: String,
         systemImage: String,
-        tag: String,
-        abi: String,
         force: Boolean = false,
     ): String {
         val avd = requireAvdManagerBinary()
@@ -555,8 +551,6 @@ object DeviceService {
             "create", "avd",
             "--name", name,
             "--package", systemImage,
-            "--tag", tag,
-            "--abi", abi,
             "--device", device,
         )
 

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -3,7 +3,6 @@ package maestro.device
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonValue
 import maestro.device.locale.AndroidLocale
 import maestro.device.locale.DeviceLocale
 import maestro.device.locale.IosLocale
@@ -22,29 +21,10 @@ enum class CPU_ARCHITECTURE(val value: String) {
 }
 
 /**
- * The Google-defined system-image tag — the third segment of
- * `system-images;<os>;<tag>;<abi>`. `.value` is the literal tag string, mirroring
- * the `cpuArchitecture.value` precedent; `@JsonValue` serializes it as that string.
- */
-enum class SystemImageTag(@JsonValue val value: String) {
-    GOOGLE_APIS("google_apis"),
-    GOOGLE_APIS_PLAYSTORE("google_apis_playstore");
-
-    companion object {
-        fun fromString(value: String): SystemImageTag {
-            return entries.firstOrNull { it.value == value }
-                ?: throw IllegalArgumentException(
-                    "Unknown system-image tag: '$value'. Must be one of: ${entries.joinToString { it.value }}"
-                )
-        }
-    }
-}
-
-/**
  * Strongly typed device configuration. Callers must provide `model` and `os`;
  * all other fields have sensible defaults that can be overridden when needed.
  *
- * Derived values (osVersion, deviceName, emulatorImage) are computed at
+ * Derived values (osVersion, deviceName, systemImage) are computed at
  * access time via `get()` properties — they are not stored in the data class
  * and therefore never serialized or persisted.
  *
@@ -72,27 +52,32 @@ sealed class DeviceSpec {
         private val systemImageOverride: String? = null,
         override val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
         val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
-        // Vestigial: retained only so existing callers compile; nothing reads it to build the
-        // system image. Removed entirely in the contract PR (PR 2).
-        val tag: SystemImageTag = SystemImageTag.GOOGLE_APIS,
     ) : DeviceSpec() {
         init {
             require(model.isNotBlank()) { "DeviceSpec.Android: model cannot be blank" }
             require(os.isNotBlank()) { "DeviceSpec.Android: os cannot be blank" }
+            systemImageOverride?.let {
+                require(it.startsWith("system-images;") && it.split(";").size == 4) {
+                    "systemImage must be a full 'system-images;<os>;<tag>;<abi>' string"
+                }
+                require(it.split(";")[1] == os) { "systemImage OS segment must match os ($os)" }
+            }
         }
 
         override val platform = Platform.ANDROID
         override val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
-        override val deviceName: String get() = "Maestro_ANDROID_${model}_${os}"
+        override val deviceName: String get() {
+            val tag = systemImage.split(";")[2]
+            return "Maestro_ANDROID_${model}_${os}" + if (tag == DEFAULT_TAG) "" else "_$tag"
+        }
 
         /** The sdkmanager/avdmanager package to actually use; always non-null. */
         val systemImage: String get() =
-            systemImageOverride ?: "system-images;$os;google_apis;${cpuArchitecture.value}"
-
-        val emulatorImage: String get() = "system-images;$os;${tag.value};${cpuArchitecture.value}"
+            systemImageOverride ?: "system-images;$os;$DEFAULT_TAG;${cpuArchitecture.value}"
 
         companion object {
             val DEFAULT: Android = Android(model = "pixel_6", os = "android-33")
+            private const val DEFAULT_TAG = "google_apis"
         }
     }
 

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -1,5 +1,6 @@
 package maestro.device
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
@@ -48,8 +49,19 @@ sealed class DeviceSpec {
     data class Android(
         override val model: String,
         override val os: String,
+        // Public so the backend's DeviceSpec.validate() can fire supported-set
+        // resolution only for an explicit override (null for every legacy spec).
+        // @get:JsonIgnore keeps Jackson's bean-property introspection from picking up
+        // the now-public getter: without it, Jackson merges the @param:JsonProperty
+        // rename onto this property's own getter too, which collides with the
+        // unrelated computed `systemImage` getter below (both would claim the
+        // "systemImage" JSON key and deserialization fails with a
+        // "Conflicting getter definitions" error). The custom
+        // DeviceSpecSparseSerializer reads this property via kotlin-reflect, not
+        // Jackson bean introspection, so it is unaffected by the ignore.
         @param:JsonProperty("systemImage")
-        private val systemImageOverride: String? = null,
+        @get:JsonIgnore
+        val systemImageOverride: String? = null,
         override val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
         val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
     ) : DeviceSpec() {
@@ -61,6 +73,9 @@ sealed class DeviceSpec {
                     "systemImage must be a full 'system-images;<os>;<tag>;<abi>' string"
                 }
                 require(it.split(";")[1] == os) { "systemImage OS segment must match os ($os)" }
+                require(it.split(";")[3] == cpuArchitecture.value) {
+                    "systemImage abi segment (${it.split(";")[3]}) must match cpuArchitecture (${cpuArchitecture.value})"
+                }
             }
         }
 

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -154,4 +154,29 @@ internal class DeviceSpecTest {
             AndroidLocale.fromString("en")
         }
     }
+
+    @Test
+    fun `systemImageOverride whose abi segment mismatches cpuArchitecture throws`() {
+        val error = assertThrows<IllegalArgumentException> {
+            DeviceSpec.Android(
+                model = "pixel_6",
+                os = "android-34",
+                systemImageOverride = "system-images;android-34;google_apis;x86_64",
+                cpuArchitecture = CPU_ARCHITECTURE.ARM64,
+            )
+        }
+        assertThat(error).hasMessageThat().contains("arm64-v8a")
+    }
+
+    @Test
+    fun `systemImageOverride abi matching cpuArchitecture is accepted`() {
+        val spec = DeviceSpec.Android(
+            model = "pixel_6",
+            os = "android-34",
+            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            cpuArchitecture = CPU_ARCHITECTURE.ARM64,
+        )
+        assertThat(spec.systemImageOverride)
+            .isEqualTo("system-images;android-34;google_apis_playstore;arm64-v8a")
+    }
 }

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -55,32 +55,6 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `Android computed emulatorImage reflects cpuArchitecture`() {
-        val arm = DeviceSpec.Android(model = "pixel_6", os = "android-33", cpuArchitecture = CPU_ARCHITECTURE.ARM64)
-        val x86 = DeviceSpec.Android(model = "pixel_6", os = "android-33", cpuArchitecture = CPU_ARCHITECTURE.X86_64)
-
-        assertThat(arm.emulatorImage).isEqualTo("system-images;android-33;google_apis;arm64-v8a")
-        assertThat(x86.emulatorImage).isEqualTo("system-images;android-33;google_apis;x86_64")
-    }
-
-    @Test
-    fun `Android default tag is google_apis and emulatorImage derives from it`() {
-        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-36")
-        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS)
-        assertThat(spec.emulatorImage).isEqualTo("system-images;android-36;google_apis;arm64-v8a")
-    }
-
-    @Test
-    fun `Android playstore tag flows into emulatorImage`() {
-        val spec = DeviceSpec.Android(
-            model = "pixel_6",
-            os = "android-36",
-            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
-        )
-        assertThat(spec.emulatorImage).isEqualTo("system-images;android-36;google_apis_playstore;arm64-v8a")
-    }
-
-    @Test
     fun `systemImage resolves to the override when set`() {
         val spec = DeviceSpec.Android(
             model = "pixel_6",
@@ -97,23 +71,28 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `tag and emulatorImage remain readable`() {
-        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34", tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE)
-        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS_PLAYSTORE)
-        assertThat(spec.emulatorImage).isNotNull()
+    fun `systemImageOverride with fewer than 4 segments throws`() {
+        assertThrows<IllegalArgumentException> {
+            DeviceSpec.Android(model = "pixel_6", os = "android-34",
+                systemImageOverride = "system-images;android-34;google_apis")
+        }
     }
 
     @Test
-    fun `SystemImageTag fromString parses a known tag value`() {
-        assertThat(SystemImageTag.fromString("google_apis_playstore"))
-            .isEqualTo(SystemImageTag.GOOGLE_APIS_PLAYSTORE)
+    fun `systemImageOverride not starting with system-images throws`() {
+        assertThrows<IllegalArgumentException> {
+            DeviceSpec.Android(model = "pixel_6", os = "android-34",
+                systemImageOverride = "android-34;google_apis;arm64-v8a;extra")
+        }
     }
 
     @Test
-    fun `SystemImageTag fromString rejects an unknown tag value`() {
-        val error = assertThrows<IllegalArgumentException> { SystemImageTag.fromString("nonsense") }
-        assertThat(error).hasMessageThat().contains("nonsense")
-        assertThat(error).hasMessageThat().contains("google_apis_playstore")
+    fun `systemImageOverride with a mismatched os segment throws`() {
+        val error = assertThrows<IllegalArgumentException> {
+            DeviceSpec.Android(model = "pixel_6", os = "android-34",
+                systemImageOverride = "system-images;android-33;google_apis;arm64-v8a")
+        }
+        assertThat(error).hasMessageThat().contains("android-34")
     }
 
     @Test
@@ -129,9 +108,16 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `Android computed deviceName uses model and os`() {
+    fun `deviceName has no suffix for the default google_apis tag`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
         assertThat(spec.deviceName).isEqualTo("Maestro_ANDROID_pixel_6_android-34")
+    }
+
+    @Test
+    fun `deviceName is suffixed with a non-default tag from the override`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34",
+            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a")
+        assertThat(spec.deviceName).isEqualTo("Maestro_ANDROID_pixel_6_android-34_google_apis_playstore")
     }
 
     @Test

--- a/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
+++ b/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.google.common.truth.Truth.assertThat
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
-import maestro.device.SystemImageTag
 import maestro.device.locale.AndroidLocale
 import org.junit.jupiter.api.Test
 
@@ -86,29 +85,6 @@ class DeviceSpecSerializationTest {
     }
 
     @Test
-    fun `default google_apis tag is omitted from sparse output`() {
-        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-36")
-        val json = mapper.readTree(mapper.writeValueAsString(spec))
-        assertThat(json.has("tag")).isFalse()
-        assertThat(json.fieldNames().asSequence().toSet())
-            .containsExactly("platform", "model", "os")
-    }
-
-    @Test
-    fun `non-default playstore tag is emitted as its JsonValue string and round-trips`() {
-        val spec = DeviceSpec.Android(
-            model = "pixel_6",
-            os = "android-36",
-            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
-        )
-        val json = mapper.readTree(mapper.writeValueAsString(spec))
-        assertThat(json.get("tag").asText()).isEqualTo("google_apis_playstore")
-
-        val deserialized = mapper.readValue(mapper.writeValueAsString(spec), DeviceSpec::class.java)
-        assertThat(deserialized).isEqualTo(spec)
-    }
-
-    @Test
     fun `default spec omits systemImage from sparse output`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
         val json = mapper.readTree(mapper.writeValueAsString(spec))
@@ -180,8 +156,6 @@ class DeviceSpecSerializationTest {
 
         assertThat(json.has("osVersion")).isFalse()
         assertThat(json.has("deviceName")).isFalse()
-        assertThat(json.has("tag")).isFalse()
-        assertThat(json.has("emulatorImage")).isFalse()
         assertThat(json.has("systemImage")).isFalse()
     }
 


### PR DESCRIPTION
## Why

Let a caller pin a full Android system image, and make this the first real caller of the typed `DeviceSpec` upload path (`MaestroUploadRequest.deviceSpec`) — it's existed since #2399, but no client has ever sent it. Every upload today still sends loose device fields, and a system image doesn't fit that shape cleanly, so we route it through `DeviceSpec` instead of adding another loose field.

This revision drops the dedicated `--android-system-image` flag an earlier version of this PR added. Instead we overload `--device-os`: it keeps taking a version (`android-34`), and now also takes a full `system-images;<os>;<tag>;<abi>` path — one flag, no new surface. Worker and `maestro-device` already boot from `DeviceSpec.systemImage` (merged on `main` separately), so this PR is CLI-only.

## Approach

When `--device-os` is a full path, the CLI builds one `DeviceSpec.Android` (os and cpuArchitecture parsed from the path, `systemImageOverride` set to the full string) and sends it as the typed `deviceSpec` field; loose device fields go null. Any other `--device-os` value — a version, or nothing — keeps today's loose-field path untouched.

- `DeviceSpec.Android` reshaped: `systemImageOverride` exposed, `systemImage` getter added, `SystemImageTag`/`tag`/`emulatorImage` removed. `init` validates a full-string image, including that `cpuArchitecture` agrees with the image's own abi segment.
- `ApiClient.upload` gained a `deviceSpec` param and registers the sparse `DeviceSpecModule` on its Jackson mapper so `systemImageOverride` serializes under the `systemImage` key.
- A local guard fails fast if a full-path `--device-os` is used against a non-Android app.

Worker / `maestro-device` / ansible are out of scope — already on `main`.

## Verification

All CI green (macOS/Ubuntu/Windows builds, Unit Test on Java 17, Android/iOS/Web E2E). Locally, `maestro-cli` and `maestro-client` suites are green, including tests that a full-path `--device-os` sends a `deviceSpec` (os/cpuArchitecture parsed from the path) with no loose device keys, and that a version-shaped `--device-os` is unchanged.

This PR merges first but the CLI isn't released until the backend (copilot #2766) deploys, so the typed path is live before any CLI can send it; old CLIs stay on the untouched legacy path.
