### PR TITLE
fix(orchestra): route the assertScreenshot diff into the run bundle

### DIFF
--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/ArtifactManifest.kt
@@ -4,6 +4,7 @@ package maestro.orchestra
 enum class ArtifactKind {
     SCREENSHOT,             // per-step screenshots (all steps when captureFullArtifacts, else failed step only)
     TAKE_SCREENSHOT,        // takeScreenshot command output
+    SCREENSHOT_DIFF,        // assertScreenshot failure diffs
     SCREEN_RECORDING,       // full-run recording, flag-gated
     START_SCREEN_RECORDING, // startRecording command output
     SCREEN_HIERARCHY,

--- a/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v1.schema.json
+++ b/maestro-orchestra-models/src/main/resources/maestro/orchestra/artifact-manifest/v1.schema.json
@@ -63,6 +63,10 @@
           "description": "Output of the takeScreenshot command, under the run-root takeScreenshot/ folder."
         },
         {
+          "const": "SCREENSHOT_DIFF",
+          "description": "Visual diff PNGs produced by failed assertScreenshot commands, in the run-root assertScreenshot/ folder. Named for the producing step, so a retried assertion keeps every attempt. The reference image itself is workspace input and is not part of the bundle."
+        },
+        {
           "const": "SCREEN_RECORDING",
           "description": "The whole-run MP4 recording at the run-root screen-recording.mp4. Flag-gated; emitted by the worker, not the local CLI."
         },

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -696,7 +696,10 @@ class Orchestra(
             debugMessage = "The assertScreenshot command requires a valid image file. Supported formats include PNG, JPEG, GIF, BMP, TIFF, and WBMP. The file at ${expectedFile.absolutePath} could not be read."
         )
 
-        val diffFile = expectedFile.resolveSibling("${expectedFile.nameWithoutExtension}_diff.png")
+        // The reference is an INPUT the flow reads from its own directory; the diff is this
+        // run's OUTPUT. Deriving the diff's location from the reference's is what put it in the
+        // workspace, which Cloud deletes with the machine.
+        val diffFile = artifacts.file(ArtifactKind.SCREENSHOT_DIFF, "${expectedFile.nameWithoutExtension}_diff")
 
         when (val result = ScreenshotMatch.compare(expectedImage, actualImage, thresholdPercentage, diffFile)) {
             is ScreenshotMatch.Result.Match -> return false // Screenshots are non-interactive
@@ -708,7 +711,9 @@ class Orchestra(
             is ScreenshotMatch.Result.Mismatch -> throw MaestroException.AssertionFailure(
                 message = "Comparison error: ${command.description()} - threshold not met, current: ${result.matchPercent}%",
                 hierarchyRoot = maestro.viewHierarchy().root,
-                debugMessage = "Screenshot comparison failed. Check the diff image at ${diffFile.absolutePath} to see the differences. Adjust the thresholdPercentage if the differences are acceptable."
+                debugMessage = "Screenshot comparison failed. Check the diff image in this run's artifacts under " +
+                    "${BundleLayout.SCREENSHOT_DIFF_DIR}/${diffFile.name} to see the differences. " +
+                    "Adjust the thresholdPercentage if the differences are acceptable."
             )
         }
     }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactRegistry.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/ArtifactRegistry.kt
