### PR TITLE
feat(ios): opt-in single-gesture double tap

### DIFF
--- a/maestro-client/src/main/java/maestro/Capability.kt
+++ b/maestro-client/src/main/java/maestro/Capability.kt
@@ -2,4 +2,5 @@ package maestro
 
 enum class Capability {
     FAST_HIERARCHY,
+    ATOMIC_DOUBLE_TAP,
 }

--- a/maestro-client/src/main/java/maestro/Driver.kt
+++ b/maestro-client/src/main/java/maestro/Driver.kt
@@ -51,6 +51,9 @@ interface Driver {
 
     fun longPress(point: Point)
 
+    fun doubleTap(point: Point, intervalMs: Long): Unit =
+        throw UnsupportedOperationException("Atomic double tap is not supported by this driver")
+
     fun pressKey(code: KeyCode)
 
     fun contentDescriptor(excludeKeyboardElements: Boolean = false): TreeNode

--- a/maestro-client/src/main/java/maestro/Maestro.kt
+++ b/maestro-client/src/main/java/maestro/Maestro.kt
@@ -221,7 +221,8 @@ class Maestro(
         longPress: Boolean = false,
         appId: String? = null,
         tapRepeat: TapRepeat? = null,
-        waitToSettleTimeoutMs: Int? = null
+        waitToSettleTimeoutMs: Int? = null,
+        singleGestureTap: Boolean = false
     ) {
         LOGGER.info("Tapping on element: ${tapRepeat ?: ""} $element")
 
@@ -251,7 +252,8 @@ class Maestro(
             longPress = longPress,
             initialHierarchy = hierarchyBeforeTap,
             tapRepeat = tapRepeat,
-            waitToSettleTimeoutMs = waitToSettleTimeoutMs
+            waitToSettleTimeoutMs = waitToSettleTimeoutMs,
+            singleGestureTap = singleGestureTap
         )
 
         if (waitUntilVisible) {
@@ -270,7 +272,8 @@ class Maestro(
                     retryIfNoChange = false,
                     waitUntilVisible = false,
                     longPress = longPress,
-                    tapRepeat = tapRepeat
+                    tapRepeat = tapRepeat,
+                    singleGestureTap = singleGestureTap
                 )
             }
         }
@@ -338,7 +341,8 @@ class Maestro(
         retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         tapRepeat: TapRepeat? = null,
-        waitToSettleTimeoutMs: Int? = null
+        waitToSettleTimeoutMs: Int? = null,
+        singleGestureTap: Boolean = false
     ) {
         val deviceInfo = runInterruptible(Dispatchers.IO) { driver.deviceInfo() }
         val x = deviceInfo.widthGrid * percentX / 100
@@ -349,7 +353,8 @@ class Maestro(
             retryIfNoChange = retryIfNoChange,
             longPress = longPress,
             tapRepeat = tapRepeat,
-            waitToSettleTimeoutMs = waitToSettleTimeoutMs
+            waitToSettleTimeoutMs = waitToSettleTimeoutMs,
+            singleGestureTap = singleGestureTap
         )
     }
 
@@ -359,7 +364,8 @@ class Maestro(
         retryIfNoChange: Boolean = false,
         longPress: Boolean = false,
         tapRepeat: TapRepeat? = null,
-        waitToSettleTimeoutMs: Int? = null
+        waitToSettleTimeoutMs: Int? = null,
+        singleGestureTap: Boolean = false
     ) {
         performTap(
             x = x,
@@ -367,7 +373,8 @@ class Maestro(
             retryIfNoChange = retryIfNoChange,
             longPress = longPress,
             tapRepeat = tapRepeat,
-            waitToSettleTimeoutMs = waitToSettleTimeoutMs
+            waitToSettleTimeoutMs = waitToSettleTimeoutMs,
+            singleGestureTap = singleGestureTap
         )
     }
 
@@ -382,16 +389,45 @@ class Maestro(
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
         tapRepeat: TapRepeat? = null,
-        waitToSettleTimeoutMs: Int? = null
+        waitToSettleTimeoutMs: Int? = null,
+        singleGestureTap: Boolean = false
     ) {
         recentScroll = false // consume the scroll hint (MA-4135)
 
         val capabilities = runInterruptible(Dispatchers.IO) { driver.capabilities() }
 
         if (Capability.FAST_HIERARCHY in capabilities) {
-            hierarchyBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs)
+            hierarchyBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs, singleGestureTap, capabilities)
         } else {
-            screenshotBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs)
+            screenshotBasedTap(x, y, retryIfNoChange, longPress, initialHierarchy, tapRepeat, waitToSettleTimeoutMs, singleGestureTap, capabilities)
+        }
+    }
+
+    private suspend fun performTapRepeat(
+        x: Int,
+        y: Int,
+        tapRepeat: TapRepeat,
+        singleGestureTap: Boolean,
+        capabilities: List<Capability>
+    ) {
+        if (singleGestureTap && tapRepeat.repeat == 2 && Capability.ATOMIC_DOUBLE_TAP in capabilities) {
+            try {
+                runInterruptible(Dispatchers.IO) { driver.doubleTap(Point(x, y), tapRepeat.delay) }
+                return
+            } catch (ignored: UnsupportedOperationException) {
+                LOGGER.info("Driver cannot deliver a single-gesture double tap, tapping twice instead")
+            }
+        }
+
+        for (i in 0 until tapRepeat.repeat) {
+
+            // subtract execution duration from tap delay
+            val duration = measureTimeMillis {
+                runInterruptible(Dispatchers.IO) { driver.tap(Point(x, y)) }
+            }
+            val tapDelay = if (duration >= tapRepeat.delay) 0 else tapRepeat.delay - duration
+
+            if (tapRepeat.repeat > 1) delay(tapDelay) // do not wait for single taps
         }
     }
 
