### PR TITLE
refactor(orchestra): name the artifact classes for what they do

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestRunner.kt
@@ -66,7 +66,7 @@ object TestRunner {
         aiOutput = aiOutput.copy(flowName = flowName)
         logger.info("Running flow ${flowFile.name}...")
 
-        // Per-flow folder ArtifactsGenerator writes the bundle into (see BundleLayout).
+        // Per-flow folder BundleWriter writes the bundle into (see BundleLayout).
         val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName)
 
         val result = runCatching(resultView, maestro) {

--- a/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/TestSuiteInteractor.kt
@@ -180,7 +180,7 @@ class TestSuiteInteractor(
 
         logger.info("$shardPrefix Running flow $flowName")
 
-        // Per-flow folder ArtifactsGenerator writes the bundle into (see BundleLayout).
+        // Per-flow folder BundleWriter writes the bundle into (see BundleLayout).
         val flowDir = TestDebugReporter.createFlowDir(debugOutputPath, flowName, shardIndex)
 
         var debugOutput = FlowDebugOutput()

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -45,9 +45,9 @@ import maestro.js.GraalJsEngine
 import maestro.js.JsEngine
 import maestro.orchestra.ArtifactKind
 import maestro.orchestra.ArtifactManifest
-import maestro.orchestra.debug.ArtifactsGenerator
+import maestro.orchestra.debug.BundleWriter
 import maestro.orchestra.debug.BundleLayout
-import maestro.orchestra.debug.ArtifactCollector
+import maestro.orchestra.debug.ArtifactRegistry
 import maestro.orchestra.debug.CommandOutcome
 import maestro.orchestra.debug.FlowDebugOutput
 import maestro.orchestra.debug.OrchestraListener
@@ -172,11 +172,11 @@ class Orchestra(
 
     private val rawCommandToMetadata = mutableMapOf<MaestroCommand, CommandMetadata>()
 
-    // ArtifactsGenerator is always the first listener: it writes the bundle when
+    // BundleWriter is always the first listener: it writes the bundle when
     // artifactsDir is set and populates debugOutput either way.
-    private val artifactsGenerator: ArtifactsGenerator =
-        ArtifactsGenerator(artifactsDir, maestro, captureFullArtifacts, onStepScreenshotCaptured)
-    private val effectiveListeners: List<OrchestraListener> = listOf(artifactsGenerator) + listeners
+    private val bundleWriter: BundleWriter =
+        BundleWriter(artifactsDir, maestro, captureFullArtifacts, onStepScreenshotCaptured)
+    private val effectiveListeners: List<OrchestraListener> = listOf(bundleWriter) + listeners
 
     private var commandSequenceCounter: Int = 0
 
@@ -266,8 +266,8 @@ class Orchestra(
 
             return FlowResult(
                 success = onCompleteSuccess && flowSuccess,
-                debugOutput = artifactsGenerator.debugOutput,
-                artifactManifest = artifactsGenerator.artifactManifest,
+                debugOutput = bundleWriter.debugOutput,
+                artifactManifest = bundleWriter.artifactManifest,
             )
         }
     }
@@ -1198,9 +1198,9 @@ class Orchestra(
     }
 
     private suspend fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
-        ArtifactCollector.validateCommandPath(command.path, "takeScreenshot")
+        ArtifactRegistry.validateCommandPath(command.path, "takeScreenshot")
         // Generator owns the bundle path and records the file; null means no bundle (write CWD-relative).
-        val outFile = artifactsGenerator
+        val outFile = bundleWriter
             .allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "${command.path}.png", "takeScreenshot")
             ?: File("${command.path}.png")
         val fileSink = artifactSink(outFile, command.path, "takeScreenshot")
@@ -1224,9 +1224,9 @@ class Orchestra(
     }
 
     private suspend fun startRecordingCommand(command: StartRecordingCommand): Boolean {
-        ArtifactCollector.validateCommandPath(command.path, "startRecording")
+        ArtifactRegistry.validateCommandPath(command.path, "startRecording")
         // Recorded at start; the file is finalized at stopRecording.
-        val outFile = artifactsGenerator
+        val outFile = bundleWriter
             .allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "${command.path}.mp4", "startRecording")
             ?: File("${command.path}.mp4")
         screenRecording = maestro.startScreenRecording(artifactSink(outFile, command.path, "startRecording"))

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactRegistry.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactRegistry.kt
@@ -11,10 +11,13 @@ import java.nio.file.InvalidPathException
 import java.nio.file.Path
 
 /**
- * Single owner of the artifacts bundle. Allocates every path core writes and
- * records every artifact as it is produced; the manifest is its records and the
- * per-command list is the same records grouped by owning command. Nothing
- * reaches the bundle unrecorded, and there is no end-of-flow disk scan.
+ * The record of what is in the run's bundle: every path core writes is reserved here, and every
+ * artifact is registered as it is produced. The manifest is those records, and each command's
+ * artifact list is the same records grouped by owning command, so the two cannot disagree.
+ *
+ * Registered as produced, never gathered afterwards — there is no end-of-flow disk scan. An
+ * artifact that reaches the bundle by any other route is therefore invisible to whatever reads
+ * the manifest, the Cloud uploader included.
  *
  * Layout knowledge — which kinds are folder collections — lives here, the one
  * place the bundle shape is encoded, resolving paths against [BundleLayout].
@@ -22,7 +25,7 @@ import java.nio.file.Path
  * Not thread-safe: assumes Orchestra's single-threaded, synchronous per-flow
  * dispatch (the same invariant the listener relies on).
  */
-internal class ArtifactCollector(artifactsDir: Path) {
+internal class ArtifactRegistry(artifactsDir: Path) {
 
     private val artifactsDir: Path = artifactsDir.toFile().canonicalFile.toPath()
 

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleWriter.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleWriter.kt
@@ -20,7 +20,18 @@ import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 
 /**
- * Internal listener Orchestra always installs. Populates [FlowDebugOutput]
+ * Builds the run's artifact bundle over the flow's lifetime. Four jobs, all in service of that:
+ *
+ *  1. **listens** — the [OrchestraListener] callbacks below are its clock
+ *  2. **captures** — step screenshots, view hierarchies, the full-run recording, device logs
+ *  3. **writes the index** — `commands.json` and `manifest.json` at flow end
+ *  4. **holds the run's in-memory state** — [debugOutput] and [artifactManifest]
+ *
+ * Capture is how it obtains what to write; [ArtifactRegistry] decides where each file lands and
+ * records it. Splitting capture from index-writing would be the tidier shape and is deliberately
+ * not done here.
+ *
+ * Installed by Orchestra always. Populates [FlowDebugOutput]
  * in memory (always on; consumers read it via `Orchestra.debugOutput`) and,
  * when [artifactsDir] is non-null, writes the per-flow artifact bundle
  * directly under it — see [BundleLayout] for the layout. With a null
@@ -36,12 +47,12 @@ import java.nio.file.StandardCopyOption
  * chain with the screen the run ended on — after any onFlowComplete teardown — giving
  * complete start-and-end evidence.
  *
- * Every file is routed through an [ArtifactCollector]: the manifest is the
+ * Every file is routed through an [ArtifactRegistry]: the manifest is the
  * collector's records and each command's artifact list is the same records
  * grouped by command, so the two can never disagree. Device logs + crash/ANR
  * are captured by [DeviceArtifactCapturer] and adopted into that same collector.
  */
-internal class ArtifactsGenerator(
+internal class BundleWriter(
     private val artifactsDir: Path?,
     private val maestro: Maestro,
     private val captureFullArtifacts: Boolean = false,
@@ -53,7 +64,7 @@ internal class ArtifactsGenerator(
     /** The run's artifact manifest; populated at [onFlowEnd], empty when [artifactsDir] is null. */
     var artifactManifest: ArtifactManifest = ArtifactManifest()
         private set
-    private var collector: ArtifactCollector? = null
+    private var collector: ArtifactRegistry? = null
     private var logCapture: ScopedLogCapture? = null
     private var fullRunRecording: ScreenRecording? = null
     private var fullRunRecordingFile: File? = null
@@ -69,7 +80,7 @@ internal class ArtifactsGenerator(
     override fun onFlowStart() {
         if (artifactsDir == null) return
         try {
-            val collector = ArtifactCollector(artifactsDir).also { this.collector = it }
+            val collector = ArtifactRegistry(artifactsDir).also { this.collector = it }
             val logFile = collector.allocate(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, BundleLayout.MAESTRO_LOG)
             logCapture = ScopedLogCapture.start(logFile)
             flowStartMs = System.currentTimeMillis()
@@ -223,7 +234,7 @@ internal class ArtifactsGenerator(
         }
     }
 
-    private fun ArtifactCollector.adoptDeviceArtifact(captured: CapturedDeviceArtifact) {
+    private fun ArtifactRegistry.adoptDeviceArtifact(captured: CapturedDeviceArtifact) {
         val kind = when (captured.type) {
             CapturedDeviceArtifact.Type.DEVICE_LOG -> ArtifactKind.DEVICE_LOG
             CapturedDeviceArtifact.Type.CRASH_REPORT -> ArtifactKind.CRASH_REPORT
@@ -322,6 +333,6 @@ internal class ArtifactsGenerator(
     }
 
     companion object {
-        private val logger = LoggerFactory.getLogger(ArtifactsGenerator::class.java)
+        private val logger = LoggerFactory.getLogger(BundleWriter::class.java)
     }
 }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/TestOutputWriter.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/TestOutputWriter.kt
@@ -13,7 +13,7 @@ import java.nio.file.Path
 import kotlin.io.path.absolutePathString
 
 /**
- * Pure write-path for the flow-debug bundle files. Callers (ArtifactsGenerator,
+ * Pure write-path for the flow-debug bundle files. Callers (BundleWriter,
  * the CLI's TestDebugReporter, the cloud worker) compose their own filenames, so
  * no prefix/suffix knobs are threaded through the API.
  */

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactRegistryTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/ArtifactRegistryTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import java.nio.file.Path
 
-class ArtifactCollectorTest {
+class ArtifactRegistryTest {
 
     @TempDir
     lateinit var tempDir: Path
@@ -23,7 +23,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `allocate creates parent dirs and returns a file under the artifacts folder`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
 
         val file = collector.allocate(
             ArtifactKind.SCREEN_HIERARCHY,
@@ -38,7 +38,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `manifest folds a collection kind into one folder entry with a count`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
 
         collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-0.png").writeText("a")
         collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-1.png").writeText("b")
@@ -51,7 +51,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `manifest emits a single-file entry with sizeBytes for non-collection kinds`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
 
         collector.allocate(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, "logs/maestro.log").writeText("hello")
 
@@ -63,7 +63,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `records whose file was never written are dropped from the manifest`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
 
         // Allocated but never written (e.g. the capture threw mid-write).
         collector.allocate(ArtifactKind.SCREENSHOT, ArtifactFormat.PNG, "screenshots/step-0.png")
@@ -73,7 +73,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `adopt records an externally-produced file with its metadata`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
         tempDir.resolve("logs").toFile().mkdirs()
         tempDir.resolve("logs/device-logcat.txt").toFile().writeText("logcat")
 
@@ -92,7 +92,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `allocate normalizes the path so the dirs it creates are the ones the write opens`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
 
         val file = collector.allocate(
             ArtifactKind.START_SCREEN_RECORDING,
@@ -107,7 +107,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `manifest reports the normalized path, so lookups find the file that was written`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
 
         collector.allocate(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, "logs/./maestro.log").writeText("hello")
 
@@ -120,20 +120,20 @@ class ArtifactCollectorTest {
     @ValueSource(strings = ["startRecording/../../clip.mp4", "/tmp/clip.mp4"])
     fun `allocate refuses a path that escapes the artifacts folder`(escaping: String) {
         assertThrows<IllegalArgumentException> {
-            ArtifactCollector(tempDir).allocate(ArtifactKind.START_SCREEN_RECORDING, ArtifactFormat.MP4, escaping)
+            ArtifactRegistry(tempDir).allocate(ArtifactKind.START_SCREEN_RECORDING, ArtifactFormat.MP4, escaping)
         }
     }
 
     @ParameterizedTest
     @ValueSource(strings = ["clip", "login/home", "login/../home", "/tmp/clip"])
     fun `validateCommandPath accepts any path that names a file`(path: String) {
-        ArtifactCollector.validateCommandPath(path, "startRecording")
+        ArtifactRegistry.validateCommandPath(path, "startRecording")
     }
 
     @Test
     fun `validateCommandPath rejects a blank path`() {
         val e = assertThrows<MaestroException.InvalidCommand> {
-            ArtifactCollector.validateCommandPath("", "startRecording")
+            ArtifactRegistry.validateCommandPath("", "startRecording")
         }
 
         assertThat(e.message).contains("startRecording")
@@ -144,7 +144,7 @@ class ArtifactCollectorTest {
     @ValueSource(strings = ["logs/screenshots/", "logs\\screenshots\\"])
     fun `validateCommandPath rejects a path that names no file`(path: String) {
         val e = assertThrows<MaestroException.InvalidCommand> {
-            ArtifactCollector.validateCommandPath(path, "startRecording")
+            ArtifactRegistry.validateCommandPath(path, "startRecording")
         }
 
         assertThat(e.message).contains("file name")
@@ -152,7 +152,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `allocateCommandOutput keeps a path that walks back within the command folder`() {
-        val file = ArtifactCollector(tempDir)
+        val file = ArtifactRegistry(tempDir)
             .allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, "login/../clip.mp4", "startRecording", null)
 
         assertThat(file.toPath()).isEqualTo(realTempDir.resolve("startRecording/clip.mp4"))
@@ -162,7 +162,7 @@ class ArtifactCollectorTest {
     fun `allocateCommandOutput accepts an absolute path that lands in the command folder`() {
         val absolute = tempDir.resolve("startRecording/clip.mp4").toString()
 
-        val file = ArtifactCollector(tempDir)
+        val file = ArtifactRegistry(tempDir)
             .allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, absolute, "startRecording", null)
 
         assertThat(file.toPath()).isEqualTo(realTempDir.resolve("startRecording/clip.mp4"))
@@ -170,7 +170,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `allocateCommandOutput records an absolute path relative to the artifacts folder`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
         val absolute = tempDir.resolve("startRecording/clip.mp4").toString()
 
         collector.allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, absolute, "startRecording", 1)
@@ -183,7 +183,7 @@ class ArtifactCollectorTest {
     @ValueSource(strings = ["../clip.mp4", "login/../../clip.mp4", "/tmp/clip.mp4", "login/.."])
     fun `allocateCommandOutput rejects a path that lands outside the command folder as a flow error`(escaping: String) {
         val e = assertThrows<MaestroException.InvalidCommand> {
-            ArtifactCollector(tempDir)
+            ArtifactRegistry(tempDir)
                 .allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, escaping, "startRecording", null)
         }
 
@@ -194,7 +194,7 @@ class ArtifactCollectorTest {
     @Test
     @EnabledOnOs(OS.LINUX, OS.MAC)
     fun `allocateCommandOutput treats a backslash as a file-name character, not an escape`() {
-        val file = ArtifactCollector(tempDir)
+        val file = ArtifactRegistry(tempDir)
             .allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, "..\\clip.mp4", "startRecording", null)
 
         assertThat(file.toPath()).isEqualTo(realTempDir.resolve("startRecording/..\\clip.mp4"))
@@ -204,7 +204,7 @@ class ArtifactCollectorTest {
     fun `allocateCommandOutput accepts a plain name when the artifacts dir carries a dot segment`() {
         val dotted = tempDir.resolve(".").resolve("art")
 
-        val file = ArtifactCollector(dotted)
+        val file = ArtifactRegistry(dotted)
             .allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, "clip.mp4", "startRecording", null)
 
         assertThat(file.toPath()).isEqualTo(realTempDir.resolve("art/startRecording/clip.mp4"))
@@ -212,7 +212,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `allocateCommandOutput accepts an absolute path given through the artifacts dir's real path`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
         val viaRealPath = tempDir.toRealPath().resolve("startRecording/clip.mp4").toString()
 
         collector.allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, viaRealPath, "startRecording", 1)
@@ -224,7 +224,7 @@ class ArtifactCollectorTest {
     @Test
     fun `allocateCommandOutput rejects a path the filesystem cannot represent as a flow error`() {
         val e = assertThrows<MaestroException.InvalidCommand> {
-            ArtifactCollector(tempDir)
+            ArtifactRegistry(tempDir)
                 .allocateCommandOutput(ArtifactKind.START_SCREEN_RECORDING, "a\u0000b.mp4", "startRecording", null)
         }
 
@@ -233,7 +233,7 @@ class ArtifactCollectorTest {
 
     @Test
     fun `a path overwritten across loop iterations counts once, not per record`() {
-        val collector = ArtifactCollector(tempDir)
+        val collector = ArtifactRegistry(tempDir)
         tempDir.resolve("takeScreenshot").toFile().mkdirs()
         tempDir.resolve("takeScreenshot/shot.png").toFile().writeText("x")
 

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/BundleWriterTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/BundleWriterTest.kt
@@ -32,7 +32,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.exists
 
-class ArtifactsGeneratorTest {
+class BundleWriterTest {
 
     @TempDir
     lateinit var tempDir: Path
@@ -52,7 +52,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `populates debugOutput in memory even when artifactsDir is null`() {
-        val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = null, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -68,7 +68,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `writes commands_json at the artifacts folder at onFlowEnd`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -84,7 +84,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `writes maestro_log under logs subdir`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -97,7 +97,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `with null artifactsDir, writes no files and produces an empty manifest`() {
-        val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = null, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -113,7 +113,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `on failure with artifactsDir, captures hierarchy and screenshot independently`() {
         val maestro = mockMaestro()
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro)
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
         val error = RuntimeException("boom")
 
@@ -142,7 +142,7 @@ class ArtifactsGeneratorTest {
                 TreeNode(attributes = mutableMapOf("text" to "root"))
             )
         }
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro)
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -167,7 +167,7 @@ class ArtifactsGeneratorTest {
             }
             coEvery { viewHierarchy(any()) } throws RuntimeException("hierarchy boom")
         }
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro)
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -181,7 +181,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `MaestroException on failure populates debugOutput_exception`() {
-        val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = null, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
         val mErr = MaestroException.UnableToLaunchApp("nope")
 
@@ -193,7 +193,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `onCommandReset leaves an already-recorded execution intact`() {
-        val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = null, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onCommandStart(cmd, 0)
@@ -206,7 +206,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `manifest exposes command metadata and maestro log entries at the artifacts folder`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -229,7 +229,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `failed run yields a single SCREENSHOT folder entry for the screenshots dir`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -247,7 +247,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `writes manifest_json to artifactsDir root at onFlowEnd`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -281,7 +281,7 @@ class ArtifactsGeneratorTest {
             listOf(CapturedDeviceArtifact(CapturedDeviceArtifact.Type.CRASH_REPORT, crashFile, friendlyMessage = "App crashed"))
         }
 
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro)
         val cmd = MaestroCommand(launchAppCommand = LaunchAppCommand(appId = "com.x"))
 
         gen.onFlowStart()
@@ -314,7 +314,7 @@ class ArtifactsGeneratorTest {
         coEvery { maestro.stopAndCollectDeviceLogs(any()) } throws RuntimeException("logcat fail")
         coEvery { maestro.collectCrashArtifacts(any(), any(), any()) } returns emptyList()
 
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro)
         val cmd = MaestroCommand(launchAppCommand = LaunchAppCommand(appId = "com.x"))
 
         gen.onFlowStart()
@@ -333,7 +333,7 @@ class ArtifactsGeneratorTest {
     fun `registers takeScreenshot and startRecording folders as collections`() {
         // Command output is allocated through the generator (as Orchestra does via
         // allocateCommandArtifact); the collector folds same-kind files into one entry.
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
@@ -361,7 +361,7 @@ class ArtifactsGeneratorTest {
     fun `omits takeScreenshot and startRecording entries when folders are absent or empty`() {
         Files.createDirectories(tempDir.resolve("startRecording")) // present but empty
 
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         gen.onFlowStart()
         gen.onFlowEnd()
 
@@ -371,7 +371,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `per-step screenshot is attributed to its command when captureFullArtifacts is true`() {
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -391,7 +391,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `captures per-step screenshots into screenshots folder when captureFullArtifacts is true`() {
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -414,7 +414,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `under captureFullArtifacts the step screenshot is captured before the command runs`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -444,7 +444,7 @@ class ArtifactsGeneratorTest {
             }
             coEvery { viewHierarchy(any()) } returns ViewHierarchy(TreeNode(attributes = mutableMapOf("text" to "root")))
         }
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -476,7 +476,7 @@ class ArtifactsGeneratorTest {
             coEvery { viewHierarchy(any()) } returns ViewHierarchy(TreeNode(attributes = mutableMapOf("text" to "root")))
         }
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = maestro,
             captureFullArtifacts = true,
@@ -497,7 +497,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `under captureFullArtifacts a warned step pairs a single shot with its hierarchy`() {
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -519,7 +519,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `under captureFullArtifacts a flow-end screenshot lands as final png, flow-level`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -544,7 +544,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `with captureFullArtifacts off no flow-end screenshot is captured`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -557,7 +557,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `with captureFullArtifacts off no screenshot is captured at command start`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -569,7 +569,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `does not capture per-step screenshots by default`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -584,7 +584,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `starts and stops a full-run recording when captureFullArtifacts is true`() {
         val maestro = mockMaestro()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = maestro,
             captureFullArtifacts = true,
@@ -599,7 +599,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `does not start a full-run recording by default`() {
         val maestro = mockMaestro()
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro)
 
         gen.onFlowStart()
         gen.onFlowEnd()
@@ -620,7 +620,7 @@ class ArtifactsGeneratorTest {
             mockk(relaxed = true)
         }
 
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
         gen.onFlowStart()
         gen.onFlowEnd()
 
@@ -635,7 +635,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `drops an empty full-run recording instead of surfacing a 0-byte placeholder`() {
         val maestro = mockMaestro() // relaxed startScreenRecording writes no bytes
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
 
         gen.onFlowStart()
         gen.onFlowEnd()
@@ -649,7 +649,7 @@ class ArtifactsGeneratorTest {
         val maestro = mockMaestro()
         coEvery { maestro.startScreenRecording(any()) } throws
             UnsupportedOperationException("driver does not support screen recording")
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = maestro, captureFullArtifacts = true)
 
         gen.onFlowStart()
         gen.onFlowEnd()
@@ -660,7 +660,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `command output is attributed to the running command`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -679,7 +679,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `commands without artifacts omit the artifacts key from commands_json`() {
         // Skipped commands produce no artifacts — use one to pin the NON_EMPTY omission.
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -693,7 +693,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `command output is attributed only to the command running when allocated`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val first = MaestroCommand(tapOnElement = null)
         val second = MaestroCommand(scrollCommand = ScrollCommand())
 
@@ -714,7 +714,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `failure screenshot is attributed to the failed command's artifacts`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -733,7 +733,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `allocateCommandArtifact returns null and records nothing when artifactsDir is null`() {
-        val gen = ArtifactsGenerator(artifactsDir = null, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = null, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -747,7 +747,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `points manifest at the stable schema URL and bundles no schema file`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -767,7 +767,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `passing command captures a screenshot but no hierarchy even when captureFullArtifacts is true`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -786,7 +786,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `passing command gets no hierarchy file when captureFullArtifacts is false`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -799,7 +799,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `skipped commands get no hierarchy file`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -812,7 +812,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `failed command gets a hierarchy file and commands_json has no inline hierarchy`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -829,7 +829,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `failed command gets a step screenshot even when captureFullArtifacts is false`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -845,7 +845,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `warned command gets a step screenshot even when captureFullArtifacts is false`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -860,7 +860,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `a re-run command yields one commands entry per execution, each with its own screenshot`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
         val cmd = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()
@@ -890,7 +890,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `AI screenshot is recorded as AI_ANALYSIS attributed to the running command`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
 
         gen.onFlowStart()
@@ -909,7 +909,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `the failed command's screenshot is part of the per-step set when captureFullArtifacts is true`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
         // ScrollCommand.equals() ignores its fields, so two would collide as
         // debugOutput.commands map keys — use distinct command types.
         val ok = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
@@ -931,7 +931,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `serialized error carries only message and debugMessage, no stack trace or hierarchy`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
         val error = MaestroException.AssertionFailure(
             message = "Assertion is false",
@@ -957,7 +957,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `callback reports the step screenshot path for a completed step when captureFullArtifacts is true`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -976,7 +976,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `callback reports the failure screenshot path for a failed step`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
@@ -994,7 +994,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `callback reports the step screenshot path for a warned step even when captureFullArtifacts is false`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
@@ -1013,7 +1013,7 @@ class ArtifactsGeneratorTest {
     fun `a skipped command still carries its pre-command screenshot`() {
         // Shot taken at onCommandStart, before the skip is decided.
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -1032,7 +1032,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `callback does not fire for a passing step when captureFullArtifacts is false`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
@@ -1056,7 +1056,7 @@ class ArtifactsGeneratorTest {
             )
         }
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = maestro,
             captureFullArtifacts = true,
@@ -1084,7 +1084,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `a throwing consumer propagates instead of being swallowed as a capture failure`() {
         // Callback fires outside the capture try (at onCommandStart), so a throwing consumer propagates.
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -1106,7 +1106,7 @@ class ArtifactsGeneratorTest {
     fun `separate failures each keep their own screenshot, not just the first`() {
         // Two sibling commands fail (continue-on-failure / optional) — both are real,
         // distinct failures, so each must keep its own screenshot.
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         // ScrollCommand.equals() ignores its fields, so two would collide as
         // debugOutput.commands map keys — use distinct command types.
         val first = MaestroCommand(evalScriptCommand = EvalScriptCommand("1"))
@@ -1129,7 +1129,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `composite failing captures its own screenshot but no hierarchy`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val composite = MaestroCommand(repeatCommand = RepeatCommand(commands = emptyList()))
 
         gen.onFlowStart()
@@ -1148,7 +1148,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `composite failing after its leaf keeps its own screenshot and fires the callback`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             onStepScreenshotCaptured = { seq, path -> captured.add(seq to path) },
@@ -1179,7 +1179,7 @@ class ArtifactsGeneratorTest {
     @Test
     fun `full-artifacts mode captures a pre-command shot for a composite parent`() {
         val captured = mutableListOf<Pair<Int, String>>()
-        val gen = ArtifactsGenerator(
+        val gen = BundleWriter(
             artifactsDir = tempDir,
             maestro = mockMaestro(),
             captureFullArtifacts = true,
@@ -1205,7 +1205,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `non-visible leaf captures no pre-command shot`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro(), captureFullArtifacts = true)
         val defineVars = MaestroCommand(defineVariablesCommand = DefineVariablesCommand(mapOf("a" to "b")))
 
         gen.onFlowStart()
@@ -1222,7 +1222,7 @@ class ArtifactsGeneratorTest {
 
     @Test
     fun `failing leaf pairs screenshot and hierarchy under the same stem`() {
-        val gen = ArtifactsGenerator(artifactsDir = tempDir, maestro = mockMaestro())
+        val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val leaf = MaestroCommand(scrollCommand = ScrollCommand())
 
         gen.onFlowStart()


### PR DESCRIPTION
Pure rename, no behaviour change. First of three stacked PRs; the other two add an artifact API and fix a bug that API prevents.

## Why

Both names are contradicted by their own KDoc's first sentence.

**`ArtifactCollector` collects nothing.** Artifacts are registered with it as they are created — its doc has to deny the name outright: *"there is no end-of-flow disk scan."* Every method either registers (`allocate`, `allocateCommandOutput`, `adopt`) or looks up (`artifactsForStep`, `manifest`). → **`ArtifactRegistry`**

**`ArtifactsGenerator` generates nothing**, and "generate" already means something specific here — `FlowCommandSchema` derives a schema from types. It listens to the flow, captures screenshots/hierarchies/recordings off the device, and writes `commands.json` + `manifest.json`. Its doc opens *"Internal listener Orchestra always installs"*. The bundle is what all of it produces. → **`BundleWriter`**

## Honest weakness

`BundleWriter` is the weaker rename. Most of its lines talk to a device, and "writer" suggests only serialisation. No single word covers "listens + captures + writes an index" — the real fix is splitting capture from index-writing, deliberately not done here.

## Verification

`./gradlew test` — **1225 tests, 0 failed**, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR1yrawifxaUgWfGXrPNfR