### PR TITLE
perf(android): read the manifest off the device instead of pulling the APK

### DIFF
--- a/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidAppFiles.kt
@@ -36,15 +36,28 @@ object AndroidAppFiles {
     }
 
     fun getApkFile(connection: AndroidDeviceConnection, appId: String): File {
+        val dst = File.createTempFile("tmp", ".apk")
+        connection.pull(dst, apkPath(connection, appId)).orThrowOnFailure()
+        return dst
+    }
+
+    private fun apkPath(connection: AndroidDeviceConnection, appId: String): String {
         val apkPath = connection.shell("pm list packages -f --user 0 | grep $appId | head -1")
             .orThrow().substringAfterLast("package:").substringBefore("=$appId")
         if (apkPath.isBlank()) {
             throw AndroidOperationFailedException("No APK path found for package $appId")
         }
-        val dst = File.createTempFile("tmp", ".apk")
-        connection.pull(dst, apkPath).orThrowOnFailure()
-        return dst
+        return apkPath
     }
+
+    /**
+     * Reads an app's binary `AndroidManifest.xml` without transferring the APK it sits in. Devices
+     * before API 27 have no `unzip` and answer with an error message instead of one.
+     */
+    fun readManifest(connection: AndroidDeviceConnection, appId: String): ByteArray =
+        connection.open("exec:unzip -p ${apkPath(connection, appId)} AndroidManifest.xml").use { stream ->
+            stream.source.inputStream().readBytes()
+        }
 
     fun push(connection: AndroidDeviceConnection, packageName: String, appFilesZip: File) {
         val remoteZip = "/data/local/tmp/app.zip"

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -48,16 +48,20 @@ import maestro.utils.ScreenshotUtils
 import maestro.utils.StringUtils.toRegexSafe
 import maestro_android.*
 import net.dongliu.apk.parser.ApkFile
+import net.dongliu.apk.parser.ByteArrayApkFile
 import okio.*
 import org.slf4j.LoggerFactory
 import org.w3c.dom.Element
 import org.w3c.dom.Node
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.IOException
 import java.util.Base64
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import javax.xml.parsers.DocumentBuilderFactory
 import kotlin.io.use
 
@@ -1038,19 +1042,46 @@ class AndroidDriver(
     }
 
     private fun setAllPermissions(appId: String, permissionValue: String) {
-        val permissionsResult = runCatching {
-            val apkFile = AndroidAppFiles.getApkFile(connection, appId)
-            val permissions = ApkFile(apkFile).apkMeta.usesPermissions
+        val permissions = runCatching { requestedPermissions(appId) }
+            .onFailure { logger.debug("Failed to read the permissions declared by app $appId: ${it.message}") }
+            .getOrNull()
+            ?: return
+
+        permissions.forEach { permission ->
+            setPermissionInternal(appId, permission, permissionValue)
+        }
+    }
+
+    /** The permissions [appId] declares, read from its manifest rather than the APK holding it. */
+    private fun requestedPermissions(appId: String): List<String> =
+        permissionsFromManifest(appId) ?: permissionsFromApk(appId)
+
+    private fun permissionsFromManifest(appId: String): List<String>? {
+        val manifest = AndroidAppFiles.readManifest(connection, appId)
+
+        return runCatching { ByteArrayApkFile(asApk(manifest)).use { it.apkMeta.usesPermissions } }
+            .onFailure { logger.debug("No manifest came back for app $appId: ${it.message}") }
+            .getOrNull()
+    }
+
+    private fun permissionsFromApk(appId: String): List<String> {
+        val apkFile = AndroidAppFiles.getApkFile(connection, appId)
+        return try {
+            ApkFile(apkFile).apkMeta.usesPermissions
+        } finally {
             apkFile.delete()
-            permissions
         }
-        if (permissionsResult.isSuccess) {
-            permissionsResult.getOrNull()?.let {
-                it.forEach { permission ->
-                    setPermissionInternal(appId, permission, permissionValue)
-                }
-            }
+    }
+
+    /** apk-parser only reads manifests that sit inside an APK, so the manifest is given one. */
+    private fun asApk(manifest: ByteArray): ByteArray {
+        val apk = ByteArrayOutputStream()
+        ZipOutputStream(apk).use { zip ->
+            zip.putNextEntry(ZipEntry("AndroidManifest.xml"))
+            zip.write(manifest)
+            zip.closeEntry()
         }
+        return apk.toByteArray()
     }
 
     private val appOpsPermissions = setOf(

--- a/maestro-client/src/test/java/maestro/drivers/AndroidDriverAllPermissionsTest.kt
+++ b/maestro-client/src/test/java/maestro/drivers/AndroidDriverAllPermissionsTest.kt
@@ -1,0 +1,127 @@
+package maestro.drivers
+
+import com.google.common.truth.Truth.assertThat
+import dadb.AdbShellResponse
+import dadb.AdbStream
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import maestro.android.AndroidDeviceConnection
+import okio.Buffer
+import org.junit.jupiter.api.Test
+import java.util.zip.ZipInputStream
+
+/**
+ * Unit tests for `permissions: { all: allow }`, the default `launchApp` applies. `maestro-app.apk`
+ * stands in for the app under test, so the manifest flowing through is real binary XML.
+ */
+class AndroidDriverAllPermissionsTest {
+
+    private val apkBytes = javaClass.getResourceAsStream("/maestro-app.apk")!!.use { it.readBytes() }
+
+    private val manifestBytes = ZipInputStream(apkBytes.inputStream()).use { zip ->
+        generateSequence { zip.nextEntry }.first { it.name == "AndroidManifest.xml" }
+        zip.readBytes()
+    }
+
+    private val basePath = "/data/app/~~abc==/com.example.app-xyz==/base.apk"
+
+    // What maestro-app.apk declares.
+    private val declaredPermissions = listOf(
+        "android.permission.INTERNET",
+        "android.permission.ACCESS_FINE_LOCATION",
+        "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.ACCESS_MOCK_LOCATION",
+        "android.permission.CHANGE_CONFIGURATION",
+        "android.permission.QUERY_ALL_PACKAGES",
+        "android.permission.WRITE_SETTINGS",
+    )
+
+    private fun reply(text: String): AdbShellResponse = mockk {
+        every { exitCode } returns 0
+        every { output } returns text
+    }
+
+    private fun stream(bytes: ByteArray): AdbStream = mockk {
+        every { source } returns Buffer().write(bytes)
+        every { close() } returns Unit
+    }
+
+    /** Nothing is relaxed: a call this does not script is a call the driver was not to make. */
+    private fun connection(
+        apkPathLine: String = "package:$basePath=com.example.app",
+        unzipOutput: ByteArray = manifestBytes,
+    ): AndroidDeviceConnection = mockk<AndroidDeviceConnection>().also { connection ->
+        every { connection.shell(any()) } returns reply("")
+        every { connection.shell(APK_PATH_COMMAND) } returns reply(apkPathLine)
+        every { connection.open(any()) } returns stream(unzipOutput)
+    }
+
+    private fun allowAll(connection: AndroidDeviceConnection) {
+        AndroidDriver(connection = connection).setPermissions("com.example.app", mapOf("all" to "allow"))
+    }
+
+    private fun grantedBy(connection: AndroidDeviceConnection): List<String> {
+        val commands = mutableListOf<String>()
+        verify { connection.shell(capture(commands)) }
+        return commands.filter { it.startsWith("pm grant ") }.map { it.substringAfterLast(' ') }
+    }
+
+    @Test
+    fun `grants the permissions the manifest declares`() {
+        val connection = connection()
+
+        allowAll(connection)
+
+        assertThat(grantedBy(connection)).containsExactlyElementsIn(declaredPermissions)
+    }
+
+    @Test
+    fun `lifts the manifest out of the app instead of pulling the APK`() {
+        val connection = connection()
+
+        allowAll(connection)
+
+        verify { connection.open("exec:unzip -p $basePath AndroidManifest.xml") }
+        // Both routes open by looking the APK up, so one lookup means the old one never began.
+        // (`pull` itself is beyond mockk, which cannot stand in for its sealed return type.)
+        verify(exactly = 1) { connection.shell(APK_PATH_COMMAND) }
+    }
+
+    @Test
+    fun `falls back to pulling the APK when the device has no unzip`() {
+        // `unzip` only exists from API 27 on; before that the shell complains where the manifest
+        // should be, and the parser rejecting that is what takes the old route.
+        val connection = connection(unzipOutput = "/system/bin/sh: unzip: not found\n".toByteArray())
+
+        allowAll(connection)
+
+        // The old route looks the APK up again on its way to the transfer, which needs a device.
+        verify(exactly = 2) { connection.shell(APK_PATH_COMMAND) }
+        assertThat(grantedBy(connection)).isEmpty()
+    }
+
+    @Test
+    fun `grants nothing when the device cannot locate the app`() {
+        val connection = connection(apkPathLine = "")
+
+        allowAll(connection)
+
+        assertThat(grantedBy(connection)).isEmpty()
+    }
+
+    @Test
+    fun `an explicit permission map still bypasses the all path entirely`() {
+        val connection = connection()
+
+        AndroidDriver(connection = connection).setPermissions("com.example.app", mapOf("camera" to "deny"))
+
+        verify { connection.shell("pm revoke com.example.app android.permission.CAMERA") }
+        verify(exactly = 0) { connection.shell(APK_PATH_COMMAND) }
+        verify(exactly = 0) { connection.open(any()) }
+    }
+
+    private companion object {
+        const val APK_PATH_COMMAND = "pm list packages -f --user 0 | grep com.example.app | head -1"
+    }
+}


### PR DESCRIPTION
## Proposed changes

`launchApp` defaults to `permissions: { all: allow }`, and resolving `all` reads the permissions the app declares — a few kilobytes of its manifest. Getting there pulled the entire APK across adb first, so the cost grew with the app while the answer never changed. `unzip -p <apk> AndroidManifest.xml` hands back that one entry instead, and apk-parser reads it exactly as before.

A one-step `launchApp` flow on an Android 15 emulator, two runs each:

| APK size | before | after |
|---|---|---|
| 466 MB | 11.25s / 9.92s | **2.05s / 2.19s** |
| 39 MB | 1.51s / 1.34s | **0.50s / 0.57s** |

`clearState` improves with it, since it asks for `all` too.

`unzip` arrived on the device in API 27 and `minSdk` is 24, so an older one answers with an error message where the manifest should be. Nothing inspects those bytes to decide — apk-parser's rejection is what falls back to pulling the APK, down the path that exists today, untouched.

One side effect: apk-parser throws on the resource table of some APKs (Google's own Search and Keep apps among them) and `runCatching` swallowed that, so `all: allow` silently granted nothing for those. A manifest carries no resource table, so those apps now get their permissions.

## Testing

`AndroidDriverAllPermissionsTest` drives the driver with a real APK's manifest (`maestro-app.apk`), pinning the command sent, the permissions granted, and the fallback. On an Android 15 emulator against the released 2.8.0 CLI the granted permissions come out identical for `launchApp` (466 MB and 39 MB apps), for `clearState: true`, and for an explicit `permissions:` map; the fallback was exercised by pointing `unzip` at a command that does not exist.

## Issues fixed

None open that covers this.
