### PR TITLE
feat(harness): GCS direct-fetch — push metadata only, host fetches APK+workspace

### DIFF
--- a/validation-harness/batch_differential.py
+++ b/validation-harness/batch_differential.py
@@ -50,6 +50,11 @@ DEFAULTS = {
     # bare `python3` on the hosts is macOS 3.9; the harness needs >=3.10, which
     # is installed at the brew path. See remote_run_script's python_bin.
     "remote_python": "/opt/homebrew/bin/python3",
+    # on-host GCS fetch: the service-account key lives on the host (never
+    # touches the laptop or the repo) and names the bucket holding the corpus
+    # artifacts (app binaries + workspace.zip) that dispatch no longer pushes.
+    "sa_key": os.environ.get("MAESTRO_REPLAY_SA_KEY", ""),
+    "gcs_bucket": os.environ.get("MAESTRO_REPLAY_GCS_BUCKET", ""),
 }
 
 _DEVICE_BIN_REL = "build/install/maestro-device/bin/maestro-device"
@@ -159,9 +164,15 @@ def _renamed_tree(bin_path, alias):
 
 def dispatch_host(host, entry, creds, artifacts, remote_root, transport,
                   remote_python="/opt/homebrew/bin/python3", keep_scratch=False,
-                  manifest_path=None):
+                  manifest_path=None,
+                  sa_key="",
+                  gcs_bucket=""):
     platform = entry["platform"]
     remote_dir = f"{remote_root}/{host}"
+
+    if not sa_key or not gcs_bucket:
+        raise ValueError("GCS fetch needs a bucket and SA key: set --gcs-bucket/--sa-key or MAESTRO_REPLAY_GCS_BUCKET/MAESTRO_REPLAY_SA_KEY")
+
     if not claim_host(creds, platform, transport):
         return {"host": host, "status": "skipped-busy", "remote_dir": remote_dir}
 
@@ -205,20 +216,34 @@ def dispatch_host(host, entry, creds, artifacts, remote_root, transport,
     if manifest_path and os.path.isfile(manifest_path):
         transport.scp_put(creds, manifest_path, f"{remote_dir}/manifest.json")
         manifest_remote = "manifest.json"
-    # the host's folder slice. SF-4: namespace each folder by its index so two
-    # folders that share a basename (e.g. run_1) don't overwrite each other. The
-    # original basename is PRESERVED inside corpus/<i>/ so run_differential's runId
-    # (derived from the basename) is unchanged.
+    # Push ONLY metadata.json per folder — the app binary + workspace come from
+    # GCS via host_fetch.py below. SF-4 namespacing is preserved: corpus/<i>/<basename>
+    # keeps the runId stable even when two folders share a basename.
+    folder_rel = []
     for i, folder in enumerate(entry["folders"]):
-        transport.ssh_run(creds, f"mkdir -p {remote_dir}/corpus/{i}")
-        transport.scp_put(creds, folder, f"{remote_dir}/corpus/{i}/")
+        base = os.path.basename(os.path.normpath(folder))
+        dest_dir = f"{remote_dir}/corpus/{i}/{base}"
+        transport.ssh_run(creds, f"mkdir -p {dest_dir}")
+        transport.scp_put(creds, os.path.join(folder, "metadata.json"),
+                          f"{dest_dir}/metadata.json")
+        folder_rel.append(f"corpus/{i}/{base}")
+
+    # Ship the host-side fetcher and run it once (token minted once, reused).
+    transport.scp_put(creds, os.path.join(here, "host_fetch.py"), f"{remote_dir}/host_fetch.py")
+    fetch = transport.host_fetch_script(
+        remote_dir=remote_dir, folders=folder_rel,
+        key_path=sa_key, bucket=gcs_bucket, python_bin=remote_python,
+    )
+    fetch_res = transport.ssh_run(creds, fetch)
+    if getattr(fetch_res, "returncode", 0) != 0:
+        return {"host": host, "status": "fetch-failed", "remote_dir": remote_dir}
 
     script = transport.remote_run_script(
         remote_dir=remote_dir,
         device_bin="art/maestro-device/bin/maestro-device",
         cli_2x="art/2x/bin/maestro", cli_3x="art/3x/bin/maestro",
         out_dir="out",
-        folders=[f"corpus/{i}/{os.path.basename(f)}" for i, f in enumerate(entry["folders"])],
+        folders=folder_rel,                         # unchanged: corpus/<i>/<basename>
         done_sentinel="out/DONE", log="out/run.log",
         python_bin=remote_python,
         keep_scratch=keep_scratch,
@@ -255,7 +280,9 @@ def cmd_dispatch(args, transport=remote):
         hosts_state.append(dispatch_host(host, entry, creds, art_trees, args.remote_root, transport,
                                          remote_python=args.remote_python,
                                          keep_scratch=keep_remote,
-                                         manifest_path=manifest_path))
+                                         manifest_path=manifest_path,
+                                         sa_key=getattr(args, "sa_key", DEFAULTS["sa_key"]),
+                                         gcs_bucket=getattr(args, "gcs_bucket", DEFAULTS["gcs_bucket"])))
 
     state = {"smoke": bool(getattr(args, "smoke", False)), "hosts": hosts_state,
              "remote_root": args.remote_root}
@@ -428,6 +455,10 @@ def main(argv=None) -> int:
     d.add_argument("--keep-remote", dest="keep_remote", action="store_true",
                    help="tell the remote run to keep per-run scratch + leaked sim clones "
                         "on the host for debugging (self-cleaned by default)")
