### PR TITLE
fix(orchestra-models): js interpolation with multiple closing braces

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/Env.kt
@@ -7,23 +7,8 @@ import maestro.orchestra.MaestroCommand
 
 object Env {
 
-    fun String.evaluateScripts(jsEngine: JsEngine): String {
-        val result = "(?<!\\\\)\\\$\\{([^\$]*)}".toRegex()
-            .replace(this) { match ->
-                val script = match.groups[1]?.value ?: ""
-
-                if (script.isNotBlank()) {
-                    jsEngine.evaluateScript(script).toString()
-                } else {
-                    ""
-                }
-            }
-
-        return result
-            .replace("\\\\\\\$\\{([^\$]*)}".toRegex()) { match ->
-                match.value.substringAfter('\\')
-            }
-    }
+    fun String.evaluateScripts(jsEngine: JsEngine): String =
+        interpolate(this) { script -> jsEngine.evaluateScript(script).toString() }
 
     fun List<String>.evaluateScripts(jsEngine: JsEngine): List<String> =
         map { it.evaluateScripts(jsEngine) }

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
@@ -1,0 +1,168 @@
+package maestro.orchestra.util
+
+internal fun interpolate(input: String, evaluate: (String) -> String): String {
+    if (input.contains("\${")) return input
+
+    val out = StringBuilder(input.length)
+    var i = 0
+
+    while (i < input.length) {
+        val currentChar = input[i]
+
+        if (currentChar == '\\' && input.startsWith("\${", i + 1)) {
+            val close =  findClosingBrace(input, i + 3)
+            if (close == -1) {
+                out.append(currentChar)
+                i++
+            } else {
+                out.append(input, i + 1, close + 1)
+                i = close + 1
+            }
+            continue
+        }
+        if (currentChar == '$' && input.getOrNull(i + 1) == '{'){
+            val close = findClosingBrace(input, i + 2)
+            if (close == -1) {
+                out.append(currentChar)
+                i++
+            } else {
+                val script = input.substring(i + 2, close)
+                if (script.isNotBlank()) out.append(evaluate(script))
+                i = close + 1
+            }
+            continue
+        }
+        out.append(currentChar)
+        i++
+    }
+    return out.toString()
+}
+
+private fun findClosingBrace(expression: String, from: Int): Int {
+    val stack = ArrayDeque<Char>()
+    stack.addLast('{')
+
+    var i = from
+    var lastSignificant = -1
+
+    while (i < expression.length) {
+        if (stack.last() == '`') {
+            when {
+                expression[i] == '\\' -> i += 2
+                expression[i] == '`' -> {
+                    stack.removeLast()
+                    lastSignificant = i
+                    i++
+                }
+                expression[i] == '$' && expression.getOrNull(i + 1) == '{' -> {
+                    stack.addLast('{')
+                    i += 2
+                }
+                else -> i++
+            }
+            continue
+        }
+        val currentChar = expression[i]
+        when {
+            currentChar == '{' -> {
+                stack.addLast('{')
+                lastSignificant = i
+                i++
+            }
+            currentChar == '}' -> {
+                stack.removeLast()
+                if (stack.isEmpty()) return i
+                lastSignificant = i
+                i++
+            }
+            currentChar == '`' -> {
+                stack.addLast('`')
+                i++
+            }
+            currentChar == '\'' || currentChar == '"' -> {
+                i = skipString(expression, i, currentChar)
+                lastSignificant = i - 1
+            }
+            currentChar == '/' && expression.getOrNull(i + 1) == '/' -> i = skipLineComment(expression, i)
+
+            currentChar == '/' && expression.getOrNull(i + 1) == '*' -> i = skipBlockComment(expression, i)
+
+            currentChar == '/' && regexCanStart(expression, lastSignificant) -> {
+                i = skipRegex(expression, i)
+                lastSignificant = i - 1
+            }
+            currentChar.isWhitespace() -> i++
+            else -> {
+                lastSignificant = i
+                i++
+            }
+        }
+    }
+    return -1
+}
+
+private fun skipString(expression: String, open: Int, quote: Char): Int {
+    var i = open + 1
+    while (i < expression.length) {
+        when (expression[i]) {
+            '\\' -> i += 2
+            quote -> return i + 1
+            '\n' -> return i
+            else -> i++
+        }
+    }
+    return expression.length
+}
+
+private fun skipLineComment(expression: String, open: Int): Int {
+    val end = expression.indexOf('\n', open)
+    return if (end == -1) expression.length else end
+}
+
+private fun skipBlockComment(expression: String, open: Int): Int {
+    val end = expression.indexOf("*/", open + 2)
+    return if (end == -1) expression.length else end + 2
+}
+
+private fun skipRegex(expression: String, open: Int): Int {
+    var i = open + 1
+    var inCharClass = false
+    while (i < expression.length) {
+        when (expression[i]) {
+            '\\' -> i += 2
+            '[' -> { inCharClass = true; i++ }
+            ']' -> { inCharClass = false; i++ }
+            '/' -> if (inCharClass) i++ else return i + 1
+            '\n' -> return open + 1
+            else -> i++
+        }
+    }
+    return open + 1
+}
+
+private fun regexCanStart(expression: String, lastSignificant: Int): Boolean {
+    if (lastSignificant < 0) return true
+
+    val currentChar = expression[lastSignificant]
+    if (currentChar == ')'
+        || currentChar == ']'
+        || currentChar == '}'
+        || currentChar == '\''
+        || currentChar == '"'
+        || currentChar == '`')
+        return false
+    if (currentChar.isLetterOrDigit() || currentChar == '_' || currentChar == '$') {
+        var start = lastSignificant
+        while (start > 0 && expression[start - 1].isJsIdentifierChar()) start--
+        return expression.substring(start, lastSignificant + 1) in KEYWORDS_BEFORE_REGEX
+    }
+    return true
+}
+
+
+private fun Char.isJsIdentifierChar() = isLetterOrDigit() || this == '_' || this == '$'
+
+private val KEYWORDS_BEFORE_REGEX = setOf(
+    "return", "typeof", "instanceof", "in", "of", "new", "delete", "void",
+    "case", "do", "else", "yield", "await",
+)

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
@@ -1,7 +1,17 @@
 package maestro.orchestra.util
 
+private const val BLOCK_OPEN = "\${"
+private const val VALUE_ENDING = ")]}'\"`"
+
+/**
+ * Replaces every `${ script }` in [input] with [evaluate]'s result; `\${ ... }` stays literal.
+ *
+ * The closing brace is found by scanning brace depth, not by regex: a regex match is greedy and
+ * takes the last `}` in the string, so any later brace broke the block. Braces
+ * inside string, template, comment and regex literals are not counted.
+ */
 internal fun interpolate(input: String, evaluate: (String) -> String): String {
-    if (!input.contains("\${")) return input
+    if (!input.contains(BLOCK_OPEN)) return input
 
     val out = StringBuilder(input.length)
     var i = 0
@@ -9,8 +19,8 @@ internal fun interpolate(input: String, evaluate: (String) -> String): String {
     while (i < input.length) {
         val currentChar = input[i]
 
-        if (currentChar == '\\' && input.startsWith("\${", i + 1)) {
-            val close = findClosingBrace(input, i + 3)
+        if (currentChar == '\\' && input.startsWith(BLOCK_OPEN, i + 1)) {
+            val close = findClosingBrace(input, i + 1 + BLOCK_OPEN.length)
             if (close == -1) {
                 out.append(currentChar)
                 i++
@@ -20,13 +30,13 @@ internal fun interpolate(input: String, evaluate: (String) -> String): String {
             }
             continue
         }
-        if (currentChar == '$' && input.getOrNull(i + 1) == '{'){
-            val close = findClosingBrace(input, i + 2)
+        if (input.startsWith(BLOCK_OPEN, i)) {
+            val close = findClosingBrace(input, i + BLOCK_OPEN.length)
             if (close == -1) {
                 out.append(currentChar)
                 i++
             } else {
-                val script = input.substring(i + 2, close)
+                val script = input.substring(i + BLOCK_OPEN.length, close)
                 if (script.isNotBlank()) out.append(evaluate(script))
                 i = close + 1
             }
@@ -38,6 +48,7 @@ internal fun interpolate(input: String, evaluate: (String) -> String): String {
     return out.toString()
 }
 
+/** Index OF the brace closing the block whose body starts at [from], or -1 if it never closes. */
 private fun findClosingBrace(expression: String, from: Int): Int {
     val stack = ArrayDeque<Char>()
     stack.addLast('{')
@@ -54,9 +65,9 @@ private fun findClosingBrace(expression: String, from: Int): Int {
                     lastSignificant = i
                     i++
                 }
-                expression[i] == '$' && expression.getOrNull(i + 1) == '{' -> {
+                expression.startsWith(BLOCK_OPEN, i) -> {
                     stack.addLast('{')
-                    i += 2
+                    i += BLOCK_OPEN.length
                 }
                 else -> i++
             }
@@ -81,15 +92,13 @@ private fun findClosingBrace(expression: String, from: Int): Int {
             }
             currentChar == '\'' || currentChar == '"' -> {
                 i = skipString(expression, i, currentChar)
-                lastSignificant = i - 1
+                lastSignificant = i - 1 // the closing quote: skipString returned the index past it
             }
-            currentChar == '/' && expression.getOrNull(i + 1) == '/' -> i = skipLineComment(expression, i)
-
-            currentChar == '/' && expression.getOrNull(i + 1) == '*' -> i = skipBlockComment(expression, i)
-
+            expression.startsWith("//", i) -> i = skipLineComment(expression, i)
+            expression.startsWith("/*", i) -> i = skipBlockComment(expression, i)
             currentChar == '/' && regexCanStart(expression, lastSignificant) -> {
                 i = skipRegex(expression, i)
-                lastSignificant = i - 1
+                lastSignificant = i - 1 // the closing slash: skipRegex returned the index past it
             }
             currentChar.isWhitespace() -> i++
             else -> {
@@ -101,6 +110,9 @@ private fun findClosingBrace(expression: String, from: Int): Int {
     return -1
 }
 
+/**
+* Every `skip*` below returns the index just PAST the run it skipped.
+*/
 private fun skipString(expression: String, open: Int, quote: Char): Int {
     var i = open + 1
     while (i < expression.length) {
@@ -130,8 +142,14 @@ private fun skipRegex(expression: String, open: Int): Int {
     while (i < expression.length) {
         when (expression[i]) {
             '\\' -> i += 2
-            '[' -> { inCharClass = true; i++ }
-            ']' -> { inCharClass = false; i++ }
+            '[' -> {
+                inCharClass = true
+                i++
+            }
+            ']' -> {
+                inCharClass = false
+                i++
+            }
             '/' -> if (inCharClass) i++ else return i + 1
             '\n' -> return open + 1
             else -> i++
@@ -140,25 +158,22 @@ private fun skipRegex(expression: String, open: Int): Int {
     return open + 1
 }
 
+/**
+ * Can a regex literal start here? `/` is also division and only a full JS parser can be sure;
+ * the rule is that a regex cannot follow a value. `}` is read as ending an object literal.
+ */
 private fun regexCanStart(expression: String, lastSignificant: Int): Boolean {
     if (lastSignificant < 0) return true
 
-    val currentChar = expression[lastSignificant]
-    if (currentChar == ')'
-        || currentChar == ']'
-        || currentChar == '}'
-        || currentChar == '\''
-        || currentChar == '"'
-        || currentChar == '`')
-        return false
-    if (currentChar.isLetterOrDigit() || currentChar == '_' || currentChar == '$') {
+    val previous = expression[lastSignificant]
+    if (previous in VALUE_ENDING) return false
+    if (previous.isJsIdentifierChar()) {
         var start = lastSignificant
         while (start > 0 && expression[start - 1].isJsIdentifierChar()) start--
         return expression.substring(start, lastSignificant + 1) in KEYWORDS_BEFORE_REGEX
     }
     return true
 }
-
 
 private fun Char.isJsIdentifierChar() = isLetterOrDigit() || this == '_' || this == '$'
 

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
@@ -92,13 +92,13 @@ private fun findClosingBrace(expression: String, from: Int): Int {
             }
             currentChar == '\'' || currentChar == '"' -> {
                 i = skipString(expression, i, currentChar)
-                lastSignificant = i - 1 // the closing quote: skipString returned the index past it
+                lastSignificant = i - 1
             }
             expression.startsWith("//", i) -> i = skipLineComment(expression, i)
             expression.startsWith("/*", i) -> i = skipBlockComment(expression, i)
             currentChar == '/' && regexCanStart(expression, lastSignificant) -> {
                 i = skipRegex(expression, i)
-                lastSignificant = i - 1 // the closing slash: skipRegex returned the index past it
+                lastSignificant = i - 1
             }
             currentChar.isWhitespace() -> i++
             else -> {

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/util/ScriptInterpolator.kt
@@ -1,7 +1,7 @@
 package maestro.orchestra.util
 
 internal fun interpolate(input: String, evaluate: (String) -> String): String {
-    if (input.contains("\${")) return input
+    if (!input.contains("\${")) return input
 
     val out = StringBuilder(input.length)
     var i = 0
@@ -10,7 +10,7 @@ internal fun interpolate(input: String, evaluate: (String) -> String): String {
         val currentChar = input[i]
 
         if (currentChar == '\\' && input.startsWith("\${", i + 1)) {
-            val close =  findClosingBrace(input, i + 3)
+            val close = findClosingBrace(input, i + 3)
             if (close == -1) {
                 out.append(currentChar)
                 i++

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/ScriptInterpolatorTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/ScriptInterpolatorTest.kt
@@ -240,7 +240,13 @@ class ScriptInterpolatorTest {
 
     @Test
     fun `Non-ASCII text and identifiers are preserved`() {
-        assertThat(interp("Привет, \${имя}!")).isEqualTo("Привет, <имя>!")
+        assertThat(interp("Grüße, \${straße}!")).isEqualTo("Grüße, <straße>!")
+        assertThat(interp("\${名前} さん")).isEqualTo("<名前> さん")
+    }
+
+    @Test
+    fun `Characters outside the basic plane survive the scan`() {
+        assertThat(interp("👋 \${'🎉'} {x}")).isEqualTo("👋 <'🎉'> {x}")
     }
 
 }

--- a/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/ScriptInterpolatorTest.kt
+++ b/maestro-orchestra-models/src/test/kotlin/maestro/orchestra/util/ScriptInterpolatorTest.kt
@@ -1,0 +1,246 @@
+package maestro.orchestra.util
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+
+class ScriptInterpolatorTest {
+
+    private fun interp(input: String) = interpolate(input){
+        "<$it>"
+    }
+
+    @Test
+    fun `Later brace in plain text does not end the block`() {
+        assertThat(interp("\${output.count} things {expected}"))
+            .isEqualTo("<output.count> things {expected}")
+    }
+
+    @Test
+    fun `a regex quantifier after the block is left alone`() {
+        assertThat(interp("\${output.count} items \\d{2}"))
+            .isEqualTo("<output.count> items \\d{2}")
+    }
+
+    @Test
+    fun `Block inside a JSON payload is bounded correctly`() {
+        assertThat(interp("""{"user": "${'$'}{output.name}"}"""))
+            .isEqualTo("""{"user": "<output.name>"}""")
+    }
+
+    @Test
+    fun `Script may contain the text dollar-brace`() {
+        assertThat(interp("\${'\\\${A}'}")).isEqualTo("<'\\\${A}'>")
+    }
+
+    @Test
+    fun `Script may contain a nested interpolation in a template literal`() {
+        assertThat(interp("\${`a\${b}c`}")).isEqualTo("<`a\${b}c`>")
+    }
+
+
+    @Test
+    fun `Braces before the block are plain text`() {
+        assertThat(interp("{literal} \${output.name}")).isEqualTo("{literal} <output.name>")
+    }
+
+    @Test
+    fun `Brace inside a string literal is not counted`() {
+        assertThat(interp("\${'}'}")).isEqualTo("<'}'>")
+        assertThat(interp("\${'{'}")).isEqualTo("<'{'>")
+    }
+
+    @Test
+    fun `Brace inside a regex literal is not counted`() {
+        assertThat(interp("\${'a'.replace(/[{]/g, '')}")).isEqualTo("<'a'.replace(/[{]/g, '')>")
+    }
+
+    @Test
+    fun `Quoted brace no longer depends on being last in the string`() {
+        assertThat(interp("\${'}'} and one more }")).isEqualTo("<'}'> and one more }")
+    }
+
+    @Test
+    fun `Every block in a string is evaluated`() {
+        assertThat(interp("\${A} and \${B}")).isEqualTo("<A> and <B>")
+    }
+
+    @Test
+    fun `Escaped block stays literal`() {
+        assertThat(interp("\\\${LITERAL}")).isEqualTo("\${LITERAL}")
+    }
+
+    @Test
+    fun `Escaped backslash still escapes the block`() {
+        assertThat(interp("\\\\\${A}")).isEqualTo("\\\${A}")
+    }
+
+    @Test
+    fun `Empty block evaluates to nothing`() {
+        assertThat(interp("a\${}b")).isEqualTo("ab")
+        assertThat(interp("a\${  }b")).isEqualTo("ab")
+    }
+
+    @Test
+    fun `String without a block is returned unchanged`() {
+        assertThat(interp("no scripts { } here")).isEqualTo("no scripts { } here")
+    }
+
+    @Test
+    fun `Object literal inside the block is bounded correctly`() {
+        assertThat(interp("\${ {a: 1}.a } tail")).isEqualTo("< {a: 1}.a > tail")
+    }
+
+    @Test
+    fun `Division is not mistaken for a regex literal`() {
+        assertThat(interp("\${ 10 / 2 } {x}")).isEqualTo("< 10 / 2 > {x}")
+    }
+
+    @Test
+    fun `Slashes inside a string are not a comment`() {
+        assertThat(interp("\${ '//' + '}' } {x}")).isEqualTo("< '//' + '}' > {x}")
+    }
+
+    @Test
+    fun `Brace inside a block comment is not counted`() {
+        assertThat(interp("\${ 1 /* } */ + 1 }")).isEqualTo("< 1 /* } */ + 1 >")
+    }
+
+    @Test
+    fun `Unterminated block is emitted verbatim`() {
+        assertThat(interp("cost: \${foo")).isEqualTo("cost: \${foo")
+    }
+
+    @Test
+    fun `Unterminated escaped block is emitted verbatim`() {
+        assertThat(interp("cost: \\\${foo")).isEqualTo("cost: \\\${foo")
+    }
+
+    @Test
+    fun `Brace on a later line does not end the block`() {
+        assertThat(interp("line1 \${A}\nline2 }")).isEqualTo("line1 <A>\nline2 }")
+    }
+
+    @Test
+    fun `Brace inside a line comment is not counted`() {
+        assertThat(interp("\${ 1 + // }\n 1 }")).isEqualTo("< 1 + // }\n 1 >")
+    }
+
+    @Test
+    fun `Blocks on separate lines are evaluated independently`() {
+        assertThat(interp("\${ 'a' }\n\${ 'b' }")).isEqualTo("< 'a' >\n< 'b' >")
+    }
+
+    @Test
+    fun `A keyword before the slash starts a regex literal`() {
+        assertThat(interp("\${ (function(){ return /}/.test('a') })() }"))
+            .isEqualTo("< (function(){ return /}/.test('a') })() >")
+    }
+
+    @Test
+    fun `A slash after a closing parenthesis is a division`() {
+        assertThat(interp("\${ f(x) / 2 }")).isEqualTo("< f(x) / 2 >")
+    }
+
+    @Test
+    fun `A closing brace inside a regex character class is not counted`() {
+        assertThat(interp("\${'a'.replace(/[}]/g, '')}")).isEqualTo("<'a'.replace(/[}]/g, '')>")
+    }
+
+    @Test
+    fun `A slash inside a regex character class does not end the regex`() {
+        assertThat(interp("\${'a/b'.split(/[/]/)}")).isEqualTo("<'a/b'.split(/[/]/)>")
+    }
+
+    @Test
+    fun `A quote inside a regex literal does not open a string`() {
+        assertThat(interp("\${'x'.replace(/'/g, '')}")).isEqualTo("<'x'.replace(/'/g, '')>")
+    }
+
+    @Test
+    fun `An escaped quote does not end the string literal`() {
+        assertThat(interp("\${ 'don\\'t }' }")).isEqualTo("< 'don\\'t }' >")
+    }
+
+    @Test
+    fun `An escaped backtick does not end the template literal`() {
+        assertThat(interp("\${`a\\`}b`}")).isEqualTo("<`a\\`}b`>")
+    }
+
+    @Test
+    fun `A quote inside a template literal is plain text`() {
+        assertThat(interp("\${`it's }`}")).isEqualTo("<`it's }`>")
+    }
+
+    @Test
+    fun `Templates nest to any depth`() {
+        assertThat(interp("\${`a\${`b\${c}d`}e`}")).isEqualTo("<`a\${`b\${c}d`}e`>")
+    }
+
+    @Test
+    fun `A block with an unterminated string is emitted verbatim`() {
+        assertThat(interp("\${ 'oops }")).isEqualTo("\${ 'oops }")
+    }
+
+    @Test
+    fun `A block with an unterminated template is emitted verbatim`() {
+        assertThat(interp("\${ `oops }")).isEqualTo("\${ `oops }")
+    }
+
+    @Test
+    fun `An unterminated regex falls back to a plain slash and the block still closes`() {
+        assertThat(interp("\${ /oops }")).isEqualTo("< /oops >")
+    }
+
+    @Test
+    fun `The evaluated result is not scanned again`() {
+        val evaluated = interpolate("x \${A} y") { "\${INJECTED} }" }
+
+        assertThat(evaluated).isEqualTo("x \${INJECTED} } y")
+    }
+
+    @Test
+    fun `An escaped block is never evaluated`() {
+        val scripts = mutableListOf<String>()
+
+        val evaluated = interpolate("\\\${A} and \${B}") {
+            scripts += it
+            "<$it>"
+        }
+
+        assertThat(scripts).containsExactly("B")
+        assertThat(evaluated).isEqualTo("\${A} and <B>")
+    }
+
+    @Test
+    fun `A dollar that opens no block is plain text`() {
+        assertThat(interp("price: \$5")).isEqualTo("price: \$5")
+        assertThat(interp("costs 100\$")).isEqualTo("costs 100\$")
+    }
+
+    @Test
+    fun `A block opened at the very end of the string is emitted verbatim`() {
+        assertThat(interp("abc\${")).isEqualTo("abc\${")
+    }
+
+    @Test
+    fun `A trailing backslash is plain text`() {
+        assertThat(interp("trailing backslash \\")).isEqualTo("trailing backslash \\")
+    }
+
+    @Test
+    fun `Adjacent blocks are evaluated separately`() {
+        assertThat(interp("\${A}\${B}")).isEqualTo("<A><B>")
+    }
+
+    @Test
+    fun `An escaped block next to a real one does not affect it`() {
+        assertThat(interp("\\\${A}\${B}")).isEqualTo("\${A}<B>")
+        assertThat(interp("\${A}\\\${B}")).isEqualTo("<A>\${B}")
+    }
+
+    @Test
+    fun `Non-ASCII text and identifiers are preserved`() {
+        assertThat(interp("Привет, \${имя}!")).isEqualTo("Привет, <имя>!")
+    }
+
+}


### PR DESCRIPTION
## Proposed changes

## Problem
`Env.String.evaluateScripts` located `${...}` blocks with the regex `(?<!\\)\$\{([^$]*)}`.  The body pattern is greedy, so the `}` it picked was the **last** one in the string rather than the one that ends the block. Any brace appearing after an interpolation broke it.

## Solution
Replaces the regex with a single-pass scanner (`ScriptInterpolator.kt`) that finds the  closing brace by tracking brace depth, skipping over string, template, comment and regex  literals so braces inside them are not counted. Env.String.evaluateScripts` becomes a  one-line call into it.

## Testing

44 unit tests added in `ScriptInterpolatorTest`, covering the regressions above, everything that already worked, and the edges (multiline input, unterminated literals, adjacent blocks,  `$` without a brace, non-ASCII). The scanner is tested without the JS engine by passing a  stub `evaluate`.

## Issues fixed
Fixes https://github.com/mobile-dev-inc/Maestro/issues/3540