### PR TITLE
feat(device): carry system-image intent in DeviceSpec, resolve the package on the host

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -860,9 +860,8 @@ class ApiClient(
         private const val UPLOAD_READ_TIMEOUT_MINUTES = 15L
         private val JSON = jacksonObjectMapper()
             .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-            // Without this, DeviceSpec.Android's systemImageOverride (@get:JsonIgnore, see
-            // DeviceSpec.kt) is invisible to Jackson's default bean introspection and the
-            // requestPart["deviceSpec"] send would silently drop the system-image override.
+            // Registers the sparse serializer so the requestPart["deviceSpec"] send emits
+            // only non-default intent fields (os, tag, abi, locale). See DeviceSpec.kt.
             .registerModule(DeviceSpecModule())
     }
 }

--- a/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/cloud/CloudInteractor.kt
@@ -42,6 +42,7 @@ import maestro.orchestra.validation.WorkspaceValidationException
 import maestro.orchestra.validation.WorkspaceValidator
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
+import maestro.device.SystemImageTag
 import maestro.device.locale.AndroidLocale
 import maestro.utils.TemporaryDirectory
 import okio.BufferedSink
@@ -189,11 +190,20 @@ class CloudInteractor(
                         "--device-os is a full Android system image ($image) but the app is ${resolvedPlatform?.description}."
                     )
                 }
+                // Decompose the full path into intent (os, tag, abi); the worker resolves the package.
                 val segments = image.split(";")