+    d.add_argument("--sa-key", default=DEFAULTS["sa_key"], dest="sa_key",
+                   help="service-account key path ON THE HOST for GCS fetch")
+    d.add_argument("--gcs-bucket", default=DEFAULTS["gcs_bucket"], dest="gcs_bucket",
+                   help="GCS bucket holding the corpus artifacts")
     d.set_defaults(func=cmd_dispatch, keep_remote=False)
 
     c = sub.add_parser("collect", help="verified tar-pull + merge + triage list + remote cleanup")

--- a/validation-harness/host_fetch.py
+++ b/validation-harness/host_fetch.py
@@ -1,0 +1,218 @@
+"""host_fetch.py — runs ON a remote host: mint a GCS OAuth token from the
+service-account key (openssl + python3 stdlib, no google-auth/gcloud/gsutil),
+then download each flow's app binary + workspace.zip from the configured GCS bucket and
+unzip the workspace. Stdlib only. Never prints the key, token, or creds."""
+from __future__ import annotations
+
+import argparse
+import base64
+import http.client
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+
+_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
+_AUD = "https://oauth2.googleapis.com/token"
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def build_signing_input(client_email, now, scope=_SCOPE, aud=_AUD, lifetime=3600):
+    header = {"alg": "RS256", "typ": "JWT"}
+    claims = {"iss": client_email, "scope": scope, "aud": aud,
+              "iat": now, "exp": now + lifetime}
+    h = _b64url(json.dumps(header, separators=(",", ":")).encode())
+    c = _b64url(json.dumps(claims, separators=(",", ":")).encode())
+    return f"{h}.{c}"
+
+
+def sign_rs256(signing_input, private_key_pem, runner=subprocess.run):
+    # openssl -sign needs the key in a file; write it 0600 and always remove it.
+    fd, keyfile = tempfile.mkstemp(prefix="hf-", suffix=".pem")
+    try:
+        os.close(fd)
+        os.chmod(keyfile, 0o600)
+        with open(keyfile, "w") as fh:
+            fh.write(private_key_pem)
+        p = runner(["openssl", "dgst", "-sha256", "-sign", keyfile],
+                   input=signing_input.encode(), capture_output=True, check=False)
+        if p.returncode != 0:
+            # Deliberately generic: never echo the key or openssl stderr.
+            raise RuntimeError("openssl signing failed")
+        return _b64url(p.stdout)
+    finally:
+        try:
+            os.unlink(keyfile)
+        except OSError:
+            pass
+
+
+def mint_token(key_path, urlopen=urllib.request.urlopen, runner=subprocess.run, now=None):
+    with open(key_path) as fh:
+        key = json.load(fh)
+    now = int(time.time()) if now is None else now
+    signing_input = build_signing_input(key["client_email"], now)
+    signature = sign_rs256(signing_input, key["private_key"], runner=runner)
+    assertion = f"{signing_input}.{signature}"
+    body = urllib.parse.urlencode({
+        "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        "assertion": assertion,
+    }).encode()
+    req = urllib.request.Request(
+        _AUD, data=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    with urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read())
+    tok = payload.get("access_token")
+    if not tok:
+        # Never echo the payload — it may carry error detail but also the assertion.
+        raise RuntimeError("token exchange returned no access_token")
+    return tok
+
+
+_DOWNLOAD_BASE = "https://storage.googleapis.com/download/storage/v1/b"
+_CHUNK = 1024 * 1024
+
+
+def object_media_url(bucket, object_path):
+    encoded = urllib.parse.quote(object_path, safe="")
+    return f"{_DOWNLOAD_BASE}/{bucket}/o/{encoded}?alt=media"
+
+
+def download_object(bucket, object_path, dest, token,
+                    urlopen=urllib.request.urlopen, retries=3, sleep=time.sleep,
+                    token_provider=None):
+    """token_provider: optional zero-arg callable that re-mints a fresh token.
+    A stage can outlive the token minted at the start of a host run; a 401
+    is recoverable (re-mint once, retry) instead of the fail-fast path used
+    for every other 4xx. Never log the token on any path."""
+    url = object_media_url(bucket, object_path)
+    part = dest + ".part"
+    last = None
+    refreshed = False
+    attempt = 0
+    while True:
+        try:
+            req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+            with urlopen(req, timeout=120) as resp:
+                cl = resp.headers.get("Content-Length")
+                expected = int(cl) if cl not in (None, "") else None
+                n = 0
+                with open(part, "wb") as fh:
+                    while True:
+                        chunk = resp.read(_CHUNK)
+                        if not chunk:
+                            break
+                        fh.write(chunk)
+                        n += len(chunk)
+            if expected is not None and n != expected:
+                os.unlink(part)
+                raise IOError(f"truncated download: got {n} of {expected} bytes for {object_path}")
+            os.replace(part, dest)
+            return n
+        except urllib.error.HTTPError as e:
+            if e.code == 401 and token_provider is not None and not refreshed:
+                token = token_provider()
+                refreshed = True
+                _rm(part)
+                continue                      # retry now with the fresh token; doesn't
+                                               # count against the transient-error budget
+            if 400 <= e.code < 500:
+                _rm(part)
+                raise                          # 4xx (e.g. 404) — not transient
+            last = e
+        except (urllib.error.URLError, IOError, http.client.IncompleteRead) as e:
+            last = e
+        _rm(part)
+        attempt += 1
+        if attempt >= retries:
+            break
+        sleep(min(2 ** (attempt - 1), 8))
+    raise RuntimeError(f"download failed after {retries} attempts for {object_path}: {last}")
+
+
+def _rm(path):
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+_APP_NAME = {"ANDROID": "app.apk", "IOS": "app.ipa"}
+
+
+def fetch_folder(folder, bucket, token, urlopen=urllib.request.urlopen, token_provider=None):
+    """token_provider: optional zero-arg callable that re-mints a fresh token,
+    threaded down to download_object so a 401 (token outlived by a long stage)
+    is recovered with a single re-mint-and-retry instead of failing the folder."""
+    with open(os.path.join(folder, "metadata.json")) as fh:
+        meta = json.load(fh)
+    platform = str(meta["platform"]).upper()
+
+    dl_kwargs = {"urlopen": urlopen}
+    if token_provider is not None:
+        dl_kwargs["token_provider"] = token_provider
+
+    # workspace.zip -> workspace/ (the replay tars the whole workspace dir).
+    ws_dest = os.path.join(folder, "workspace.zip")
+    download_object(bucket, meta["workspace_storage_path"], ws_dest, token, **dl_kwargs)
+    ws_dir = os.path.join(folder, "workspace")
+    os.makedirs(ws_dir, exist_ok=True)
+    with zipfile.ZipFile(ws_dest) as z:
+        z.extractall(ws_dir)
+
+    # app binary — skipped for a built-in app (requires_app_install: false) or when
+    # no app object is recorded. NEVER fetch run_artifacts_storage_prefix.
+    if meta.get("requires_app_install") is not False and meta.get("app_storage_path"):
+        app_dest = os.path.join(folder, _APP_NAME[platform])
+        download_object(bucket, meta["app_storage_path"], app_dest, token, **dl_kwargs)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description="Fetch corpus artifacts from GCS on the host.")
+    ap.add_argument("--key", required=True, help="service-account key JSON path")
+    ap.add_argument("--bucket", required=True, help="GCS bucket name")
+    ap.add_argument("folders", nargs="+", help="corpus folder paths (each holds metadata.json)")
+    args = ap.parse_args(argv)
+
+    try:
+        token = mint_token(args.key)          # once per host; reused for all folders
+    except Exception as e:
+        print(f"[host_fetch] FATAL: token mint failed: {e}", file=sys.stderr)
+        return 1
+
+    # Zero-arg re-mint, threaded down so a 401 (token outlived by a long stage)
+    # is recovered in place instead of failing the folder.
+    token_provider = lambda: mint_token(args.key)
+
+    failed = []
+    for folder in args.folders:
+        try:
+            fetch_folder(folder, args.bucket, token, token_provider=token_provider)
+        except Exception as e:
+            # A single flow's fetch failure must not abort the others.
+            print(f"[host_fetch] WARN: fetch failed for {folder}: {e}", file=sys.stderr)
+            failed.append(folder)
+    if failed:
+        print(f"[host_fetch] {len(failed)} folder(s) failed; the rest fetched OK",
+              file=sys.stderr)
+        if len(failed) == len(args.folders):
+            # Every folder missed — nothing to diff. Distinct from a partial
+            # miss (still 0) so dispatch_host marks the host fetch-failed
+            # instead of running the diff against zero inputs.
+            return 1
+    return 0                                   # partial or full success: run_differential reports the misses
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/validation-harness/remote.py
+++ b/validation-harness/remote.py
@@ -148,7 +148,23 @@ def remote_run_script(remote_dir, device_bin, cli_2x, cli_3x, out_dir,
         f"{_REMOTE_ENV_PREAMBLE}{run} > {q(log)} 2>&1; "
         f"rc=$?; echo \"$rc\" > {q(done_sentinel)}"
     )
