### PR TITLE
feat(orchestra): one way for a command to produce a file

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -176,6 +176,9 @@ class Orchestra(
     // artifactsDir is set and populates debugOutput either way.
     private val bundleWriter: BundleWriter =
         BundleWriter(artifactsDir, maestro, captureFullArtifacts, onStepScreenshotCaptured)
+    /** Where a command puts anything it produces. The only artifact surface commands use. */
+    private val artifacts = bundleWriter.artifacts
+
     private val effectiveListeners: List<OrchestraListener> = listOf(bundleWriter) + listeners
 
     private var commandSequenceCounter: Int = 0
@@ -649,7 +652,7 @@ class Orchestra(
 
         val candidates = buildList {
             command.flowPath?.let { add(it.resolve(path).toFile()) }
-            artifactsDir?.let { add(it.resolve(BundleLayout.TAKE_SCREENSHOT_DIR).resolve(path).normalize().toFile()) }
+            artifacts.existing(ArtifactKind.TAKE_SCREENSHOT, path)?.let { add(it) }
             add(File(path))
         }.distinctBy { it.canonicalPath }
 
@@ -1198,11 +1201,7 @@ class Orchestra(
     }
 
     private suspend fun takeScreenshotCommand(command: TakeScreenshotCommand): Boolean {
-        ArtifactRegistry.validateCommandPath(command.path, "takeScreenshot")
-        // Generator owns the bundle path and records the file; null means no bundle (write CWD-relative).
-        val outFile = bundleWriter
-            .allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "${command.path}.png", "takeScreenshot")
-            ?: File("${command.path}.png")
+        val outFile = artifacts.file(ArtifactKind.TAKE_SCREENSHOT, command.path)
         val fileSink = artifactSink(outFile, command.path, "takeScreenshot")
 
         val cropOn = command.cropOn
@@ -1224,11 +1223,8 @@ class Orchestra(
     }
 
     private suspend fun startRecordingCommand(command: StartRecordingCommand): Boolean {
-        ArtifactRegistry.validateCommandPath(command.path, "startRecording")
         // Recorded at start; the file is finalized at stopRecording.
-        val outFile = bundleWriter
-            .allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "${command.path}.mp4", "startRecording")
-            ?: File("${command.path}.mp4")
+        val outFile = artifacts.file(ArtifactKind.START_SCREEN_RECORDING, command.path)
         screenRecording = maestro.startScreenRecording(artifactSink(outFile, command.path, "startRecording"))
         return false
     }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactRegistry.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactRegistry.kt
@@ -32,12 +32,7 @@ internal class ArtifactRegistry(artifactsDir: Path) {
     /** A kind the manifest reports as one folder entry with a member count. */
     private data class Collection(val dir: String, val format: ArtifactFormat)
 
-    private val collectionKinds: Map<ArtifactKind, Collection> = mapOf(
-        ArtifactKind.TAKE_SCREENSHOT to Collection(BundleLayout.TAKE_SCREENSHOT_DIR, ArtifactFormat.PNG),
-        ArtifactKind.START_SCREEN_RECORDING to Collection(BundleLayout.START_RECORDING_DIR, ArtifactFormat.MP4),
-        ArtifactKind.SCREENSHOT to Collection(BundleLayout.STEP_SCREENSHOTS_DIR, ArtifactFormat.PNG),
-        ArtifactKind.SCREEN_HIERARCHY to Collection(BundleLayout.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),
-    )
+    private val collectionKinds: Map<ArtifactKind, Collection> get() = COLLECTION_KINDS
 
     private data class Record(
         val kind: ArtifactKind,
@@ -99,6 +94,25 @@ internal class ArtifactRegistry(artifactsDir: Path) {
             artifactsDir.relativize(resolved).joinToString("/"),
             sequenceNumber = sequenceNumber,
         )
+    }
+
+    /**
+     * Read-only lookup of an artifact this run already produced, inside the folder this registry
+     * owns for [kind]. Registers nothing and creates nothing; null when the kind owns no folder,
+     * the path escapes it, or the file is not there.
+     */
+    fun locate(kind: ArtifactKind, path: String): File? {
+        val collection = collectionKinds[kind] ?: return null
+        val folder = artifactsDir.resolve(collection.dir)
+        val resolved = try {
+            folder.resolve(path).toFile().canonicalFile.toPath()
+        } catch (e: IOException) {
+            return null
+        } catch (e: InvalidPathException) {
+            return null
+        }
+        if (!resolved.startsWith(folder) || resolved == folder) return null
+        return resolved.toFile().takeIf { it.isFile }
     }
 
     /** Record a file written outside the generator's own path (device logs, crash/ANR) that already lives in the artifacts folder. */
@@ -177,6 +191,22 @@ internal class ArtifactRegistry(artifactsDir: Path) {
          * — after it, a path naming no file looks like one. Holds with or without a bundle, so it
          * cannot need a collector instance; where the path lands is [allocateCommandOutput]'s call.
          */
+        /**
+         * Which kinds the manifest reports as one folder entry, and the folder they live in. In
+         * the companion because a name's folder and extension are settled before any registry
+         * exists (with no bundle there is none) — the one place the layout is encoded.
+         */
+        private val COLLECTION_KINDS: Map<ArtifactKind, Collection> = mapOf(
+            ArtifactKind.TAKE_SCREENSHOT to Collection(BundleLayout.TAKE_SCREENSHOT_DIR, ArtifactFormat.PNG),
+            ArtifactKind.START_SCREEN_RECORDING to Collection(BundleLayout.START_RECORDING_DIR, ArtifactFormat.MP4),
+            ArtifactKind.SCREENSHOT to Collection(BundleLayout.STEP_SCREENSHOTS_DIR, ArtifactFormat.PNG),
+            ArtifactKind.SCREEN_HIERARCHY to Collection(BundleLayout.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),
+        )
+
+        /** The extension a [kind]'s own format implies, e.g. PNG -> ".png". */
+        fun extensionFor(kind: ArtifactKind): String =
+            COLLECTION_KINDS[kind]?.format?.let { ".${it.name.lowercase()}" }.orEmpty()
+
         fun validateCommandPath(path: String, commandName: String) {
             if (path.isBlank()) {
                 throw invalidCommandPath(path, commandName, "the path is empty")

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/Artifacts.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/Artifacts.kt
@@ -1,0 +1,58 @@
+package maestro.orchestra.debug
+
+import maestro.orchestra.ArtifactKind
+import java.io.File
+
+/**
+ * Where a command puts anything it produces, and reads back anything it already produced.
+ *
+ * This is the whole answer to "my command needs to write a file — where does it go?". A command
+ * names a *kind* and a *name*; everything else is decided here, because everything else is
+ * something a caller would otherwise have to remember:
+ *
+ *  - which folder, and which extension, from the kind's own `ArtifactFormat`
+ *  - whether the name needs validating as flow-supplied — see [FLOW_NAMED]
+ *  - registration, so the run's manifest — and therefore the Cloud uploader — knows the file
+ *
+ * That last one is the point. A file written by any other route is not registered, and whatever
+ * reads the manifest never sees it.
+ *
+ * The shape is androidx.test's `TestStorage.openOutputFile` / `openInputFile`: the caller names
+ * a thing, the framework owns where it lands.
+ */
+class Artifacts internal constructor(
+    private val writer: BundleWriter,
+) {
+
+    /**
+     * A file to write [kind] output into, called [name] — *without* an extension.
+     *
+     * Never null: with no bundle the file is CWD-relative and unregistered, as command output has
+     * always been, so no caller needs a fallback of its own.
+     */
+    fun file(kind: ArtifactKind, name: String): File {
+        val label = kind.commandLabel()
+        // Only a name a flow can influence can be blank, "." or ".." — and the check has to run
+        // before the extension is appended, or "." becomes "..png" and stops looking like one.
+        if (kind in FLOW_NAMED) ArtifactRegistry.validateCommandPath(name, label)
+
+        val fileName = "$name${ArtifactRegistry.extensionFor(kind)}"
+        val registry = writer.registry ?: return File(fileName)
+        return registry.allocateCommandOutput(kind, fileName, label, writer.currentSequenceNumber)
+    }
+
+    /** An artifact of [kind] this run already produced under [name], or null. Registers nothing. */
+    fun existing(kind: ArtifactKind, name: String): File? = writer.registry?.locate(kind, name)
+
+    private companion object {
+        /** Kinds whose name comes from the flow, so it can be empty, "." or "..". */
+        private val FLOW_NAMED = setOf(ArtifactKind.TAKE_SCREENSHOT, ArtifactKind.START_SCREEN_RECORDING)
+
+        /** The command a kind belongs to, for the "invalid path for X" message. */
+        private fun ArtifactKind.commandLabel(): String = when (this) {
+            ArtifactKind.TAKE_SCREENSHOT -> "takeScreenshot"
+            ArtifactKind.START_SCREEN_RECORDING -> "startRecording"
+            else -> name
+        }
+    }
+}

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleWriter.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleWriter.kt
@@ -64,7 +64,9 @@ internal class BundleWriter(
     /** The run's artifact manifest; populated at [onFlowEnd], empty when [artifactsDir] is null. */
     var artifactManifest: ArtifactManifest = ArtifactManifest()
         private set
-    private var collector: ArtifactRegistry? = null
+    /** Visible to [Artifacts], which registers on a command's behalf. Null until flow start. */
+    internal var registry: ArtifactRegistry? = null
+        private set
     private var logCapture: ScopedLogCapture? = null
     private var fullRunRecording: ScreenRecording? = null
     private var fullRunRecordingFile: File? = null
@@ -80,8 +82,8 @@ internal class BundleWriter(
     override fun onFlowStart() {
         if (artifactsDir == null) return
         try {
-            val collector = ArtifactRegistry(artifactsDir).also { this.collector = it }
-            val logFile = collector.allocate(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, BundleLayout.MAESTRO_LOG)
+            val registry = ArtifactRegistry(artifactsDir).also { this.registry = it }
+            val logFile = registry.allocate(ArtifactKind.MAESTRO_LOG, ArtifactFormat.TXT, BundleLayout.MAESTRO_LOG)
             logCapture = ScopedLogCapture.start(logFile)
             flowStartMs = System.currentTimeMillis()
             appUnderTest = null
@@ -112,17 +114,11 @@ internal class BundleWriter(
         if (captureFullArtifacts && StepArtifactNaming.capturesScreenshot(cmd)) captureStepScreenshot(metadata)
     }
 
-    /**
-     * Allocate (and record) a command-output file through the collector, attributed
-     * to the running command. Null when no bundle is produced ([artifactsDir] null) —
-     * the caller then writes CWD-relative, as before.
-     */
-    fun allocateCommandArtifact(kind: ArtifactKind, path: String, commandName: String): File? {
-        val collector = collector ?: return null
-        return collector.allocateCommandOutput(
-            kind, path, commandName, currentCommandMetadata?.sequenceNumber,
-        )
-    }
+    /** The executing command's step, or null outside a command. Visible to [Artifacts]. */
+    internal val currentSequenceNumber: Int? get() = currentCommandMetadata?.sequenceNumber
+
+    /** Where a command puts anything it produces — see [Artifacts]. */
+    val artifacts: Artifacts = Artifacts(this)
 
     override fun onCommandFinished(
         cmd: MaestroCommand,
@@ -172,7 +168,7 @@ internal class BundleWriter(
     }
 
     override fun onAIArtifactGenerated(screenshot: Buffer, defectCount: Int) {
-        val collector = collector ?: return
+        val collector = registry ?: return
         val meta = currentCommandMetadata ?: return
         try {
             val destFile = collector.allocate(
@@ -192,13 +188,13 @@ internal class BundleWriter(
         // Capture the resting screen before the recording is torn down.
         if (captureFullArtifacts) captureFinalScreenshot()
         stopFullRunRecording()
-        val collector = collector
-        if (artifactsDir != null && collector != null) {
+        val registry = registry
+        if (artifactsDir != null && registry != null) {
             // Per execution, keyed by sequence number — the same records the manifest
             // reads, so commands.json can't drift and each attempt keeps its own shot.
             debugOutput.executedSteps.forEach { step ->
                 step.artifacts.clear()
-                step.artifacts.addAll(collector.artifactsForStep(step.sequenceNumber))
+                step.artifacts.addAll(registry.artifactsForStep(step.sequenceNumber))
             }
             try {
                 TestOutputWriter.saveCommands(
@@ -206,7 +202,7 @@ internal class BundleWriter(
                     debugOutput = debugOutput,
                     commandsFilename = BundleLayout.COMMANDS_JSON,
                 )
-                collector.adopt(ArtifactKind.COMMAND_METADATA, BundleLayout.COMMANDS_JSON, ArtifactFormat.JSON)
+                registry.adopt(ArtifactKind.COMMAND_METADATA, BundleLayout.COMMANDS_JSON, ArtifactFormat.JSON)
             } catch (e: Exception) {
                 logger.warn("Failed to write commands.json under $artifactsDir", e)
             }
@@ -219,13 +215,13 @@ internal class BundleWriter(
             logCapture = null
         }
 
-        if (artifactsDir != null && collector != null) {
+        if (artifactsDir != null && registry != null) {
             // Device logs + crash/ANR land under logs/ and are adopted flow-level
             // (no owning command) so they appear in the manifest like any artifact.
             capturer?.collect(appUnderTest, flowStartMs).orEmpty()
-                .forEach { collector.adoptDeviceArtifact(it) }
+                .forEach { registry.adoptDeviceArtifact(it) }
             capturer = null
-            artifactManifest = collector.manifest()
+            artifactManifest = registry.manifest()
             try {
                 TestOutputWriter.saveManifest(artifactsDir, artifactManifest)
             } catch (e: Exception) {
@@ -249,7 +245,7 @@ internal class BundleWriter(
     }
 
     private fun captureStepHierarchy(metadata: CommandDebugMetadata) {
-        val collector = collector ?: return
+        val collector = registry ?: return
         try {
             val tree = runBlocking { maestro.viewHierarchy() }.root
             val destFile = collector.allocate(
@@ -285,7 +281,7 @@ internal class BundleWriter(
      * never destroys a frame already there), returning the bundle-relative path or null on failure.
      */
     private fun captureScreenshot(relativePath: String, sequenceNumber: Int?): String? {
-        val collector = collector ?: return null
+        val collector = registry ?: return null
         val destFile = collector.allocate(
             ArtifactKind.SCREENSHOT,
             ArtifactFormat.PNG,
@@ -309,7 +305,7 @@ internal class BundleWriter(
     }
 
     private fun startFullRunRecording() {
-        val collector = collector ?: return
+        val collector = registry ?: return
         try {
             val destFile = collector.allocate(ArtifactKind.SCREEN_RECORDING, ArtifactFormat.MP4, BundleLayout.SCREEN_RECORDING)
             fullRunRecordingFile = destFile

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/BundleWriterTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/BundleWriterTest.kt
@@ -332,14 +332,14 @@ class BundleWriterTest {
     @Test
     fun `registers takeScreenshot and startRecording folders as collections`() {
         // Command output is allocated through the generator (as Orchestra does via
-        // allocateCommandArtifact); the collector folds same-kind files into one entry.
+        // artifacts.file); the registry folds same-kind files into one entry.
         val gen = BundleWriter(artifactsDir = tempDir, maestro = mockMaestro())
         val cmd = MaestroCommand(tapOnElement = null)
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "login/home.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "splash.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
-        gen.allocateCommandArtifact(ArtifactKind.START_SCREEN_RECORDING, "clip.mp4", "startRecording")!!.writeBytes(byteArrayOf(1))
+        gen.artifacts.file(ArtifactKind.TAKE_SCREENSHOT, "login/home").writeBytes(byteArrayOf(1))
+        gen.artifacts.file(ArtifactKind.TAKE_SCREENSHOT, "splash").writeBytes(byteArrayOf(1))
+        gen.artifacts.file(ArtifactKind.START_SCREEN_RECORDING, "clip").writeBytes(byteArrayOf(1))
         gen.onFlowEnd()
 
         val takeScreenshot = gen.artifactManifest.entries
@@ -665,7 +665,7 @@ class BundleWriterTest {
 
         gen.onFlowStart()
         gen.onCommandStart(cmd, sequenceNumber = 0)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
+        gen.artifacts.file(ArtifactKind.TAKE_SCREENSHOT, "checkout").writeBytes(byteArrayOf(1))
         gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
         gen.onFlowEnd()
 
@@ -701,7 +701,7 @@ class BundleWriterTest {
         gen.onCommandStart(first, sequenceNumber = 0)
         gen.onCommandFinished(first, CommandOutcome.Completed, 100L, 150L)
         gen.onCommandStart(second, sequenceNumber = 1)
-        gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")!!.writeBytes(byteArrayOf(1))
+        gen.artifacts.file(ArtifactKind.TAKE_SCREENSHOT, "checkout").writeBytes(byteArrayOf(1))
         gen.onCommandFinished(second, CommandOutcome.Completed, 150L, 200L)
         gen.onFlowEnd()
 
@@ -729,20 +729,6 @@ class BundleWriterTest {
         val screenshotArtifact = artifacts.single { it.type == ArtifactKind.SCREENSHOT }
         assertThat(screenshotArtifact.path).isEqualTo("screenshots/step-001-scroll.png")
         assertThat(tempDir.resolve(screenshotArtifact.path).exists()).isTrue()
-    }
-
-    @Test
-    fun `allocateCommandArtifact returns null and records nothing when artifactsDir is null`() {
-        val gen = BundleWriter(artifactsDir = null, maestro = mockMaestro())
-        val cmd = MaestroCommand(tapOnElement = null)
-
-        gen.onFlowStart()
-        gen.onCommandStart(cmd, sequenceNumber = 0)
-        assertThat(gen.allocateCommandArtifact(ArtifactKind.TAKE_SCREENSHOT, "checkout.png", "takeScreenshot")).isNull()
-        gen.onCommandFinished(cmd, CommandOutcome.Completed, 100L, 150L)
-        gen.onFlowEnd()
-
-        assertThat(gen.debugOutput.commands[cmd]!!.artifacts).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
Stacked on #3581. No behaviour change.

## The problem

Producing an artifact took three steps, and the knowledge was nowhere a caller would look:

```kotlin
ArtifactRegistry.validateCommandPath(command.path, "takeScreenshot")   // 1. remember this
val outFile = bundleWriter
    .allocateCommandArtifact(TAKE_SCREENSHOT, "${command.path}.png", "takeScreenshot")  // 2. and the extension
    ?: File("${command.path}.png")                                      // 3. and the fallback
```

Worse, step 1 has a rule you can only learn by reading the implementation: it must run *before* the extension is appended, or `.` becomes `..png` and stops looking like a directory.

Get any of it wrong and the file is still written — just not registered. Nothing that reads the manifest, the Cloud uploader included, ever sees it.

## The change

```kotlin
val outFile = artifacts.file(ArtifactKind.TAKE_SCREENSHOT, command.path)
artifacts.existing(ArtifactKind.TAKE_SCREENSHOT, path)
```

The **kind** decides the folder, the extension, and whether the name needs validating as flow-supplied. `file` is non-null — with no bundle it is CWD-relative and unregistered, exactly as before — so no call site has a reason to build its own path.

## Inspiration

androidx.test's `TestStorage`:

```java
OutputStream openOutputFile(String pathname)
InputStream  openInputFile(String pathname)
```

One verb per direction; the caller names a thing, the runner owns where it lands. Same shape here.

## Verification

`./gradlew test` — **1224 tests, 0 failed**, 5 skipped. (One test removed: it pinned `allocateCommandArtifact`'s null return, which no longer exists.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR1yrawifxaUgWfGXrPNfR