### PR TITLE
Configurable JS HTTP request timeout

### DIFF
--- a/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsEngine.kt
@@ -35,11 +35,12 @@ class GraalJsEngine(
     platform: String = "unknown"
 ) : JsEngine {
 
-    private val httpBinding = GraalJsHttp(httpClient)
     private val outputBinding = HashMap<String, Any>()
     private val maestroBinding = HashMap<String, Any?>()
     private val envBinding = HashMap<String, String>()
     private val envScopeStack = mutableListOf<HashMap<String, String>>()  // for scope isolation
+    private val httpBinding = GraalJsHttp(httpClient, envBinding)
+
 
     // Keys that should never be removed from context bindings
     private val permanentBindingKeys = setOf(

--- a/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
+++ b/maestro-client/src/main/java/maestro/js/GraalJsHttp.kt
@@ -7,12 +7,24 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.graalvm.polyglot.HostAccess.Export
 import org.graalvm.polyglot.proxy.ProxyObject
+import java.io.InterruptedIOException
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
 
 class GraalJsHttp(
-    private val httpClient: OkHttpClient
+    private val httpClient: OkHttpClient,
+    private val env: Map<String, String> = emptyMap(), // Live view of env, read by JsHttpOptions
 ) {
     @Volatile
     private var currentScriptDir: java.io.File? = null
+
+    /**
+     * Clients derived for non-default [JsHttpOptions]. OkHttp's `newBuilder()` copies the
+     * parent's connection pool, dispatcher, interceptors and event listener, so a derived
+     * client is cheap and shares connections. Cached so a `repeat` loop issuing the same
+     * call a thousand times derives one client rather than a thousand.
+     */
+    private val derivedClients = ConcurrentHashMap<JsHttpOptions, OkHttpClient>()
 
     fun setCurrentScriptDir(scriptDir: String?) {
       currentScriptDir = scriptDir?.let { java.io.File(it) }
@@ -92,10 +104,25 @@ class GraalJsHttp(
         }
 
         val request = requestBuilder.build()
+        val client = clientFor(JsHttpOptions.resolve(params, env))
 
-        val response = httpClient
-            .newCall(request)
-            .execute()
+        val response = try {
+            client
+                .newCall(request)
+                .execute()
+        } catch (e: InterruptedIOException) {
+            // OkHttp reports a socket timeout as SocketTimeoutException and a call timeout as
+            // InterruptedIOException; the same type also carries thread interruption, which
+            // leaves the interrupt flag set (see DadbChromeDevToolsClient). Only the timeouts
+            // get the friendlier message; interruption keeps propagating untouched.
+            if (Thread.interrupted()) {
+                Thread.currentThread().interrupt()
+                throw e
+            }
+            // InterruptedIOException is the common supertype of both timeout cases, so callers
+            // catching either the old type or IOException still match.
+            throw InterruptedIOException(timeoutMessage(method, request, client)).apply { initCause(e) }
+        }
 
         return ProxyObject.fromMap(mapOf(
             "ok" to response.isSuccessful,
@@ -104,6 +131,38 @@ class GraalJsHttp(
             "headers" to convertHeaders(response.headers)
         ))
     }
+
+    internal fun clientFor(options: JsHttpOptions): OkHttpClient {
+        if (options == JsHttpOptions.DEFAULT) return httpClient
+
+        return derivedClients.computeIfAbsent(options) { opts ->
+            httpClient.newBuilder()
+                .apply {
+                    opts.timeoutMs?.let {
+                        callTimeout(it, TimeUnit.MILLISECONDS)
+                        readTimeout(it, TimeUnit.MILLISECONDS)
+                        writeTimeout(it, TimeUnit.MILLISECONDS)
+                    }
+                }
+                .build()
+        }
+    }
+
+    private fun timeoutMessage(method: String, request: Request, client: OkHttpClient): String {
+        val effectiveMs = client.callTimeoutMillis.takeIf { it > 0 } ?: client.readTimeoutMillis
+
+        return "HTTP $method ${request.url.withoutSecrets()} timed out after $effectiveMs ms. " +
+            "Raise it for this request with `timeout: <milliseconds>` in the http params, " +
+            "or for the whole run by setting MAESTRO_JS_HTTP_TIMEOUT=<milliseconds>."
+    }
+
+    /** Keeps the path, which is what makes the error useful, but drops credentials and query. */
+    private fun okhttp3.HttpUrl.withoutSecrets(): String = newBuilder()
+        .username("")
+        .password("")
+        .query(null)
+        .build()
+        .toString()
 
     private fun convertHeaders(headers: Headers): ProxyObject {
         val headersMap = headers.toMultimap().mapValues { (_, values) ->

--- a/maestro-client/src/main/java/maestro/js/JsHttpOptions.kt
+++ b/maestro-client/src/main/java/maestro/js/JsHttpOptions.kt
@@ -1,0 +1,63 @@
+package maestro.js
+
+/**
+ * Per-request overrides for the JS `http` binding.
+ *
+ * Every option resolves through two layers, in order:
+ *  1. the request's own params map — `http.post(url, { timeout: 900000 })`
+ *  2. the flow env — `MAESTRO_JS_HTTP_TIMEOUT=900000`
+ *
+ * Shell `MAESTRO_*` vars are copied into the flow env (see
+ * `maestro.orchestra.util.Env.withInjectedShellEnvVars`), which also carries
+ * `--env` values and a flow's own `config: env:` block, and which is uploaded
+ * with cloud runs.
+ *
+ * [DEFAULT] means "change nothing", so the caller can keep using the shared
+ * client instead of deriving a new one.
+ */
+data class JsHttpOptions(
+    val timeoutMs: Long? = null,
+) {
+
+    companion object {
+        val DEFAULT = JsHttpOptions()
+
+        fun resolve(params: Map<String, Any>?, env: Map<String, String>): JsHttpOptions =
+            JsHttpOptions(
+                timeoutMs = positiveMillis(params?.get("timeout"), "`timeout` param")
+                    ?: positiveMillis(env["MAESTRO_JS_HTTP_TIMEOUT"], "MAESTRO_JS_HTTP_TIMEOUT"),
+            )
+
+        /**
+         * Accepts a JS number or a numeric string — env values are always strings.
+         * A value that is present but unusable throws rather than silently falling
+         * back to the default, which would leave the flow behaving as though the
+         * override had been applied.
+         */
+        private fun positiveMillis(value: Any?, source: String): Long? {
+            if (value == null) return null
+
+            val millis = when (value) {
+                is Number -> value.toLong()
+                is CharSequence -> value.toString().trim().let {
+                    if (it.isEmpty()) return null
+                    it.toLongOrNull()
+                        ?: throw IllegalArgumentException(
+                            "$source must be a whole number of milliseconds, but was \"$it\""
+                        )
+                }
+                else -> throw IllegalArgumentException(
+                    "$source must be a whole number of milliseconds, but was ${value.javaClass.simpleName}"
+                )
+            }
+
+            if (millis <= 0) {
+                throw IllegalArgumentException(
+                    "$source must be a positive number of milliseconds, but was $millis"
+                )
+            }
+
+            return millis
+        }
+    }
+}

--- a/maestro-client/src/test/java/maestro/js/GraalJsHttpTest.kt
+++ b/maestro-client/src/test/java/maestro/js/GraalJsHttpTest.kt
@@ -1,0 +1,68 @@
+package maestro.js
+
+import com.google.common.truth.Truth.assertThat
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class GraalJsHttpTest {
+
+    private val parent = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(5, TimeUnit.MINUTES)
+        .writeTimeout(5, TimeUnit.MINUTES)
+        .callTimeout(5, TimeUnit.MINUTES)
+        .build()
+
+    private val http = GraalJsHttp(parent)
+
+    @Test
+    fun `default options reuse the shared client`() {
+        assertThat(http.clientFor(JsHttpOptions.DEFAULT)).isSameInstanceAs(parent)
+    }
+
+    @Test
+    fun `a timeout override applies to the call, read and write timeouts`() {
+        val client = http.clientFor(JsHttpOptions(timeoutMs = 900_000))
+
+        assertThat(client.callTimeoutMillis).isEqualTo(900_000)
+        assertThat(client.readTimeoutMillis).isEqualTo(900_000)
+        assertThat(client.writeTimeoutMillis).isEqualTo(900_000)
+    }
+
+    @Test
+    fun `a timeout override leaves the connect timeout alone`() {
+        val client = http.clientFor(JsHttpOptions(timeoutMs = 900_000))
+
+        assertThat(client.connectTimeoutMillis).isEqualTo(parent.connectTimeoutMillis)
+    }
+
+    @Test
+    fun `derived clients share the parent's connection pool and dispatcher`() {
+        val client = http.clientFor(JsHttpOptions(timeoutMs = 1_000))
+
+        assertThat(client.connectionPool).isSameInstanceAs(parent.connectionPool)
+        assertThat(client.dispatcher).isSameInstanceAs(parent.dispatcher)
+        assertThat(client.eventListenerFactory).isSameInstanceAs(parent.eventListenerFactory)
+        assertThat(client.interceptors).isEqualTo(parent.interceptors)
+        assertThat(client.networkInterceptors).isEqualTo(parent.networkInterceptors)
+    }
+
+    @Test
+    fun `equal options are derived once`() {
+        // Guards flows that make the same call in a long `repeat` loop.
+        val first = http.clientFor(JsHttpOptions(timeoutMs = 1_000))
+        val second = http.clientFor(JsHttpOptions(timeoutMs = 1_000))
+
+        assertThat(second).isSameInstanceAs(first)
+    }
+
+    @Test
+    fun `different options get different clients`() {
+        val first = http.clientFor(JsHttpOptions(timeoutMs = 1_000))
+        val second = http.clientFor(JsHttpOptions(timeoutMs = 2_000))
+
+        assertThat(second).isNotSameInstanceAs(first)
+        assertThat(second.callTimeoutMillis).isEqualTo(2_000)
+    }
+}

--- a/maestro-client/src/test/java/maestro/js/JsHttpOptionsTest.kt
+++ b/maestro-client/src/test/java/maestro/js/JsHttpOptionsTest.kt
@@ -1,0 +1,100 @@
+package maestro.js
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class JsHttpOptionsTest {
+
+    private val noEnv = emptyMap<String, String>()
+
+    @Test
+    fun `resolves to the default when nothing is set`() {
+        assertThat(JsHttpOptions.resolve(null, noEnv)).isEqualTo(JsHttpOptions.DEFAULT)
+        assertThat(JsHttpOptions.resolve(mapOf("body" to "{}"), noEnv)).isEqualTo(JsHttpOptions.DEFAULT)
+    }
+
+    @Test
+    fun `reads the timeout param as a number`() {
+        val options = JsHttpOptions.resolve(mapOf("timeout" to 900_000), noEnv)
+
+        assertThat(options.timeoutMs).isEqualTo(900_000L)
+    }
+
+    @Test
+    fun `reads a JS number that arrives as a double`() {
+        // GraalJS hands numeric literals to host code as Integer or Double depending on the value.
+        val options = JsHttpOptions.resolve(mapOf("timeout" to 1_500.0), noEnv)
+
+        assertThat(options.timeoutMs).isEqualTo(1_500L)
+    }
+
+    @Test
+    fun `reads the timeout from the flow env when no param is given`() {
+        val options = JsHttpOptions.resolve(null, mapOf("MAESTRO_JS_HTTP_TIMEOUT" to "45000"))
+
+        assertThat(options.timeoutMs).isEqualTo(45_000L)
+    }
+
+    @Test
+    fun `the timeout param overrides the flow env`() {
+        val options = JsHttpOptions.resolve(
+            mapOf("timeout" to 1_000),
+            mapOf("MAESTRO_JS_HTTP_TIMEOUT" to "45000"),
+        )
+
+        assertThat(options.timeoutMs).isEqualTo(1_000L)
+    }
+
+    @Test
+    fun `tolerates surrounding whitespace in an env value`() {
+        val options = JsHttpOptions.resolve(null, mapOf("MAESTRO_JS_HTTP_TIMEOUT" to " 45000 "))
+
+        assertThat(options.timeoutMs).isEqualTo(45_000L)
+    }
+
+    @Test
+    fun `treats a blank env value as unset`() {
+        val options = JsHttpOptions.resolve(null, mapOf("MAESTRO_JS_HTTP_TIMEOUT" to "   "))
+
+        assertThat(options).isEqualTo(JsHttpOptions.DEFAULT)
+    }
+
+    @Test
+    fun `rejects a non-numeric timeout param instead of silently ignoring it`() {
+        val error = assertThrows<IllegalArgumentException> {
+            JsHttpOptions.resolve(mapOf("timeout" to "soon"), noEnv)
+        }
+
+        assertThat(error).hasMessageThat().contains("`timeout` param")
+        assertThat(error).hasMessageThat().contains("soon")
+    }
+
+    @Test
+    fun `rejects a non-numeric env value and names the variable`() {
+        val error = assertThrows<IllegalArgumentException> {
+            JsHttpOptions.resolve(null, mapOf("MAESTRO_JS_HTTP_TIMEOUT" to "5m"))
+        }
+
+        assertThat(error).hasMessageThat().contains("MAESTRO_JS_HTTP_TIMEOUT")
+    }
+
+    @Test
+    fun `rejects a timeout param of the wrong type`() {
+        val error = assertThrows<IllegalArgumentException> {
+            JsHttpOptions.resolve(mapOf("timeout" to true), noEnv)
+        }
+
+        assertThat(error).hasMessageThat().contains("`timeout` param")
+    }
+
+    @Test
+    fun `rejects a non-positive timeout`() {
+        assertThrows<IllegalArgumentException> {
+            JsHttpOptions.resolve(mapOf("timeout" to 0), noEnv)
+        }
+        assertThrows<IllegalArgumentException> {
+            JsHttpOptions.resolve(null, mapOf("MAESTRO_JS_HTTP_TIMEOUT" to "-1"))
+        }
+    }
+}

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -6,6 +6,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.okJson
+import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.CancellationException
@@ -45,6 +50,7 @@ import maestro.orchestra.SwipeCommand
 import maestro.ScrollDirection
 import kotlinx.coroutines.TimeoutCancellationException
 import maestro.js.JsEngine
+import maestro.js.JsEvaluationException
 import maestro.js.GraalJsEngine
 import maestro.orchestra.util.Env.withDefaultEnvVars
 import maestro.orchestra.util.Env.withEnv
@@ -5397,6 +5403,41 @@ class IntegrationTest {
         }
         assertThat(onCommandWarnedCalled).isTrue()
         assertThat(onCommandFailedCalled).isFalse()
+    }
+
+    @Test
+    fun `Case 155 - JS http timeout is read from the script's env`() {
+        // Given: an endpoint slower than the timeout the flow's env asks for
+        val server = WireMockServer(options().dynamicPort())
+        server.start()
+        try {
+            server.stubFor(
+                post(urlPathEqualTo("/slow"))
+                    .willReturn(okJson("""{"message": "too late"}""").withFixedDelay(2_000))
+            )
+
+            val commands = readCommands("155_js_http_timeout_env") {
+                mapOf("BASE_URL" to "http://localhost:${server.port()}")
+            }
+            val driver = driver {
+            }
+
+            // When
+            Maestro(driver).use {
+                val error = assertThrows<JsEvaluationException> {
+                    runBlocking { orchestra(it).runFlow(commands) }
+                }
+
+                // Then: the value travelled the command's env -> Orchestra -> engine sub-scope
+                // -> http binding, which is the path a real flow uses
+                val detail = listOfNotNull(error.error.message, error.error.causeMessage)
+                    .joinToString(" | ")
+                assertThat(detail).contains("timed out after 250 ms")
+                assertThat(detail).contains("MAESTRO_JS_HTTP_TIMEOUT")
+            }
+        } finally {
+            server.stop()
+        }
     }
 
     private fun readCommands(

--- a/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
@@ -7,13 +7,16 @@ import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
 import com.github.tomakehurst.wiremock.junit5.WireMockTest
 import com.github.tomakehurst.wiremock.matching.MultipartValuePatternBuilder
 import com.google.common.net.HttpHeaders
 import com.google.common.truth.Truth.assertThat
 import maestro.js.JsEngine
+import maestro.js.JsEvaluationException
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.nio.file.Files
 
 @WireMockTest
@@ -310,5 +313,113 @@ abstract class JsEngineTest {
         } finally {
             tempDir.toFile().deleteRecursively()
         }
+    }
+
+    @Test
+    fun `HTTP - the timeout param aborts a request that takes too long`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        // Path-only match so the request's query string still hits the delayed stub.
+        stubFor(
+            get(urlPathEqualTo("/slow"))
+                .willReturn(okJson("""{"message": "too late"}""").withFixedDelay(SLOW_RESPONSE_MS))
+        )
+
+        val script = "http.get('http://localhost:$port/slow?access_token=s3cret', { timeout: 250 })"
+
+        // When
+        val error = assertThrows<JsEvaluationException> { engine.evaluateScript(script) }
+
+        // Then: the error names both ways of raising the limit
+        assertThat(error.detail()).contains("timed out after 250 ms")
+        assertThat(error.detail()).contains("MAESTRO_JS_HTTP_TIMEOUT")
+
+        // ...and identifies the request by path without echoing the query string
+        assertThat(error.detail()).contains("/slow")
+        assertThat(error.detail()).doesNotContain("s3cret")
+    }
+
+    @Test
+    fun `HTTP - MAESTRO_JS_HTTP_TIMEOUT applies to requests that set no timeout`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        stubFor(get("/slow").willReturn(okJson("""{"message": "too late"}""").withFixedDelay(SLOW_RESPONSE_MS)))
+        engine.putEnv("MAESTRO_JS_HTTP_TIMEOUT", "250")
+
+        val script = "http.get('http://localhost:$port/slow')"
+
+        // When
+        val error = assertThrows<JsEvaluationException> { engine.evaluateScript(script) }
+
+        // Then
+        assertThat(error.detail()).contains("timed out after 250 ms")
+    }
+
+    @Test
+    fun `HTTP - the timeout param overrides MAESTRO_JS_HTTP_TIMEOUT`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given: an env default that the response would breach
+        val port = wiremockInfo.httpPort
+        stubFor(get("/slow").willReturn(okJson("""{"message": "in time"}""").withFixedDelay(400)))
+        engine.putEnv("MAESTRO_JS_HTTP_TIMEOUT", "250")
+
+        val script = """
+            var response = http.get('http://localhost:$port/slow', { timeout: 10000 })
+
+            json(response.body).message
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then
+        assertThat(result.toString()).isEqualTo("in time")
+    }
+
+    @Test
+    fun `HTTP - a non-numeric timeout fails with an explanatory error`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+
+        val script = "http.get('http://localhost:$port/json', { timeout: 'soon' })"
+
+        // When
+        val error = assertThrows<JsEvaluationException> { engine.evaluateScript(script) }
+
+        // Then
+        assertThat(error.detail()).contains("must be a whole number of milliseconds")
+    }
+
+    @Test
+    fun `HTTP - a timed-out request is catchable in the flow's own script`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        stubFor(get("/slow").willReturn(okJson("""{"message": "too late"}""").withFixedDelay(SLOW_RESPONSE_MS)))
+
+        val script = """
+            try {
+                http.get('http://localhost:$port/slow', { timeout: 250 })
+                'not reached'
+            } catch (e) {
+                String(e.message)
+            }
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then: flows that catch their own HTTP failures still see a message, and it is the new one
+        assertThat(result.toString()).contains("timed out after 250 ms")
+        assertThat(result.toString()).contains("MAESTRO_JS_HTTP_TIMEOUT")
+    }
+
+    /**
+     * Graal can carry a host exception's message on either field, depending on how it wraps it.
+     */
+    private fun JsEvaluationException.detail() =
+        listOfNotNull(error.message, error.causeMessage).joinToString(" | ")
+
+    private companion object {
+        /** Long enough that a sub-second timeout always fires first, short enough not to slow the suite. */
+        const val SLOW_RESPONSE_MS = 1500
     }
 }

--- a/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/JsEngineTest.kt
@@ -2,10 +2,12 @@ package maestro.test
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.equalTo
+import com.github.tomakehurst.wiremock.client.WireMock.findAll
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.okJson
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.stubFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
@@ -410,6 +412,37 @@ abstract class JsEngineTest {
         // Then: flows that catch their own HTTP failures still see a message, and it is the new one
         assertThat(result.toString()).contains("timed out after 250 ms")
         assertThat(result.toString()).contains("MAESTRO_JS_HTTP_TIMEOUT")
+    }
+
+    @Test
+    fun `HTTP - the timeout param shapes the client without touching the request`(wiremockInfo: WireMockRuntimeInfo) {
+        // Given
+        val port = wiremockInfo.httpPort
+        stubFor(post(urlPathEqualTo("/json")).willReturn(okJson("""{"message": "POST endpoint"}""")))
+
+        val script = """
+            var response = http.post('http://localhost:$port/json', {
+                body: JSON.stringify({ payload: 'Value' }),
+                headers: { 'X-Trace': 'abc' },
+                timeout: 10000
+            })
+
+            json(response.body).message
+        """.trimIndent()
+
+        // When
+        val result = engine.evaluateScript(script)
+
+        // Then: the request still succeeds through the derived client...
+        assertThat(result.toString()).isEqualTo("POST endpoint")
+
+        // ...and `timeout` reached the client only — never the body, the URL or the headers
+        val recorded = findAll(postRequestedFor(urlPathEqualTo("/json")))
+        assertThat(recorded).hasSize(1)
+        assertThat(recorded.single().bodyAsString).isEqualTo("""{"payload":"Value"}""")
+        assertThat(recorded.single().url).isEqualTo("/json")
+        assertThat(recorded.single().getHeader("X-Trace")).isEqualTo("abc")
+        assertThat(recorded.single().headers.keys().map { it.lowercase() }).doesNotContain("timeout")
     }
 
     /**

--- a/maestro-test/src/test/resources/155_js_http_timeout_env.yaml
+++ b/maestro-test/src/test/resources/155_js_http_timeout_env.yaml
@@ -1,0 +1,8 @@
+appId: com.example.app
+---
+# The timeout is set on the command's own env block, so it reaches the http binding
+# through runScript's sub-scope rather than the flow's top-level env.
+- runScript:
+    file: 155_script.js
+    env:
+      MAESTRO_JS_HTTP_TIMEOUT: 250

--- a/maestro-test/src/test/resources/155_script.js
+++ b/maestro-test/src/test/resources/155_script.js
@@ -1,0 +1,6 @@
+// BASE_URL is a flow env var; MAESTRO_JS_HTTP_TIMEOUT comes from this command's own env
+// block. Together they prove the env default reaches the http binding through Orchestra
+// and runScript's sub-scope, rather than being set on the engine directly by a test.
+http.post(BASE_URL + '/slow', {
+    body: JSON.stringify({ payload: 'Value' })
+})


### PR DESCRIPTION
## Proposed changes

Provides env and request level configuration of timeouts for HTTP requests made from inside our JS engine.

Customers sometimes have sub-optimal test environments that require more leniency.

### Usage

```sh
export MAESTRO_JS_HTTP_TIMEOUT=60000
maestro test ./flows
```
or
```yaml
appId: com.example
env:
  MAESTRO_JS_HTTP_TIMEOUT: 60000
---
- runScript: callMyApi.js
```
or
```js
var response = http.post('http://example.com/endpoint', {
  body: JSON.stringify({foo: 'bar'}),
  timeout: 60000
})
```

## Testing

Unit + integration tests added. No e2e tests - the added tests run up to the end 

## Issues fixed

Fixes #1490 