-    return f"cd {_remote_path(remote_dir)} && nohup bash -c {q(inner)} > /dev/null 2>&1 &"
+    return f"cd {_remote_path(remote_dir)} && nohup bash -c {q(inner)} < /dev/null > /dev/null 2>&1 &"
+
+
+def host_fetch_script(remote_dir, folders, key_path, bucket,
+                      python_bin="/opt/homebrew/bin/python3", script="host_fetch.py"):
+    """Build the synchronous host-side GCS fetch invocation (see host_fetch.py).
+
+    Runs in the host's <remote_dir> so the folder args are remote-relative
+    (corpus/<i>/<basename>), matching the run script. Synchronous: its exit
+    status is the ssh_run return code, so dispatch can see a token-mint failure.
+    """
+    q = shlex.quote
+    folder_args = " ".join(q(f) for f in folders)
+    return (
+        f"cd {_remote_path(remote_dir)} && "
+        f"{q(python_bin)} {q(script)} --key {q(key_path)} --bucket {q(bucket)} {folder_args}"
+    )
 
 
 # Catastrophic rm -rf targets: the harness only ever creates

--- a/validation-harness/test_batch_differential.py
+++ b/validation-harness/test_batch_differential.py
@@ -218,10 +218,12 @@ class FakeTransport:
     def __init__(self, idle=True):
         self.idle = idle
         self.ssh_calls = []; self.scp_calls = []; self.run_scripts = []
+        self.fetch_scripts = []; self.ssh_rc = 0
     # mirror remote.* surface used by dispatch
     def ssh_run(self, creds, script, runner=None, timeout=None):
         self.ssh_calls.append(script)
-        class R: stdout = "idle-probe-output"; stderr=""; returncode=0
+        rc = self.ssh_rc
+        class R: stdout = "idle-probe-output"; stderr=""; returncode = rc
         return R()
     def scp_put(self, creds, local, remote_path, runner=None):
         self.scp_calls.append((local, remote_path))
@@ -229,6 +231,8 @@ class FakeTransport:
     def host_is_idle(self, platform, out): return self.idle
     def remote_run_script(self, **kw):
         self.run_scripts.append(kw); return "nohup ... &"
+    def host_fetch_script(self, **kw):
+        self.fetch_scripts.append(kw); return "cd ... && host_fetch.py ..."
 
 def _write_manifests(tmp_path):
     work = tmp_path / "bo"; work.mkdir()
