### PR TITLE
docs: fix dead link to the demo_app flows

### DIFF
--- a/e2e/demo_app/README.md
+++ b/e2e/demo_app/README.md
@@ -10,7 +10,7 @@ A simple cross-platform Android & iOS app, built with Flutter, for testing
 3. Link to the binaries in GCS bucket are in [e2e/manifest.txt][manifest]
 
 Whenever E2E pipeline of Maestro runs, it downloads the binaries from the GCS
-and runs flows in the [e2e/workspaces/demo_app][workspace] workspace (among others).
+and runs flows in [e2e/demo_app/.maestro][flows] (among others).
 
-[workspace]: https://github.com/mobile-dev-inc/maestro/tree/main/e2e/workspaces/demo_app
+[flows]: https://github.com/mobile-dev-inc/maestro/tree/main/e2e/demo_app/.maestro
 [manifest]: https://github.com/mobile-dev-inc/maestro/blob/main/e2e/manifest.txt


### PR DESCRIPTION
## Proposed changes

`e2e/demo_app/README.md` links to `e2e/workspaces/demo_app`, which 404s:

```
https://github.com/mobile-dev-inc/maestro/tree/main/e2e/workspaces/demo_app  ->  404
```

`e2e/workspaces/` holds `simple_web_view`, `web` and `wikipedia`. The demo_app flows are in `e2e/demo_app/.maestro`, which is why `e2e/run_tests` describes the two as separate places:

```
# Runs all tests in demo_app/.maestro and the workspaces directory.
```

So the sentence is also slightly misleading beyond the link — demo_app isn't one of the workspaces. The wording now points at the flows directly rather than calling it a workspace.

```diff
-and runs flows in the [e2e/workspaces/demo_app][workspace] workspace (among others).
+and runs flows in [e2e/demo_app/.maestro][flows] (among others).
```

New link returns 200. I kept the existing lowercase `/maestro/` URL style used elsewhere in the file rather than switching it to `/Maestro/`, to keep the diff to the thing that was broken.

## Testing

Link checked before and after (404 → 200). No code paths involved.

While confirming, I found `takeScreenshot.yaml` and `takeScreenshotFullScreen.yaml` also contain `workspaces/demo_app/...`, but as relative output paths — `takeScreenshot` writes and `assertScreenshot` reads the same path, so they're self-consistent and currently passing. **I've deliberately left those alone**: changing a passing test's paths for a naming tidy-up isn't worth the risk, and it's a separate question from the dead link. Happy to open a follow-up if you'd like them aligned.

## Issues fixed

None filed — found while working on #3496.
