### PR TITLE
feat(android): honor ANDROID_ADB_SERVER_PORT for device discovery

### DIFF
--- a/maestro-client/src/main/java/maestro/android/AndroidDeviceConnection.kt
+++ b/maestro-client/src/main/java/maestro/android/AndroidDeviceConnection.kt
@@ -351,7 +351,16 @@ class AndroidDeviceConnection private constructor(
         private val LOGGER = LoggerFactory.getLogger(AndroidDeviceConnection::class.java)
 
         const val DEFAULT_DRIVER_HOST_PORT = 7001
-        private const val DEFAULT_ADB_SERVER_PORT = 5037
+        /**
+         * The adb server port Maestro records for a discovered device. Sourced from dadb, which
+         * resolves the standard `ANDROID_ADB_SERVER_PORT` environment variable — the same one the
+         * `adb` CLI reads — and otherwise falls back to 5037. Deliberately not re-derived from the
+         * environment here: dadb owns that resolution, and a second reading of it could drift.
+         *
+         * Read per access rather than cached, so a malformed value surfaces on a normal call path
+         * instead of as a class-initialization failure.
+         */
+        private val DEFAULT_ADB_SERVER_PORT: Int get() = AdbServer.DEFAULT_ADB_SERVER_PORT
         // 1s: a liveness probe must stay quick — better to occasionally misjudge a momentarily-busy
         // adbd as unreachable than to block the failure path. Bounds the connect in probeEndpoint().
         private const val PROBE_MS = 1000

--- a/maestro-client/src/main/java/maestro/device/DeviceService.kt
+++ b/maestro-client/src/main/java/maestro/device/DeviceService.kt
@@ -1,6 +1,7 @@
 package maestro.device
 
 import maestro.DeviceConnectionException
+import dadb.adbserver.AdbServer
 import maestro.android.AndroidDeviceConnection
 import maestro.device.util.AndroidEnvUtils
 import maestro.device.util.AvdDevice
@@ -223,13 +224,22 @@ object DeviceService {
         // Fetch AVD info once (model + os) to avoid repeated avdmanager calls
         val avdInfoList = fetchAndroidAvdInfo()
 
+        // Resolved here, outside the runCatching below, so a malformed ANDROID_ADB_SERVER_PORT
+        // surfaces as its own error rather than being swallowed into an empty device list.
+        val adbServerPort = AdbServer.DEFAULT_ADB_SERVER_PORT
+
         val connected = runCatching {
             AndroidDeviceConnection.list(host = host).map { connection ->
                 connection.use {
                     val avdName = runCatching {
                         connection.shell("getprop ro.kernel.qemu").output.trim().let { qemuProp ->
                             if (qemuProp == "1") {
-                                val avdNameResult = ProcessBuilder("adb", "-s", connection.serial, "emu", "avd", "name")
+                                // -P: without it this always asks the adb server on 5037, which is
+                                // the wrong server whenever ANDROID_ADB_SERVER_PORT points elsewhere.
+                                val avdNameResult = ProcessBuilder(
+                                    "adb", "-P", adbServerPort.toString(),
+                                    "-s", connection.serial, "emu", "avd", "name",
+                                )
                                     .redirectErrorStream(true)
                                     .start()
                                     .apply { waitFor(5, TimeUnit.SECONDS) }


### PR DESCRIPTION
> [!IMPORTANT]
> **Depends on [mobile-dev-inc/dadb#106](https://github.com/mobile-dev-inc/dadb/pull/106) landing (with the fixes noted there), and on a dadb release containing it.** This PR reads `AdbServer.DEFAULT_ADB_SERVER_PORT`, which that PR introduces, so it does not compile against the pinned dadb 2.0.0 and CI will be red until the pin is bumped. Draft until then.

## Proposed changes

Maestro can only reach Android devices on the **default** adb server (5037). A device managed by an adb server on another port is invisible even with an explicit `--device`:

```
$ ANDROID_ADB_SERVER_PORT=5039 maestro --device emulator-5566 test flow.yaml
Device emulator-5566 was requested, but it is not connected.
```

This blocks a common parallel-execution setup: one adb server per worker (`ANDROID_ADB_SERVER_PORT=5038/5039/…`), each owning its device.

dadb#106 resolves the port from the environment the way the `adb` CLI does. Maestro takes the value from `AdbServer.DEFAULT_ADB_SERVER_PORT` and deliberately does **not** re-read the environment itself, so there is a single source of truth. It is read per access rather than cached, so a malformed value surfaces on a normal call path instead of as a class-initialization failure.

Two Maestro call sites need it:

**`AndroidDeviceConnection`** wraps every discovered device with `Endpoint(host, port)`, and that `Endpoint` — not dadb — is what the liveness probe connects to (`transportAlive()` → `probeEndpoint()`). Recording a hardcoded 5037 while the device was found via another server makes every subsequent liveness check probe a port nothing is listening on and report the device as dead.

**`DeviceService`** shelled out to `adb -s <serial> emu avd name` with no `-P`, so it always asked the server on 5037 — the wrong server whenever the variable points elsewhere. Resolving the port *before* the surrounding `runCatching` also stops a malformed value being swallowed into an empty device list and misreported as "device not connected".

Discovery itself needs no Maestro change: `Dadb.list` / `Dadb.discover` call `AdbServer.listDadbs` without a port argument, so dadb's resolution propagates on its own.

## Testing

Verified end-to-end on Linux against a dedicated emulator (`ci_36ps_android2` / `emulator-5556`, API 36), with dadb built from #106 and published to `mavenLocal`, CLI built via `./gradlew :maestro-cli:installDist`.

| # | `ANDROID_ADB_SERVER_PORT` | expected | result |
| --- | --- | --- | --- |
| 1 | unset (device on 5037) | flow runs | ✅ exit 0 |
| 2 | `5041` — that server owns the device | flow runs | ✅ exit 0 |
| 3 | `1` — unusable, device present on 5037 | refuses, fast | ✅ exit 1, 7 s |
| 4 | `" 5041 "` — whitespace | flow runs via 5041 | ✅ exit 0 |
| 5 | `" 1 "` — whitespace + unusable | refuses | ✅ exit 1 |
| 6 | `not-a-port` | names the bad value | ✅ exit 1 |
| 7 | `99999` / `0` | names the bad value | ✅ exit 1 |
| 8 | `65535` — unused port | flow runs | ✅ exit 0 |

Case 3 is the design check: the device *is* reachable on 5037 and Maestro correctly refuses it, which is what proves the port is honored rather than merely tolerated.

Case 8 matches the `adb` CLI — `adb -P <unused> devices` also starts a server on that port, which then auto-discovers local emulators.

## Scope: this enables per-worker adb servers, it does not by itself isolate devices

#3461 describes the goal as one adb server per worker. This change is necessary for that but not sufficient, and the gap is in adb rather than here. Measured:

- Emulators **register themselves** with the adb server named by `ANDROID_ADB_SERVER_PORT` *at launch*. Choosing console ports outside the scan range does not hide them — an emulator booted on 5900/5901 was still picked up by the default server as `emulator-5900`. So the variable has to be set when launching the emulator, not only when running Maestro.
- An adb server scans console ports **when it starts**: one already running when your emulator launches never learns about it, one started afterwards finds everything. Per-worker isolation therefore holds only when each worker's server starts before any other emulator exists — in practice one worker per container or fresh VM. On a shared host with concurrent emulators it does not hold.

Also worth stating: `ANDROID_ADB_SERVER_PORT` is process-global, so this cannot express per-session ports within a single JVM. `--shard-split` / `--shard-all` run shards concurrently in one process, so all shards share one adb server port. Supporting a server per shard would need a per-session option rather than an environment variable — out of scope here, noted so the limit is explicit.

Cases 4–7 depend on fixes proposed on dadb#106 (trimming, and rejecting rather than silently defaulting on an invalid value). Without them, `" 1 "` silently falls back to 5037 and the flow runs — the failure mode this feature exists to prevent.

## Issues fixed

Fixes #3461