@@ -260,7 +264,8 @@ def test_dispatch_smoke_hits_one_ios_one_android_and_stops(tmp_path):
     work, inv = _write_manifests(tmp_path)
     t = FakeTransport(idle=True)
     args = bd._ns(work_dir=work, inventory=inv, smoke=True,
-                  remote_root="~/scratch/dcdiff")
+                  remote_root="~/scratch/dcdiff",
+                  sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     state = bd.cmd_dispatch(args, transport=t)
     assert set(e["status"] for e in state["hosts"]) == {"running"}
     assert len(state["hosts"]) == 2                      # exactly one per platform
@@ -272,7 +277,8 @@ def test_dispatch_smoke_hits_one_ios_one_android_and_stops(tmp_path):
 def test_dispatch_skips_busy_host_never_self_selects(tmp_path):
     work, inv = _write_manifests(tmp_path)
     t = FakeTransport(idle=False)
-    args = bd._ns(work_dir=work, inventory=inv, smoke=True, remote_root="~/scratch")
+    args = bd._ns(work_dir=work, inventory=inv, smoke=True, remote_root="~/scratch",
+                  sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     state = bd.cmd_dispatch(args, transport=t)
     assert all(e["status"] == "skipped-busy" for e in state["hosts"])
     assert t.run_scripts == []                            # nothing ran on a busy host
@@ -288,14 +294,67 @@ def test_dispatch_namespaces_colliding_basenames(tmp_path):
     # overwrite each other (and collide as runIds). Each must land distinctly.
     t = FakeTransport(idle=True)
     entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1", "/proj_b/run_1"]}
-    res = bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t)
+    res = bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                           sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     assert res["status"] == "running"
+    # push shape changed: only metadata.json per folder now (app + workspace come
+    # from GCS), but the namespacing invariant (SF-4) still holds — each folder's
+    # metadata.json lands at a distinct path, no collision.
     corpus_targets = [rp for (lp, rp) in t.scp_calls if "corpus" in rp]
     assert len(corpus_targets) == 2
     assert len(set(corpus_targets)) == 2          # distinct scp targets, no collision
+    assert all(rp.endswith("/metadata.json") for rp in corpus_targets)
     rs = t.run_scripts[0]
     assert len(set(rs["folders"])) == 2           # distinct run-script folder args
     assert rs["folders"] == ["corpus/0/run_1", "corpus/1/run_1"]
+
+def test_dispatch_pushes_only_metadata_not_whole_folder(tmp_path):
+    t = FakeTransport(idle=True)
+    entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1", "/proj_b/run_2"]}
+    res = bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                           sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
+    assert res["status"] == "running"
+    corpus_scps = [(lp, rp) for (lp, rp) in t.scp_calls if "corpus" in rp]
+    # exactly one push per folder, and it is metadata.json — not the folder itself
+    assert len(corpus_scps) == 2
+    assert all(lp.endswith("/metadata.json") for lp, rp in corpus_scps)
+    assert all(rp.endswith("/metadata.json") for lp, rp in corpus_scps)
+    assert {rp for _, rp in corpus_scps} == {
+        "~/scratch/m2-1/corpus/0/run_1/metadata.json",
+        "~/scratch/m2-1/corpus/1/run_2/metadata.json",
+    }
+
+
+def test_dispatch_ships_host_fetch_and_invokes_it(tmp_path):
+    t = FakeTransport(idle=True)
+    entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
+    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
+    assert any(rp.endswith("/host_fetch.py") for _, rp in t.scp_calls)
+    assert len(t.fetch_scripts) == 1
+    fk = t.fetch_scripts[0]
+    assert fk["folders"] == ["corpus/0/run_1"]
+    assert fk["bucket"] == "test-bucket"
+    assert fk["key_path"] == "/path/to/sa-key.json"
+
+
+def test_dispatch_run_script_folders_unchanged(tmp_path):
+    t = FakeTransport(idle=True)
+    entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1", "/proj_b/run_1"]}
+    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
+    assert t.run_scripts[0]["folders"] == ["corpus/0/run_1", "corpus/1/run_1"]
+
+
+def test_dispatch_marks_fetch_failed_on_nonzero_fetch(tmp_path):
+    t = FakeTransport(idle=True)
+    t.ssh_rc = 1                                   # host_fetch returns non-zero (token mint failed)
+    entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
+    res = bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                           sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
+    assert res["status"] == "fetch-failed"
+    assert t.run_scripts == []                      # never ran the diff
+
 
 def test_dispatch_ships_manifest_and_passes_it_to_run_script(tmp_path):
     # Fix 2: the batch path emitted no provenance.json because manifest.json was
@@ -306,7 +365,8 @@ def test_dispatch_ships_manifest_and_passes_it_to_run_script(tmp_path):
     t = FakeTransport(idle=True)
     entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
     bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
-                     manifest_path=str(manifest))
+                     manifest_path=str(manifest),
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     manifest_scps = [(lp, rp) for (lp, rp) in t.scp_calls if lp == str(manifest)]
     assert manifest_scps == [(str(manifest), "~/scratch/m2-1/manifest.json")]
     # and the run script references the shipped copy by its remote-relative path
@@ -318,7 +378,8 @@ def test_dispatch_omits_manifest_when_absent(tmp_path):
     t = FakeTransport(idle=True)
     entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
     bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
-                     manifest_path=str(tmp_path / "nope.json"))
+                     manifest_path=str(tmp_path / "nope.json"),
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     assert not any("manifest.json" in rp for (_, rp) in t.scp_calls)
     assert t.run_scripts[0].get("manifest") is None
 
