### PR TITLE
fix(devicecore): wall element-anchored swipe; route copyTextFrom through inspect()

### DIFF
--- a/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/Orchestra.kt
@@ -1468,9 +1468,13 @@ class Orchestra(
                 // Swiping from a resolved element needs that element's on-screen geometry (its bounds
                 // center, or a relative point within it) as the swipe start — geometry the legacy
                 // matching engine resolved Maestro-side. Device-core owns element resolution now and
-                // has no element-anchored swipe yet (roadmap), so route through the seam swipe verb to
-                // surface NotImplemented rather than resolving bounds here.
+                // has no element-anchored swipe yet (roadmap; the drafted Locator.swipe(Direction)
+                // isn't realized), so route through the seam's element-anchored swipe overload, which
+                // walls with NotImplemented. Passing only the direction to the targetless variadic
+                // swipe would slip past its point/relative wall-guard and serve a plain directional,
+                // silently dropping the anchor.
                 driver.swipe(
+                    elementSelector = elementSelector,
                     swipeDirection = direction,
                     duration = command.duration,
                     waitToSettleTimeoutMs = command.waitToSettleTimeoutMs,
@@ -1505,11 +1509,18 @@ class Orchestra(
     }
 
     private suspend fun copyTextFromCommand(command: CopyTextFromCommand): Boolean {
-        // Copying an element's text reads that element's text/hint/accessibility attributes from the
-        // on-device view tree — the device hierarchy, which the seam does not expose yet (device-core
-        // has no serializable tree; roadmap). Route through the seam so this surfaces NotImplemented
-        // instead of silently copying empty text.
-        driver.hierarchy()
+        // Copying an element's text reads that element's text off device-core's inspect() verdict via
+        // the seam's readText — NOT the never-built hierarchy() dump. An absent element surfaces as
+        // ElementNotFound (honored by `optional`, like legacy findElement); a resolved element with no
+        // copyable text is UnableToCopyTextFromElement, matching legacy copyTextFrom's resolveText.
+        copiedText = driver.readText(command.selector)
+            ?: throw MaestroException.UnableToCopyTextFromElement(
+                "Element does not contain text to copy: ${command.selector.description()}"
+            )
+        jsEngine.setCopiedText(copiedText)
+
+        // Internal variable setting - no UI effect
+        return false
     }
 
     private fun setClipboardCommand(command: SetClipboardCommand): Boolean {

--- a/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceGateway.kt
+++ b/maestro-orchestra/src/main/java/maestro/orchestra/devicecore/DeviceGateway.kt
@@ -13,6 +13,7 @@ import dev.mobile.devicecore.prototype.api.Permission
 import dev.mobile.devicecore.prototype.api.Screen
 import dev.mobile.devicecore.prototype.api.Key
 import dev.mobile.devicecore.prototype.api.Relation
+import dev.mobile.devicecore.prototype.api.Resolution
 import dev.mobile.devicecore.prototype.api.Selector
 import dev.mobile.devicecore.prototype.api.Travel
 import dev.mobile.devicecore.prototype.api.TargetId
@@ -102,6 +103,16 @@ interface DeviceGateway {
      */
     fun hierarchy(): Nothing = notImplemented("hierarchy")
 
+    /**
+     * Reads the resolved element's text — device-core's `Locator.inspect()` verdict, off
+     * [dev.mobile.devicecore.prototype.api.ElementEvidence.matched] →
+     * [dev.mobile.devicecore.prototype.api.MatchedText.text]. Backs `copyTextFrom`, which used to
+     * reach for the never-built [hierarchy]. Returns null when the element resolves but carries no
+     * copyable text; an absent element throws [MaestroException.ElementNotFound], so `copyTextFrom`'s
+     * `optional` governs warn-vs-fail exactly as legacy `findElement` did.
+     */
+    fun readText(selector: ElementSelector): String? = notImplemented("readText")
+
     fun takeScreenshot(out: Sink, compressed: Boolean, cropOn: ElementSelector? = null): Unit =
         notImplemented("takeScreenshot")
     fun startScreenRecording(out: Sink): ScreenRecording = notImplemented("startScreenRecording")
@@ -146,6 +157,21 @@ interface DeviceGateway {
 
     fun swipeFromCenter(swipeDirection: SwipeDirection, durationMs: Long, waitToSettleTimeoutMs: Int?): Unit =
         notImplemented("swipeFromCenter")
+
+    /**
+     * Element-anchored directional swipe: a swipe that STARTS from a resolved element, travelling
+     * [swipeDirection]. device-core owns element resolution but ships no element-anchored swipe verb
+     * yet (the drafted `Locator.swipe(Direction)` isn't realized), so this walls honestly. It is its
+     * own overload precisely so the anchor cannot be dropped: routing an element-anchored swipe onto
+     * the targetless variadic [swipe] with direction only slips past that overload's point/relative
+     * wall-guard and serves a plain directional, silently discarding the element.
+     */
+    fun swipe(
+        elementSelector: ElementSelector,
+        swipeDirection: SwipeDirection,
+        duration: Long,
+        waitToSettleTimeoutMs: Int? = null,
+    ): Unit = throw MaestroException.NotImplemented("element-anchored swipe")
 
     /** Legacy scrollUntilVisible, served whole by device-core's `Locator.scrollTo` — a swipe loop
      *  bounded by [timeoutMs] that stops when the locator resolves. The scroll mechanics (cadence,
@@ -384,6 +410,30 @@ class RealDeviceGateway(
         return chosenElementOfAction(action, sel)
     }
 
+    /**
+     * copyTextFrom's read: resolve the selector and read its text off device-core's `inspect()`
+     * verdict ([dev.mobile.devicecore.prototype.api.ElementEvidence.matched] → `MatchedText.text`) —
+     * never a hierarchy dump. An [dev.mobile.devicecore.prototype.api.Resolution.Absent] element is
+     * not-found ([MaestroException.ElementNotFound], the same taxonomy as tap's Absent); a resolved
+     * element with no matched text returns null, which copyTextFrom turns into
+     * [MaestroException.UnableToCopyTextFromElement]. Infra throws route through [DeviceCoreErrorMapper.mapInfraThrow].
+     */
+    override fun readText(selector: ElementSelector): String? {
+        val sel = SelectorTranslator.translate(selector)
+        val evidence = try {
+            runBlocking { screen.locatorFor(sel).inspect() }
+        } catch (t: Throwable) {
+            throw DeviceCoreErrorMapper.mapInfraThrow(t, "readText ${selector.description()}")
+        }
+        if (evidence.resolution is Resolution.Absent) {
+            throw MaestroException.ElementNotFound(
+                message = "No visible element found: ${selector.description()}",
+                debugMessage = "device-core inspect resolved Absent for ${selector.description()}",
+            )
+        }
+        return evidence.matched.value?.text
+    }
+
     override fun inputText(text: String) {
         // device-core's inputText ignores the selector and writes to the FOCUSED editable node
         // (FocusedSetTextInputTextStrategy) — matching legacy's targetless inputText, whose focus is
@@ -433,9 +483,9 @@ class RealDeviceGateway(
     }
 
     /** Targetless directional swipe, served by device-core's `Screen.swipe(Travel)`. Only the
-     *  direction-only form is served; a swipe with explicit start/end points or relative anchors
-     *  (or one anchored to an element — Orchestra routes those here too, dropping the element) has
-     *  no device-core verb yet, so it walls honestly rather than degrading to a plain directional. */
+     *  direction-only form is served; a swipe with explicit start/end points or relative anchors has
+     *  no device-core verb yet, so it walls honestly rather than degrading to a plain directional.
+     *  (An element-anchored swipe walls at its own [swipe] overload — it is never routed here.) */
     override fun swipe(
         swipeDirection: SwipeDirection?,
         startPoint: Point?,

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/OrchestraDeviceCoreRoutingTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/OrchestraDeviceCoreRoutingTest.kt
@@ -41,6 +41,8 @@ class OrchestraDeviceCoreRoutingTest {
     private class RecordingDeviceGateway(
         /** Injected verdict for [assertVisibility]: throw an AssertionFailure to simulate a false verdict. */
         private val onAssert: (ElementSelector, AssertMode) -> Unit = { _, _ -> },
+        /** The text [readText] returns for a selector — the inspect()-side read copyTextFrom uses. */
+        private val textFor: (ElementSelector) -> String? = { "copied text" },
     ) : DeviceGateway {
         val launched = mutableListOf<String>()
         val launchArgs = mutableListOf<Map<String, Any>>()
@@ -55,6 +57,7 @@ class OrchestraDeviceCoreRoutingTest {
         val asserted = mutableListOf<Pair<ElementSelector, AssertMode>>()
         val assertedSelectors = mutableListOf<Selector>()
         val assertedTimeouts = mutableListOf<Long>()
+        val readTexts = mutableListOf<ElementSelector>()
 
         override fun connect(target: DeviceCoreTarget, appId: String?) {}
         override fun close() {}
@@ -82,6 +85,7 @@ class OrchestraDeviceCoreRoutingTest {
             throw AssertionError("W1.3 must not route a built verb onto roadmap DeviceGateway.$verb")
 
         override fun hierarchy(): Nothing = boom("hierarchy")
+        override fun readText(selector: ElementSelector): String? { readTexts += selector; return textFor(selector) }
         override fun takeScreenshot(out: Sink, compressed: Boolean, cropOn: ElementSelector?) = boom("takeScreenshot")
         override fun startScreenRecording(out: Sink): ScreenRecording = boom("startScreenRecording")
         override fun longPress(selector: ElementSelector, timeoutMs: Long): ChosenElement? { longPressed += selector; return null }
@@ -481,6 +485,42 @@ class OrchestraDeviceCoreRoutingTest {
         val result = run(driver, MaestroCommand(swipeCommand = SwipeCommand(direction = SwipeDirection.UP)))
         assertThat(result.success).isTrue()
         assertThat(driver.swipes).containsExactly(SwipeDirection.UP)
+    }
+
+    @Test
+    fun `group B - an element-anchored swipe walls, never degrading to a targetless directional`() {
+        // An element+direction swipe needs the element's on-screen geometry as the swipe start, which
+        // device-core owns and has no verb for yet (the drafted Locator.swipe(Direction) isn't
+        // realized). It must WALL honestly, never silently drop the anchor and serve a plain
+        // directional swipe. Routed to the seam's element-anchored swipe overload, which the recording
+        // gateway leaves at its throwing default — the targetless directional verb is never reached.
+        val driver = RecordingDeviceGateway()
+        val e = assertThrows(MaestroException.NotImplemented::class.java) {
+            run(driver, MaestroCommand(swipeCommand = SwipeCommand(
+                elementSelector = ElementSelector(idRegex = "row"),
+                direction = SwipeDirection.UP,
+            )))
+        }
+        assertThat(e.message).isEqualTo("element-anchored swipe")
+        // The anchor was NOT degraded to a targetless directional: the served swipe verb never ran.
+        assertThat(driver.swipes).isEmpty()
+    }
+
+    @Test
+    fun `group A - copyTextFrom reads element text via readText (inspect), never the roadmap hierarchy`() {
+        // copyTextFrom resolves the selector and reads its text off device-core's inspect() verdict
+        // (readText), NOT the never-built hierarchy() dump. The recording gateway BOOMS on hierarchy,
+        // so reaching it would fail loudly; a following pasteText proves the text actually flowed into
+        // the JS `copiedText` and back out through inputText.
+        val driver = RecordingDeviceGateway(textFor = { "Copied Value" })
+        val result = run(
+            driver,
+            MaestroCommand(copyTextCommand = CopyTextFromCommand(selector = ElementSelector(idRegex = "field"))),
+            MaestroCommand(pasteTextCommand = PasteTextCommand()),
+        )
+        assertThat(result.success).isTrue()
+        assertThat(driver.readTexts).containsExactly(ElementSelector(idRegex = "field"))
+        assertThat(driver.inputTexts).containsExactly("Copied Value")
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/OrchestraLegacyEngineRemovalTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/OrchestraLegacyEngineRemovalTest.kt
@@ -41,6 +41,7 @@ class OrchestraLegacyEngineRemovalTest {
     private class SeamFakeDriver : DeviceGateway {
         val tapped = mutableListOf<ElementSelector>()
         val asserted = mutableListOf<Pair<ElementSelector, AssertMode>>()
+        val readFrom = mutableListOf<ElementSelector>()
 
         override fun connect(target: DeviceCoreTarget, appId: String?) {}
         override fun close() {}
@@ -50,6 +51,14 @@ class OrchestraLegacyEngineRemovalTest {
             SelectorTranslator.translate(selector) // unsupported fields throw NotImplemented, as on device
             tapped += selector
             return null
+        }
+
+        // readText is a BUILT verb now (device-core inspect()); mirror the real driver — translate the
+        // selector like on device and return the resolved element's text.
+        override fun readText(selector: ElementSelector): String? {
+            SelectorTranslator.translate(selector)
+            readFrom += selector
+            return "field text"
         }
 
         override fun assertVisibility(selector: ElementSelector, mode: AssertMode, timeoutMs: Long): ChosenElement? {
@@ -210,12 +219,14 @@ class OrchestraLegacyEngineRemovalTest {
     }
 
     @Test
-    fun `copyTextFrom throws NotImplemented instead of silently copying empty text`() {
+    fun `copyTextFrom resolves the element's text through the seam's readText, never the never-built hierarchy`() {
+        // copyTextFrom used to reach for the roadmap hierarchy() dump and wall; it now reads the
+        // resolved element's text off the seam's readText (device-core inspect()). The fake booms on
+        // hierarchy, so reaching it would fail loudly — success proves the read routes through readText.
         val driver = SeamFakeDriver()
-        val e = assertThrows(MaestroException.NotImplemented::class.java) {
-            run(driver, MaestroCommand(copyTextCommand = CopyTextFromCommand(selector = ElementSelector(idRegex = "field"))))
-        }
-        assertThat(e.message).contains("hierarchy")
+        val result = run(driver, MaestroCommand(copyTextCommand = CopyTextFromCommand(selector = ElementSelector(idRegex = "field"))))
+        assertThat(result.success).isTrue()
+        assertThat(driver.readFrom).containsExactly(ElementSelector(idRegex = "field"))
     }
 
     @Test

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreEvidence.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceCoreEvidence.kt
@@ -3,11 +3,13 @@ package maestro.orchestra.devicecore
 import dev.mobile.devicecore.prototype.api.Actionability
 import dev.mobile.devicecore.prototype.api.ElementEvidence
 import dev.mobile.devicecore.prototype.api.EvidenceSource
+import dev.mobile.devicecore.prototype.api.MatchedText
 import dev.mobile.devicecore.prototype.api.Resolution
 import dev.mobile.devicecore.prototype.api.ResolvedChannel
 import dev.mobile.devicecore.prototype.api.SearchedSurface
 import dev.mobile.devicecore.prototype.api.Signal
 import dev.mobile.devicecore.prototype.api.Sourced
+import dev.mobile.devicecore.prototype.api.TextChannel
 
 /**
  * A tiny test factory building real device-core [ElementEvidence] values — no mocks, no
@@ -28,6 +30,29 @@ object DeviceCoreEvidence {
             stable = Signal(false, EvidenceSource.UNAVAILABLE),
         ),
         bounds = Sourced(null, EvidenceSource.UNAVAILABLE),
+    )
+
+    /** Resolved and carrying a matched text value — what `inspect()` reads for copyTextFrom. */
+    fun resolvedWithText(target: String, text: String): ElementEvidence = ElementEvidence(
+        target = target,
+        resolution = Resolution.Resolved(ResolvedChannel.TEXT),
+        actionability = Actionability(
+            attached = Signal(true, EvidenceSource.MEASURED),
+            visible = Signal(true, EvidenceSource.MEASURED),
+            enabled = Signal(true, EvidenceSource.MEASURED),
+            hittable = Signal(true, EvidenceSource.MEASURED),
+            stable = Signal(false, EvidenceSource.UNAVAILABLE),
+        ),
+        bounds = Sourced(null, EvidenceSource.UNAVAILABLE),
+        matched = Sourced(
+            MatchedText(
+                text = text,
+                channel = TextChannel.VALUE,
+                displayed = Sourced(text, EvidenceSource.MEASURED),
+                truncated = Signal(false, EvidenceSource.UNAVAILABLE),
+            ),
+            EvidenceSource.MEASURED,
+        ),
     )
 
     /** Not found anywhere on screen. */

--- a/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceGatewayTest.kt
+++ b/maestro-orchestra/src/test/kotlin/maestro/orchestra/devicecore/DeviceGatewayTest.kt
@@ -157,6 +157,34 @@ class DeviceGatewayTest {
     }
 
     @Test
+    fun `readText reads the resolved element's text off device-core inspect`() {
+        // copyTextFrom's read: the selector resolves and its text comes from inspect()'s
+        // ElementEvidence.matched, NOT a hierarchy dump.
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.resolvedWithText("field", "Hello World") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThat(d.readText(ElementSelector(idRegex = "field"))).isEqualTo("Hello World")
+        assertThat(provider.lastInspectedSelector).isNotNull()
+    }
+
+    @Test
+    fun `readText returns null when the resolved element carries no copyable text`() {
+        // Resolved but no matched text (ElementEvidence.matched.value is null) -> null, which
+        // copyTextFrom turns into UnableToCopyTextFromElement.
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.resolvedVisible("field") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThat(d.readText(ElementSelector(idRegex = "field"))).isNull()
+    }
+
+    @Test
+    fun `readText surfaces an Absent element as ElementNotFound`() {
+        // An element device-core cannot resolve is not-found, the same as tap's Absent — ElementNotFound
+        // (which copyTextFrom's `optional` then governs), never a silent empty copy.
+        val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("field") }
+        val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
+        assertThrows<MaestroException.ElementNotFound> { d.readText(ElementSelector(idRegex = "field")) }
+    }
+
+    @Test
     fun `inputText writes to the focused node via device-core`() {
         val provider = FakeDeviceProvider { DeviceCoreEvidence.absent("x") }
         val d = driver(provider).apply { connect(DeviceCoreTarget(Platform.ANDROID), null) }
@@ -238,6 +266,18 @@ class DeviceGatewayTest {
         assertThrows<MaestroException.NotImplemented> {
             d.swipeFromCenter(SwipeDirection.UP, 400, null)
         }
+    }
+
+    @Test
+    fun `swipe anchored to an element is not implemented (device-core has no element-anchored swipe)`() {
+        // device-core owns element resolution but has no element-anchored swipe verb yet, so an
+        // element+direction swipe walls with its own message rather than degrading to a targetless
+        // directional that would drop the anchor.
+        val d = unimplementedDriver()
+        val e = assertThrows<MaestroException.NotImplemented> {
+            d.swipe(ElementSelector(idRegex = "row"), SwipeDirection.UP, duration = 400, waitToSettleTimeoutMs = null)
+        }
+        assertThat(e.message).isEqualTo("element-anchored swipe")
     }
 
     @Test


### PR DESCRIPTION
## Why

Two verbs in the device-core gateway seam were wired to the wrong place before the current pin. Both are seam bugs, not part of the bump/wire flow.

**Element-anchored swipe silently degraded.** An element-anchored `SwipeCommand` (element selector + direction) was dispatched to the targetless variadic `swipe(...)` passing only `direction`. That overload's wall-guard only fires when `startPoint`/`endPoint`/`startRelative`/`endRelative` are non-null, so an element-anchored swipe slipped past it and the gateway served a plain directional swipe — dropping the anchor. This contradicts the seam's own KDoc, which says element-anchored swipes wall. device-core has no element-anchored swipe verb (the drafted `Locator.swipe(Direction)` isn't realized), so the honest answer is to wall, not to serve a different gesture.

**copyTextFrom was routed through the never-built hierarchy().** `CopyTextFromCommand` called `driver.hierarchy()`, a roadmap verb that only throws, so copyText always walled. device-core actually serves this read — `Locator.inspect()` → `ElementEvidence.matched` (`MatchedText.text`).

## Approach

Test-first for both (each RED pinned the correct behavior before the fix).

- **Swipe:** added a dedicated `swipe(elementSelector, swipeDirection, duration, waitToSettleTimeoutMs)` overload that walls with `NotImplemented("element-anchored swipe")`, and repointed Orchestra's element-anchored branch at it. It's its own overload so the anchor can't be dropped again by falling back to the targetless form. The targetless directional swipe is untouched and still serves.
- **copyText:** added a `readText(selector): String?` gateway verb that resolves the selector and reads text off `inspect()`. `Resolution.Absent` → `ElementNotFound` (honored by `optional`, matching legacy `findElement`); a resolved element with no matched text → `null`, which copyText turns into `UnableToCopyTextFromElement` (matching legacy `resolveText`). Repointed `copyTextFromCommand` at it and removed the `hierarchy()` call.

I verified `inspect()`, `ElementEvidence.matched`, and `MatchedText.text` are all present on the currently pinned build (`0.1.0-13913efb6d7d`) before wiring — no pin bump. Seam-only: device-core untouched, no corpus run.

## Verification

`./gradlew :maestro-orchestra:build` — 546 tests, 0 failures, 27 skipped (pre-existing).

Tests added/changed:
- `DeviceGatewayTest`: element-anchored `swipe` walls with the exact message; `readText` reads matched text off `inspect()`, returns null when there's no copyable text, and surfaces Absent as `ElementNotFound`.
- `OrchestraDeviceCoreRoutingTest`: an element-anchored swipe walls and never degrades (the targetless directional verb is never reached); copyTextFrom reads via `readText`, never `hierarchy()`, and the text flows through to a following `pasteText`.
- `OrchestraLegacyEngineRemovalTest`: updated the copyText case that pinned the old hierarchy() wall to pin the corrected read-through-the-seam behavior.

The pre-existing `group B - direction swipe routes onto the seam` and `swipe (targetless direction) routes to device-core` tests still pass, confirming the served directional swipe and other verbs are unchanged.