@@ -402,7 +438,9 @@ class Maestro(
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
         tapRepeat: TapRepeat? = null,
-        waitToSettleTimeoutMs: Int? = null
+        waitToSettleTimeoutMs: Int? = null,
+        singleGestureTap: Boolean = false,
+        capabilities: List<Capability> = emptyList()
     ) {
         LOGGER.info("Tapping at ($x, $y) using hierarchy based logic for wait")
 
@@ -413,16 +451,7 @@ class Maestro(
             if (longPress) {
                 runInterruptible(Dispatchers.IO) { driver.longPress(Point(x, y)) }
             } else if (tapRepeat != null) {
-                for (i in 0 until tapRepeat.repeat) {
-
-                    // subtract execution duration from tap delay
-                    val duration = measureTimeMillis {
-                        runInterruptible(Dispatchers.IO) { driver.tap(Point(x, y)) }
-                    }
-                    val tapDelay = if (duration >= tapRepeat.delay) 0 else tapRepeat.delay - duration
-
-                    if (tapRepeat.repeat > 1) delay(tapDelay) // do not wait for single taps
-                }
+                performTapRepeat(x, y, tapRepeat, singleGestureTap, capabilities)
             } else {
                 runInterruptible(Dispatchers.IO) { driver.tap(Point(x, y)) }
             }
@@ -442,7 +471,9 @@ class Maestro(
         longPress: Boolean = false,
         initialHierarchy: ViewHierarchy? = null,
         tapRepeat: TapRepeat? = null,
-        waitToSettleTimeoutMs: Int? = null
+        waitToSettleTimeoutMs: Int? = null,
+        singleGestureTap: Boolean = false,
+        capabilities: List<Capability> = emptyList()
     ) {
         LOGGER.info("Try tapping at ($x, $y) using hierarchy based logic for wait")
 
@@ -454,16 +485,7 @@ class Maestro(
             if (longPress) {
                 runInterruptible(Dispatchers.IO) { driver.longPress(Point(x, y)) }
             } else if (tapRepeat != null) {
-                for (i in 0 until tapRepeat.repeat) {
-
-                    // subtract execution duration from tap delay
-                    val duration = measureTimeMillis {
-                        runInterruptible(Dispatchers.IO) { driver.tap(Point(x, y)) }
-                    }
-                    val tapDelay = if (duration >= tapRepeat.delay) 0 else tapRepeat.delay - duration
-
-                    if (tapRepeat.repeat > 1) delay(tapDelay) // do not wait for single taps
-                }
+                performTapRepeat(x, y, tapRepeat, singleGestureTap, capabilities)
             } else {
                 runInterruptible(Dispatchers.IO) { driver.tap(Point(x, y)) }
             }

--- a/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
+++ b/maestro-client/src/main/java/maestro/drivers/IOSDriver.kt
@@ -35,6 +35,7 @@ import maestro.MediaExt
 import maestro.NamedSource
 import maestro.Point
 import maestro.ScreenRecording
+import maestro.utils.network.XCUITestServerError
 import maestro.SwipeDirection
 import maestro.TreeNode
 import maestro.UiElement.Companion.toUiElement
@@ -152,6 +153,21 @@ class IOSDriver(
     override fun tap(point: Point) {
         metrics.measured("operation", mapOf("command" to "tap")) {
             runDeviceCall("tap") { iosDevice.tap(point.x, point.y) }
+        }
+    }
+
+    override fun doubleTap(point: Point, intervalMs: Long) {
+        metrics.measured("operation", mapOf("command" to "doubleTap")) {
+            runDeviceCall("doubleTap") {
+                try {
+                    iosDevice.doubleTap(point.x, point.y, intervalMs)
+                } catch (badRequest: XCUITestServerError.BadRequest) {
+                    // A driver build predating the doubleTouch route 404s here.
+                    throw UnsupportedOperationException(
+                        "The installed XCUITest runner has no doubleTouch route", badRequest
+                    )
+                }
+            }
         }
     }
 
@@ -507,7 +523,7 @@ class IOSDriver(
     }
 
     override fun capabilities(): List<Capability> {
-        return emptyList()
+        return listOf(Capability.ATOMIC_DOUBLE_TAP)
     }
 
     override fun setPermissions(appId: String, permissions: Map<String, String>) {

--- a/maestro-ios-driver/src/main/kotlin/device/IOSDevice.kt
+++ b/maestro-ios-driver/src/main/kotlin/device/IOSDevice.kt
@@ -37,6 +37,9 @@ interface IOSDevice : AutoCloseable {
 
     fun tap(x: Int, y: Int)
 
+    fun doubleTap(x: Int, y: Int, intervalMs: Long): Unit =
+        throw UnsupportedOperationException("Atomic double tap is not supported by this device")
+
     fun longPress(x: Int, y: Int, durationMs: Long)
 
     fun scroll(

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/XCTestDriverClient.kt
@@ -186,6 +186,18 @@ class XCTestDriverClient(
         ))
     }
 
+    fun doubleTap(
+        x: Float,
+        y: Float,
+        interval: Double? = null,
+    ) {
+        executeJsonRequest("doubleTouch", DoubleTouchRequest(
+            x = x,
+            y = y,
+            interval = interval
+        ))
+    }
+
     fun setOrientation(orientation: String) {
         executeJsonRequest("setOrientation", SetOrientationRequest(orientation))
     }

--- a/maestro-ios-driver/src/main/kotlin/xcuitest/api/DoubleTouchRequest.kt
+++ b/maestro-ios-driver/src/main/kotlin/xcuitest/api/DoubleTouchRequest.kt
@@ -1,0 +1,8 @@
+package xcuitest.api
+
+data class DoubleTouchRequest(
+    val x: Float,
+    val y: Float,
+    val interval: Double?,
+    val duration: Double? = null,
+)

--- a/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/project.pbxproj
+++ b/maestro-ios-xctest-runner/maestro-driver-ios.xcodeproj/project.pbxproj
@@ -14,7 +14,9 @@
 		32A9C73C2D7A62B500545435 /* LaunchAppHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A9C73B2D7A62AF00545435 /* LaunchAppHandler.swift */; };
 		32A9C73E2D7A631A00545435 /* LaunchAppRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A9C73D2D7A631400545435 /* LaunchAppRequest.swift */; };
 		32ECCB262980449200A1A0A0 /* TouchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ECCB252980449200A1A0A0 /* TouchRequest.swift */; };
+		32ECCB412980449200A1A0A0 /* DoubleTouchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ECCB402980449200A1A0A0 /* DoubleTouchRequest.swift */; };
 		32ECCB28298044C200A1A0A0 /* TouchRouteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ECCB27298044C200A1A0A0 /* TouchRouteHandler.swift */; };
+		32ECCB432980449200A1A0A0 /* DoubleTouchRouteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ECCB422980449200A1A0A0 /* DoubleTouchRouteHandler.swift */; };
 		39F002647AA68C9B8DC39E61 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF897D5D1CB7C6C46344E543 /* Foundation.framework */; };
 		52047F782A7A638E00BF982D /* StatusHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52047F772A7A638E00BF982D /* StatusHandler.swift */; };
 		52049BD72935039F00807AA3 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52049BD62935039F00807AA3 /* AppDelegate.swift */; };