@@ -329,7 +390,8 @@ def test_cmd_dispatch_ships_workdir_manifest(tmp_path):
     work, inv = _write_manifests(tmp_path)
     t = FakeTransport(idle=True)
     args = bd._ns(work_dir=work, inventory=inv, smoke=True,
-                  remote_root="~/scratch/dcdiff")
+                  remote_root="~/scratch/dcdiff",
+                  sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     bd.cmd_dispatch(args, transport=t)
     manifest_targets = [rp for (lp, rp) in t.scp_calls if lp.endswith("manifest.json")]
     assert manifest_targets                                  # at least one host got it
@@ -342,7 +404,8 @@ def test_dispatch_defaults_remote_python_to_brew(tmp_path):
     # interpreter (>=3.10) so run_folder.py's PEP-604 unions import cleanly.
     t = FakeTransport(idle=True)
     entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
-    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t)
+    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     assert t.run_scripts[0]["python_bin"] == "/opt/homebrew/bin/python3"
 
 
@@ -350,7 +413,8 @@ def test_dispatch_threads_remote_python_override(tmp_path):
     t = FakeTransport(idle=True)
     entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
     bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
-                     remote_python="/usr/bin/python3.11")
+                     remote_python="/usr/bin/python3.11",
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     assert t.run_scripts[0]["python_bin"] == "/usr/bin/python3.11"
 
 
@@ -359,7 +423,8 @@ def test_dispatch_cleans_cli_staging_before_scp(tmp_path):
     # nest as art/maestro/maestro. Clean the staging path before each CLI scp.
     t = FakeTransport(idle=True)
     entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
-    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t)
+    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     staging_cleans = [s for s in t.ssh_calls
                       if "rm -rf ~/scratch/m2-1/art/maestro" in s and "mv" not in s]
     assert len(staging_cleans) == 2               # once per CLI tree (2x, 3x)
@@ -371,7 +436,8 @@ def test_dispatch_clears_stale_remote_out_before_run(tmp_path):
     # batch's runs.
     t = FakeTransport(idle=True)
     entry = {"platform": "ANDROID", "folders": ["/proj_a/run_1"]}
-    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t)
+    bd.dispatch_host("m2-1", entry, _CREDS, _ART, "~/scratch", t,
+                     sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     out_clears = [s for s in t.ssh_calls if "rm -rf ~/scratch/m2-1/out" in s]
     assert len(out_clears) == 1                       # out/ is cleared exactly once
     # it must happen BEFORE the detached run script is issued
@@ -610,7 +676,8 @@ def test_dispatch_keep_remote_threads_keep_scratch_to_the_run(tmp_path):
     work, inv = _write_manifests(tmp_path)
     t = FakeTransport(idle=True)
     args = bd._ns(work_dir=work, inventory=inv, smoke=True,
-                  remote_root="/tmp/maestro-differential", keep_remote=True)
+                  remote_root="/tmp/maestro-differential", keep_remote=True,
+                  sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     bd.cmd_dispatch(args, transport=t)
     assert all(rs["keep_scratch"] is True for rs in t.run_scripts)
 
@@ -619,6 +686,7 @@ def test_dispatch_defaults_to_self_cleaning_run(tmp_path):
     work, inv = _write_manifests(tmp_path)
     t = FakeTransport(idle=True)
     args = bd._ns(work_dir=work, inventory=inv, smoke=True,
-                  remote_root="/tmp/maestro-differential", keep_remote=False)
+                  remote_root="/tmp/maestro-differential", keep_remote=False,
+                  sa_key="/path/to/sa-key.json", gcs_bucket="test-bucket")
     bd.cmd_dispatch(args, transport=t)
     assert all(rs["keep_scratch"] is False for rs in t.run_scripts)

