### PR TITLE
Add command to verify prerequisites

### DIFF
--- a/.github/workflows/bitdrift-release.yaml
+++ b/.github/workflows/bitdrift-release.yaml
@@ -1,0 +1,74 @@
+name: Bitdrift Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "CLI version in major.minor.patch form (for example, 2.8.1)"
+        required: true
+        type: string
+      prerelease:
+        description: "Mark the GitHub release as a pre-release"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish bitdrift-maestro
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+
+      - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must use major.minor.patch form; got '$VERSION'"
+            exit 1
+          fi
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 17
+          cache: gradle
+
+      - name: Build CLI distribution
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          ./gradlew :maestro-cli:distZip \
+            -PCLI_VERSION="$VERSION" \
+            -x :maestro-ios-driver:buildIosDriver
+          cp maestro-cli/build/distributions/maestro.zip bitdrift-maestro.zip
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ inputs.prerelease }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          tag="bitdrift-maestro-v$VERSION"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "::error::Release '$tag' already exists. Releases are immutable; choose a new version."
+            exit 1
+          fi
+
+          prerelease_args=()
+          if [ "$PRERELEASE" = "true" ]; then
+            prerelease_args+=(--prerelease)
+          fi
+
+          gh release create "$tag" bitdrift-maestro.zip \
+            --target "$GITHUB_SHA" \
+            --title "bitdrift-maestro v$VERSION" \
+            --generate-notes \
+            "${prerelease_args[@]}"

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
-# Vite 8 (maestro-cli/mcp-viewer) requires Node ^20.19.0 || >=22.12.0; v22.23.1 is the current LTS.
 v22.23.1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help build test test-ios lint verify
+
+help: ## List available targets.
+	@awk 'BEGIN {FS = ":.*##"} /^[a-zA-Z_-]+:.*##/ {printf "%-12s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+build: ## Compile and package the CLI distribution
+	./gradlew :maestro-cli:installDist
+
+test: ## Run the complete Gradle test suite
+	./gradlew test
+
+test-ios: ## Run tests for the iOS modules
+	./gradlew :maestro-ios-driver:check :maestro-ios:check
+
+lint: ## Run Detekt
+	./gradlew detekt
+
+verify: build test lint ## Run the local build, complete test suite, and linter

