### PR TITLE
Fix file separators on Windows for Cloud uploads

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
@@ -85,8 +85,11 @@ object WorkspaceUtils {
         // Forward slashes and single quotes: on Windows, relativize() returns a
         // backslash-separated path, and backslash is a YAML escape character inside
         // double-quoted scalars (e.g. "\r" would be read as a literal carriage return).
+        // Single-quoted scalars keep backslashes literal, but need their own escape:
+        // a lone ' terminates the scalar, so every ' has to be doubled.
         val flowRelativePath = relativeTo.relativize(normalizePath(flowFile)).toString()
             .replace(File.separatorChar, '/')
+            .replace("'", "''")
         return "flows:\n  - '$flowRelativePath'\n"
     }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/workspace/WorkspaceUtils.kt
@@ -1,5 +1,6 @@
 package maestro.orchestra.workspace
 
+import java.io.File
 import java.io.FileNotFoundException
 import java.net.URI
 import java.nio.file.FileSystems
@@ -81,8 +82,12 @@ object WorkspaceUtils {
     }
 
     private fun syntheticSingleFlowConfig(flowFile: Path, relativeTo: Path): String {
+        // Forward slashes and single quotes: on Windows, relativize() returns a
+        // backslash-separated path, and backslash is a YAML escape character inside
+        // double-quoted scalars (e.g. "\r" would be read as a literal carriage return).
         val flowRelativePath = relativeTo.relativize(normalizePath(flowFile)).toString()
-        return "flows:\n  - \"$flowRelativePath\"\n"
+            .replace(File.separatorChar, '/')
+        return "flows:\n  - '$flowRelativePath'\n"
     }
 
     private fun isWorkspaceConfigYaml(path: Path): Boolean {

--- a/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/workspace/WorkspaceUtilsTest.kt
@@ -1,5 +1,6 @@
 package maestro.orchestra.workspace
 
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -159,6 +160,46 @@ class WorkspaceUtilsTest {
         val configContent = readZipEntry(outZip, "config.yaml")
         assertThat(configContent).contains("flows:")
         assertThat(configContent).contains("main.yaml")
+    }
+
+    @Test
+    fun `synthetic config yaml round-trips a path containing an apostrophe`(@TempDir tempDir: Path) {
+        // A lone ' terminates a single-quoted YAML scalar, so the emitted config has to
+        // double it. The substring assertions above pass even on malformed YAML, so this
+        // one parses the config the cloud side would actually read.
+        Files.createDirectories(tempDir.resolve("Dan's flows"))
+        Files.createDirectories(tempDir.resolve("shared"))
+
+        val helperFlow = tempDir.resolve("shared/helper.yaml")
+        Files.writeString(
+            helperFlow,
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            """.trimIndent()
+        )
+
+        val mainFlow = tempDir.resolve("Dan's flows/user's_login.yaml")
+        Files.writeString(
+            mainFlow,
+            """
+            appId: com.example.app
+            ---
+            - launchApp
+            - runFlow:
+                file: ../shared/helper.yaml
+            """.trimIndent()
+        )
+
+        val outZip = tempDir.resolve("workspace.zip")
+        WorkspaceUtils.createWorkspaceZip(mainFlow, outZip)
+
+        val configContent = readZipEntry(outZip, "config.yaml")
+        val flows = YAMLMapper().readTree(configContent)["flows"]
+
+        assertThat(flows.map { it.asText() })
+            .containsExactly("Dan's flows/user's_login.yaml")
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

Fixes a bug where running an individual flow that includes a runFlow to a flow in another folder could be rejected on upload

<img width="895" height="184" alt="image" src="https://github.com/user-attachments/assets/db91f726-cc25-42cb-a1be-46fb8b3034a8" />

<img width="503" height="72" alt="image" src="https://github.com/user-attachments/assets/a55d4434-fc7c-4a05-93d1-9932b856bd9d" />

The above errors are seen in Studio, but can reproduced in CLI too. The error received depends on the flows relative position to one another, and the names involved.

Maestro creates a synthetic config.yaml in these cases, and using Windows file separators can create special escapings, like `\r`. 

This fix enforces unix-style path separators in the synthetic config.

## Testing

- Built CLI and tested a previously broken flow
- Build Studio locally using this dependency and did the same

## Issues fixed

https://maestro--dev.slack.com/archives/C041FU72T54/p1788473393390039