### PR TITLE
fix(cli): actionable error when a --device-os system image abi doesn't match the host

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -102,12 +102,21 @@ class StartDeviceCommand : Callable<Int> {
                         cpuArchitecture = hostArchitecture,
                     )
                 } catch (e: IllegalArgumentException) {
-                    val imageAbi = fullImage.split(";")[3]
-                    throw CliError(
-                        "System image '$fullImage' targets $imageAbi, but this machine is ${hostArchitecture.value}. " +
-                            "Use an image whose ABI matches your machine, e.g. " +
-                            "${fullImage.split(";").dropLast(1).joinToString(";")};${hostArchitecture.value}."
-                    )
+                    val segments = fullImage.split(";")
+                    if (segments.size == 4) {
+                        val imageAbi = segments[3]
+                        throw CliError(
+                            "System image '$fullImage' targets $imageAbi, but this machine is ${hostArchitecture.value}. " +
+                                "Use an image whose ABI matches your machine, e.g. " +
+                                "${segments.dropLast(1).joinToString(";")};${hostArchitecture.value}."
+                        )
+                    } else {
+                        throw CliError(
+                            "'$fullImage' is not a valid system image. Expected " +
+                                "'system-images;<os>;<tag>;<abi>', e.g. " +
+                                "system-images;android-34;google_apis;${hostArchitecture.value}."
+                        )
+                    }
                 }
             } else {
                 DeviceSpec.Android(

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -88,18 +88,38 @@ class StartDeviceCommand : Callable<Int> {
         Platform.ANDROID -> {
             val default = DeviceSpec.Android.DEFAULT
             val isFullImage = deviceOs?.startsWith("system-images;") == true
-            DeviceSpec.Android(
-                // osVersion is nullable; ?.let prevents interpolating "android-null"
-                model = deviceModel ?: default.model,
-                // A full-image --device-os supplies os via its 2nd segment; otherwise the
-                // prefixed version, then --os-version, then the default.
-                os = if (isFullImage) deviceOs!!.split(";")[1]
-                     else deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
-                systemImageOverride = if (isFullImage) deviceOs else null,
-                // AndroidLocale is a data class (no pre-defined constant); parse the default
-                locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
-                cpuArchitecture = EnvUtils.getMacOSArchitecture(),
-            )
+            val hostArchitecture = EnvUtils.getMacOSArchitecture()
+            if (isFullImage) {
+                val fullImage = deviceOs!!
+                try {
+                    DeviceSpec.Android(
+                        model = deviceModel ?: default.model,
+                        // A full-image --device-os supplies os via its 2nd segment.
+                        os = fullImage.split(";")[1],
+                        systemImageOverride = fullImage,
+                        // AndroidLocale is a data class (no pre-defined constant); parse the default
+                        locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
+                        cpuArchitecture = hostArchitecture,
+                    )
+                } catch (e: IllegalArgumentException) {
+                    val imageAbi = fullImage.split(";")[3]
+                    throw CliError(
+                        "System image '$fullImage' targets $imageAbi, but this machine is ${hostArchitecture.value}. " +
+                            "Use an image whose ABI matches your machine, e.g. " +
+                            "${fullImage.split(";").dropLast(1).joinToString(";")};${hostArchitecture.value}."
+                    )
+                }
+            } else {
+                DeviceSpec.Android(
+                    // osVersion is nullable; ?.let prevents interpolating "android-null"
+                    model = deviceModel ?: default.model,
+                    os = deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
+                    systemImageOverride = null,
+                    // AndroidLocale is a data class (no pre-defined constant); parse the default
+                    locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
+                    cpuArchitecture = hostArchitecture,
+                )
+            }
         }
         Platform.IOS -> {
             val default = DeviceSpec.Ios.DEFAULT

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
@@ -1,6 +1,7 @@
 package maestro.cli.command
 
 import com.google.common.truth.Truth.assertThat
+import maestro.cli.CliError
 import maestro.cli.util.EnvUtils
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
@@ -41,18 +42,25 @@ class StartDeviceCommandTest {
     }
 
     @Test
-    fun `a full-path device-os with an abi that doesn't match this host throws`() {
+    fun `a full-path device-os with an abi that doesn't match this host throws an actionable CliError`() {
         // cpuArchitecture always reflects the actual host (EnvUtils.getMacOSArchitecture()), so a
         // full-path --device-os naming a different abi fails DeviceSpec.Android's own consistency
-        // check rather than silently launching the wrong image.
+        // check. buildDeviceSpec should surface that as a CliError with a message that names the
+        // host arch and points at a corrected image, not a raw IllegalArgumentException with
+        // internal DeviceSpec vocabulary.
+        val hostAbi = EnvUtils.getMacOSArchitecture().value
         val mismatchedAbi = if (EnvUtils.getMacOSArchitecture() == CPU_ARCHITECTURE.ARM64) "x86_64" else "arm64-v8a"
 
-        assertThrows<IllegalArgumentException> {
+        val error = assertThrows<CliError> {
             parse(
                 "--platform", "android",
                 "--device-os", "system-images;android-34;google_apis;$mismatchedAbi",
             ).buildDeviceSpec(Platform.ANDROID)
         }
+
+        assertThat(error.message).contains(mismatchedAbi)
+        assertThat(error.message).contains(hostAbi)
+        assertThat(error.message).contains("system-images;android-34;google_apis;$hostAbi")
     }
 
     @Test

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
@@ -5,6 +5,7 @@ import maestro.cli.util.EnvUtils
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
 import maestro.device.Platform
+import maestro.device.locale.AndroidLocale
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import picocli.CommandLine
@@ -52,6 +53,66 @@ class StartDeviceCommandTest {
                 "--device-os", "system-images;android-34;google_apis;$mismatchedAbi",
             ).buildDeviceSpec(Platform.ANDROID)
         }
+    }
+
+    @Test
+    fun `a version-shaped device-os sets os without a systemImage override`() {
+        val spec = parse(
+            "--platform", "android",
+            "--device-os", "android-34",
+        ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
+
+        assertThat(spec.os).isEqualTo("android-34")
+        assertThat(spec.systemImageOverride).isNull()
+    }
+
+    @Test
+    fun `os-version alone derives the android- prefixed os when device-os is unset`() {
+        val spec = parse(
+            "--platform", "android",
+            "--os-version", "34",
+        ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
+
+        assertThat(spec.os).isEqualTo("android-34")
+        assertThat(spec.systemImageOverride).isNull()
+    }
+
+    @Test
+    fun `a version-shaped device-os takes precedence over os-version`() {
+        val spec = parse(
+            "--platform", "android",
+            "--device-os", "android-31",
+            "--os-version", "34",
+        ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
+
+        assertThat(spec.os).isEqualTo("android-31")
+    }
+
+    @Test
+    fun `a full-path device-os derives os from its own segment, ignoring an unrelated os-version`() {
+        val abi = EnvUtils.getMacOSArchitecture().value
+        val spec = parse(
+            "--platform", "android",
+            "--device-os", "system-images;android-30;google_apis_playstore;$abi",
+            "--os-version", "34",
+        ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
+
+        assertThat(spec.os).isEqualTo("android-30")
+        assertThat(spec.systemImageOverride).isEqualTo("system-images;android-30;google_apis_playstore;$abi")
+    }
+
+    @Test
+    fun `device-model and device-locale flow through unchanged for a full-path device-os`() {
+        val abi = EnvUtils.getMacOSArchitecture().value
+        val spec = parse(
+            "--platform", "android",
+            "--device-os", "system-images;android-34;google_apis_playstore;$abi",
+            "--device-model", "pixel_7",
+            "--device-locale", "de_DE",
+        ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
+
+        assertThat(spec.model).isEqualTo("pixel_7")
+        assertThat(spec.locale).isEqualTo(AndroidLocale.fromString("de_DE"))
     }
 
     @Test

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
@@ -64,6 +64,24 @@ class StartDeviceCommandTest {
     }
 
     @Test
+    fun `a full-path device-os with too few segments throws a CliError describing the expected format`() {
+        // "system-images;android-34" matches the "system-images;" prefix (isFullImage = true) but
+        // has only 2 of the required 4 segments. DeviceSpec.Android's segment-count check throws
+        // IllegalArgumentException same as the abi-mismatch case, but the catch handler must not
+        // blindly index [3] for the abi (that segment doesn't exist here) - it should recognize the
+        // malformed shape and explain the expected format instead of crashing with
+        // IndexOutOfBoundsException.
+        val error = assertThrows<CliError> {
+            parse(
+                "--platform", "android",
+                "--device-os", "system-images;android-34",
+            ).buildDeviceSpec(Platform.ANDROID)
+        }
+
+        assertThat(error.message).contains("system-images;<os>;<tag>;<abi>")
+    }
+
+    @Test
     fun `a version-shaped device-os sets os without a systemImage override`() {
         val spec = parse(
             "--platform", "android",


### PR DESCRIPTION
## Why

#3543 shipped the full-image `--device-os` (`system-images;<os>;<tag>;<abi>`), but left two gaps. The permutation tests I wrote to confirm `StartDeviceCommand`'s behavior never made it onto `main` (that PR was squash-merged). And a full-image whose abi doesn't match the host throws a raw `IllegalArgumentException` from `DeviceSpec.Android.init`, so `App.kt` dumps a full stack trace with internal vocabulary ("systemImage abi segment", "cpuArchitecture") — someone on Apple Silicon passing an x86_64 Playstore image just sees a crash, not what to do about it.

## Approach

- Land the 5 `StartDeviceCommand` permutation tests on `main` (cherry-picked): version-shaped `--device-os`, `--os-version` alone, precedence, a full-path ignoring an unrelated `--os-version`, and model/locale passthrough.
- Wrap the Android full-image spec construction in `StartDeviceCommand` so a construction failure becomes a `CliError`:
  - abi ≠ host arch (a valid 4-segment image) → an actionable message naming the host arch and suggesting the matching-abi image.
  - a malformed full-image path (wrong segment count) → an "expected `system-images;<os>;<tag>;<abi>`" message, rather than crashing while building the error.
- Scoped to the full-image branch only; the version/`--os-version`/default paths are untouched.

## Verification

`./gradlew :maestro-cli:test` green — 11 `StartDeviceCommandTest` cases. The two new error tests are host-independent (they stub the host arch) and were confirmed red before the fix, green after: abi-mismatch → `CliError`, and a too-few-segments full path → `CliError` (not `IndexOutOfBoundsException`).
