### PR TITLE
fix(record): respect --no-ansi when recording

### DIFF
--- a/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
+++ b/maestro-cli/src/main/java/maestro/cli/api/ApiClient.kt
@@ -14,7 +14,7 @@ import maestro.cli.analytics.TrialStartFailedEvent
 import maestro.cli.analytics.TrialStartPromptedEvent
 import maestro.cli.insights.AnalysisDebugFiles
 import maestro.cli.model.FlowStatus
-import maestro.cli.runner.resultview.AnsiResultView
+import maestro.cli.runner.resultview.Frame
 import maestro.cli.util.CiUtils
 import maestro.cli.util.EnvUtils
 import maestro.cli.util.PrintUtils
@@ -201,7 +201,7 @@ class ApiClient(
 
     fun render(
         screenRecording: File,
-        frames: List<AnsiResultView.Frame>,
+        frames: List<Frame>,
         progressListener: (totalBytes: Long, bytesWritten: Long) -> Unit = { _, _ -> },
     ): String {
         val baseUrl = "https://maestro-record.ngrok.io"

--- a/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
+++ b/maestro-cli/src/main/java/maestro/cli/command/RecordCommand.kt
@@ -33,6 +33,7 @@ import maestro.cli.graphics.SkiaFrameRenderer
 import maestro.cli.report.TestDebugReporter
 import maestro.cli.runner.TestRunner
 import maestro.cli.runner.resultview.AnsiResultView
+import maestro.cli.runner.resultview.PlainTextResultView
 import maestro.cli.session.MaestroSessionManager
 import maestro.cli.util.FileUtils.isWebFlow
 import maestro.orchestra.workspace.WorkspaceExecutionPlanner
@@ -147,7 +148,12 @@ class RecordCommand : Callable<Int> {
                     )
                 }
 
-                val resultView = AnsiResultView()
+                val resultView =
+                    if (DisableAnsiMixin.ansiEnabled) {
+                        AnsiResultView()
+                    } else {
+                        PlainTextResultView()
+                    }
                 val screenRecording = kotlin.io.path.createTempFile(suffix = ".mp4").toFile()
                 val exitCode = screenRecording.sink().use { out ->
                     runBlocking { maestro.startScreenRecording(out) }.use {

--- a/maestro-cli/src/main/java/maestro/cli/graphics/LocalVideoRenderer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/graphics/LocalVideoRenderer.kt
@@ -1,6 +1,6 @@
 package maestro.cli.graphics
 
-import maestro.cli.runner.resultview.AnsiResultView
+import maestro.cli.runner.resultview.Frame
 import maestro.cli.view.ProgressBar
 import maestro.cli.view.render
 import okio.ByteString.Companion.decodeBase64
@@ -31,7 +31,7 @@ class LocalVideoRenderer(
 
     override fun render(
         screenRecording: File,
-        textFrames: List<AnsiResultView.Frame>,
+        textFrames: List<Frame>,
     ) {
         System.err.println()
         System.err.println("@|bold Rendering video - This may take some time...|@".render())

--- a/maestro-cli/src/main/java/maestro/cli/graphics/RemoteVideoRenderer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/graphics/RemoteVideoRenderer.kt
@@ -1,7 +1,7 @@
 package maestro.cli.graphics
 
 import maestro.cli.api.ApiClient
-import maestro.cli.runner.resultview.AnsiResultView
+import maestro.cli.runner.resultview.Frame
 import maestro.cli.view.ProgressBar
 import maestro.cli.view.render
 import java.io.File
@@ -10,7 +10,7 @@ class RemoteVideoRenderer : VideoRenderer {
 
     override fun render(
         screenRecording: File,
-        textFrames: List<AnsiResultView.Frame>
+        textFrames: List<Frame>
     ) {
         val client = ApiClient("")
 

--- a/maestro-cli/src/main/java/maestro/cli/graphics/VideoRenderer.kt
+++ b/maestro-cli/src/main/java/maestro/cli/graphics/VideoRenderer.kt
@@ -1,11 +1,11 @@
 package maestro.cli.graphics
 
-import maestro.cli.runner.resultview.AnsiResultView
+import maestro.cli.runner.resultview.Frame
 import java.io.File
 
 interface VideoRenderer {
     fun render(
         screenRecording: File,
-        textFrames: List<AnsiResultView.Frame>,
+        textFrames: List<Frame>,
     )
 }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/AnsiResultView.kt
@@ -58,7 +58,7 @@ class AnsiResultView(
         }
     }
 
-    fun getFrames(): List<Frame> {
+    override fun getFrames(): List<Frame> {
         return frames.toList()
     }
 
@@ -282,8 +282,6 @@ class AnsiResultView(
             }
         }
     }
-
-    data class Frame(val timestamp: Long, val content: String)
 }
 
 // Helper launcher to play around with presentation

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/Frame.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/Frame.kt
@@ -1,0 +1,6 @@
+package maestro.cli.runner.resultview
+
+data class Frame(
+    val timestamp: Long,
+    val content: String,
+)

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/PlainTextResultView.kt
@@ -1,5 +1,6 @@
 package maestro.cli.runner.resultview
 
+import io.ktor.util.encodeBase64
 import maestro.cli.runner.CommandState
 import maestro.orchestra.debug.CommandStatus
 import maestro.orchestra.CompositeCommand
@@ -9,6 +10,12 @@ import maestro.utils.chunkStringByWordCount
 class PlainTextResultView: ResultView {
 
     private val printed = mutableSetOf<String>()
+
+    private val output = StringBuilder()
+
+    private val frames = mutableListOf<Frame>()
+
+    private val startTimestamp = System.currentTimeMillis()
 
     private val terminalStatuses = setOf(
         CommandStatus.COMPLETED,
@@ -21,15 +28,36 @@ class PlainTextResultView: ResultView {
         if (printed.add(key)) block()
     }
 
+    override fun getFrames(): List<Frame> {
+        return frames.toList()
+    }
+
+    private fun emit(text: String) {
+        output.append(text)
+        print(text)
+    }
+
+    private fun emitLine(text: String = "") {
+        output.append(text).append('\n')
+        println(text)
+    }
+
     override fun setState(state: UiState) {
         when (state) {
             is UiState.Running -> renderRunningState(state)
             is UiState.Error -> renderErrorState(state)
         }
+
+        frames.add(
+            Frame(
+                timestamp = System.currentTimeMillis() - startTimestamp,
+                content = output.toString().encodeBase64(),
+            )
+        )
     }
 
     private fun renderErrorState(state: UiState.Error) {
-        println(state.message)
+        emitLine(state.message)
     }
 
     private fun renderRunningState(state: UiState.Running) {
@@ -38,20 +66,20 @@ class PlainTextResultView: ResultView {
 
     private fun renderRunningStatePlainText(state: UiState.Running) {
         state.device?.let {
-            printOnce("device") { println("Running on ${state.device.description}") }
+            printOnce("device") { emitLine("Running on ${it.description}") }
         }
 
         if (state.onFlowStartCommands.isNotEmpty()) {
-            printOnce("onFlowStart") { println("  > On Flow Start") }
+            printOnce("onFlowStart") { emitLine("  > On Flow Start") }
             renderCommandsPlainText(state.onFlowStartCommands, prefix = "onFlowStart")
         }
 
-        printOnce("flowName:${state.flowName}") { println(" > Flow ${state.flowName}") }
+        printOnce("flowName:${state.flowName}") { emitLine(" > Flow ${state.flowName}") }
 
         renderCommandsPlainText(state.commands, prefix = "main")
 
         if (state.onFlowCompleteCommands.isNotEmpty()) {
-            printOnce("onFlowComplete") { println("  > On Flow Complete") }
+            printOnce("onFlowComplete") { emitLine("  > On Flow Complete") }
             renderCommandsPlainText(state.onFlowCompleteCommands, prefix = "onFlowComplete")
         }
     }
@@ -73,12 +101,12 @@ class PlainTextResultView: ResultView {
             is CompositeCommand -> {
                 // Print start line once when command begins
                 if (command.status != CommandStatus.PENDING) {
-                    printOnce("$key:start") { println("$pad$desc...") }
+                    printOnce("$key:start") { emitLine("$pad$desc...") }
                 }
 
                 // onFlowStart hooks
                 command.subOnStartCommands?.let { cmds ->
-                    printOnce("$key:onStart") { println("$pad  > On Flow Start") }
+                    printOnce("$key:onStart") { emitLine("$pad  > On Flow Start") }
                     renderCommandsPlainText(cmds, indent + 1, "$key:subOnStart")
                 }
 
@@ -89,13 +117,13 @@ class PlainTextResultView: ResultView {
 
                 // onFlowComplete hooks
                 command.subOnCompleteCommands?.let { cmds ->
-                    printOnce("$key:onComplete") { println("$pad  > On Flow Complete") }
+                    printOnce("$key:onComplete") { emitLine("$pad  > On Flow Complete") }
                     renderCommandsPlainText(cmds, indent + 1, "$key:subOnComplete")
                 }
 
                 // Print completion line once when it reaches a terminal status
                 if (command.status in terminalStatuses) {
-                    printOnce("$key:complete") { println("$pad$desc... ${status(command.status)}") }
+                    printOnce("$key:complete") { emitLine("$pad$desc... ${status(command.status)}") }
                 }
             }
 
@@ -103,13 +131,13 @@ class PlainTextResultView: ResultView {
                 // Simple command (tapOn, assertVisible, etc.)
                 when (command.status) {
                     CommandStatus.RUNNING -> {
-                        printOnce("$key:start") { print("$pad$desc...") }
+                        printOnce("$key:start") { emit("$pad$desc...") }
                     }
 
                     in terminalStatuses -> {
-                        printOnce("$key:start") { print("$pad$desc...") }
+                        printOnce("$key:start") { emit("$pad$desc...") }
                         printOnce("$key:complete") {
-                            println(" ${status(command.status)}")
+                            emitLine(" ${status(command.status)}")
                             renderInsight(command.insight, indent + 1)
                         }
                     }
@@ -122,13 +150,13 @@ class PlainTextResultView: ResultView {
 
     private fun renderInsight(insight: Insight, indent: Int) {
         if (insight.level != Insight.Level.NONE) {
-            println("\n")
+            emitLine("\n")
             val level = insight.level.toString().lowercase().replaceFirstChar(Char::uppercase)
-            print(" ".repeat(indent) + level + ":")
+            emit(" ".repeat(indent) + level + ":")
             insight.message.chunkStringByWordCount(12).forEach { chunkedMessage ->
-                print(" ".repeat(indent))
-                print(chunkedMessage)
-                print("\n")
+                emit(" ".repeat(indent))
+                emit(chunkedMessage)
+                emit("\n")
             }
         }
     }

--- a/maestro-cli/src/main/java/maestro/cli/runner/resultview/ResultView.kt
+++ b/maestro-cli/src/main/java/maestro/cli/runner/resultview/ResultView.kt
@@ -2,4 +2,11 @@ package maestro.cli.runner.resultview
 
 interface ResultView {
     fun setState(state: UiState)
+
+    /**
+     * Frames captured while rendering, used to overlay text on screen recordings.
+     * Views that do not render to a terminal (or cannot capture frames) may return
+     * an empty list.
+     */
+    fun getFrames(): List<Frame>
 }

--- a/maestro-cli/src/test/kotlin/maestro/cli/runner/resultview/PlainTextResultViewTest.kt
+++ b/maestro-cli/src/test/kotlin/maestro/cli/runner/resultview/PlainTextResultViewTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.io.PrintStream
+import java.util.Base64
 
 class PlainTextResultViewTest {
 
@@ -332,6 +333,61 @@ class PlainTextResultViewTest {
         assertThat(output).contains("Run level1.yml")
         assertThat(output).contains("Run level2.yml")
         assertThat(output).contains("Assert that")
+    }
+
+    @Test
+    fun `getFrames captures rendered output without ansi escape codes`() {
+        // Given
+        val resultView = PlainTextResultView()
+
+        val command = MaestroCommand(
+            assertConditionCommand = AssertConditionCommand(
+                condition = Condition(visible = ElementSelector(textRegex = "hello"))
+            )
+        )
+
+        val commandState = CommandState(
+            status = CommandStatus.COMPLETED,
+            command = command,
+            subOnStartCommands = null,
+            subOnCompleteCommands = null,
+            subCommands = null
+        )
+
+        val state = UiState.Running(
+            flowName = "main.yml",
+            commands = listOf(
+                CommandState(
+                    status = CommandStatus.COMPLETED,
+                    command = MaestroCommand(
+                        runFlowCommand = RunFlowCommand(
+                            commands = listOf(command),
+                            sourceDescription = "open_app.yml",
+                            config = null
+                        )
+                    ),
+                    subOnStartCommands = null,
+                    subOnCompleteCommands = null,
+                    subCommands = listOf(commandState)
+                )
+            )
+        )
+
+        // When
+        resultView.setState(state)
+
+        // Then
+        val frames = resultView.getFrames()
+        assertThat(frames).isNotEmpty()
+
+        val decoded = String(Base64.getDecoder().decode(frames.last().content), Charsets.UTF_8)
+        assertThat(decoded).contains("main.yml")
+        assertThat(decoded).contains("Run open_app.yml")
+        assertThat(decoded).contains("Assert that")
+        // --no-ansi output must not contain ANSI escape sequences
+        assertThat(decoded).doesNotContain("\u001B[")
+
+        tearDown()
     }
 }
 


### PR DESCRIPTION
## Proposed changes

`maestro --no-ansi record` ignored `--no-ansi` and still emitted ANSI escape sequences, because `RecordCommand` always constructed an `AnsiResultView`.

`maestro test` already handles this by selecting a `PlainTextResultView` when ANSI output is disabled (`TestCommand`). This PR does the same for `record`:

- Moves `Frame` out of `AnsiResultView` into a top-level `resultview.Frame`.
- Adds `getFrames(): List<Frame>` to the `ResultView` interface, implemented by both `AnsiResultView` (behavior unchanged) and `PlainTextResultView` (now captures cumulative plain-text frames, base64-encoded, so recordings still get text overlays).
- Updates `RecordCommand` to choose the view based on `DisableAnsiMixin.ansiEnabled`.
- Updates `VideoRenderer`, `LocalVideoRenderer`, `RemoteVideoRenderer` and `ApiClient` to use the top-level `Frame`.

## Testing

- `./gradlew :maestro-cli:compileKotlin` — builds.
- `./gradlew :maestro-cli:test --tests "maestro.cli.runner.resultview.PlainTextResultViewTest"` — passes.
- Added a unit test asserting `PlainTextResultView.getFrames()` returns base64-encoded content that contains the rendered text and no ANSI escape sequences.
- Full `./gradlew :maestro-cli:test`: 161 tests, 27 failures. The 27 failures are pre-existing/environment-related (Windows path expectations in `SessionStoreTest`, `EnvUtilsTest`, `TestDebugReporterTest`, `JUnitTestSuiteReporterTest` and `ApiClientUploadRetryTest`) and are identical on the base commit (160 tests, 27 failed). The one added test passes.

> **Does this need e2e tests?** Not applicable — this is CLI output/flag handling, covered by the unit test above; recording itself still requires a device and is exercised by the existing e2e suite.

## Issues fixed

Fixes #1009
