### PR TITLE
feat(devicecore): wire stopApp/killApp gateway verbs to device-core

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceGateway.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceGateway.kt
@@ -278,6 +278,20 @@ class RealDeviceGateway(
         }
     }
 
+    override fun stopApp(appId: String) {
+        val d = device ?: error("device-core driver used before connect()")
+        try {
+            runBlocking { d.stopApp(AppId(appId)) }
+        } catch (t: Throwable) {
+            throw DeviceCoreErrorMapper.mapInfraThrow(t, "stopApp $appId")
+        }
+    }
+
+    // device-core collapses killApp onto stopApp via `am force-stop`.
+    override fun killApp(appId: String) {
+        stopApp(appId)
+    }
+
     override fun setPermissions(appId: String, permissions: Map<String, String>) {
         val d = device ?: error("device-core driver used before connect()")
         try {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceGateway.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceGateway.kt
@@ -287,7 +287,7 @@ class RealDeviceGateway(
         }
     }
 
-    // device-core collapses killApp onto stopApp via `am force-stop`.
+    // device-core serves kill and stop through the same verb.
     override fun killApp(appId: String) {
         stopApp(appId)
     }


### PR DESCRIPTION
## Why

`stopApp` and `killApp` sat on the `DeviceGateway` interface's `notImplemented` default, so any flow reaching them walled with a `NotImplemented` — the Android build-out plan's Stage 0e item, worth 4 corpus flows. device-core already serves `stopApp` on our pinned build (`0.1.0-ba529198f969`), so this is pure gateway wiring — **no `devicecore.version` bump**.

## Approach

Override both verbs in `RealDeviceGateway`, following the `clearAppState` template — `device ?: error(...)`, `runBlocking { d.stopApp(AppId(appId)) }`, throwables routed through `DeviceCoreErrorMapper.mapInfraThrow`. `killApp` delegates to `stopApp`, since device-core serves both through one stop verb.

## Verification

Ran the 4 flows that wall on these verbs through the 2.x-vs-3.x differential harness on pool hosts arm-m2m-005 and 007 (2 each, concurrent), 3x candidate built from this branch. All four progress past the stopApp/killApp step — the verb is green in every case, and every residual wall is a different verb:

- one moves to `setLocation` (already walling underneath)
- one reaches a later `assertVisible` with an `Nth` selector — device-core's Android adaptor realizes only `Id`/`Text`/`Relative`, a separate gap
- two hit an env mismatch (`UiAutomation.clearCache` needs API 34; the emulators were API 33 and 29), not a device-core gap

One flow's residual `diverge=2` predates this change and is unrelated.