@@ -198,6 +198,7 @@ internal class ArtifactRegistry(artifactsDir: Path) {
          */
         private val COLLECTION_KINDS: Map<ArtifactKind, Collection> = mapOf(
             ArtifactKind.TAKE_SCREENSHOT to Collection(BundleLayout.TAKE_SCREENSHOT_DIR, ArtifactFormat.PNG),
+            ArtifactKind.SCREENSHOT_DIFF to Collection(BundleLayout.SCREENSHOT_DIFF_DIR, ArtifactFormat.PNG),
             ArtifactKind.START_SCREEN_RECORDING to Collection(BundleLayout.START_RECORDING_DIR, ArtifactFormat.MP4),
             ArtifactKind.SCREENSHOT to Collection(BundleLayout.STEP_SCREENSHOTS_DIR, ArtifactFormat.PNG),
             ArtifactKind.SCREEN_HIERARCHY to Collection(BundleLayout.SCREEN_HIERARCHY_DIR, ArtifactFormat.JSON),

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/Artifacts.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/Artifacts.kt
@@ -36,9 +36,17 @@ class Artifacts internal constructor(
         // before the extension is appended, or "." becomes "..png" and stops looking like one.
         if (kind in FLOW_NAMED) ArtifactRegistry.validateCommandPath(name, label)
 
-        val fileName = "$name${ArtifactRegistry.extensionFor(kind)}"
+        // A framework-named artifact carries its step, or two attempts of one retried command
+        // write the same file — which is how a flow that failed four times produced one diff.
+        val sequenceNumber = writer.currentSequenceNumber
+        val scoped = if (kind in STEP_SCOPED && sequenceNumber != null) {
+            "step-${StepArtifactNaming.index(sequenceNumber)}-$name"
+        } else {
+            name
+        }
+        val fileName = "$scoped${ArtifactRegistry.extensionFor(kind)}"
         val registry = writer.registry ?: return File(fileName)
-        return registry.allocateCommandOutput(kind, fileName, label, writer.currentSequenceNumber)
+        return registry.allocateCommandOutput(kind, fileName, label, sequenceNumber)
     }
 
     /** An artifact of [kind] this run already produced under [name], or null. Registers nothing. */
@@ -48,10 +56,14 @@ class Artifacts internal constructor(
         /** Kinds whose name comes from the flow, so it can be empty, "." or "..". */
         private val FLOW_NAMED = setOf(ArtifactKind.TAKE_SCREENSHOT, ArtifactKind.START_SCREEN_RECORDING)
 
+        /** Kinds the framework names, where the step keeps retries of one command apart. */
+        private val STEP_SCOPED = setOf(ArtifactKind.SCREENSHOT_DIFF)
+
         /** The command a kind belongs to, for the "invalid path for X" message. */
         private fun ArtifactKind.commandLabel(): String = when (this) {
             ArtifactKind.TAKE_SCREENSHOT -> "takeScreenshot"
             ArtifactKind.START_SCREEN_RECORDING -> "startRecording"
+            ArtifactKind.SCREENSHOT_DIFF -> "assertScreenshot"
             else -> name
         }
     }

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/BundleLayout.kt
@@ -17,6 +17,7 @@ package maestro.orchestra.debug
  *     maestro.log
  *     device logs, crash/ANR  ← worker/cloud only
  *   takeScreenshot/           ← takeScreenshot command output
+ *   assertScreenshot/         ← assertScreenshot failure diffs
  *   startRecording/           ← startRecording command output
  *   screenshots/              ← step screenshots, step-<NNN>-<type>[-<arg>].png (action steps + final.png; failed step only when flag off)
  *   screen-hierarchy/         ← per-step view hierarchy JSON
@@ -33,6 +34,13 @@ internal object BundleLayout {
     const val MAESTRO_LOG = "$LOGS_DIR/maestro.log"
 
     const val TAKE_SCREENSHOT_DIR = "takeScreenshot"
+
+    /**
+     * assertScreenshot failure diffs. Its own OUTPUT folder: the diff used to be written next
+     * to the *reference*, which is workspace INPUT and not part of the bundle — so on Cloud it
+     * was discarded with the workspace when the run ended.
+     */
+    const val SCREENSHOT_DIFF_DIR = "assertScreenshot"
 
     const val START_RECORDING_DIR = "startRecording"
 

--- a/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
+++ b/maestro-orchestra/src/main/kotlin/maestro/orchestra/debug/StepArtifactNaming.kt
@@ -38,8 +38,15 @@ internal object StepArtifactNaming {
         return leaf !is CompositeCommand && leaf.visible()
     }
 
+    /**
+     * The 1-based, zero-padded step index shared by every step-prefixed bundle name, so a diff,
+     * a screenshot and a hierarchy from one step share a prefix and correlate on sight.
+     */
+    fun index(sequenceNumber: Int): String =
+        (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
+
     fun stem(sequenceNumber: Int, command: MaestroCommand?): String {
-        val index = (sequenceNumber + 1).toString().padStart(MIN_INDEX_WIDTH, '0')
+        val index = index(sequenceNumber)
         val slug = command?.let(::slug)
         return if (slug.isNullOrEmpty()) "step-$index" else "step-$index-$slug"
     }

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/debug/OrchestraListenerDispatchTest.kt
@@ -16,6 +16,7 @@ import maestro.device.Platform
 import maestro.js.JsEngine
 import maestro.orchestra.ApplyConfigurationCommand
 import maestro.orchestra.AssertConditionCommand
+import maestro.orchestra.ArtifactKind
 import maestro.orchestra.AssertScreenshotCommand
 import maestro.orchestra.Condition
 import maestro.orchestra.DefineVariablesCommand
@@ -552,7 +553,39 @@ class OrchestraListenerDispatchTest {
     }
 
     @Test
-    fun `assertScreenshot writes its diff beside a reference reached through a parent segment`() {
+    fun `a retried assertScreenshot keeps a diff per attempt`() {
+        // The reported flow wrapped the assertion in `Retry 3 times`; it failed on all four
+        // attempts and, with the name taken only from the reference, they overwrote one file.
+        val commands = listOf(
+            MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "home")),
+            MaestroCommand(
+                retryCommand = RetryCommand(
+                    maxRetries = "3",
+                    config = null,
+                    commands = listOf(
+                        MaestroCommand(
+                            assertScreenshotCommand = AssertScreenshotCommand(
+                                path = "home",
+                                thresholdPercentage = "99",
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val orchestra = Orchestra(maestro = mockMaestroWithScreenshots(changing = true), artifactsDir = tempDir)
+
+        assertThrows<MaestroException.AssertionFailure> {
+            runBlocking { orchestra.runFlow(commands) }
+        }
+
+        val diffs = tempDir.resolve(BundleLayout.SCREENSHOT_DIFF_DIR).toFile().listFiles().orEmpty()
+        assertThat(diffs).hasLength(4)
+        assertThat(diffs.map { it.name }.toSet()).hasSize(4)
+    }
+
+    @Test
+    fun `assertScreenshot writes its diff into the bundle, not beside the reference`() {
         val commands = listOf(
             MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "login/../home")),
             MaestroCommand(
@@ -569,7 +602,14 @@ class OrchestraListenerDispatchTest {
         }
 
         assertThat(e.message).contains("threshold not met")
-        assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isTrue()
+        // Beside the reference is where it used to go, and why Cloud never had it.
+        assertThat(tempDir.resolve("${BundleLayout.TAKE_SCREENSHOT_DIR}/home_diff.png").toFile().exists()).isFalse()
+        val diffs = tempDir.resolve(BundleLayout.SCREENSHOT_DIFF_DIR).toFile().listFiles().orEmpty()
+        assertThat(diffs).hasLength(1)
+        assertThat(diffs.single().name).endsWith("home_diff.png")
+        // Registered, so whatever reads the manifest — the Cloud uploader included — sees it.
+        assertThat(tempDir.resolve(BundleLayout.MANIFEST_JSON).toFile().readText())
+            .contains(ArtifactKind.SCREENSHOT_DIFF.name)
     }
 
     @Test


### PR DESCRIPTION
Stacked on #3582. Fixes the reported bug.

`assertScreenshot` failures arrive on Cloud with no diff image. Reported by Nando's UKI (upload `mupload_01kyhjn1pyfn4v0gjycgd5ysft`, flow *Simple Delivery Journey*): the run artifacts hold the per-step screenshots, but not the one image that says *why* the assertion failed.

## Cause

```kotlin
val diffFile = expectedFile.resolveSibling("${expectedFile.nameWithoutExtension}_diff.png")
```

`expectedFile` is the **reference** — an input the flow reads from its own directory. The diff is an **output**. Deriving the second from the first puts the diff in the workspace checkout.

Locally the workspace is the folder you are already looking at, so it looks correct. On Cloud the workspace is scratch space deleted with the machine, and only the artifact bundle is uploaded.

**Not a regression** — `git log -L 696,698` shows the line predates the bundle work (`0d9b257e2`). Cloud diffs have never worked.

## Aggravators

- The name derives only from the reference, so the customer's `Retry 3 times` produced **four failures and one file** — three attempts lost even locally.
- The failure message pointed at `${diffFile.absolutePath}`, a path on a machine that no longer exists by the time anyone reads it.

## Change

```diff
-        val diffFile = expectedFile.resolveSibling("${expectedFile.nameWithoutExtension}_diff.png")
+        val diffFile = artifacts.file(ArtifactKind.SCREENSHOT_DIFF, "${expectedFile.nameWithoutExtension}_diff")
```

The diff goes through the same door as every other command output (added in #3582), into its own `assertScreenshot/` folder, named with the shared step index so retries keep every attempt.

## Behaviour changes

- **The local diff moves** from beside the reference to `<run folder>/assertScreenshot/`. Intended — local and Cloud now agree — but user-visible.
- **`assertScreenshot`'s second reference candidate is now confined.** It previously normalised without confinement, so `../../logs/...` could resolve *outside* the bundle and match there. Consistent with #3459's intent.

## Tests

- `assertScreenshot writes its diff into the bundle, not beside the reference` — asserts it is **not** beside the reference, **is** in `assertScreenshot/`, and appears in `manifest.json`, which is what the uploader iterates
- `a retried assertScreenshot keeps a diff per attempt` — the reported shape: 4 attempts, 4 distinct diffs

`./gradlew test` — **1225 tests, 0 failed**, 5 skipped.

## Scope

This puts the diff in the run archive customers download. Listing it as a *typed* artifact on the run page needs the backend to stop dropping kinds it does not recognise (`RunArtifactMapper` ends `else -> null`, which also hides `takeScreenshot` output today) — a separate copilot-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AR1yrawifxaUgWfGXrPNfR