### PR TITLE
fix(cli): let the OS assign the MCP viewer port

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/mcp/viewer/McpViewerServer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/mcp/viewer/McpViewerServer.kt
@@ -30,11 +30,11 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import maestro.cli.Dependencies
-import maestro.cli.util.getFreePort
 import maestro.device.Device
 import maestro.device.DeviceService
 import maestro.device.Platform
@@ -106,7 +106,6 @@ internal class McpViewerServer private constructor(
                 ?: "<!doctype html><p>Viewer resource missing — build the CLI first.</p>"
 
         fun start(port: Int? = null): McpViewerServer {
-            val resolvedPort = port ?: getFreePort(host = "127.0.0.1")
             val mapper = jacksonObjectMapper()
             val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
             // Single-threaded dispatcher for publishing SSE events so snapshots reach
@@ -150,7 +149,9 @@ internal class McpViewerServer private constructor(
             }
 
             val server = embeddedServer(
-                port = resolvedPort,
+                // Bind first, read the port after: port 0 leaves no window for another
+                // process to take the port between picking it and binding it.
+                port = port ?: 0,
                 factory = Netty,
                 configure = { shutdownTimeout = 0; shutdownGracePeriod = 0 },
                 host = "127.0.0.1",
@@ -206,6 +207,8 @@ internal class McpViewerServer private constructor(
                     }
                 }
             }.start(wait = false)
+
+            val resolvedPort = runBlocking { server.resolvedConnectors().first().port }
 
             System.err.println("mcp_viewer_ready http://127.0.0.1:$resolvedPort")
 

--- a/maestro-cli/src/test/kotlin/maestro/cli/mcp/viewer/McpViewerServerTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/mcp/viewer/McpViewerServerTest.kt
@@ -1,0 +1,41 @@
+package maestro.cli.mcp.viewer
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.org.webcompere.systemstubs.jupiter.SystemStub
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension
+import uk.org.webcompere.systemstubs.stream.SystemErr
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+
+@ExtendWith(SystemStubsExtension::class)
+class McpViewerServerTest {
+
+    @SystemStub
+    private val systemErr = SystemErr()
+
+    @Test
+    fun `without a requested port it reports the port the OS assigned`() {
+        McpViewerServer.start().use { viewer ->
+            assertThat(viewer.port).isNotEqualTo(0)
+            assertThat(systemErr.text).contains("mcp_viewer_ready http://127.0.0.1:${viewer.port}")
+            // The announced port is bound, not merely picked.
+            Socket().use { it.connect(InetSocketAddress("127.0.0.1", viewer.port), CONNECT_TIMEOUT_MS) }
+        }
+    }
+
+    @Test
+    fun `a requested port is used as is`() {
+        val requested = ServerSocket(0).use { it.localPort }
+
+        McpViewerServer.start(port = requested).use { viewer ->
+            assertThat(viewer.port).isEqualTo(requested)
+        }
+    }
+
+    private companion object {
+        const val CONNECT_TIMEOUT_MS = 2_000
+    }
+}


### PR DESCRIPTION
## Problem

Starting several `maestro mcp` processes at once (two Claude Code sessions reading the same `.mcp.json`) kills one of them:

```
Server stderr: | Address already in use | java.net.BindException: Address already in use
Connection failed after 10778ms (CONNECTION_CLOSED): Connection closed
```

The viewer is optional, but its bind failure escapes `McpCommand.call()` and the STDIO MCP server never starts — the client just sees `CONNECTION_CLOSED`.

## Cause

`McpViewerServer.start()` picked a port with `getFreePort()`, which opens and immediately closes a `ServerSocket` on 9999..11000 and returns the number. Processes starting in the same second all see 9999 as free; whoever wins the later `embeddedServer(...).start()` keeps it, the rest get `BindException`.

## Fix

Bind with `port = 0` and read the port back from `resolvedConnectors()`, leaving no window between picking a port and owning it. `--viewer-port` is still honoured as is, `SocketUtils.getFreePort()` stays for its other caller, and the `mcp_viewer_ready` / `open_maestro_viewer` contracts are unchanged. Only visible difference: the viewer no longer prefers 9999.

Out of scope: surviving a viewer that cannot bind at all (loopback-restricted sandboxes) — a `runCatching` fallback in `McpCommand.call()` would make a good follow-up.

## Testing

`./gradlew test detekt` green; the new `McpViewerServerTest` covers both port paths. With a local `installDist` build, 5 rounds of

```bash
for i in 1 2 3; do (maestro mcp </dev/null 2> /tmp/mcp$i.err &); done
```

before: 1 of 3 died with `BindException` in every round; after: 3 of 3 answered `initialize` in every round. Also verified that `--viewer-port 12345` binds 12345 and `open_maestro_viewer` returns `http://127.0.0.1:12345/`, that `--no-viewer` is unchanged, and that an occupied `--viewer-port` still exits with `BindException` rather than hanging.