--- a/validation-harness/test_host_fetch.py
+++ b/validation-harness/test_host_fetch.py
@@ -1,0 +1,336 @@
+import base64, json
+import http.client
+import io
+import os
+import shutil
+import subprocess
+import urllib.error
+import zipfile
+
+import pytest
+
+import host_fetch as hf
+
+
+def _b64url_decode(s):
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def test_signing_input_has_expected_header_and_claims():
+    si = hf.build_signing_input("svc@example.iam.gserviceaccount.com", now=1000)
+    header_b64, claims_b64 = si.split(".")
+    header = json.loads(_b64url_decode(header_b64))
+    claims = json.loads(_b64url_decode(claims_b64))
+    assert header == {"alg": "RS256", "typ": "JWT"}
+    assert claims["iss"] == "svc@example.iam.gserviceaccount.com"
+    assert claims["aud"] == "https://oauth2.googleapis.com/token"
+    assert claims["scope"] == "https://www.googleapis.com/auth/devstorage.read_only"
+    assert claims["iat"] == 1000 and claims["exp"] == 1000 + 3600
+    # base64url: no '+' '/' or '=' padding
+    assert "=" not in si and "+" not in si and "/" not in si
+
+
+def test_sign_rs256_invokes_openssl_and_b64url_encodes(monkeypatch):
+    calls = {}
+
+    class R:
+        returncode = 0
+        stdout = b"\xDE\xAD\xBE\xEF"
+        stderr = b""
+
+    def fake_runner(argv, input=None, capture_output=False, check=False):
+        calls["argv"] = argv
+        calls["input"] = input
+        return R()
+
+    sig = hf.sign_rs256("aaa.bbb", "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+                        runner=fake_runner)
+    assert calls["argv"][:4] == ["openssl", "dgst", "-sha256", "-sign"]
+    assert calls["input"] == b"aaa.bbb"
+    assert sig == base64.urlsafe_b64encode(b"\xDE\xAD\xBE\xEF").rstrip(b"=").decode()
+
+
+def test_sign_rs256_raises_without_echoing_key_on_failure():
+    class R:
+        returncode = 1
+        stdout = b""
+        stderr = b"some openssl noise"
+
+    def failing_runner(argv, input=None, capture_output=False, check=False):
+        return R()
+
+    try:
+        hf.sign_rs256("a.b", "SECRET-KEY-MATERIAL", runner=failing_runner)
+        assert False, "expected RuntimeError"
+    except RuntimeError as e:
+        assert "SECRET-KEY-MATERIAL" not in str(e)
+
+
+def test_mint_token_posts_jwt_bearer_and_returns_access_token(tmp_path, monkeypatch):
+    key = {"client_email": "svc@example.iam.gserviceaccount.com",
+           "private_key": "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n"}
+    kp = tmp_path / "creds.json"
+    kp.write_text(json.dumps(key))
+
+    seen = {}
+
+    class Resp:
+        def read(self): return json.dumps({"access_token": "ya29.TESTTOKEN"}).encode()
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+
+    def fake_urlopen(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["body"] = req.data.decode()
+        return Resp()
+
+    def fake_runner(argv, input=None, capture_output=False, check=False):
+        class R: returncode = 0; stdout = b"sig"; stderr = b""
+        return R()
+
+    tok = hf.mint_token(str(kp), urlopen=fake_urlopen, runner=fake_runner, now=1000)
+    assert tok == "ya29.TESTTOKEN"
+    assert seen["url"] == "https://oauth2.googleapis.com/token"
+    assert "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer" in seen["body"]
+    assert "assertion=" in seen["body"]
+
+
+class _FakeResp(io.BytesIO):
+    def __init__(self, data, content_length=None):
+        super().__init__(data)
+        self.headers = {"Content-Length": str(content_length)} if content_length is not None else {}
+    def __enter__(self): return self
+    def __exit__(self, *a): return False
+
+
+def test_object_media_url_percent_encodes_slashes():
+    url = hf.object_media_url("test-bucket", "prod/apk/03d941bab8db")
+    assert url == ("https://storage.googleapis.com/download/storage/v1/b/"
+                   "test-bucket/o/prod%2Fapk%2F03d941bab8db?alt=media")
+
+
+def test_download_object_writes_dest_and_returns_count(tmp_path):
+    dest = str(tmp_path / "app.apk")
+    def urlopen(req, timeout=None):
+        assert req.headers["Authorization"] == "Bearer TOK"
+        return _FakeResp(b"APKDATA", content_length=7)
+    n = hf.download_object("test-bucket", "prod/apk/x", dest, "TOK", urlopen=urlopen)
+    assert n == 7
+    assert open(dest, "rb").read() == b"APKDATA"
+
+
+def test_download_object_rejects_truncation_and_leaves_no_partial(tmp_path):
+    dest = str(tmp_path / "app.apk")
+    def urlopen(req, timeout=None):
+        return _FakeResp(b"SHORT", content_length=999)   # claims 999, sends 5
+    try:
+        hf.download_object("test-bucket", "prod/apk/x", dest, "TOK", urlopen=urlopen, retries=1)
+        assert False, "expected truncation error"
+    except (IOError, RuntimeError):
+        pass
+    assert not os.path.exists(dest)
+    assert not os.path.exists(dest + ".part")
+
+
+def test_download_object_retries_5xx_then_succeeds(tmp_path):
+    dest = str(tmp_path / "app.apk")
+    calls = {"n": 0}
+    def urlopen(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise urllib.error.HTTPError(req.full_url, 503, "busy", {}, None)
+        return _FakeResp(b"OK", content_length=2)
+    n = hf.download_object("test-bucket", "prod/apk/x", dest, "TOK",
+                           urlopen=urlopen, retries=3, sleep=lambda s: None)
+    assert n == 2 and calls["n"] == 2
+
+
+def test_download_object_fails_fast_on_404(tmp_path):
+    dest = str(tmp_path / "app.apk")
+    calls = {"n": 0}
+    def urlopen(req, timeout=None):
+        calls["n"] += 1
+        raise urllib.error.HTTPError(req.full_url, 404, "not found", {}, None)
+    def token_provider():
+        raise AssertionError("404 is not a token problem — must not re-mint")
+    try:
+        hf.download_object("test-bucket", "prod/apk/x", dest, "TOK",
+                           urlopen=urlopen, retries=5, sleep=lambda s: None,
+                           token_provider=token_provider)
+        assert False, "expected immediate failure"
+    except urllib.error.HTTPError as e:
+        assert e.code == 404
+    assert calls["n"] == 1                      # no retry on a 4xx
+
+
+def test_download_object_refreshes_token_once_on_401_then_succeeds(tmp_path):
+    dest = str(tmp_path / "app.apk")
+    calls = {"get": 0}
+    refreshes = {"n": 0}
+
+    def urlopen(req, timeout=None):
+        calls["get"] += 1
+        if calls["get"] == 1:
+            assert req.headers["Authorization"] == "Bearer STALE"
+            raise urllib.error.HTTPError(req.full_url, 401, "expired token", {}, None)
+        assert req.headers["Authorization"] == "Bearer FRESH"
+        return _FakeResp(b"OK", content_length=2)
+
+    def token_provider():
+        refreshes["n"] += 1
+        return "FRESH"
+
+    n = hf.download_object("test-bucket", "prod/apk/x", dest, "STALE",
+                           urlopen=urlopen, retries=3, sleep=lambda s: None,
+                           token_provider=token_provider)
+    assert n == 2
+    assert open(dest, "rb").read() == b"OK"
+    assert refreshes["n"] == 1                  # re-minted exactly once
+    assert calls["get"] == 2                    # failed GET, then the retry
+    assert not os.path.exists(dest + ".part")
+
+
+def test_download_object_retries_incomplete_read_then_succeeds(tmp_path):
+    dest = str(tmp_path / "app.apk")
+    calls = {"n": 0}
+    def urlopen(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise http.client.IncompleteRead(b"partial")
+        return _FakeResp(b"OK", content_length=2)
+    n = hf.download_object("test-bucket", "prod/apk/x", dest, "TOK",
+                           urlopen=urlopen, retries=3, sleep=lambda s: None)
+    assert n == 2 and calls["n"] == 2
+    assert not os.path.exists(dest + ".part")
+
+
+def _write_meta(folder, **over):
+    os.makedirs(folder, exist_ok=True)
+    meta = {"platform": "ANDROID", "flow_file_path": "flow.yaml",
+            "app_storage_path": "prod/apk/APPHASH",
+            "workspace_storage_path": "prod/workspaces/WS",
+            "run_artifacts_storage_prefix": "prod/run_artifacts/run_x/"}
+    meta.update(over)
+    with open(os.path.join(folder, "metadata.json"), "w") as fh:
+        json.dump(meta, fh)
+
+
+def _zip_bytes(names):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for n in names:
+            z.writestr(n, "x")
+    return buf.getvalue()
+
+
+def test_fetch_folder_downloads_app_and_workspace_never_run_artifacts(tmp_path):
+    folder = str(tmp_path / "corpus" / "0" / "run_1")
+    _write_meta(folder)
+    ws_zip = _zip_bytes(["flow.yaml"])
+    requested = []
+    def fake_download(bucket, object_path, dest, token, urlopen=None):
+        requested.append(object_path)
+        if object_path.endswith("WS"):
+            with open(dest, "wb") as fh: fh.write(ws_zip)
+        else:
+            with open(dest, "wb") as fh: fh.write(b"APK")
+        return 3
+    import host_fetch as hf
+    orig = hf.download_object
+    hf.download_object = fake_download
+    try:
+        hf.fetch_folder(folder, "test-bucket", "TOK")
+    finally:
+        hf.download_object = orig
+    assert os.path.exists(os.path.join(folder, "app.apk"))
+    assert os.path.exists(os.path.join(folder, "workspace.zip"))
+    assert os.path.isfile(os.path.join(folder, "workspace", "flow.yaml"))
+    assert "prod/apk/APPHASH" in requested and "prod/workspaces/WS" in requested
+    assert not any("run_artifacts" in p for p in requested)
+
+
+def test_fetch_folder_ios_names_ipa(tmp_path):
+    folder = str(tmp_path / "run_ios")
+    _write_meta(folder, platform="IOS")
+    ws_zip = _zip_bytes(["flow.yaml"])
+    def fake_download(bucket, object_path, dest, token, urlopen=None):
+        with open(dest, "wb") as fh:
+            fh.write(ws_zip if object_path.endswith("WS") else b"IPA")
+        return 3
+    import host_fetch as hf
+    orig = hf.download_object; hf.download_object = fake_download
+    try:
+        hf.fetch_folder(folder, "test-bucket", "TOK")
+    finally:
+        hf.download_object = orig
+    assert os.path.exists(os.path.join(folder, "app.ipa"))
+    assert not os.path.exists(os.path.join(folder, "app.apk"))
+
+
+def test_fetch_folder_skips_app_when_requires_app_install_false(tmp_path):
+    folder = str(tmp_path / "run_builtin")
+    _write_meta(folder, requires_app_install=False)
+    ws_zip = _zip_bytes(["flow.yaml"])
+    requested = []
+    def fake_download(bucket, object_path, dest, token, urlopen=None):
+        requested.append(object_path)
+        with open(dest, "wb") as fh: fh.write(ws_zip)
+        return 3
+    import host_fetch as hf
+    orig = hf.download_object; hf.download_object = fake_download
+    try:
+        hf.fetch_folder(folder, "test-bucket", "TOK")
+    finally:
+        hf.download_object = orig
+    assert requested == ["prod/workspaces/WS"]           # workspace only, no app
+    assert not os.path.exists(os.path.join(folder, "app.apk"))
+
+
+def test_main_returns_nonzero_when_all_folders_fail(tmp_path, monkeypatch):
+    monkeypatch.setattr(hf, "mint_token", lambda key_path: "TOK")
+    def fail_fetch(folder, bucket, token, urlopen=None, token_provider=None):
+        raise RuntimeError("boom")
+    monkeypatch.setattr(hf, "fetch_folder", fail_fetch)
+    key = tmp_path / "key.json"
+    key.write_text("{}")
+    rc = hf.main(["--key", str(key), "--bucket", "test-bucket", "f1", "f2"])
+    assert rc != 0
+
+
+def test_main_returns_zero_on_partial_fail(tmp_path, monkeypatch):
+    monkeypatch.setattr(hf, "mint_token", lambda key_path: "TOK")
+    def sometimes_fail(folder, bucket, token, urlopen=None, token_provider=None):
+        if folder == "f1":
+            raise RuntimeError("boom")
+    monkeypatch.setattr(hf, "fetch_folder", sometimes_fail)
+    key = tmp_path / "key.json"
+    key.write_text("{}")
+    rc = hf.main(["--key", str(key), "--bucket", "test-bucket", "f1", "f2"])
+    assert rc == 0
+
+
+def test_sign_rs256_real_openssl_roundtrip(tmp_path):
+    # Real subprocess.run (no fake runner) against an ephemeral, throwaway key
+    # generated in a tmp dir — never the real SA key. Catches flag/encoding
+    # regressions (e.g. wrong digest, PKCS1 vs raw) that a mocked runner can't.
+    if shutil.which("openssl") is None:
+        pytest.skip("openssl not on PATH")
+
+    keyfile = tmp_path / "throwaway.pem"
+    pubfile = tmp_path / "throwaway_pub.pem"
+    subprocess.run(["openssl", "genrsa", "-out", str(keyfile), "2048"],
+                   check=True, capture_output=True)
+    subprocess.run(["openssl", "rsa", "-in", str(keyfile), "-pubout", "-out", str(pubfile)],
+                   check=True, capture_output=True)
+
+    signing_input = "aaa.bbb"
+    sig_b64url = hf.sign_rs256(signing_input, keyfile.read_text())   # real runner
+
+    sigfile = tmp_path / "sig.bin"
+    sigfile.write_bytes(_b64url_decode(sig_b64url))
+    verify = subprocess.run(
+        ["openssl", "dgst", "-sha256", "-verify", str(pubfile), "-signature", str(sigfile)],
+        input=signing_input.encode(), capture_output=True,
+    )
+    assert verify.returncode == 0, verify.stderr
+    assert b"Verified OK" in verify.stdout

--- a/validation-harness/test_remote.py
+++ b/validation-harness/test_remote.py
@@ -61,6 +61,24 @@ def test_remote_run_script_invokes_run_differential_and_touches_done():
     assert s.rstrip().endswith("&")
 
 
+def test_remote_run_script_redirects_stdin_from_dev_null():
+    # Backgrounded nohup inherits the SSH session's stdin, which delays SSH return
+    # by ~3-4 minutes (channel-close timeout). Redirect stdin from /dev/null so the
+    # SSH session returns promptly after the remote command detaches.
+    s = remote_run_script(
+        remote_dir="~/scratch/host",
+        device_bin="art/maestro-device/bin/maestro-device",
+        cli_2x="art/2x/bin/maestro", cli_3x="art/3x/bin/maestro",
+        out_dir="out", folders=["corpus/run_a"],
+        done_sentinel="out/DONE", log="out/run.log",
+    )
+    # stdin redirect must appear before stdout/stderr redirect and the trailing &
+    assert "< /dev/null" in s
+    stdin_idx = s.index("< /dev/null")
+    stdout_idx = s.index("> /dev/null 2>&1 &")
+    assert stdin_idx < stdout_idx
+
+
 def test_remote_run_script_sentinel_carries_exit_status():
     # 3b: an unconditional `touch DONE` can't distinguish a clean finish from a
     # crash-at-startup (e.g. a ModuleNotFoundError before any flow runs) — which is
@@ -549,3 +567,44 @@ def test_tar_tolerates_dead_symlink_where_scp_r_would_abort(tmp_path):
     base = os.path.basename(str(run))
     rc = sp.run(["tar", "-C", parent, "-cf", "/dev/null", base]).returncode
     assert rc == 0
+
+
+# --- Task 5: host_fetch_script invocation builder ---
+
+def test_host_fetch_script_builds_synchronous_invocation():
+    s = remote.host_fetch_script(
+        remote_dir="/tmp/maestro-differential/007",
+        folders=["corpus/0/run_1", "corpus/1/run_2"],
+        key_path="/path/to/sa-key.json",
+        bucket="test-bucket",
+        python_bin="/opt/homebrew/bin/python3",
+    )
+    # Exact output: safe strings without special chars are unquoted, structure is locked
+    assert s == "cd /tmp/maestro-differential/007 && /opt/homebrew/bin/python3 host_fetch.py --key /path/to/sa-key.json --bucket test-bucket corpus/0/run_1 corpus/1/run_2"
+    # Synchronous: no nohup, no trailing &
+    assert "nohup" not in s
+    assert not s.rstrip().endswith("&")
+
+
+def test_host_fetch_script_quotes_home_relative_root():
+    s = remote.host_fetch_script(
+        remote_dir="~/scratch/007", folders=["corpus/0/run_1"],
+        key_path="/k.json", bucket="test-bucket")
+    # ~/ stays bare for remote expansion, exact command structure
+    assert s == "cd ~/scratch/007 && /opt/homebrew/bin/python3 host_fetch.py --key /k.json --bucket test-bucket corpus/0/run_1"
+    assert "nohup" not in s and not s.rstrip().endswith("&")
+
+
+def test_host_fetch_script_quotes_unsafe_characters():
+    # shlex.quote adds quotes only when needed; prove it engages for spaces
+    s = remote.host_fetch_script(
+        remote_dir="/tmp/test",
+        folders=["corpus/0/run 1", "corpus/1/run 2"],
+        key_path="/k.json",
+        bucket="my bucket"
+    )
+    # Arguments with spaces must be quoted by shlex.quote for shell safety
+    assert "'my bucket'" in s
+    assert "'corpus/0/run 1'" in s
+    assert "'corpus/1/run 2'" in s
+    assert "nohup" not in s and not s.rstrip().endswith("&")


### PR DESCRIPTION
## Why

The batch harness staged each flow by uploading its whole ~748M folder from the laptop over SSH — most of it the app binary — even though the app and workspace already live in cloud storage the hosts can read directly. On a home uplink that upload dominated the run and dropped SSH pipes under load.

## Approach

Push only `metadata.json` per flow. Each host mints a short-lived OAuth token from its own service-account key (openssl + python3 stdlib, no extra deps) and fetches the app binary + `workspace.zip` from the configured GCS bucket, landing the folder in the same layout as before so `run_differential.py` is unchanged. Downloads retry transient errors, fail fast on 4xx, re-mint once on a 401, and never accept a truncated body. The bucket and key path are configuration (`--gcs-bucket` / `--sa-key`, or env), not hardcoded.

Also redirects stdin on the detached remote run so `dispatch` returns promptly instead of hanging a few minutes per host.

## Verification

Unit suite green. Proven on two hosts end to end: both fetch from GCS (only `metadata.json` pushed), the reconstructed folder is byte-identical to an uploaded one and produces an identical `diff.json`, and `collect` removes all host scratch — nothing left behind. Per-flow laptop transfer drops from ~90 MiB to ~2 KiB.