--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -40,15 +40,6 @@ tasks.named<Jar>("jar") {
     manifest {
         attributes["Main-Class"] = "maestro.cli.AppKt"
     }
-    // Include the driver source directly
-    from("../maestro-ios-xctest-runner") {
-        into("driver/ios")
-        include(
-            "maestro-driver-ios/**",
-            "maestro-driver-iosUITests/**",
-            "maestro-driver-ios.xcodeproj/**",
-        )
-    }
 }
 
 tasks.named<JavaExec>("run") {
@@ -323,6 +314,15 @@ tasks.register<Exec>("buildMcpViewer") {
 tasks.named<ProcessResources>("processResources") {
     dependsOn("buildMcpViewer")
     dependsOn(downloadSimulatorServer)
+    from("../maestro-ios-xctest-runner") {
+        into("driver/ios")
+        include(
+            "MaestroDriverLib/**",
+            "maestro-driver-ios/**",
+            "maestro-driver-iosUITests/**",
+            "maestro-driver-ios.xcodeproj/**",
+        )
+    }
     from(mcpViewerDir.dir("build/raw")) {
         into("mcp-viewer")
     }
@@ -366,6 +366,7 @@ tasks.register<Copy>("createTestResources") {
     from("../maestro-ios-xctest-runner") {
         into("driver/ios")
         include(
+            "MaestroDriverLib/**",
             "maestro-driver-ios/**",
             "maestro-driver-iosUITests/**",
             "maestro-driver-ios.xcodeproj/**"

--- a/maestro-cli/src/main/java/maestro/cli/App.kt
+++ b/maestro-cli/src/main/java/maestro/cli/App.kt
@@ -37,6 +37,7 @@ import maestro.cli.command.McpCommand
 import maestro.cli.command.PrintHierarchyCommand
 import maestro.cli.command.QueryCommand
 import maestro.cli.command.RecordCommand
+import maestro.cli.command.SetupIOSDeviceCommand
 import maestro.cli.command.StartDeviceCommand
 import maestro.cli.command.StudioCommand
 import maestro.cli.command.TestCommand
@@ -75,6 +76,7 @@ import kotlin.system.exitProcess
         ChatCommand::class,
         CheckSyntaxCommand::class,
         DriverCommand::class,
+        SetupIOSDeviceCommand::class,
         McpCommand::class,
     ]
 )

--- a/maestro-cli/src/main/java/maestro/cli/command/IOSDeviceSetup.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/IOSDeviceSetup.kt
@@ -1,0 +1,107 @@
+package maestro.cli.command
+
+import util.DeviceCtlResponse
+import util.LocalIOSDevice
+import java.util.concurrent.TimeUnit
+
+internal class IOSDeviceSetup(
+    private val operatingSystemName: () -> String = { System.getProperty("os.name") },
+    private val commandRunner: CommandRunner = ProcessCommandRunner(),
+    private val connectedDeviceCount: () -> Int = ::connectedDeviceCount,
+) {
+    fun run(installDependencies: Boolean): Result {
+        if (operatingSystemName() != "Mac OS X") {
+            return Result(
+                checks = listOf(Check("macOS", false, "Physical iOS devices require macOS.")),
+                nextStep = null,
+            )
+        }
+
+        val devicectlAvailable = commandRunner.run("xcrun", "--find", "devicectl").succeeded
+        var iproxyAvailable = commandRunner.run("iproxy", "--version").succeeded
+        val homebrewAvailable = commandRunner.run("brew", "--version").succeeded
+        var installationFailed = false
+
+        if (!iproxyAvailable && installDependencies && homebrewAvailable) {
+            installationFailed = !commandRunner.run("brew", "install", "libimobiledevice", inheritOutput = true).succeeded
+            iproxyAvailable = commandRunner.run("iproxy", "--version").succeeded
+        }
+
+        val connectedDevices = if (devicectlAvailable) {
+            runCatching(connectedDeviceCount).getOrDefault(0)
+        } else {
+            0
+        }
+
+        val nextStep = when {
+            installationFailed -> "Homebrew could not install libimobiledevice. Resolve the error above and run this command again."
+            !iproxyAvailable && !homebrewAvailable -> "Install Homebrew, then run: brew install libimobiledevice"
+            !iproxyAvailable -> "Run: brew install libimobiledevice"
+            !devicectlAvailable -> "Install or select Xcode 26 or newer: xcode-select --switch /Applications/Xcode.app/Contents/Developer"
+            connectedDevices == 0 -> "Connect and trust an iPhone with Developer Mode enabled, then run this command again."
+            else -> "Next, build and sign the XCTest runner with: maestro driver-setup --apple-team-id <APPLE_TEAM_ID> --destination 'platform=iOS,id=<DEVICE_UDID>'"
+        }
+
+        return Result(
+            checks = listOf(
+                Check("macOS", true, "Detected macOS."),
+                Check("Xcode devicectl", devicectlAvailable, "Required for app lifecycle and device discovery."),
+                Check("iproxy", iproxyAvailable, "Required to forward the XCTest runner port."),
+                Check("connected iPhone", connectedDevices > 0, "Found $connectedDevices connected physical iPhone(s)."),
+            ),
+            nextStep = nextStep,
+        )
+    }
+
+    data class Result(
+        val checks: List<Check>,
+        val nextStep: String?,
+    ) {
+        val isReady: Boolean
+            get() = checks.all(Check::succeeded)
+    }
+
+    data class Check(
+        val name: String,
+        val succeeded: Boolean,
+        val detail: String,
+    )
+
+    internal interface CommandRunner {
+        fun run(vararg command: String, inheritOutput: Boolean = false): CommandResult
+    }
+
+    internal data class CommandResult(val succeeded: Boolean)
+
+    private class ProcessCommandRunner : CommandRunner {
+        override fun run(vararg command: String, inheritOutput: Boolean): CommandResult {
+            return try {
+                val processBuilder = ProcessBuilder(*command)
+                if (inheritOutput) {
+                    processBuilder.inheritIO()
+                } else {
+                    processBuilder.redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    processBuilder.redirectError(ProcessBuilder.Redirect.DISCARD)
+                }
+
+                val process = processBuilder.start()
+                if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                    process.destroyForcibly()
+                    return CommandResult(false)
+                }
+
+                CommandResult(process.exitValue() == 0)
+            } catch (_: Exception) {
+                CommandResult(false)
+            }
+        }
+    }
+
+    private companion object {
+        const val COMMAND_TIMEOUT_SECONDS = 30L
+
+        fun connectedDeviceCount(): Int = LocalIOSDevice()
+            .listDeviceViaDeviceCtl()
+            .count { it.connectionProperties.tunnelState == DeviceCtlResponse.ConnectionProperties.CONNECTED }
+    }
+}

--- a/maestro-cli/src/main/java/maestro/cli/command/SetupIOSDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/SetupIOSDeviceCommand.kt
@@ -1,0 +1,35 @@
+package maestro.cli.command
+
+import maestro.cli.util.PrintUtils.err
+import maestro.cli.util.PrintUtils.info
+import maestro.cli.util.PrintUtils.success
+import picocli.CommandLine
+import java.util.concurrent.Callable
+
+@CommandLine.Command(
+    name = "setup-ios-device",
+    description = ["Check the local requirements for running Maestro on a physical iOS device."],
+)
+class SetupIOSDeviceCommand : Callable<Int> {
+
+    @CommandLine.Option(
+        names = ["--install-dependencies"],
+        description = ["Install missing system dependencies with Homebrew."],
+    )
+    private var installDependencies: Boolean = false
+
+    override fun call(): Int {
+        val result = IOSDeviceSetup().run(installDependencies)
+
+        result.checks.forEach { check ->
+            if (check.succeeded) {
+                success("✓ ${check.name}: ${check.detail}")
+            } else {
+                err("✗ ${check.name}: ${check.detail}")
+            }
+        }
+
+        result.nextStep?.let { info("\n$it") }
+        return if (result.isReady) 0 else 1
+    }
+}

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/IOSDeviceSetupTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/IOSDeviceSetupTest.kt
@@ -1,0 +1,112 @@
+package maestro.cli.command
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class IOSDeviceSetupTest {
+
+    @Test
+    fun `reports a ready device when all checks succeed`() {
+        val setup = IOSDeviceSetup(
+            operatingSystemName = { "Mac OS X" },
+            commandRunner = FakeCommandRunner(),
+            connectedDeviceCount = { 1 },
+        )
+
+        val result = setup.run(installDependencies = false)
+
+        assertThat(result.isReady).isTrue()
+        assertThat(result.nextStep).contains("maestro driver-setup")
+    }
+
+    @Test
+    fun `installs libimobiledevice when iproxy is missing`() {
+        val commandRunner = FakeCommandRunner(
+            responses = mutableMapOf(
+                "iproxy --version" to false,
+            ),
+            installMakesIproxyAvailable = true,
+        )
+        val setup = IOSDeviceSetup(
+            operatingSystemName = { "Mac OS X" },
+            commandRunner = commandRunner,
+            connectedDeviceCount = { 1 },
+        )
+
+        val result = setup.run(installDependencies = true)
+
+        assertThat(result.isReady).isTrue()
+        assertThat(commandRunner.commands).contains("brew install libimobiledevice")
+    }
+
+    @Test
+    fun `explains how to install iproxy without changing the system by default`() {
+        val commandRunner = FakeCommandRunner(
+            responses = mutableMapOf(
+                "iproxy --version" to false,
+            ),
+        )
+        val setup = IOSDeviceSetup(
+            operatingSystemName = { "Mac OS X" },
+            commandRunner = commandRunner,
+            connectedDeviceCount = { 1 },
+        )
+
+        val result = setup.run(installDependencies = false)
+
+        assertThat(result.isReady).isFalse()
+        assertThat(result.nextStep).isEqualTo("Run: brew install libimobiledevice")
+        assertThat(commandRunner.commands).doesNotContain("brew install libimobiledevice")
+    }
+
+    @Test
+    fun `reports a failed Homebrew installation`() {
+        val setup = IOSDeviceSetup(
+            operatingSystemName = { "Mac OS X" },
+            commandRunner = FakeCommandRunner(
+                responses = mutableMapOf(
+                    "iproxy --version" to false,
+                    "brew install libimobiledevice" to false,
+                ),
+            ),
+            connectedDeviceCount = { 1 },
+        )
+
+        val result = setup.run(installDependencies = true)
+
+        assertThat(result.isReady).isFalse()
+        assertThat(result.nextStep).contains("could not install")
+    }
+
+    @Test
+    fun `does not attempt macOS setup on another operating system`() {
+        val commandRunner = FakeCommandRunner()
+        val setup = IOSDeviceSetup(
+            operatingSystemName = { "Linux" },
+            commandRunner = commandRunner,
+            connectedDeviceCount = { 1 },
+        )
+
+        val result = setup.run(installDependencies = true)
+
+        assertThat(result.isReady).isFalse()
+        assertThat(result.checks.single().name).isEqualTo("macOS")
+        assertThat(commandRunner.commands).isEmpty()
+    }
+
+    private class FakeCommandRunner(
+        private val responses: MutableMap<String, Boolean> = mutableMapOf(),
+        private val installMakesIproxyAvailable: Boolean = false,
+    ) : IOSDeviceSetup.CommandRunner {
+        val commands = mutableListOf<String>()
+
+        override fun run(vararg command: String, inheritOutput: Boolean): IOSDeviceSetup.CommandResult {
+            val invocation = command.joinToString(" ")
+            commands += invocation
+            if (invocation == "brew install libimobiledevice" && installMakesIproxyAvailable) {
+                responses["iproxy --version"] = true
+            }
+            return IOSDeviceSetup.CommandResult(responses[invocation] ?: true)
+        }
+    }
+}

--- a/maestro-ios-driver/src/main/kotlin/util/DeviceCtlProcess.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/DeviceCtlProcess.kt
@@ -1,0 +1,47 @@
+package util
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import maestro.utils.TempFileHandler
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+class DeviceCtlProcess {
+
+    fun listDevices(): List<DeviceCtlResponse.Device> =
+        TempFileHandler().use { tempFiles ->
+            val output = tempFiles.createTempFile("devicectl_response", ".json")
+            val process = ProcessBuilder(
+                listOf("xcrun", "devicectl", "--json-output", output.path, "list", "devices"),
+            )
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+
+            if (!process.waitFor(LIST_DEVICES_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                throw IllegalStateException("Timed out while listing iOS devices with devicectl")
+            }
+
+            check(process.exitValue() == 0) {
+                "devicectl list devices failed with exit code ${process.exitValue()}"
+            }
+
+            parseDeviceList(output)
+        }
+
+    internal fun parseDeviceList(output: File): List<DeviceCtlResponse.Device> {
+        if (output.length() == 0L) {
+            return emptyList()
+        }
+
+        return jacksonObjectMapper()
+            .readValue<DeviceCtlResponse>(output)
+            .result
+            .devices
+    }
+
+    private companion object {
+        const val LIST_DEVICES_TIMEOUT_SECONDS = 15L
+    }
+}

--- a/maestro-ios-driver/src/main/kotlin/util/IOSDevicePortForwarder.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/IOSDevicePortForwarder.kt
@@ -1,0 +1,28 @@
+package util
+
+import java.io.Closeable
+
+class IOSDevicePortForwarder : Closeable {
+
+    private var process: Process? = null
+
+    fun start(port: Int, deviceId: String) {
+        if (process?.isAlive == true) {
+            return
+        }
+
+        process = ProcessBuilder("iproxy", "--udid", deviceId, "$port:$port")
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+    }
+
+    override fun close() {
+        process?.let { process ->
+            if (process.isAlive) {
+                process.destroy()
+            }
+        }
+        process = null
+    }
+}

--- a/maestro-ios-driver/src/main/kotlin/util/LocalIOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/LocalIOSDevice.kt
@@ -1,25 +1,5 @@
 package util
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.module.kotlin.KotlinFeature
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
-import java.io.File
-
-class DeviceCtlProcess {
-
-    fun devicectlDevicesOutput(): File {
-        val tempOutput = File.createTempFile("devicectl_response", ".json")
-        ProcessBuilder(listOf("xcrun", "devicectl", "--json-output", tempOutput.path, "list", "devices"))
-            .redirectError(ProcessBuilder.Redirect.PIPE).start().apply {
-                waitFor()
-            }
-
-        return tempOutput
-    }
-}
-
 class LocalIOSDevice(private val deviceCtlProcess: DeviceCtlProcess = DeviceCtlProcess()) {
 
     fun uninstall(deviceId: String, bundleIdentifier: String) {
@@ -38,37 +18,9 @@ class LocalIOSDevice(private val deviceCtlProcess: DeviceCtlProcess = DeviceCtlP
     }
 
     fun listDeviceViaDeviceCtl(deviceId: String): DeviceCtlResponse.Device {
-        val tempOutput = File.createTempFile("devicectl_response", ".json")
-        try {
-            ProcessBuilder(listOf("xcrun" , "devicectl", "--json-output", tempOutput.path, "list", "devices"))
-                .redirectError(ProcessBuilder.Redirect.PIPE).start().apply {
-                    waitFor()
-                }
-            val bytes = tempOutput.readBytes()
-            val response = String(bytes)
-
-            val jacksonObjectMapper = jacksonObjectMapper()
-            jacksonObjectMapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, false)
-            val deviceCtlResponse = jacksonObjectMapper.readValue<DeviceCtlResponse>(response)
-            return deviceCtlResponse.result.devices.find {
-                it.hardwareProperties?.udid == deviceId
-            } ?: throw IllegalArgumentException("iOS device with identifier $deviceId not connected or available")
-        } finally {
-            tempOutput.delete()
-        }
+        return deviceCtlProcess.listDevices().find { it.hardwareProperties?.udid == deviceId }
+            ?: throw IllegalArgumentException("iOS device with identifier $deviceId not connected or available")
     }
 
-    fun listDeviceViaDeviceCtl(): List<DeviceCtlResponse.Device> {
-        val tempOutput = deviceCtlProcess.devicectlDevicesOutput()
-        try {
-            val bytes = tempOutput.readBytes()
-            val response = String(bytes)
-            if (response.isBlank()) return emptyList()
-
-            val deviceCtlResponse = jacksonObjectMapper().readValue<DeviceCtlResponse>(response)
-            return deviceCtlResponse.result.devices
-        } finally {
-            tempOutput.delete()
-        }
-    }
+    fun listDeviceViaDeviceCtl(): List<DeviceCtlResponse.Device> = deviceCtlProcess.listDevices()
 }

--- a/maestro-ios-driver/src/main/kotlin/util/PhysicalDeviceXCTestRunConfiguration.kt
+++ b/maestro-ios-driver/src/main/kotlin/util/PhysicalDeviceXCTestRunConfiguration.kt
@@ -1,0 +1,18 @@
+package util
+
+import java.io.File
+
+object PhysicalDeviceXCTestRunConfiguration {
+    fun configurePort(xcTestRunFile: File, port: Int) {
+        CommandLineUtils.runCommand(
+            listOf(
+                "plutil",
+                "-replace",
+                "maestro-driver-iosUITests.EnvironmentVariables.PORT",
+                "-string",
+                port.toString(),
+                xcTestRunFile.absolutePath,
+            ),
+        )
+    }
+}

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -11,8 +11,10 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.slf4j.LoggerFactory
 import util.IOSDeviceType
+import util.IOSDevicePortForwarder
 import util.LocalIOSDeviceController
 import util.LocalSimulatorUtils
+import util.PhysicalDeviceXCTestRunConfiguration
 import util.XCRunnerCLIUtils
 import xcuitest.XCTestClient
 import java.io.File
@@ -58,6 +60,7 @@ class LocalXCTestInstaller(
         deviceType = deviceType,
     )
     private val xcRunnerCLIUtils = XCRunnerCLIUtils(tempFileHandler)
+    private val devicePortForwarder = IOSDevicePortForwarder()
 
     private var xcTestProcess: Process? = null
 
@@ -103,6 +106,10 @@ class LocalXCTestInstaller(
     override fun start(): XCTestClient {
         return metrics.measured("operation", mapOf("command" to "start")) {
             logger.info("start()")
+
+            if (deviceType == IOSDeviceType.REAL) {
+                devicePortForwarder.start(defaultPort, deviceId)
+            }
 
             if (useXcodeTestRunner) {
                 logger.info("USE_XCODE_TEST_RUNNER is set. Will wait for XCTest runner to be started manually")
@@ -205,6 +212,9 @@ class LocalXCTestInstaller(
         } else {
             logger.info("Installing driver with xcodebuild")
             logger.info("[Start] Running XcUITest with `xcodebuild test-without-building` with $defaultPort and config: $iOSDriverConfig")
+            if (deviceType == IOSDeviceType.REAL) {
+                PhysicalDeviceXCTestRunConfiguration.configurePort(buildProducts.xctestRunPath, defaultPort)
+            }
             xcTestProcess = xcRunnerCLIUtils.runXcTestWithoutBuild(
                 deviceId = this.deviceId,
                 xcTestRunFilePath = buildProducts.xctestRunPath.absolutePath,
@@ -247,6 +257,7 @@ class LocalXCTestInstaller(
         }
 
         logger.info("[Start] Cleaning up the ui test runner files")
+        devicePortForwarder.close()
         tempFileHandler.close()
         if(reinstallDriver) {
             uninstall()

--- a/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
+++ b/maestro-ios-driver/src/test/kotlin/DeviceCtlResponseTest.kt
@@ -1,30 +1,27 @@
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
+import maestro.utils.TempFileHandler
 import org.junit.jupiter.api.Test
 import util.DeviceCtlProcess
 import util.LocalIOSDevice
-import java.nio.file.Files
-import kotlin.io.path.writeText
 
 class DeviceCtlResponseTest {
 
 
     @Test
     fun `test if deserializing device list works`() {
-        // given
-        val deviceCtlOutput = getDeviceCtlOutput()
-        val deviceOutput = Files.createTempFile("output", ".json").apply {
-            writeText(deviceCtlOutput)
+        TempFileHandler().use { tempFiles ->
+            val deviceOutput = tempFiles.createTempFile("output", ".json").apply {
+                writeText(getDeviceCtlOutput())
+            }
+            val deviceCtlProcess = mockk<DeviceCtlProcess>()
+            every { deviceCtlProcess.listDevices() } returns DeviceCtlProcess().parseDeviceList(deviceOutput)
+
+            val connectedDevices = LocalIOSDevice(deviceCtlProcess).listDeviceViaDeviceCtl()
+
+            assertThat(connectedDevices).isNotEmpty()
         }
-        val deviceCtlProcess = mockk<DeviceCtlProcess>()
-        every { deviceCtlProcess.devicectlDevicesOutput() } returns deviceOutput.toFile()
-
-        // when
-        val connectedDevices = LocalIOSDevice(deviceCtlProcess).listDeviceViaDeviceCtl()
-
-        // then
-        assertThat(connectedDevices).isNotEmpty()
     }
 
     private fun getDeviceCtlOutput(): String {

--- a/maestro-ios/src/main/java/ios/devicectl/DeviceControlIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/devicectl/DeviceControlIOSDevice.kt
@@ -6,6 +6,7 @@ import device.IOSScreenRecording
 import hierarchy.ViewHierarchy
 import okio.Sink
 import org.slf4j.LoggerFactory
+import util.IOSLaunchArguments.toIOSLaunchArguments
 import util.LocalIOSDevice
 import xcuitest.api.DeviceInfo
 import xcuitest.installer.LocalXCTestInstaller
@@ -14,6 +15,7 @@ import java.io.InputStream
 class DeviceControlIOSDevice(override val deviceId: String) : IOSDevice {
 
     private val localIOSDevice by lazy { LocalIOSDevice() }
+    private val appLauncher = DeviceCtlAppLauncher()
 
     companion object {
         private val logger = LoggerFactory.getLogger(DeviceControlIOSDevice::class.java)
@@ -64,7 +66,7 @@ class DeviceControlIOSDevice(override val deviceId: String) : IOSDevice {
     }
 
     override fun launch(id: String, launchArguments: Map<String, Any>) {
-        TODO("Not yet implemented")
+        appLauncher.launch(deviceId, id, launchArguments.toIOSLaunchArguments())
     }
 
     override fun stop(id: String) {

--- a/maestro-ios/src/main/java/ios/devicectl/DeviceCtlAppLauncher.kt
+++ b/maestro-ios/src/main/java/ios/devicectl/DeviceCtlAppLauncher.kt
@@ -1,0 +1,21 @@
+package ios.devicectl
+
+import util.CommandLineUtils
+
+class DeviceCtlAppLauncher {
+   fun launch(deviceId: String, bundleId: String, launchArguments: List<String>) {
+        CommandLineUtils.runCommand(
+            listOf(
+                "xcrun",
+                "devicectl",
+                "device",
+                "process",
+                "launch",
+                "--terminate-existing",
+                "--device",
+                deviceId,
+                bundleId,
+            ) + launchArguments,
+        )
+    }
+}


### PR DESCRIPTION
# Overview
In order to run on devices maestro, we use some dependencies. Aside of being on macOS, or using Xcode, we also need to install and use `iproxy` (from `libimobiledevice`). So, in order to simplify this (both for local dev and CI) we added a new command in the cli to do so