@@ -169,7 +171,9 @@
 		32A9C73B2D7A62AF00545435 /* LaunchAppHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAppHandler.swift; sourceTree = "<group>"; };
 		32A9C73D2D7A631400545435 /* LaunchAppRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAppRequest.swift; sourceTree = "<group>"; };
 		32ECCB252980449200A1A0A0 /* TouchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchRequest.swift; sourceTree = "<group>"; };
+		32ECCB402980449200A1A0A0 /* DoubleTouchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTouchRequest.swift; sourceTree = "<group>"; };
 		32ECCB27298044C200A1A0A0 /* TouchRouteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchRouteHandler.swift; sourceTree = "<group>"; };
+		32ECCB422980449200A1A0A0 /* DoubleTouchRouteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleTouchRouteHandler.swift; sourceTree = "<group>"; };
 		52047F772A7A638E00BF982D /* StatusHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusHandler.swift; sourceTree = "<group>"; };
 		52049BD32935039F00807AA3 /* maestro-driver-ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "maestro-driver-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		52049BD62935039F00807AA3 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -664,6 +668,7 @@
 				32762AF92966DC8300FB69BD /* SwipeRequest.swift */,
 				32097964297092A800340282 /* InputTextRequest.swift */,
 				32ECCB252980449200A1A0A0 /* TouchRequest.swift */,
