### PR TITLE
Rebase of: perf: 4x faster startup — skip unnecessary driver reinstall, cache build products

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/PrintHierarchyCommand.kt
@@ -69,12 +69,12 @@ class PrintHierarchyCommand : Runnable {
 
     @CommandLine.Option(
         names = ["--reinstall-driver"],
-        description = ["Reinstalls driver before running the test. On iOS, reinstalls xctestrunner driver. On Android, reinstalls both driver and server apps. Set to false to skip reinstallation."],
+        description = ["Force reinstall of the driver before running the test. On iOS, reinstalls xctestrunner driver. On Android, reinstalls both driver and server apps. By default, reuses an existing healthy driver."],
         negatable = true,
-        defaultValue = "true",
+        defaultValue = "false",
         fallbackValue = "true"
     )
-    private var reinstallDriver: Boolean = true
+    private var reinstallDriver: Boolean = false
 
     @Option(
         names = ["--apple-team-id"],

--- a/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/TestCommand.kt
@@ -205,12 +205,12 @@ class TestCommand : Callable<Int> {
 
     @Option(
         names = ["--reinstall-driver"],
-        description = ["Reinstalls driver before running the test. On iOS, reinstalls xctestrunner driver. On Android, reinstalls both driver and server apps. Set to false to skip reinstallation."],
+        description = ["Force reinstall of the driver before running the test. On iOS, reinstalls xctestrunner driver. On Android, reinstalls both driver and server apps. By default, reuses an existing healthy driver."],
         negatable = true,
-        defaultValue = "true",
+        defaultValue = "false",
         fallbackValue = "true"
     )
-    private var reinstallDriver: Boolean = true
+    private var reinstallDriver: Boolean = false
 
     @Option(
         names = ["--apple-team-id"],

--- a/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
+++ b/maestro-cli/src/main/java/maestro/cli/session/MaestroSessionManager.kt
@@ -73,7 +73,7 @@ object MaestroSessionManager {
         isStudio: Boolean = false,
         isHeadless: Boolean = false,
         screenSize: String? = null,
-        reinstallDriver: Boolean = true,
+        reinstallDriver: Boolean = false,
         deviceIndex: Int? = null,
         executionPlan: WorkspaceExecutionPlanner.ExecutionPlan? = null,
         block: (MaestroSession) -> T,

--- a/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/AndroidDriver.kt
@@ -83,7 +83,7 @@ data class LocaleRetryPolicy(
 class AndroidDriver(
     private val connection: AndroidDeviceConnection,
     private var emulatorName: String = "",
-    private val reinstallDriver: Boolean = true,
+    private val reinstallDriver: Boolean = false,
     private val metricsProvider: Metrics = MetricsProvider.getInstance(),
     private val localeRetry: LocaleRetryPolicy = LocaleRetryPolicy(),
 ) : Driver {

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/IOSBuildProductsExtractor.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/IOSBuildProductsExtractor.kt
@@ -15,6 +15,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
 import kotlin.io.path.isRegularFile
 
 data class BuildProducts(val xctestRunPath: File, val uiRunnerPath: File)
@@ -35,6 +36,19 @@ class IOSBuildProductsExtractor(
     }
 
     fun extract(sourceDirectory: String): BuildProducts {
+        val targetFile = target.toFile()
+        val hashFile = File(targetFile, ".source-hash")
+        val sourceHash = computeSourceHash(sourceDirectory)
+
+        if (sourceHash != null && hashFile.exists() && hashFile.readText() == sourceHash) {
+            val xctestRun = targetFile.walkTopDown().firstOrNull { it.extension == "xctestrun" }
+            val uiRunner = targetFile.walkTopDown().firstOrNull { it.name == "maestro-driver-iosUITests-Runner.app" }
+            if (xctestRun != null && uiRunner != null) {
+                LOGGER.info("Build products cached and up to date, skipping extraction")
+                return BuildProducts(xctestRunPath = xctestRun, uiRunnerPath = uiRunner)
+            }
+        }
+
         LOGGER.info("[Start] Writing build products")
         writeBuildProducts(sourceDirectory)
         LOGGER.info("[Done] Writing build products")
@@ -47,7 +61,10 @@ class IOSBuildProductsExtractor(
         extractZipToApp("maestro-driver-ios.zip")
         LOGGER.info("[Done] Writing maestro-driver-ios app")
 
-        val targetFile = target.toFile()
+        if (sourceHash != null) {
+            hashFile.writeText(sourceHash)
+        }
+
         val xctestRun = targetFile.walkTopDown().firstOrNull { it.extension == "xctestrun" }
             ?: throw FileNotFoundException("xctestrun config does not exist")
         val uiRunner = targetFile.walkTopDown().firstOrNull { it.name == "maestro-driver-iosUITests-Runner.app" }
@@ -57,6 +74,42 @@ class IOSBuildProductsExtractor(
             xctestRunPath = xctestRun,
             uiRunnerPath = uiRunner
         )
+    }
+
+    private fun computeSourceHash(sourceDirectory: String): String? {
+        return try {
+            val uri = LocalXCTestInstaller::class.java.classLoader.getResource(sourceDirectory)?.toURI()
+                ?: return null
+
+            val sourcePath = if (uri.scheme == "jar") {
+                val fs = try {
+                    FileSystems.getFileSystem(uri)
+                } catch (e: FileSystemNotFoundException) {
+                    uri.getOrCreateFileSystem()
+                }
+                fs.getPath(sourceDirectory)
+            } else {
+                Paths.get(uri)
+            }
+
+            val digest = MessageDigest.getInstance("SHA-256")
+            Files.walk(sourcePath).use { paths ->
+                paths.filter { it.isRegularFile() }.sorted().forEach { file ->
+                    digest.update(file.fileName.toString().toByteArray())
+                    Files.newInputStream(file).use { input ->
+                        val buffer = ByteArray(8192)
+                        var bytesRead: Int
+                        while (input.read(buffer).also { bytesRead = it } != -1) {
+                            digest.update(buffer, 0, bytesRead)
+                        }
+                    }
+                }
+            }
+            digest.digest().joinToString("") { "%02x".format(it) }
+        } catch (e: Exception) {
+            LOGGER.info("Could not compute source hash, will extract fresh: ${e.message}")
+            null
+        }
     }
 
     private fun extractZipToApp(appFileName: String) {

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/installer/LocalXCTestInstaller.kt
@@ -31,9 +31,9 @@ class LocalXCTestInstaller(
     private val httpClient: OkHttpClient = HttpClient.build(
         name = "XCUITestDriverStatusCheck",
         connectTimeout = 1.seconds,
-        readTimeout = 100.seconds,
+        readTimeout = 3.seconds,
     ),
-    val reinstallDriver: Boolean = true,
+    val reinstallDriver: Boolean = false,
     private val iOSDriverConfig: IOSDriverConfig,
     private val deviceController: IOSDevice,
     private val tempFileHandler: TempFileHandler = TempFileHandler(),
@@ -50,10 +50,10 @@ class LocalXCTestInstaller(
      * Make sure to launch the xctest runner from Xcode whenever maestro needs it.
      */
     private val useXcodeTestRunner = !System.getenv("USE_XCODE_TEST_RUNNER").isNullOrEmpty()
-    private val tempDir = tempFileHandler.createTempDirectory(deviceId)
+    private val buildProductsDir = File(System.getProperty("user.home"), ".maestro/build-products/$deviceId").also { it.mkdirs() }
     private val localSimulatorUtils = LocalSimulatorUtils(tempFileHandler)
     private val iosBuildProductsExtractor = IOSBuildProductsExtractor(
-        target = tempDir.toPath(),
+        target = buildProductsDir.toPath(),
         context = iOSDriverConfig.context,
         deviceType = deviceType,
     )


### PR DESCRIPTION
- Default --reinstall-driver to false: reuse a healthy running driver instead of killing and reinstalling on every run (~40s saved on iOS)
- XCTestDriverClient checks isChannelAlive() before reinstalling — if the user explicitly passes --reinstall-driver, honor it
- Cache extracted iOS build products per-device in ~/.maestro/build-products/<deviceId>/ with SHA-256 hash validation: skips extraction when source matches cache, re-extracts on upgrade
- Reduce XCTest status check HTTP read timeout from 100s to 3s
- Remove Thread.sleep(1000) heartbeat delay hack (no longer needed with per-device session tracking)

Single device: ~52s → ~10-12s. Three devices parallel: ~54s → ~18s.

## Proposed changes

copilot:summary

## Testing

<!--- Please describe how you tested your changes. -->

> **Does this need e2e tests?** The demo app lives in [`e2e/demo_app/`](e2e/demo_app/) — add a test screen and Maestro flow in the same PR. See [`e2e/demo_app/CLAUDE.md`](e2e/demo_app/CLAUDE.md) for details.

rebase of: https://github.com/mobile-dev-inc/Maestro/pull/3139

## Issues fixed
Closes https://github.com/mobile-dev-inc/Maestro/issues/1096