### PR TITLE
fix(orchestra): route the assertScreenshot diff into the run bundle

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
@@ -4,6 +4,7 @@ package maestro.orchestra
 enum class ArtifactKind {
     SCREENSHOT,             // per-step screenshots (all steps when captureFullArtifacts, else failed step only)
     TAKE_SCREENSHOT,        // takeScreenshot command output
+    SCREENSHOT_DIFF,        // assertScreenshot failure diffs
     SCREEN_RECORDING,       // full-run recording, flag-gated
     START_SCREEN_RECORDING, // startRecording command output
     SCREEN_HIERARCHY,

--- a/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v1.schema.json
+++ b/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v1.schema.json
@@ -63,6 +63,10 @@
           "description": "Output of the takeScreenshot command, under the run-root takeScreenshot/ folder."
         },
         {
+          "const": "SCREENSHOT_DIFF",
+          "description": "Visual diff PNGs produced by failed assertScreenshot commands, in the run-root assertScreenshot/ folder. Named for the producing step, so a retried assertion keeps every attempt. The reference image itself is workspace input and is not part of the bundle."
+        },
+        {
           "const": "SCREEN_RECORDING",
           "description": "The whole-run MP4 recording at the run-root screen-recording.mp4. Flag-gated; emitted by the worker, not the local CLI."
         },

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -130,7 +130,15 @@ class DefaultFlowController : FlowController {
  */
 class Orchestra(
     private val maestro: Maestro,
-    private val artifactsDir: Path? = null,
+    /**
+     * Where this run's artifact bundle is written; null for callers that keep nothing
+     * (interactive runners), which write command output CWD-relative as before.
+     *
+     * Deliberately not a `val`: a command body that can name this directory can work out a
+     * path outside it, which is how the assertScreenshot diff came to be written into the
+     * workspace. Commands reach artifacts only through [Artifacts].
+     */
+    artifactsDir: Path? = null,
     private val captureFullArtifacts: Boolean = false,
     private val listeners: List<OrchestraListener> = emptyList(),
     private val lookupTimeoutMs: Long = 17000L,
@@ -176,6 +184,13 @@ class Orchestra(
     // artifactsDir is set and populates debugOutput either way.
     private val artifactsGenerator: ArtifactsGenerator =
         ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts, onStepScreenshotCaptured)
+
+    /**
+     * The only artifact surface a command implementation gets — deliberately not the artifacts
+     * directory itself, since a command that can name the directory can work out a path
+     * outside it.
+     */
+    private val artifacts: Artifacts = Artifacts(artifactsGenerator)
     private val effectiveListeners: List<OrchestraListener> = listOf(artifactsGenerator) + listeners
 
     private var commandSequenceCounter: Int = 0
@@ -648,9 +663,9 @@ class Orchestra(
         val path = normalizeScreenshotPath(command.path)
 
         val candidates = buildList {
-            command.flowPath?.let { add(it.resolve(path).toFile()) }
-            artifactsDir?.let { add(it.resolve(BundleLayout.TAKE_SCREENSHOT_DIR).resolve(path).normalize().toFile()) }
-            add(File(path))
+            command.flowPath?.let { add(it.resolve(path).toFile()) } // funnel-exempt: read
+            artifacts.existing(ArtifactKind.TAKE_SCREENSHOT, path)?.let { add(it) }
+            add(File(path)) // funnel-exempt: read
         }.distinctBy { it.canonicalPath }
 
         val expectedFile = candidates.firstOrNull { it.exists() }
@@ -693,7 +708,10 @@ class Orchestra(
             debugMessage = "The assertScreenshot command requires a valid image file. Supported formats include PNG, JPEG, GIF, BMP, TIFF, and WBMP. The file at ${expectedFile.absolutePath} could not be read."
         )
 
-        val diffFile = expectedFile.resolveSibling("${expectedFile.nameWithoutExtension}_diff.png")
+        // The reference is an INPUT read from the workspace; the diff is this run's OUTPUT.
+        // Deriving the diff's location from the reference's is what put it outside the bundle,
+        // where Cloud discards it with the workspace.
+        val diffFile = artifacts.file(ArtifactKind.SCREENSHOT_DIFF, "${expectedFile.nameWithoutExtension}_diff")
 
         when (val result = ScreenshotMatch.compare(expectedImage, actualImage, thresholdPercentage, diffFile)) {
             is ScreenshotMatch.Result.Match -> return false // Screenshots are non-interactive
@@ -705,7 +723,9 @@ class Orchestra(
             is ScreenshotMatch.Result.Mismatch -> throw MaestroException.AssertionFailure(
                 message = "Comparison error: ${command.description()} - threshold not met, current: ${result.matchPercent}%",
                 hierarchyRoot = maestro.viewHierarchy().root,
-                debugMessage = "Screenshot comparison failed. Check the diff image at ${diffFile.absolutePath} to see the differences. Adjust the thresholdPercentage if the differences are acceptable."
+                debugMessage = "Screenshot comparison failed. Check the diff image in this run's artifacts under " +
+                    "${BundleLayout.SCREENSHOT_DIFF_DIR}/${diffFile.name} to see the differences. " +
+                    "Adjust the thresholdPercentage if the differences are acceptable."
             )
         }
     }
@@ -1198,11 +1218,7 @@ class Orchestra(
     }
 
     private suspend fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
-        ArtifactCollector.validateCommandPath(command.path, "takeScreenshot")
-        // Generator owns the bundle path and records the file; null means no bundle (write CWD-relative).
-        val outFile = artifactsGenerator
-            .allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "${command.path}.png", "takeScreenshot")
-            ?: File("${command.path}.png")
+        val outFile = artifacts.file(ArtifactKind.TAKE_SCREENSHOT, command.path)
         val fileSink = artifactSink(outFile, command.path, "takeScreenshot")
 
         val cropOn = command.cropOn
@@ -1224,11 +1240,8 @@ class Orchestra(
     }
 
     private suspend fun startRecordingCommand(command: StartRecordingCommand): Boolean {
-        ArtifactCollector.validateCommandPath(command.path, "startRecording")
         // Recorded at start; the file is finalized at stopRecording.
-        val outFile = artifactsGenerator
-            .allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "${command.path}.mp4", "startRecording")
-            ?: File("${command.path}.mp4")
+        val outFile = artifacts.file(ArtifactKind.START_SCREEN_RECORDING, command.path)
         screenRecording = maestro.startScreenRecording(artifactSink(outFile, command.path, "startRecording"))
         return false
     }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/Artifacts.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/Artifacts.kt
@@ -1,0 +1,45 @@
+package maestro.orchestra
+
+import maestro.orchestra.debug.ArtifactsGenerator
+import java.io.File
+
+/**
+ * How a command produces or reads a file. This is the whole artifact surface a command
+ * implementation sees.
+ *
+ * Two verbs, deliberately not interchangeable — the same split androidx.test draws with
+ * `TestStorage.openOutputFile` / `openInputFile`:
+ *
+ *  - [file] produces. The result belongs to this run and is collected with it.
+ *  - [existing] reads back something this run already produced.
+ *
+ * A command never names a directory, never asks whether a bundle exists, and never records
+ * anything as a second step: allocating the file *is* declaring it, so the manifest cannot
+ * disagree with what is on disk.
+ *
+ * What this rules out is the bug that motivated it: `assertScreenshot` derived the failure
+ * diff's location from the *reference's* location (`resolveSibling`), putting an output into
+ * the workspace — an input tree Cloud discards when the run ends. With only these two verbs
+ * there is no path from an input location to an output location, because neither hands out a
+ * directory to be relative to.
+ */
+class Artifacts internal constructor(
+    private val generator: ArtifactsGenerator,
+) {
+
+    /**
+     * A file to write [kind] output into, called [name] — without an extension: the kind's own
+     * `ArtifactFormat` supplies it, so no caller spells out ".png" again.
+     *
+     * Decided here rather than by the caller: which folder (from [kind]), the extension, path
+     * validation, attribution to the running step, disambiguation across retries of that step,
+     * and the manifest entry.
+     */
+    fun file(kind: ArtifactKind, name: String): File = generator.allocate(kind, name)
+
+    /**
+     * An artifact of [kind] this run already produced under [name], or null if there is none.
+     * Read-only: allocates nothing and records nothing.
+     */
+    fun existing(kind: ArtifactKind, name: String): File? = generator.locate(kind, name)
+}

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactCollector.kt
@@ -29,12 +29,8 @@ internal class ArtifactCollector(artifactsDir: Path) {
     /** A kind the manifest reports as one folder entry with a member count. */
     private data class Collection(val dir: String, val format: ArtifactFormat)
 
-    private val collectionKinds: Map<ArtifactKind, Collection> = mapOf(
-        ArtifactKind.TAKE_SCREENSHOT to Collection(BundleLayout.TAKE_SCREENSHOT_DIR, ArtifactFormat.PNG),
-        ArtifactKind.START_SCREEN_RECORDING to Collection(BundleLayout.START_RECORDING_DIR, ArtifactFormat.MP4),
-        ArtifactKind.SCREENSHOT to Collection(BundleLayout.STEP_SCREENSHOTS_DIR, ArtifactFormat.PNG),
-        ArtifactKind.SCREEN_HIERARCHY to Collection(BundleLayout.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),
-    )
+    private val collectionKinds: Map<ArtifactKind, Collection> get() = COLLECTION_KINDS
+
 
     private data class Record(
         val kind: ArtifactKind,
@@ -96,6 +92,25 @@ internal class ArtifactCollector(artifactsDir: Path) {
             artifactsDir.relativize(resolved).joinToString("/"),
             sequenceNumber = sequenceNumber,
         )
+    }
+
+    /**
+     * Read-only lookup of an artifact this run already produced, inside the folder this
+     * collector owns for [kind]. Records nothing and creates nothing; null when the kind owns
+     * no folder, the path escapes it, or the file is not there.
+     */
+    fun locate(kind: ArtifactKind, path: String): File? {
+        val collection = collectionKinds[kind] ?: return null
+        val folder = artifactsDir.resolve(collection.dir)
+        val resolved = try {
+            folder.resolve(path).toFile().canonicalFile.toPath()
+        } catch (e: IOException) {
+            return null
+        } catch (e: InvalidPathException) {
+            return null
+        }
+        if (!resolved.startsWith(folder) || resolved == folder) return null
+        return resolved.toFile().takeIf { it.isFile }
     }
 
     /** Record a file written outside the generator's own path (device logs, crash/ANR) that already lives in the artifacts folder. */
@@ -174,6 +189,23 @@ internal class ArtifactCollector(artifactsDir: Path) {
          * — after it, a path naming no file looks like one. Holds with or without a bundle, so it
          * cannot need a collector instance; where the path lands is [allocateCommandOutput]'s call.
          */
+        /**
+         * Which kinds the manifest reports as one folder entry, and the folder they live in.
+         * In the companion because a path's folder and extension are settled before any
+         * collector exists (with no bundle there is none) — the one place the layout is encoded.
+         */
+        private val COLLECTION_KINDS: Map<ArtifactKind, Collection> = mapOf(
+            ArtifactKind.TAKE_SCREENSHOT to Collection(BundleLayout.TAKE_SCREENSHOT_DIR, ArtifactFormat.PNG),
+            ArtifactKind.SCREENSHOT_DIFF to Collection(BundleLayout.SCREENSHOT_DIFF_DIR, ArtifactFormat.PNG),
+            ArtifactKind.START_SCREEN_RECORDING to Collection(BundleLayout.START_RECORDING_DIR, ArtifactFormat.MP4),
+            ArtifactKind.SCREENSHOT to Collection(BundleLayout.STEP_SCREENSHOTS_DIR, ArtifactFormat.PNG),
+            ArtifactKind.SCREEN_HIERARCHY to Collection(BundleLayout.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),
+        )
+
+        /** The extension a [kind]'s own format implies, e.g. PNG -> ".png"; empty for a kind with no folder. */
+        fun extensionFor(kind: ArtifactKind): String =
+            COLLECTION_KINDS[kind]?.format?.let { ".${it.name.lowercase()}" }.orEmpty()
+
         fun validateCommandPath(path: String, commandName: String) {
             if (path.isBlank()) {
                 throw invalidCommandPath(path, commandName, "the path is empty")

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactsGenerator.kt
@@ -102,16 +102,36 @@ internal class ArtifactsGenerator(
     }
 
     /**
-     * Allocate (and record) a command-output file through the collector, attributed
-     * to the running command. Null when no bundle is produced ([artifactsDir] null) —
-     * the caller then writes CWD-relative, as before.
+     * Allocate (and record) a file for the running command — the one path by which a command
+     * produces anything.
+     *
+     * [name] is the flow-supplied or framework-chosen name *without* an extension; the kind's
+     * own [ArtifactFormat] supplies that. Validation runs on [name] as given, before the
+     * extension is appended: afterwards a path naming no file (".", "..") looks like one.
+     *
+     * [STEP_SCOPED] kinds are prefixed with the producing step's index, which is what stops a
+     * retried assertion overwriting its own earlier attempts. Flow-named command output keeps
+     * exactly the path the flow asked for.
+     *
+     * Non-null: with no bundle the file is CWD-relative and unrecorded, as before, so no call
+     * site can reintroduce a raw-`File` fallback of its own.
      */
-    fun allocateCommandArtifact(kind: ArtifactKind, path: String, commandName: String): File? {
-        val collector = collector ?: return null
-        return collector.allocateCommandOutput(
-            kind, path, commandName, currentCommandMetadata?.sequenceNumber,
-        )
+    fun allocate(kind: ArtifactKind, name: String): File {
+        val label = kind.commandLabel()
+        ArtifactCollector.validateCommandPath(name, label)
+        val sequenceNumber = currentCommandMetadata?.sequenceNumber
+        val scoped = if (kind in STEP_SCOPED && sequenceNumber != null) {
+            "step-${StepArtifactNaming.index(sequenceNumber)}-$name"
+        } else {
+            name
+        }
+        val fileName = "$scoped${ArtifactCollector.extensionFor(kind)}"
+        val collector = collector ?: return File(fileName)
+        return collector.allocateCommandOutput(kind, fileName, label, sequenceNumber)
     }
+
+    /** An artifact this run already produced, or null. Records nothing. */
+    fun locate(kind: ArtifactKind, name: String): File? = collector?.locate(kind, name)
 
     override fun onCommandFinished(
         cmd: MaestroCommand,
@@ -323,5 +343,16 @@ internal class ArtifactsGenerator(
 
     companion object {
         private val logger = LoggerFactory.getLogger(ArtifactsGenerator::class.java)
+
+        /** Framework-named kinds, whose name must carry the step to stay unique across retries. */
+        private val STEP_SCOPED = setOf(ArtifactKind.SCREENSHOT_DIFF)
+
+        /** The command a kind belongs to, for the "invalid path for X" message. */
+        private fun ArtifactKind.commandLabel(): String = when (this) {
+            ArtifactKind.TAKE_SCREENSHOT -> "takeScreenshot"
+            ArtifactKind.START_SCREEN_RECORDING -> "startRecording"
+            ArtifactKind.SCREENSHOT_DIFF -> "assertScreenshot"
+            else -> name
+        }
     }
 }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
@@ -17,6 +17,7 @@ package maestro.orchestra.debug
  *     maestro.log
  *     device logs, crash/ANR  ← worker/cloud only
  *   takeScreenshot/           ← takeScreenshot command output
+ *   assertScreenshot/         ← assertScreenshot failure diffs
  *   startRecording/           ← startRecording command output
  *   screenshots/              ← step screenshots, step-<NNN>-<type>[-<arg>].png (action steps + final.png; failed step only when flag off)
  *   screen-hierarchy/         ← per-step view hierarchy JSON
@@ -33,6 +34,13 @@ internal object BundleLayout {
     const val MAESTRO_LOG = "$LOGS_DIR/maestro.log"
 
     const val TAKE_SCREENSHOT_DIR = "takeScreenshot"
+
+    /**
+     * assertScreenshot failure diffs. Deliberately its own OUTPUT folder: the diff used to
+     * be written next to the *reference*, which is workspace INPUT and not part of the
+     * bundle — so on Cloud it was discarded with the workspace.
+     */
+    const val SCREENSHOT_DIFF_DIR = "assertScreenshot"
 
     const val START_RECORDING_DIR = "startRecording"
 

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
@@ -38,8 +38,15 @@ internal object StepArtifactNaming {
         return leaf !is CompositeCommand && leaf.visible()
     }
 
+    /**
+     * The 1-based, zero-padded step index shared by every step-prefixed bundle name, so a
+     * diff, a screenshot and a hierarchy from one step share a prefix and correlate on sight.
+     */
+    fun index(sequenceNumber: Int): String =
+        (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
+
     fun stem(sequenceNumber: Int, command: MaestroCommand?): String {
-        val index = (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
+        val index = index(sequenceNumber)
         val slug = command?.let(::slug)
         return if (slug.isNullOrEmpty()) "step-$index" else "step-$index-$slug"
     }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactBoundaryTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactBoundaryTest.kt
@@ -1,0 +1,185 @@
+package maestro.orchestra.debug
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import maestro.DeviceInfo
+import maestro.Maestro
+import maestro.MaestroException
+import maestro.TreeNode
+import maestro.ViewHierarchy
+import maestro.device.Platform
+import maestro.orchestra.ArtifactManifest
+import maestro.orchestra.AssertScreenshotCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.Orchestra
+import maestro.orchestra.RetryCommand
+import maestro.orchestra.TakeScreenshotCommand
+import okio.Sink
+import okio.buffer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.awt.Color
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import javax.imageio.ImageIO
+import kotlin.io.path.createDirectories
+import kotlin.io.path.listDirectoryEntries
+
+/**
+ * The boundary the artifact bundle is supposed to hold, asserted by running a flow and
+ * looking at the filesystem.
+ *
+ * [OrchestraArtifactFunnelTest] scans one file for the *shape* of the mistake; this covers
+ * what a flow actually wrote, wherever the writing code lives. `nothing outside the bundle`
+ * is the one that matters: the assertScreenshot diff was written outside it entirely, so a
+ * manifest-orphan check alone would never have seen it.
+ */
+class ArtifactBoundaryTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun mockMaestro(): Maestro = mockk(relaxed = true) {
+        coEvery { viewHierarchy(any()) } returns ViewHierarchy(TreeNode(attributes = mutableMapOf()))
+        coEvery { cachedDeviceInfo } returns DeviceInfo(
+            platform = Platform.ANDROID,
+            widthPixels = 100,
+            heightPixels = 200,
+            widthGrid = 100,
+            heightGrid = 200,
+        )
+    }
+
+    /** Sized so the comparison keeps the diff rectangle, which is what writes a diff file. */
+    private fun png(offset: Int): ByteArray = ByteArrayOutputStream()
+        .also { out ->
+            val image = BufferedImage(100, 200, BufferedImage.TYPE_INT_RGB)
+            image.createGraphics().apply {
+                color = Color.WHITE
+                fillRect(0, 0, 100, 200)
+                color = Color.BLACK
+                fillRect(offset, 0, 60, 120)
+                dispose()
+            }
+            ImageIO.write(image, "png", out)
+        }
+        .toByteArray()
+
+    private fun maestroWithChangingScreens(): Maestro = mockMaestro().also { maestro ->
+        var captures = 0
+        coEvery { maestro.takeScreenshot(any<Sink>(), any(), any()) } answers {
+            // Never identical to the reference (png(0)): the first capture must already differ,
+            // or the assertion passes and there is no diff to look for.
+            firstArg<Sink>().buffer().use { it.write(png(40 * (++captures))) }
+        }
+    }
+
+    /** A failing screenshot assertion inside a retry — the shape from the reported issue. */
+    private fun failingAssertInsideRetry(reference: Path): List<MaestroCommand> = listOf(
+        MaestroCommand(
+            retryCommand = RetryCommand(
+                maxRetries = "3",
+                config = null,
+                commands = listOf(
+                    MaestroCommand(
+                        assertScreenshotCommand = AssertScreenshotCommand(
+                            path = reference.toString(),
+                            thresholdPercentage = "100",
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    private fun writeReference(dir: Path): Path {
+        dir.createDirectories()
+        val reference = dir.resolve("home_baseline.png")
+        Files.write(reference, png(0))
+        return reference
+    }
+
+    private fun filesUnder(root: Path): Set<String> =
+        Files.walk(root).use { paths ->
+            paths.filter(Files::isRegularFile).map { root.relativize(it).joinToString("/") }.toList().toSet()
+        }
+
+    @Test
+    fun `a flow writes nothing outside its bundle`() {
+        // Stands in for the customer's repo: a committed reference, outside the run bundle.
+        val workspace = tempDir.resolve("workspace")
+        val reference = writeReference(workspace.resolve("logs/screenshots"))
+        val before = filesUnder(workspace)
+
+        val bundle = tempDir.resolve("bundle").also { it.createDirectories() }
+        val orchestra = Orchestra(maestro = maestroWithChangingScreens(), artifactsDir = bundle)
+
+        assertThrows<MaestroException.AssertionFailure> {
+            runBlocking { orchestra.runFlow(failingAssertInsideRetry(reference)) }
+        }
+
+        // The workspace is an input tree. On Cloud it is deleted with the machine, so anything a
+        // flow leaves here is lost — which is exactly how the diff went missing.
+        assertThat(filesUnder(workspace)).isEqualTo(before)
+    }
+
+    @Test
+    fun `every file under the bundle appears in the manifest`() {
+        val reference = writeReference(tempDir.resolve("workspace/logs/screenshots"))
+        val bundle = tempDir.resolve("bundle").also { it.createDirectories() }
+        val orchestra = Orchestra(maestro = maestroWithChangingScreens(), artifactsDir = bundle)
+
+        assertThrows<MaestroException.AssertionFailure> {
+            runBlocking { orchestra.runFlow(failingAssertInsideRetry(reference)) }
+        }
+
+        // The manifest carries a `$schema` URL the model deliberately does not field.
+        val manifest: ArtifactManifest = jacksonObjectMapper()
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .readValue(bundle.resolve(BundleLayout.MANIFEST_JSON).toFile())
+        val declared = manifest.entries.map { it.relativePath }.toSet()
+
+        val undeclared = filesUnder(bundle)
+            .filterNot { it == BundleLayout.MANIFEST_JSON }
+            // A collection entry declares its folder; members live under it.
+            .filterNot { path -> declared.any { path == it || path.startsWith("$it/") } }
+
+        assertThat(undeclared).isEmpty()
+    }
+
+    @Test
+    fun `the failure diff lands in the bundle, one per retry attempt`() {
+        val reference = writeReference(tempDir.resolve("workspace/logs/screenshots"))
+        val bundle = tempDir.resolve("bundle").also { it.createDirectories() }
+        val orchestra = Orchestra(maestro = maestroWithChangingScreens(), artifactsDir = bundle)
+
+        assertThrows<MaestroException.AssertionFailure> {
+            runBlocking { orchestra.runFlow(failingAssertInsideRetry(reference)) }
+        }
+
+        val diffs = bundle.resolve(BundleLayout.SCREENSHOT_DIFF_DIR).listDirectoryEntries()
+        // 1 initial attempt + 3 retries, each keeping its own diff rather than overwriting.
+        assertThat(diffs).hasSize(4)
+        assertThat(diffs.map { it.fileName.toString() }.toSet()).hasSize(4)
+    }
+
+    @Test
+    fun `takeScreenshot still lands exactly where the flow asked, inside the bundle`() {
+        val bundle = tempDir.resolve("bundle").also { it.createDirectories() }
+        val orchestra = Orchestra(maestro = maestroWithChangingScreens(), artifactsDir = bundle)
+
+        runBlocking {
+            orchestra.runFlow(listOf(MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "shots/home"))))
+        }
+
+        assertThat(bundle.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/shots/home.png").toFile().exists()).isTrue()
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactsGeneratorTest.kt
@@ -332,14 +332,14 @@ class ArtifactsGeneratorTest {
     @Test
     fun `registers takeScreenshot and startRecording folders as collections`() {
         // Command output is allocated through the generator (as Orchestra does via
-        // allocateCommandArtifact); the collector folds same-kind files into one entry.
+        // Artifacts.file); the collector folds same-kind files into one entry.
         val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "login/home.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "splash.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
-        gen.allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "clip.mp4", "startRecording")!!.writeBytes(byteArrayOf(1))
+        gen.allocate(ArtifactKind.TAKE_SCREENSHOT, "login/home").writeBytes(byteArrayOf(1))
+        gen.allocate(ArtifactKind.TAKE_SCREENSHOT, "splash").writeBytes(byteArrayOf(1))
+        gen.allocate(ArtifactKind.START_SCREEN_RECORDING, "clip").writeBytes(byteArrayOf(1))
         gen.onFlowEnd()
 
         val takeScreenshot = gen.artifactManifest.entries
@@ -665,7 +665,7 @@ class ArtifactsGeneratorTest {
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
+        gen.allocate(ArtifactKind.TAKE_SCREENSHOT, "checkout").writeBytes(byteArrayOf(1))
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 
@@ -701,7 +701,7 @@ class ArtifactsGeneratorTest {
         gen.onCommandStart(first, sequenceNumber = 0)
         gen.onCommandFinished(first, CommandOutcome.Completed, 100L, 150L)
         gen.onCommandStart(second, sequenceNumber = 1)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
+        gen.allocate(ArtifactKind.TAKE_SCREENSHOT, "checkout").writeBytes(byteArrayOf(1))
         gen.onCommandFinished(second, CommandOutcome.Completed, 150L, 200L)
         gen.onFlowEnd()
 
@@ -729,20 +729,6 @@ class ArtifactsGeneratorTest {
         val screenshotArtifact = artifacts.single { it.type == ArtifactKind.SCREENSHOT }
         assertThat(screenshotArtifact.path).isEqualTo("screenshots/step-001-scroll.png")
         assertThat(tempDir.resolve(screenshotArtifact.path).exists()).isTrue()
-    }
-
-    @Test
-    fun `allocateCommandArtifact returns null and records nothing when artifactsDir is null`() {
-        val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
-        val cmd = MaestroCommand(tapOnElement = null)
-
-        gen.onFlowStart()
-        gen.onCommandStart(cmd, sequenceNumber = 0)
-        assertThat(gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")).isNull()
-        gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
-        gen.onFlowEnd()
-
-        assertThat(gen.debugOutput.commands[cmd]!!.artifacts).isEmpty()
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraArtifactFunnelTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraArtifactFunnelTest.kt
@@ -1,0 +1,44 @@
+package maestro.orchestra.debug
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Seam guard, adapted from the one on `ma-4167-screenshot-diff-collector`: every artifact a
+ * command produces goes through [maestro.orchestra.Artifacts], never a path the command builds
+ * itself. Self-built paths are how artifacts historically fell out of the Cloud bundle one at
+ * a time — written somewhere the uploader never reads and recorded nowhere (most recently the
+ * assertScreenshot diff, via `resolveSibling`).
+ *
+ * If this fails, route the new output through `artifacts.file()`; mark a line
+ * `// funnel-exempt: read` only when it resolves a path to *read*.
+ *
+ * A source scan of one file, so it is a tripwire, not a proof — [ArtifactBoundaryTest] covers
+ * what a flow actually writes.
+ */
+class OrchestraArtifactFunnelTest {
+
+    @Test
+    fun `orchestra builds no output paths outside the funnel`() {
+        val projectDir = System.getenv("PROJECT_DIR") ?: "."
+        val orchestra = File(projectDir, "src/main/java/maestro/orchestra/Orchestra.kt")
+        assertThat(orchestra.exists()).isTrue()
+
+        val pathConstruction = Regex("""\bFile\s*\(|\bresolveSibling\s*\(|\bPaths\.get\s*\(|\.toFile\s*\(""")
+        val source = orchestra.readText()
+
+        val unexempted = pathConstruction.findAll(source)
+            .map { source.lineAt(it.range.first) }
+            .filterNot { it.contains("// funnel-exempt:") }
+            .toList()
+
+        assertThat(unexempted).isEmpty()
+    }
+
+    private fun String.lineAt(index: Int): String {
+        val start = lastIndexOf('\n', index) + 1
+        val end = indexOf('\n', index).let { if (it == -1) length else it }
+        return substring(start, end).trim()
+    }
+}

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -552,7 +552,7 @@ class OrchestraListenerDispatchTest {
     }
 
     @Test
-    fun `assertScreenshot writes its diff beside a reference reached through a parent segment`() {
+    fun `assertScreenshot writes its diff into the bundle, not beside the reference`() {
         val commands = listOf(
             MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "login/../home")),
             MaestroCommand(
@@ -569,7 +569,11 @@ class OrchestraListenerDispatchTest {
         }
 
         assertThat(e.message).contains("threshold not met")
-        assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isTrue()
+        // Beside the reference is where it used to go, and why Cloud never had it.
+        assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
+        val diffs = tempDir.resolve(BundleLayout.SCREENSHOT_DIFF_DIR).toFile().listFiles().orEmpty()
+        assertThat(diffs).hasLength(1)
+        assertThat(diffs.single().name).endsWith("home_diff.png")
     }
 
     @Test


### PR DESCRIPTION
`assertScreenshot` failures arrive on Cloud with no diff image. Reported by Nando's UKI (upload `mupload_01kyhjn1pyfn4v0gjycgd5ysft`): the run artifacts hold the per-step screenshots, but not the one image that says *why* the assertion failed.

## Cause

`Orchestra.kt:696`

```kotlin
val diffFile = expectedFile.resolveSibling("${expectedFile.nameWithoutExtension}_diff.png")
```

`expectedFile` is the **reference** — an input, resolved from the flow's own directory. The diff is an **output**. Deriving the second from the first puts the diff in the workspace checkout.

Locally that is the folder you are already looking at, so it looks correct. On Cloud the workspace is scratch space deleted with the machine and only the artifact bundle is uploaded, so the diff is discarded. **Not a regression** — `git log -L 696,698` shows the line predates the bundle work (`0d9b257e2`), so Cloud diffs have never worked.

Two things made it worse: the diff's name derives only from the reference, so the reported flow's four failed attempts (steps 87/90/93/96) all wrote one file; and the failure message pointed at an absolute path on a machine that no longer exists.

## Not a one-off

The guard added here exists because this is a class. Prior escapes on `main`:

| Commit | What escaped |
|---|---|
| `0f86d7e0d` (#3459) | `..` paths resolving outside the run root |
| `f598a9517` (#3396) | empty recording placeholders reaching the bundle |
| `eae360a49` (#3564) | file separators on Windows for Cloud uploads |

The common shape is a command building its own output path. Today four write verbs exist (`allocate`, `allocateCommandOutput`, `adopt`, `allocateCommandArtifact`), plus a separate `validateCommandPath` you must remember to call first, plus a `?: File(...)` fallback. `assertScreenshot` used none of them.

## Change

**`Artifacts` — the one surface a command gets.** Two verbs that are deliberately not interchangeable:

```kotlin
fun file(kind: ArtifactKind, name: String): File       // produce
fun existing(kind: ArtifactKind, name: String): File?  // read back
```

`file()` owns the folder (from the kind), the extension (from the kind's `ArtifactFormat`), path validation, step attribution and the manifest entry — so every call site collapses:

```diff
-ArtifactCollector.validateCommandPath(command.path, "takeScreenshot")
-val outFile = artifactsGenerator
-    .allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "${command.path}.png", "takeScreenshot")
-    ?: File("${command.path}.png")
+val outFile = artifacts.file(ArtifactKind.TAKE_SCREENSHOT, command.path)
```

It returns non-null — with no bundle the file is CWD-relative exactly as before — so no call site can reintroduce a fallback of its own.

**`artifactsDir` stops being a property on `Orchestra`.** A command body that can name the directory can work out a path outside it, which is what happened here. Commands reach artifacts only through `Artifacts`.

**The fix itself:**

```diff
-val diffFile = expectedFile.resolveSibling("${expectedFile.nameWithoutExtension}_diff.png")
+val diffFile = artifacts.file(ArtifactKind.SCREENSHOT_DIFF, "${expectedFile.nameWithoutExtension}_diff")
```

`SCREENSHOT_DIFF` gets its own `assertScreenshot/` folder and is named with the shared 1-based step index, so each retry attempt keeps its own diff.

## Behaviour changes

- **The local diff moves** from beside the reference to `<run folder>/assertScreenshot/`. Intended — local and Cloud now agree — but it is user-visible.
- **`assertScreenshot`'s second reference candidate is now confined.** It previously normalised without confinement, so `../../logs/...` could resolve *outside* the bundle and match there. Consistent with #3459's intent.

## Guards

Two, because they catch different things.

- `OrchestraArtifactFunnelTest` — a source scan of `Orchestra.kt` for `File(`, `resolveSibling(`, `Paths.get(`, `.toFile(`, failing any line not marked `// funnel-exempt: read`. After this change only two lines need the marker, both reference reads. **Adapted from the one on `ma-4167-screenshot-diff-collector`.**
- `ArtifactBoundaryTest` — runs a flow and asserts the filesystem: *a flow writes nothing outside its bundle*. This is the one that catches this ticket; the diff was written outside the bundle entirely, where a manifest-orphan check never looks.

## Verification

`./gradlew test` — **1229 tests, 0 failed**, 5 skipped, on `75e4a03de`.

## Scope

The diff is now in the manifest and uploaded, so it reaches the run archive customers download. Listing it as a *typed* artifact on the run page needs the backend to stop dropping kinds it does not recognise (`RunArtifactMapper` ends `else -> null`, which also hides `takeScreenshot` output today) — that is a separate copilot-side change.

## Relationship to MA-4167

#3484 fixes the same bug and is approved but unmerged. This takes a different route — consolidating the producer surface rather than adding a fifth allocator — while **deliberately matching its kind name, folder and step index**, so whichever lands first the other rebases cleanly. Its funnel guard and its non-null return are borrowed here with credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR1yrawifxaUgWfGXrPNfR