+				32ECCB402980449200A1A0A0 /* DoubleTouchRequest.swift */,
 				61C0AFE429C7AAB3005D1FC5 /* PressKeyRequest.swift */,
 				5B8E0ABD2CD562F200E9D439 /* SetOrientationRequest.swift */,
 				DFA3B2307F723A0C1C707C50 /* SetAppearanceRequest.swift */,
@@ -706,6 +711,7 @@
 				61A79B9629DF0B8A00C38882 /* SwipeRouteHandlerV2.swift */,
 				320979622970925500340282 /* InputTextRouteHandler.swift */,
 				32ECCB27298044C200A1A0A0 /* TouchRouteHandler.swift */,
+				32ECCB422980449200A1A0A0 /* DoubleTouchRouteHandler.swift */,
 				9494CBD02982F719009C987C /* ScreenshotHandler.swift */,
 				94256BAC298D39DE00CDB55D /* ScreenDiffHandler.swift */,
 				61C0AFE629C7AB0C005D1FC5 /* PressKeyHandler.swift */,
@@ -1021,6 +1027,7 @@
 				521C1F072D8017480024EE42 /* AXClientProxy.m in Sources */,
 				61C0AFED29C88926005D1FC5 /* EraseTextHandler.swift in Sources */,
 				32ECCB262980449200A1A0A0 /* TouchRequest.swift in Sources */,
+				32ECCB412980449200A1A0A0 /* DoubleTouchRequest.swift in Sources */,
 				5261117A2DE5E8E7007C356B /* XCAXClient_iOS+FBSnapshotReqParams.m in Sources */,
 				52F33A942AE6823100692902 /* StatusResponse.swift in Sources */,
 				32A9C73E2D7A631A00545435 /* LaunchAppRequest.swift in Sources */,
@@ -1052,6 +1059,7 @@
 				61C0AFF729D34FEA005D1FC5 /* EventTarget.swift in Sources */,
 				612DE414298426EF003C2BE0 /* EventRecord.swift in Sources */,
 				32ECCB28298044C200A1A0A0 /* TouchRouteHandler.swift in Sources */,
