### PR TITLE
fix(cli): include MaestroDriverLib in the packaged iOS driver source

### DIFF
--- a/maestro-cli/build.gradle.kts
+++ b/maestro-cli/build.gradle.kts
@@ -47,6 +47,7 @@ tasks.named<Jar>("jar") {
             "maestro-driver-ios/**",
             "maestro-driver-iosUITests/**",
             "maestro-driver-ios.xcodeproj/**",
+            "MaestroDriverLib/**",
         )
     }
 }
@@ -368,7 +369,8 @@ tasks.register<Copy>("createTestResources") {
         include(
             "maestro-driver-ios/**",
             "maestro-driver-iosUITests/**",
-            "maestro-driver-ios.xcodeproj/**"
+            "maestro-driver-ios.xcodeproj/**",
+            "MaestroDriverLib/**",
         )
     }
     into(layout.buildDirectory.dir("resources/test"))


### PR DESCRIPTION
## Summary

Fixes #3218 — physical-device iOS driver builds fail with:

```
error: Build input file cannot be found: '.../MaestroDriverLib/Info.plist'.
Did you forget to declare this file as an output of a script phase or
custom build rule which produces it? (in target 'MaestroDriverLib' from
project 'maestro-driver-ios')
```

**Root cause**: `maestro-cli/build.gradle.kts`'s `jar` task packages the iOS
driver source into the CLI jar under `driver/ios` for `DriverBuilder` to
extract and rebuild against a user's own Apple Team ID for physical-device
runs. Its `include(...)` glob lists three directories:

```kotlin
include(
    "maestro-driver-ios/**",
    "maestro-driver-iosUITests/**",
    "maestro-driver-ios.xcodeproj/**",
)
```

`MaestroDriverLib/**` is missing — even though `maestro-driver-ios.xcodeproj`
references it directly (`INFOPLIST_FILE = MaestroDriverLib/Info.plist`) and
it's a real dependency of the `maestro-driver-ios` target. So every physical-
device build extracts an incomplete copy of the driver source and fails at
`ProcessInfoPlistFile`.

This isn't an Xcode-version incompatibility in the project itself — building
`maestro-driver-ios.xcodeproj` directly from a git checkout (which naturally
has `MaestroDriverLib` present) succeeds against the exact same Xcode
version, device, and team ID that fails through the CLI's packaged/extracted
copy. That comparison is what narrowed this down to a packaging gap.

The `createTestResources` Copy task has the identical gap and gets the same
fix, for consistency (not confirmed to cause a user-facing failure, but
there's no reason for the two lists to diverge).

## Verification

1. Reproduced the exact failure from #3218 on 2.10.0 against Xcode 26.6.
2. Built `maestro-driver-ios.xcodeproj` directly from a plain git checkout
   (same team ID, same device, same Xcode) — succeeded, narrowing the bug to
   the CLI's own packaging/extraction rather than the Xcode project.
3. Applied this fix, rebuilt `maestro-cli`'s jar (`./gradlew :maestro-cli:jar`
   under JDK 17), confirmed `MaestroDriverLib/Info.plist` is now present in
   the packaged jar.
4. Swapped the patched jar into a local install and ran
   `maestro test --apple-team-id=<team> --udid <physical iPhone UDID> ...`
   end-to-end: the iOS driver now builds and installs successfully on a
   physical device, where it previously failed 100% of the time with the
   error above.

## Test plan

- [x] `./gradlew :maestro-cli:jar` — verified `driver/ios/MaestroDriverLib/**`
      (including `Info.plist`) is present in the output jar
- [x] Physical-device `maestro test --apple-team-id=... --udid ...` — iOS
      driver builds and installs successfully post-fix (previously failed at
      driver build for every attempt)
- [ ] CI (this repo's own pipeline) — deferred to maintainers, no local
      Android/other-platform regression expected since this only touches the
      iOS driver resource glob

🤖 Generated with [Claude Code](https://claude.com/claude-code)