+                if (segments.size != 4) {
+                    throw CliError("--device-os must be a full 'system-images;<os>;<tag>;<abi>' path, got: $image")
+                }
+                val tag = try {
+                    SystemImageTag.fromImageTag(segments[2])
+                } catch (e: IllegalArgumentException) {
+                    throw CliError(e.message ?: "Unsupported system-image tag: ${segments[2]}")
+                }
                 DeviceSpec.Android(
                     model = deviceModel ?: DeviceSpec.Android.DEFAULT.model,
                     os = segments[1],
-                    systemImageOverride = image,
+                    tag = tag,
                     locale = deviceLocale?.let { AndroidLocale.fromString(it) }
                         ?: DeviceSpec.Android.DEFAULT.locale,
                     cpuArchitecture = CPU_ARCHITECTURE.entries.firstOrNull { it.value == segments[3] }

--- a/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/StartDeviceCommand.kt
@@ -10,6 +10,7 @@ import maestro.cli.util.EnvUtils
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
 import maestro.device.Platform
+import maestro.device.SystemImageTag
 import maestro.device.locale.AndroidLocale
 import maestro.device.locale.IosLocale
 import maestro.device.locale.WebLocale
@@ -88,17 +89,16 @@ class StartDeviceCommand : Callable<Int> {
         Platform.ANDROID -> {
             val default = DeviceSpec.Android.DEFAULT
             val isFullImage = deviceOs?.startsWith("system-images;") == true
+            val hostAbi = EnvUtils.getMacOSArchitecture()
+            // A full-image --device-os is decomposed into intent (os, tag); a local emulator
+            // must match the host abi.
+            val segments = if (isFullImage) parseFullImage(deviceOs!!, hostAbi) else null
             DeviceSpec.Android(
-                // osVersion is nullable; ?.let prevents interpolating "android-null"
                 model = deviceModel ?: default.model,
-                // A full-image --device-os supplies os via its 2nd segment; otherwise the
-                // prefixed version, then --os-version, then the default.
-                os = if (isFullImage) deviceOs!!.split(";")[1]
-                     else deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
-                systemImageOverride = if (isFullImage) deviceOs else null,
-                // AndroidLocale is a data class (no pre-defined constant); parse the default
+                os = segments?.get(1) ?: deviceOs ?: osVersion?.let { "android-$it" } ?: default.os,
+                tag = segments?.let { tagFromImage(it[2]) } ?: default.tag,
                 locale = deviceLocale?.let { AndroidLocale.fromString(it) } ?: default.locale,
-                cpuArchitecture = EnvUtils.getMacOSArchitecture(),
+                cpuArchitecture = hostAbi,
             )
         }
         Platform.IOS -> {
@@ -118,6 +118,26 @@ class StartDeviceCommand : Callable<Int> {
             )
         }
     }
+
+    // Validates a full `system-images;<os>;<tag>;<abi>` --device-os and returns its segments.
+    // A local emulator must match the host abi.
+    private fun parseFullImage(deviceOs: String, hostAbi: CPU_ARCHITECTURE): List<String> {
+        val segments = deviceOs.split(";")
+        if (segments.size != 4) {
+            throw CliError("--device-os must be a full 'system-images;<os>;<tag>;<abi>' path, got: $deviceOs")
+        }
+        if (segments[3] != hostAbi.value) {
+            throw CliError("--device-os names abi ${segments[3]} but this host is ${hostAbi.value}.")
+        }
+        return segments
+    }
+
+    private fun tagFromImage(imageTag: String): SystemImageTag =
+        try {
+            SystemImageTag.fromImageTag(imageTag)
+        } catch (e: IllegalArgumentException) {
+            throw CliError(e.message ?: "Unsupported system-image tag: $imageTag")
+        }
 
     override fun call(): Int {
         TestDebugReporter.install(null, printToConsole = parent?.verbose == true)

--- a/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
+++ b/maestro-cli/src/main/java/maestro/cli/device/DeviceCreateUtil.kt
@@ -91,18 +91,29 @@ object DeviceCreateUtil {
     fun getOrCreateAndroidDevice(
         deviceSpec: DeviceSpec.Android, forceCreate: Boolean, shardIndex: Int? = null
     ): Device.AvailableForLaunch {
-        val systemImage = deviceSpec.systemImage
         // check connected device
         if (DeviceService.isDeviceConnected(deviceSpec.deviceName, Platform.ANDROID) != null && shardIndex == null && !forceCreate)
             throw CliError("A device with name ${deviceSpec.deviceName} is already connected")
 
-        // existing device
+        // Reuse an existing AVD as-is, without touching the SDK.
         val existingDevice =
             if (forceCreate) null
             else DeviceService.isDeviceAvailableToLaunch(deviceSpec.deviceName, Platform.ANDROID)?.modelId
+        if (existingDevice != null) {
+            PrintUtils.message("Using existing device ${deviceSpec.deviceName}.")
+            return Device.AvailableForLaunch(
+                modelId = existingDevice,
+                description = existingDevice,
+                platform = Platform.ANDROID,
+                deviceType = Device.DeviceType.EMULATOR,
+                deviceSpec = deviceSpec,
+            )
+        }
 
-        // dependencies
-        if (existingDevice == null && !DeviceService.isAndroidSystemImageInstalled(systemImage)) {
+        // No existing AVD: resolve the concrete image from the spec's intent on this host.
+        val systemImage = resolveAndroidSystemImage(deviceSpec)
+
+        if (!DeviceService.isAndroidSystemImageInstalled(systemImage)) {
             PrintUtils.err("The required system image $systemImage is not installed.")
 
             PrintUtils.message("Would you like to install it? y/n")
@@ -125,11 +136,10 @@ object DeviceCreateUtil {
             }
         }
 
-        if (existingDevice != null) PrintUtils.message("Using existing device ${deviceSpec.deviceName}.")
-        else PrintUtils.message("Attempting to create Android emulator: ${deviceSpec.deviceName} ")
+        PrintUtils.message("Attempting to create Android emulator: ${deviceSpec.deviceName} ")
 
         val deviceLaunchId = try {
-            existingDevice ?: DeviceService.createAndroidDevice(
+            DeviceService.createAndroidDevice(
                 deviceName = deviceSpec.deviceName,
                 device = deviceSpec.model,
                 systemImage = systemImage,
@@ -139,7 +149,7 @@ object DeviceCreateUtil {
             throw CliError("${e.message}")
         }
 
-        if (existingDevice == null) PrintUtils.message("Created Android emulator: ${deviceSpec.deviceName} ($systemImage)")
+        PrintUtils.message("Created Android emulator: ${deviceSpec.deviceName} ($systemImage)")
 
         return Device.AvailableForLaunch(
             modelId = deviceLaunchId,
@@ -148,5 +158,18 @@ object DeviceCreateUtil {
             deviceType = Device.DeviceType.EMULATOR,
             deviceSpec = deviceSpec,
         )
+    }
+
+    /**
+     * The concrete package for [spec], resolved against this host's SDK; falls back to the
+     * naive package when the SDK offers nothing. Notes when resolution changes the package.
+     */
+    private fun resolveAndroidSystemImage(spec: DeviceSpec.Android): String {
+        val naive = "system-images;${spec.os};${spec.tag.value};${spec.cpuArchitecture.value}"
+        val resolved = DeviceService.resolveSystemImage(spec.os, spec.tag, spec.cpuArchitecture) ?: return naive
+        if (resolved != naive) {
+            PrintUtils.message("Resolved ${spec.os} (${spec.tag.value}) to $resolved")
+        }
+        return resolved
     }
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientAndroidSystemImageTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/api/ApiClientAndroidSystemImageTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.truth.Truth.assertThat
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
+import maestro.device.SystemImageTag
 import maestro.device.serialization.DeviceSpecModule
 import okhttp3.MultipartReader
 import okhttp3.mockwebserver.MockResponse
@@ -31,10 +32,9 @@ class ApiClientAndroidSystemImageTest {
 
     private lateinit var server: MockWebServer
 
-    // DeviceSpecModule must be registered for this test to parse the wire JSON at all: it's what
-    // makes systemImageOverride (@get:JsonIgnore on DeviceSpec.Android, see DeviceSpec.kt) visible
-    // under its "systemImage" wire name in the first place — the same module ApiClient itself
-    // must register on its own mapper for the real send to carry the override at all.
+    // DeviceSpecModule registers the sparse serializer that emits only non-default intent fields
+    // (os, tag, abi, locale) under their wire names — the same module ApiClient registers on its
+    // own mapper for the real send.
     private val mapper = jacksonObjectMapper().registerModule(DeviceSpecModule())
 
     @TempDir
@@ -52,11 +52,11 @@ class ApiClientAndroidSystemImageTest {
     }
 
     @Test
-    fun `a passed deviceSpec sends a deviceSpec part carrying the system-image override`() {
+    fun `a passed deviceSpec sends a deviceSpec part carrying the tag intent`() {
         val spec = DeviceSpec.Android(
             model = "pixel_6",
             os = "android-36",
-            systemImageOverride = "system-images;android-36;google_apis_playstore;arm64-v8a",
+            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
             cpuArchitecture = CPU_ARCHITECTURE.ARM64,
         )
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/cloud/CloudInteractorTest.kt
@@ -12,6 +12,7 @@ import maestro.cli.model.FlowStatus
 import maestro.cli.report.ReportFormat
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
+import maestro.device.SystemImageTag
 import maestro.orchestra.validation.AppMetadataAnalyzer
 import maestro.orchestra.validation.WorkspaceValidator
 import org.junit.jupiter.api.BeforeEach
@@ -381,7 +382,7 @@ class CloudInteractorTest {
         val expectedSpec = DeviceSpec.Android(
             model = "pixel_6",
             os = "android-34",
-            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
             cpuArchitecture = CPU_ARCHITECTURE.ARM64,
         )
         verify {

--- a/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/command/StartDeviceCommandTest.kt
@@ -1,10 +1,12 @@
 package maestro.cli.command
 
 import com.google.common.truth.Truth.assertThat
+import maestro.cli.CliError
 import maestro.cli.util.EnvUtils
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
 import maestro.device.Platform
+import maestro.device.SystemImageTag
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import picocli.CommandLine
@@ -18,16 +20,17 @@ class StartDeviceCommandTest {
     }
 
     @Test
-    fun `an unset flag leaves the Android spec on the default system image`() {
+    fun `an unset flag leaves the Android spec on the default os and tag`() {
         val spec = parse("--platform", "android").buildDeviceSpec(Platform.ANDROID)
 
         assertThat(spec).isInstanceOf(DeviceSpec.Android::class.java)
-        assertThat((spec as DeviceSpec.Android).systemImage)
-            .isEqualTo("system-images;android-33;google_apis;${EnvUtils.getMacOSArchitecture().value}")
+        spec as DeviceSpec.Android
+        assertThat(spec.os).isEqualTo("android-33")
+        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS)
     }
 
     @Test
-    fun `a full-path device-os reaches the constructed Android spec's systemImage`() {
+    fun `a full-path device-os is decomposed into os and tag intent`() {
         val abi = EnvUtils.getMacOSArchitecture().value
         val spec = parse(
             "--platform", "android",
@@ -35,18 +38,33 @@ class StartDeviceCommandTest {
         ).buildDeviceSpec(Platform.ANDROID) as DeviceSpec.Android
 
         assertThat(spec.os).isEqualTo("android-34")
-        assertThat(spec.systemImage)
-            .isEqualTo("system-images;android-34;google_apis_playstore;$abi")
+        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS_PLAYSTORE)
+    }
+
+    @Test
+    fun `a full-path device-os with fewer than 4 segments throws a CliError`() {
+        assertThrows<CliError> {
+            parse("--platform", "android", "--device-os", "system-images;android-34;google_apis")
+                .buildDeviceSpec(Platform.ANDROID)
+        }
+    }
+
+    @Test
+    fun `a full-path device-os with an unsupported tag throws a CliError`() {
+        val abi = EnvUtils.getMacOSArchitecture().value
+        assertThrows<CliError> {
+            parse("--platform", "android", "--device-os", "system-images;android-34;aosp_atd;$abi")
+                .buildDeviceSpec(Platform.ANDROID)
+        }
     }
 
     @Test
     fun `a full-path device-os with an abi that doesn't match this host throws`() {
-        // cpuArchitecture always reflects the actual host (EnvUtils.getMacOSArchitecture()), so a
-        // full-path --device-os naming a different abi fails DeviceSpec.Android's own consistency
-        // check rather than silently launching the wrong image.
+        // A local emulator must match the host abi, so a full-path --device-os naming a
+        // different abi is rejected rather than silently launching the wrong image.
         val mismatchedAbi = if (EnvUtils.getMacOSArchitecture() == CPU_ARCHITECTURE.ARM64) "x86_64" else "arm64-v8a"
 
-        assertThrows<IllegalArgumentException> {
+        assertThrows<CliError> {
             parse(
                 "--platform", "android",
                 "--device-os", "system-images;android-34;google_apis;$mismatchedAbi",

--- a/maestro-cli/src/test/kotlin/maestro/cli/device/DeviceCreateUtilTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/device/DeviceCreateUtilTest.kt
@@ -8,10 +8,12 @@ import io.mockk.unmockkObject
 import io.mockk.verify
 import maestro.cli.command.StartDeviceCommand
 import maestro.cli.util.EnvUtils
+import maestro.device.CPU_ARCHITECTURE
 import maestro.device.Device
 import maestro.device.DeviceService
 import maestro.device.DeviceSpec
 import maestro.device.Platform
+import maestro.device.SystemImageTag
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,6 +29,8 @@ class DeviceCreateUtilTest {
         every { DeviceService.isDeviceConnected(any(), any()) } returns null
         every { DeviceService.isAndroidSystemImageInstalled(any()) } returns true
         every { DeviceService.createAndroidDevice(any(), any(), any(), any()) } returns "avd-just-created"
+        // Default: the SDK offers nothing extra, so resolution falls back to the naive package.
+        every { DeviceService.resolveSystemImage(any(), any(), any()) } returns null
         every { DeviceService.isDeviceAvailableToLaunch(any(), Platform.ANDROID) } answers {
             val requestedName = firstArg<String>()
             if (existingGoogleApisAvd.equals(requestedName, ignoreCase = true)) {
@@ -83,5 +87,41 @@ class DeviceCreateUtilTest {
 
         assertThat(device.modelId).isEqualTo(existingGoogleApisAvd)
         verify(exactly = 0) { DeviceService.createAndroidDevice(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `reusing an existing emulator does not ask the SDK to resolve an image`() {
+        val spec = specFromCli("--platform", "android", "--device-os", "android-33") as DeviceSpec.Android
+
+        DeviceCreateUtil.getOrCreateAndroidDevice(spec, forceCreate = false)
+
+        verify(exactly = 0) { DeviceService.resolveSystemImage(any(), any(), any()) }
+    }
+
+    @Test
+    fun `android-37 is created with the image the SDK resolves for it`() {
+        val abi = EnvUtils.getMacOSArchitecture()
+        val offered = "system-images;android-37.1;google_apis_ps16k;${abi.value}"
+        every { DeviceService.resolveSystemImage("android-37", SystemImageTag.GOOGLE_APIS, abi) } returns offered
+        every { DeviceService.isAndroidSystemImageInstalled(offered) } returns true
+        val spec = specFromCli("--platform", "android", "--device-os", "android-37") as DeviceSpec.Android
+
+        DeviceCreateUtil.getOrCreateAndroidDevice(spec, forceCreate = false)
+
+        val createdImage = slot<String>()
+        verify { DeviceService.createAndroidDevice(any(), any(), systemImage = capture(createdImage), any()) }
+        assertThat(createdImage.captured).isEqualTo(offered)
+    }
+
+    @Test
+    fun `a full-path device-os is decomposed into os and tag intent`() {
+        val abi = EnvUtils.getMacOSArchitecture().value
+        val spec = specFromCli(
+            "--platform", "android",
+            "--device-os", "system-images;android-37.1;google_apis_ps16k;$abi",
+        ) as DeviceSpec.Android
+
+        assertThat(spec.os).isEqualTo("android-37.1")
+        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS)
     }
 }

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -625,6 +625,76 @@ object DeviceService {
     }
 
     /**
+     * Resolves the concrete package for [os]/[tag]/[abi] against this host's SDK, installed
+     * first. E.g. `android-37` + GOOGLE_APIS -> `system-images;android-37.1;google_apis_ps16k;arm64-v8a`.
+     */
+    fun resolveSystemImage(os: String, tag: SystemImageTag, abi: CPU_ARCHITECTURE): String? {
+        selectSystemImage(listSystemImagePackages(installedOnly = true), os, tag, abi)?.let { return it }
+        return selectSystemImage(listSystemImagePackages(installedOnly = false), os, tag, abi)
+    }
+
+    /**
+     * Picks the best of [candidates] for [os]/[tag]/[abi]: newest stable minor (no betas),
+     * same tag family, plain tag preferred over its `_ps16k` variant. Public and pure so the
+     * maestro-device worker can reuse it against its own SDK listing.
+     */
+    fun selectSystemImage(
+        candidates: List<String>,
+        os: String,
+        tag: SystemImageTag,
+        abi: CPU_ARCHITECTURE,
+    ): String? {
+        fun platformOf(image: String) = image.split(";").getOrNull(1).orEmpty()
+        fun tagOf(image: String) = image.split(";").getOrNull(2).orEmpty()
+        // "android-37" -> 0, "android-37.1" -> 1, "android-37.2-beta1" -> null (skip betas)
+        fun minorOf(platform: String): Int? {
+            val suffix = platform.removePrefix(os)
+            return when {
+                suffix.isEmpty() -> 0
+                suffix.startsWith(".") -> suffix.drop(1).toIntOrNull()
+                else -> null
+            }
+        }
+        // Same family only: google_apis -> {google_apis, google_apis_ps16k}; never playstore.
+        val base = tag.value
+        val ps16k = "${tag.value}_ps16k"
+        val matches = candidates.filter { image ->
+            val parts = image.split(";")
+            parts.size == 4 && parts[0] == "system-images" && parts[3] == abi.value &&
+                (platformOf(image) == os || platformOf(image).startsWith("$os.")) &&
+                minorOf(platformOf(image)) != null &&
+                (tagOf(image) == base || tagOf(image) == ps16k)
+        }
+        val newestMinor = matches.maxOfOrNull { minorOf(platformOf(it))!! } ?: return null
+        val inNewest = matches.filter { minorOf(platformOf(it)) == newestMinor }
+        return inNewest.firstOrNull { tagOf(it) == base } ?: inNewest.firstOrNull()
+    }
+
+    private fun listSystemImagePackages(installedOnly: Boolean): List<String> {
+        return try {
+            val command = listOf(
+                requireSdkManagerBinary().absolutePath,
+                if (installedOnly) "--list_installed" else "--list",
+                // --verbose prints each package path on its own untruncated line; without it the
+                // table column is clipped to terminal width and long paths (android-37.1 ps16k)
+                // get dropped by the 4-segment filter.
+                "--verbose",
+            )
+            val process = ProcessBuilder(*command.toTypedArray()).start()
+            if (!process.waitFor(1, TimeUnit.MINUTES)) throw TimeoutException()
+            if (process.exitValue() != 0) return emptyList()
+            String(process.inputStream.readBytes())
+                .lineSequence()
+                .map { it.trim().substringBefore(" ") }
+                .filter { it.startsWith("system-images;") && it.split(";").size == 4 }
+                .toList()
+        } catch (e: Exception) {
+            logger.error("Unable to list Android system images", e)
+            emptyList()
+        }
+    }
+
+    /**
      * Uses the Android SDK manager to install android image
      */
     fun installAndroidSystemImage(image: String): Boolean {

--- a/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceSpec.kt
@@ -1,9 +1,8 @@
 package maestro.device
 
-import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonValue
 import maestro.device.locale.AndroidLocale
 import maestro.device.locale.DeviceLocale
 import maestro.device.locale.IosLocale
@@ -22,15 +21,36 @@ enum class CPU_ARCHITECTURE(val value: String) {
 }
 
 /**
+ * The semantic system-image family: GOOGLE_APIS (rootable/userdebug) vs
+ * GOOGLE_APIS_PLAYSTORE (production Play Store). A page-size variant like
+ * `google_apis_ps16k` is the same family, resolved per host by DeviceService.
+ */
+enum class SystemImageTag(@JsonValue val value: String) {
+    GOOGLE_APIS("google_apis"),
+    GOOGLE_APIS_PLAYSTORE("google_apis_playstore");
+
+    companion object {
+        fun fromString(value: String): SystemImageTag =
+            entries.firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException(
+                    "Unknown system-image tag: '$value'. Must be one of: ${entries.joinToString { it.value }}"
+                )
+
+        // `google_apis_ps16k` -> GOOGLE_APIS, `google_apis_playstore_ps16k` -> GOOGLE_APIS_PLAYSTORE
+        fun fromImageTag(imageTag: String): SystemImageTag =
+            fromString(imageTag.removeSuffix("_ps16k"))
+    }
+}
+
+/**
  * Strongly typed device configuration. Callers must provide `model` and `os`;
  * all other fields have sensible defaults that can be overridden when needed.
  *
- * Derived values (osVersion, deviceName, systemImage) are computed at
- * access time via `get()` properties — they are not stored in the data class
- * and therefore never serialized or persisted.
+ * The spec carries intent (os, tag, abi), not a concrete system-image package;
+ * each host resolves the package against its own SDK (DeviceService.resolveSystemImage).
  *
- * Serialization is sparse: fields that match their constructor default are
- * omitted from the JSON output. See DeviceSpecSparseSerializer.
+ * Derived values (osVersion, deviceName) are computed get() properties, never
+ * serialized. Serialization is sparse (see DeviceSpecSparseSerializer).
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "platform")
 @JsonSubTypes(
@@ -49,50 +69,26 @@ sealed class DeviceSpec {
     data class Android(
         override val model: String,
         override val os: String,
-        // Public so the backend's DeviceSpec.validate() can fire supported-set
-        // resolution only for an explicit override (null for every legacy spec).
-        // @get:JsonIgnore keeps Jackson's bean-property introspection from picking up
-        // the now-public getter: without it, Jackson merges the @param:JsonProperty
-        // rename onto this property's own getter too, which collides with the
-        // unrelated computed `systemImage` getter below (both would claim the
-        // "systemImage" JSON key and deserialization fails with a
-        // "Conflicting getter definitions" error). The custom
-        // DeviceSpecSparseSerializer reads this property via kotlin-reflect, not
-        // Jackson bean introspection, so it is unaffected by the ignore.
-        @param:JsonProperty("systemImage")
-        @get:JsonIgnore
-        val systemImageOverride: String? = null,
         override val locale: AndroidLocale = AndroidLocale.fromString("en_US"),
         val cpuArchitecture: CPU_ARCHITECTURE = CPU_ARCHITECTURE.ARM64,
+        val tag: SystemImageTag = SystemImageTag.GOOGLE_APIS,
     ) : DeviceSpec() {
         init {
             require(model.isNotBlank()) { "DeviceSpec.Android: model cannot be blank" }
             require(os.isNotBlank()) { "DeviceSpec.Android: os cannot be blank" }
-            systemImageOverride?.let {
-                require(it.startsWith("system-images;") && it.split(";").size == 4) {
-                    "systemImage must be a full 'system-images;<os>;<tag>;<abi>' string"
-                }
-                require(it.split(";")[1] == os) { "systemImage OS segment must match os ($os)" }
-                require(it.split(";")[3] == cpuArchitecture.value) {
-                    "systemImage abi segment (${it.split(";")[3]}) must match cpuArchitecture (${cpuArchitecture.value})"
-                }
-            }
         }
 
         override val platform = Platform.ANDROID
-        override val osVersion: Int get() = os.removePrefix("android-").toIntOrNull() ?: 0
-        override val deviceName: String get() {
-            val tag = systemImage.split(";")[2]
-            return "Maestro_ANDROID_${model}_${os}" + if (tag == DEFAULT_TAG) "" else "_$tag"
-        }
-
-        /** The sdkmanager/avdmanager package to actually use; always non-null. */
-        val systemImage: String get() =
-            systemImageOverride ?: "system-images;$os;$DEFAULT_TAG;${cpuArchitecture.value}"
+        // "android-37.1" -> 37
+        override val osVersion: Int get() =
+            os.removePrefix("android-").substringBefore(".").toIntOrNull() ?: 0
+        // A non-default tag is suffixed so a playstore AVD never reuses a google_apis one.
+        override val deviceName: String get() =
+            "Maestro_ANDROID_${model}_${os}" +
+                if (tag == SystemImageTag.GOOGLE_APIS) "" else "_${tag.value}"
 
         companion object {
             val DEFAULT: Android = Android(model = "pixel_6", os = "android-33")
-            private const val DEFAULT_TAG = "google_apis"
         }
     }
 

--- a/maestro-client/src/test/java/maestro/device/DeviceServiceTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceServiceTest.kt
@@ -217,4 +217,87 @@ internal class DeviceServiceTest {
         assertThat(result.named("Bare_AVD")).isEqualTo(AvdInfo(name = "Bare_AVD", model = "", os = ""))
     }
 
+    // -------------------------------------------------------------------------
+    // selectSystemImage — resolves intent (os + tag family) to a concrete package
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `selectSystemImage prefers the plain tag over its ps16k variant`() {
+        val candidates = listOf(
+            "system-images;android-35;google_apis_ps16k;arm64-v8a",
+            "system-images;android-35;google_apis;arm64-v8a",
+        )
+        assertThat(DeviceService.selectSystemImage(candidates, "android-35", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.ARM64))
+            .isEqualTo("system-images;android-35;google_apis;arm64-v8a")
+    }
+
+    @Test
+    fun `selectSystemImage falls back to the ps16k variant when the plain tag is absent`() {
+        val candidates = listOf(
+            "system-images;android-37.1;google_apis_ps16k;arm64-v8a",
+            "system-images;android-37.1;google_apis_playstore_ps16k;arm64-v8a",
+        )
+        assertThat(DeviceService.selectSystemImage(candidates, "android-37.1", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.ARM64))
+            .isEqualTo("system-images;android-37.1;google_apis_ps16k;arm64-v8a")
+    }
+
+    @Test
+    fun `selectSystemImage matches a minor-versioned platform from a major os`() {
+        val candidates = listOf("system-images;android-37.1;google_apis_ps16k;x86_64")
+        assertThat(DeviceService.selectSystemImage(candidates, "android-37", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.X86_64))
+            .isEqualTo("system-images;android-37.1;google_apis_ps16k;x86_64")
+    }
+
+    @Test
+    fun `selectSystemImage filters by abi`() {
+        val candidates = listOf(
+            "system-images;android-34;google_apis;x86_64",
+            "system-images;android-34;google_apis;arm64-v8a",
+        )
+        assertThat(DeviceService.selectSystemImage(candidates, "android-34", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.ARM64))
+            .isEqualTo("system-images;android-34;google_apis;arm64-v8a")
+    }
+
+    @Test
+    fun `selectSystemImage stays within the requested tag family`() {
+        // Asking for google_apis must never resolve to a playstore image.
+        val candidates = listOf("system-images;android-34;google_apis_playstore;arm64-v8a")
+        assertThat(DeviceService.selectSystemImage(candidates, "android-34", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.ARM64)).isNull()
+    }
+
+    @Test
+    fun `selectSystemImage resolves the playstore family`() {
+        val candidates = listOf(
+            "system-images;android-34;google_apis;arm64-v8a",
+            "system-images;android-34;google_apis_playstore;arm64-v8a",
+        )
+        assertThat(DeviceService.selectSystemImage(candidates, "android-34", SystemImageTag.GOOGLE_APIS_PLAYSTORE, CPU_ARCHITECTURE.ARM64))
+            .isEqualTo("system-images;android-34;google_apis_playstore;arm64-v8a")
+    }
+
+    @Test
+    fun `selectSystemImage picks the newest stable minor for a major os`() {
+        // Real API 37 shape: 37.0 has google_apis, 37.1 (newest stable) only ps16k, 37.2 is beta.
+        val candidates = listOf(
+            "system-images;android-37.0;google_apis;arm64-v8a",
+            "system-images;android-37.0;google_apis_ps16k;arm64-v8a",
+            "system-images;android-37.1;google_apis_ps16k;arm64-v8a",
+            "system-images;android-37.2-beta1;google_apis_ps16k;arm64-v8a",
+        )
+        assertThat(DeviceService.selectSystemImage(candidates, "android-37", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.ARM64))
+            .isEqualTo("system-images;android-37.1;google_apis_ps16k;arm64-v8a")
+    }
+
+    @Test
+    fun `selectSystemImage never selects a pre-release minor`() {
+        val candidates = listOf("system-images;android-37.2-beta1;google_apis_ps16k;arm64-v8a")
+        assertThat(DeviceService.selectSystemImage(candidates, "android-37", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.ARM64)).isNull()
+    }
+
+    @Test
+    fun `selectSystemImage returns null when nothing matches the os`() {
+        val candidates = listOf("system-images;android-35;google_apis;arm64-v8a")
+        assertThat(DeviceService.selectSystemImage(candidates, "android-34", SystemImageTag.GOOGLE_APIS, CPU_ARCHITECTURE.ARM64)).isNull()
+    }
+
 }

--- a/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
+++ b/maestro-client/src/test/java/maestro/device/DeviceSpecTest.kt
@@ -55,50 +55,44 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `systemImage resolves to the override when set`() {
+    fun `Android defaults to the google_apis tag`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
+        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS)
+    }
+
+    @Test
+    fun `Android accepts a playstore tag`() {
         val spec = DeviceSpec.Android(
             model = "pixel_6",
             os = "android-34",
-            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
         )
-        assertThat(spec.systemImage).isEqualTo("system-images;android-34;google_apis_playstore;arm64-v8a")
+        assertThat(spec.tag).isEqualTo(SystemImageTag.GOOGLE_APIS_PLAYSTORE)
     }
 
     @Test
-    fun `systemImage resolves to the google_apis default when no override is set`() {
-        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
-        assertThat(spec.systemImage).isEqualTo("system-images;android-34;google_apis;arm64-v8a")
+    fun `SystemImageTag fromImageTag maps a ps16k variant to its base family`() {
+        assertThat(SystemImageTag.fromImageTag("google_apis_ps16k"))
+            .isEqualTo(SystemImageTag.GOOGLE_APIS)
+        assertThat(SystemImageTag.fromImageTag("google_apis_playstore_ps16k"))
+            .isEqualTo(SystemImageTag.GOOGLE_APIS_PLAYSTORE)
     }
 
     @Test
-    fun `systemImageOverride with fewer than 4 segments throws`() {
-        assertThrows<IllegalArgumentException> {
-            DeviceSpec.Android(model = "pixel_6", os = "android-34",
-                systemImageOverride = "system-images;android-34;google_apis")
-        }
-    }
-
-    @Test
-    fun `systemImageOverride not starting with system-images throws`() {
-        assertThrows<IllegalArgumentException> {
-            DeviceSpec.Android(model = "pixel_6", os = "android-34",
-                systemImageOverride = "android-34;google_apis;arm64-v8a;extra")
-        }
-    }
-
-    @Test
-    fun `systemImageOverride with a mismatched os segment throws`() {
-        val error = assertThrows<IllegalArgumentException> {
-            DeviceSpec.Android(model = "pixel_6", os = "android-34",
-                systemImageOverride = "system-images;android-33;google_apis;arm64-v8a")
-        }
-        assertThat(error).hasMessageThat().contains("android-34")
+    fun `SystemImageTag fromString rejects an unknown tag`() {
+        assertThrows<IllegalArgumentException> { SystemImageTag.fromString("aosp_atd") }
     }
 
     @Test
     fun `Android computed osVersion is parsed from os string`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34")
         assertThat(spec.osVersion).isEqualTo(34)
+    }
+
+    @Test
+    fun `Android osVersion parses the major level from a minor-versioned os`() {
+        val spec = DeviceSpec.Android(model = "pixel_6", os = "android-37.1")
+        assertThat(spec.osVersion).isEqualTo(37)
     }
 
     @Test
@@ -114,9 +108,9 @@ internal class DeviceSpecTest {
     }
 
     @Test
-    fun `deviceName is suffixed with a non-default tag from the override`() {
+    fun `deviceName is suffixed with a non-default tag`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-34",
-            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a")
+            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE)
         assertThat(spec.deviceName).isEqualTo("Maestro_ANDROID_pixel_6_android-34_google_apis_playstore")
     }
 
@@ -155,28 +149,4 @@ internal class DeviceSpecTest {
         }
     }
 
-    @Test
-    fun `systemImageOverride whose abi segment mismatches cpuArchitecture throws`() {
-        val error = assertThrows<IllegalArgumentException> {
-            DeviceSpec.Android(
-                model = "pixel_6",
-                os = "android-34",
-                systemImageOverride = "system-images;android-34;google_apis;x86_64",
-                cpuArchitecture = CPU_ARCHITECTURE.ARM64,
-            )
-        }
-        assertThat(error).hasMessageThat().contains("arm64-v8a")
-    }
-
-    @Test
-    fun `systemImageOverride abi matching cpuArchitecture is accepted`() {
-        val spec = DeviceSpec.Android(
-            model = "pixel_6",
-            os = "android-34",
-            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a",
-            cpuArchitecture = CPU_ARCHITECTURE.ARM64,
-        )
-        assertThat(spec.systemImageOverride)
-            .isEqualTo("system-images;android-34;google_apis_playstore;arm64-v8a")
-    }
 }

--- a/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
+++ b/maestro-client/src/test/java/maestro/device/serialization/DeviceSpecSerializationTest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.google.common.truth.Truth.assertThat
 import maestro.device.CPU_ARCHITECTURE
 import maestro.device.DeviceSpec
+import maestro.device.SystemImageTag
 import maestro.device.locale.AndroidLocale
 import org.junit.jupiter.api.Test
 
@@ -85,29 +86,27 @@ class DeviceSpecSerializationTest {
     }
 
     @Test
-    fun `default spec omits systemImage from sparse output`() {
+    fun `default spec omits the tag from sparse output`() {
         val spec = DeviceSpec.Android(model = "pixel_6", os = "android-33")
         val json = mapper.readTree(mapper.writeValueAsString(spec))
 
-        assertThat(json.has("systemImage")).isFalse()
+        assertThat(json.has("tag")).isFalse()
         assertThat(json.fieldNames().asSequence().toSet()).containsExactly(
             "platform", "model", "os"
         )
     }
 
     @Test
-    fun `systemImageOverride serializes under the systemImage key and round-trips`() {
+    fun `a non-default tag serializes as its value string and round-trips`() {
         val spec = DeviceSpec.Android(
             model = "pixel_6",
             os = "android-34",
-            systemImageOverride = "system-images;android-34;google_apis_playstore;arm64-v8a",
+            tag = SystemImageTag.GOOGLE_APIS_PLAYSTORE,
         )
         val json = mapper.readTree(mapper.writeValueAsString(spec))
 
-        assertThat(json.has("systemImage")).isTrue()
-        assertThat(json.has("systemImageOverride")).isFalse()
-        assertThat(json.get("systemImage").asText())
-            .isEqualTo("system-images;android-34;google_apis_playstore;arm64-v8a")
+        assertThat(json.has("tag")).isTrue()
+        assertThat(json.get("tag").asText()).isEqualTo("google_apis_playstore")
 
         val deserialized = mapper.readValue(mapper.writeValueAsString(spec), DeviceSpec::class.java)
         assertThat(deserialized).isEqualTo(spec)
@@ -156,7 +155,6 @@ class DeviceSpecSerializationTest {
 
         assertThat(json.has("osVersion")).isFalse()
         assertThat(json.has("deviceName")).isFalse()
-        assertThat(json.has("systemImage")).isFalse()
     }
 
     // --- Legacy verbose JSON still deserializes (DB backward compat) ---


### PR DESCRIPTION
## Why
`DeviceSpec` is the request that travels CLI → backend → worker. It used to bake the exact system-image package into the spec, but that string is host- and time-dependent: API 37 has no plain `android-37` platform, and `37.1` has no plain `google_apis`, only `google_apis_ps16k`. There is no static rule from an API number to a valid package.

## What
The spec now carries intent only: `os` (major), a semantic `SystemImageTag` (`GOOGLE_APIS` / `GOOGLE_APIS_PLAYSTORE`), and `abi`. Each host resolves the concrete package against its own `sdkmanager`:

- `DeviceService.resolveSystemImage` / `selectSystemImage`: newest stable minor, same tag family, plain tag preferred over its `_ps16k` variant, betas skipped. `ps16k` is a page-size variant of a family, not a separate tag.
- Replaced `systemImageOverride: String?` with `tag: SystemImageTag`; dropped the computed `systemImage` getter. `osVersion` is now minor-aware (`android-37.1` → 37).
- `start-device` auto-resolves on the host and prints the resolved package (parity with the iOS closest-runtime behavior).
- A full-path `--device-os` is decomposed into intent (os, tag); a `_ps16k` tag maps to its base family. The local CLI still rejects a foreign abi.

Paired with the worker-side change in copilot (same Linear issue), which resolves via the same `selectSystemImage` against the worker's SDK.

## Tests
`DeviceSpecTest`, `DeviceServiceTest` (selection policy against the real API 37 catalog shape), `DeviceCreateUtilTest`, `StartDeviceCommandTest`, `CloudInteractorTest`, serialization round-trip. All green locally.