+				32ECCB432980449200A1A0A0 /* DoubleTouchRouteHandler.swift in Sources */,
 				943A9081293F5C2500C85136 /* RouteHandlerFactory.swift in Sources */,
 				6124329C2A4B368100F5F619 /* ViewHierarchyRequest.swift in Sources */,
 				61C0AFE529C7AAB3005D1FC5 /* PressKeyRequest.swift in Sources */,

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/DoubleTouchRouteHandler.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/DoubleTouchRouteHandler.swift
@@ -1,0 +1,45 @@
+import FlyingFox
+import XCTest
+import os
+
+@MainActor
+struct DoubleTouchRouteHandler: HTTPHandler {
+    private static let defaultInterval: TimeInterval = 0.1
+
+    func handleRequest(_ request: FlyingFox.HTTPRequest) async throws -> FlyingFox.HTTPResponse {
+        let decoder = JSONDecoder()
+
+        guard let requestBody = try? await decoder.decode(DoubleTouchRequest.self, from: request.bodyData) else {
+            NSLog("Invalid request for double tapping")
+            return AppError(type: .precondition, message: "incorrect request body provided for doubleTouch route").httpResponse
+        }
+
+        let (width, height) = ScreenSizeHelper.physicalScreenSize()
+        let point = ScreenSizeHelper.orientationAwarePoint(
+            width: width,
+            height: height,
+            point: CGPoint(x: CGFloat(requestBody.x), y: CGFloat(requestBody.y))
+        )
+        let (x, y) = (point.x, point.y)
+        let interval = requestBody.interval ?? Self.defaultInterval
+
+        NSLog("Double tapping \(x), \(y) with interval \(interval)s")
+
+        do {
+            let eventRecord = EventRecord(orientation: ScreenSizeHelper.currentInterfaceOrientation())
+            _ = eventRecord.addDoubleTapEvent(
+                at: CGPoint(x: CGFloat(x), y: CGFloat(y)),
+                interval: interval,
+                holdDuration: requestBody.duration
+            )
+            let start = Date()
+            try await RunnerDaemonProxy().synthesize(eventRecord: eventRecord)
+            let duration = Date().timeIntervalSince(start)
+            NSLog("Double tapping took \(duration)")
+            return HTTPResponse(statusCode: .ok)
+        } catch {
+            NSLog("Error double tapping: \(error)")
+            return AppError(message: "Error double tapping point: \(error.localizedDescription)").httpResponse
+        }
+    }
+}

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Models/DoubleTouchRequest.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Models/DoubleTouchRequest.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct DoubleTouchRequest : Codable {
+    let x: Float
+    let y: Float
+    let interval: TimeInterval?
+    let duration: TimeInterval?
+}

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/RouteHandlerFactory.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/RouteHandlerFactory.swift
@@ -14,6 +14,8 @@ class RouteHandlerFactory {
             return InputTextRouteHandler()
         case .touch:
             return TouchRouteHandler()
+        case .doubleTouch:
+            return DoubleTouchRouteHandler()
         case .screenshot:
             return ScreenshotHandler()
         case .isScreenStatic:

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTest/EventRecord.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTest/EventRecord.swift
@@ -28,6 +28,22 @@ final class EventRecord: NSObject {
         return add(path)
     }
 
+    // Two paths, not one re-pressed path: re-pressing after a lift reads as a single
+    // continuous touch and never raises tapCount to 2, so no double-tap recognizer fires.
+    func addDoubleTapEvent(at point: CGPoint, interval: TimeInterval, holdDuration: TimeInterval? = nil) -> Self {
+        let hold = holdDuration ?? Self.defaultTapDuration
+
+        var first = PointerEventPath.pathForTouch(at: point)
+        first.offset += hold
+        first.liftUp()
+
+        var second = PointerEventPath.pathForTouch(at: point, offset: hold + interval)
+        second.offset += hold
+        second.liftUp()
+
+        return add(first).add(second)
+    }
+
     func addSwipeEvent(start: CGPoint, end: CGPoint, duration: TimeInterval) -> Self {
         var path = PointerEventPath.pathForTouch(at: start)
         path.offset += Self.defaultTapDuration

--- a/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTestHTTPServer.swift
+++ b/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/XCTestHTTPServer.swift
@@ -7,6 +7,7 @@ enum Route: String, CaseIterable {
     case swipeV2
     case inputText
     case touch
+    case doubleTouch
     case screenshot
     case isScreenStatic
     case pressKey

--- a/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/LocalIOSDevice.kt
@@ -58,6 +58,10 @@ class LocalIOSDevice(
         return xcTestDevice.tap(x, y)
     }
 
+    override fun doubleTap(x: Int, y: Int, intervalMs: Long) {
+        return xcTestDevice.doubleTap(x, y, intervalMs)
+    }
+
     override fun longPress(x: Int, y: Int, durationMs: Long) {
         xcTestDevice.longPress(x, y, durationMs)
     }

--- a/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
+++ b/maestro-ios/src/main/java/ios/xctest/XCTestIOSDevice.kt
@@ -51,6 +51,16 @@ class XCTestIOSDevice(
         }
     }
 
+    override fun doubleTap(x: Int, y: Int, intervalMs: Long) {
+        execute {
+            client.doubleTap(
+                x = x.toFloat(),
+                y = y.toFloat(),
+                interval = intervalMs.toDouble() / 1000
+            )
+        }
+    }
+
     override fun longPress(x: Int, y: Int, durationMs: Long) {
         execute {
             client.tap(

--- a/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
+++ b/maestro-orchestra-models/src/main/java/maestro/orchestra/Commands.kt
@@ -322,6 +322,7 @@ data class TapOnElementCommand(
     val repeat: TapRepeat? = null,
     val waitToSettleTimeoutMs: Int? = null,
     val relativePoint: String? = null, // New parameter for element-relative coordinates
+    val singleGestureTap: Boolean? = null,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {
@@ -372,6 +373,7 @@ data class TapOnPointV2Command(
     val longPress: Boolean? = null,
     val repeat: TapRepeat? = null,
     val waitToSettleTimeoutMs: Int? = null,
+    val singleGestureTap: Boolean? = null,
     override val label: String? = null,
     override val optional: Boolean = false,
 ) : Command {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -1343,6 +1343,7 @@ class Orchestra(
                 longPress = command.longPress ?: false,
                 tapRepeat = command.repeat,
                 waitToSettleTimeoutMs = command.waitToSettleTimeoutMs,
+                singleGestureTap = command.singleGestureTap ?: false,
             )
         } else {
             // Default behavior: tap at element center
@@ -1355,6 +1356,7 @@ class Orchestra(
                 appId = config?.appId,
                 tapRepeat = command.repeat,
                 waitToSettleTimeoutMs = command.waitToSettleTimeoutMs,
+                singleGestureTap = command.singleGestureTap ?: false,
             )
         }
 
@@ -1397,7 +1399,8 @@ class Orchestra(
                 retryIfNoChange = command.retryIfNoChange ?: false,
                 longPress = command.longPress ?: false,
                 tapRepeat = command.repeat,
-                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
+                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs,
+                singleGestureTap = command.singleGestureTap ?: false
             )
         } else {
             val (x, y) = point.split(",")
@@ -1411,7 +1414,8 @@ class Orchestra(
                 retryIfNoChange = command.retryIfNoChange ?: false,
                 longPress = command.longPress ?: false,
                 tapRepeat = command.repeat,
-                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs
+                waitToSettleTimeoutMs = command.waitToSettleTimeoutMs,
+                singleGestureTap = command.singleGestureTap ?: false
             )
         }
 

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlElementSelector.kt
@@ -50,6 +50,7 @@ data class YamlElementSelector(
     val focused: Boolean? = null,
     val repeat: Int? = null,
     val delay: Int? = null,
+    val singleGestureTap: Boolean? = null,
     val waitToSettleTimeoutMs: Int? = null,
     val childOf: YamlElementSelectorUnion? = null,
     val label: String? = null,

--- a/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/yaml/YamlFluentCommand.kt
@@ -806,6 +806,7 @@ data class YamlFluentCommand(
         val label = (tapOn as? YamlElementSelector)?.label
         val optional = (tapOn as? YamlElementSelector)?.optional ?: false
 
+        val singleGestureTap = (tapOn as? YamlElementSelector)?.singleGestureTap
         val delay = (tapOn as? YamlElementSelector)?.delay?.toLong()
         val repeat = tapRepeat ?: (tapOn as? YamlElementSelector)?.repeat?.let {
             val count = if (it <= 0) 1 else it
@@ -834,6 +835,7 @@ data class YamlFluentCommand(
                         label = label,
                         optional = optional,
                         relativePoint = point, // Parameter for element-relative coordinates
+                        singleGestureTap = singleGestureTap,
                     )
                 )
             } else {
@@ -847,6 +849,7 @@ data class YamlFluentCommand(
                         waitToSettleTimeoutMs = waitToSettleTimeoutMs,
                         label = label,
                         optional = optional,
+                        singleGestureTap = singleGestureTap,
                     )
                 )
             }
@@ -861,6 +864,7 @@ data class YamlFluentCommand(
                     waitToSettleTimeoutMs = waitToSettleTimeoutMs,
                     label = label,
                     optional = optional,
+                    singleGestureTap = singleGestureTap,
                 )
             )
         }

--- a/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
+++ b/maestro-orchestra/src/test/java/maestro/orchestra/yaml/YamlCommandReaderTest.kt
@@ -834,6 +834,21 @@ internal class YamlCommandReaderTest {
     }
 
     @Test
+    fun `doubleTapOn singleGestureTap - present, false, absent, and on the point form`(
+        @YamlFile("035_singleGestureTap.yaml") commands: List<Command>
+    ) {
+        // Opted in
+        assertThat((commands[1] as TapOnElementCommand).singleGestureTap).isTrue()
+
+        // Explicitly opted out, and absent - both must stay non-true so the default path runs
+        assertThat((commands[2] as TapOnElementCommand).singleGestureTap).isFalse()
+        assertThat((commands[3] as TapOnElementCommand).singleGestureTap).isNull()
+
+        // The point form parses to TapOnPointV2Command and must carry the flag too
+        assertThat((commands[4] as TapOnPointV2Command).singleGestureTap).isTrue()
+    }
+
+    @Test
     fun setPermissions(
         @YamlFile("030_setPermissions.yaml") commands: List<Command>
     ) {

--- a/maestro-orchestra/src/test/resources/YamlCommandReaderTest/035_singleGestureTap.yaml
+++ b/maestro-orchestra/src/test/resources/YamlCommandReaderTest/035_singleGestureTap.yaml
@@ -1,0 +1,13 @@
+appId: com.example.app
+---
+- doubleTapOn:
+    text: Submit
+    singleGestureTap: true
+- doubleTapOn:
+    text: Submit
+    singleGestureTap: false
+- doubleTapOn:
+    text: Submit
+- doubleTapOn:
+    point: 50%,90%
+    singleGestureTap: true

--- a/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
+++ b/maestro-test/src/main/kotlin/maestro/test/drivers/FakeDriver.kt
@@ -53,6 +53,9 @@ open class FakeDriver : Driver {
 
     private var currentText: String = ""
 
+    // Capabilities this fake reports. Empty by default so the standard tap paths are exercised.
+    var reportedCapabilities: List<Capability> = emptyList()
+
     private var airplaneMode: Boolean = false
 
     private var darkMode: Boolean = false
@@ -161,6 +164,19 @@ open class FakeDriver : Driver {
         layout.dispatchClick(point.x, point.y)
 
         events += Event.Tap(point)
+    }
+
+    override fun doubleTap(point: Point, intervalMs: Long) {
+        ensureOpen()
+
+        if (Capability.ATOMIC_DOUBLE_TAP !in reportedCapabilities) {
+            throw UnsupportedOperationException("Atomic double tap is not supported by this driver")
+        }
+
+        layout.dispatchClick(point.x, point.y)
+        layout.dispatchClick(point.x, point.y)
+
+        events += Event.DoubleTap(point, intervalMs)
     }
 
     override fun longPress(point: Point) {
@@ -398,7 +414,7 @@ open class FakeDriver : Driver {
     }
 
     override fun capabilities(): List<Capability> {
-        return emptyList()
+        return reportedCapabilities
     }
 
     override fun setPermissions(appId: String, permissions: Map<String, String>) {
@@ -458,6 +474,11 @@ open class FakeDriver : Driver {
 
         data class Tap(
             val point: Point
+        ) : Event(), UserInteraction
+
+        data class DoubleTap(
+            val point: Point,
+            val intervalMs: Long
         ) : Event(), UserInteraction
 
         data class LongPress(

--- a/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
+++ b/maestro-test/src/test/kotlin/maestro/test/IntegrationTest.kt
@@ -39,6 +39,7 @@ import maestro.orchestra.Orchestra
 import maestro.orchestra.RunFlowCommand
 import maestro.orchestra.RetryCommand
 import maestro.orchestra.ScrollUntilVisibleCommand
+import maestro.Capability
 import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointV2Command
 import maestro.orchestra.SwipeCommand
@@ -3061,6 +3062,81 @@ class IntegrationTest {
         // Then
         // No test failure
         driver.assertEventCount(Event.Tap(Point(50, 50)), 2)
+    }
+
+    @Test
+    fun `Case 101 - doubleTapOn with singleGestureTap uses one atomic gesture`() {
+        // Given
+        val commands = readCommands("101_doubleTapOn_singleGesture")
+
+        val driver = driver {
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+        driver.reportedCapabilities = listOf(Capability.ATOMIC_DOUBLE_TAP)
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        driver.assertEventCount(Event.DoubleTap(Point(50, 50), TapOnElementCommand.DEFAULT_REPEAT_DELAY), 1)
+        driver.assertEventCount(Event.Tap(Point(50, 50)), 0)
+    }
+
+    @Test
+    fun `Case 101 - doubleTapOn point with singleGestureTap uses one atomic gesture`() {
+        // Given
+        val commands = readCommands("101_doubleTapOn_point_singleGesture")
+
+        val driver = driver {
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+        driver.reportedCapabilities = listOf(Capability.ATOMIC_DOUBLE_TAP)
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        driver.assertEventCount(Event.DoubleTap(Point(50, 50), TapOnElementCommand.DEFAULT_REPEAT_DELAY), 1)
+        driver.assertEventCount(Event.Tap(Point(50, 50)), 0)
+    }
+
+    @Test
+    fun `Case 101 - doubleTapOn without singleGestureTap is unchanged`() {
+        // Given
+        val commands = readCommands("101_doubleTapOn")
+
+        val driver = driver {
+            element {
+                text = "Button"
+                bounds = Bounds(0, 0, 100, 100)
+            }
+        }
+        driver.reportedCapabilities = listOf(Capability.ATOMIC_DOUBLE_TAP)
+
+        // When
+        Maestro(driver).use {
+            runBlocking {
+                orchestra(it).runFlow(commands)
+            }
+        }
+
+        // Then
+        driver.assertEventCount(Event.Tap(Point(50, 50)), 2)
+        driver.assertEventCount(Event.DoubleTap(Point(50, 50), TapOnElementCommand.DEFAULT_REPEAT_DELAY), 0)
     }
 
     @Test

--- a/maestro-test/src/test/resources/101_doubleTapOn_point_singleGesture.yaml
+++ b/maestro-test/src/test/resources/101_doubleTapOn_point_singleGesture.yaml
@@ -1,0 +1,5 @@
+appId: com.other.app
+---
+- doubleTapOn:
+    point: 50,50
+    singleGestureTap: true

--- a/maestro-test/src/test/resources/101_doubleTapOn_singleGesture.yaml
+++ b/maestro-test/src/test/resources/101_doubleTapOn_singleGesture.yaml
@@ -1,0 +1,6 @@
+appId: com.other.app
+---
+- doubleTapOn:
+    text: Button
+    retryTapIfNoChange: false
+    singleGestureTap: true


### PR DESCRIPTION
## Proposed changes

`doubleTapOn` on iOS is not really a double tap. It becomes `TapRepeat(2, 100ms)`, and
`Maestro.performTap` sends each tap as its own blocking HTTP request to the XCUITest runner.
The 100ms spacing never applies: the loop measures the whole blocking call, which always takes
longer than 100ms, so the computed delay comes out as zero. What separates the two taps is
however long the round trip happens to take.

On an iPhone 17 / iOS 26.5 simulator that gap measured between 337ms and 352ms across runs,
close enough to the limit that the pair only sometimes registers as a double tap.

This adds an opt-in `singleGestureTap` flag that sends both taps as one synthesized gesture
through a new `doubleTouch` route on the runner, so the interval is a fixed number instead of
whatever the network does:

```yaml
- doubleTapOn:
    id: "cell_.*"
    singleGestureTap: true
```

Nothing changes by default on any platform. Without the flag the command makes exactly the
driver calls it makes today.

Two notes on the implementation:

- The two taps have to be separate `PointerEventPath`s in one `EventRecord`. Pressing the same
  path again after lifting it is allowed and produces a four event path, but UIKit treats that
  as one continuous touch and never sets `tapCount` to 2, so no double tap recognizer fires.
- The flag is on both `TapOnElementCommand` and `TapOnPointV2Command`, since `doubleTapOn` with
  a plain `point:` parses to the second one. Covering only the element form would leave the
  coordinate form unable to opt in.

## Testing

Automated:

- Parser tests for the new YAML field: set to true, set to false, left out entirely, and on the
  `point:` form.
- Three integration tests against `FakeDriver`, covering the element form with the flag, the
  point form with the flag, and the command *without* the flag run against a driver that does
  report `ATOMIC_DOUBLE_TAP`. That last one asserts it still makes two ordinary tap calls and no
  double tap call, which is the guard against this changing default behaviour by accident.
- Existing suites for maestro-client, maestro-ios, maestro-ios-driver, maestro-orchestra and
  maestro-test all pass, including the schema evolution test, which picked up the new field
  without a hand edit.

By hand, on a booted iPhone 17 running iOS 26.5:

- Built the runner, attached it to the simulator, and drove the new route directly with curl.
- Logged `XCSynthesizedEventRecord.description` immediately before `synthesize` to confirm what
  gets built: one record, two paths, press and lift at fixed offsets, one `synthesize` per
  double tap.
- Confirmed the gesture actually registers by pointing it at a stock app that zooms on double
  tap and diffing screenshots against a no-input baseline. This is also how the single-path
  version was ruled out: it produced a correct looking four event path but did not register as
  a double tap.
- Confirmed an unregistered route returns a clean 404, so a client falling back to the existing
  two-tap loop behaves correctly.
- Ran an app flow that depends on a double tap 20 times on the same machine and app build, 10
  with the flag and 10 without. Without the flag it passed 4 of 10, with the inter-tap gap
  measured from the runner logs at 337ms to 352ms each run. With the flag it passed 10 of 10 at
  a fixed 100ms.

## Issues fixed

<!-- link the discussion issue here -->
